### PR TITLE
Bad "Parse error" on CLI for servo RATE changes

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1113,7 +1113,7 @@ static void cliServo(char *cmdline)
             arguments[MAX] < PWM_PULSE_MIN || arguments[MAX] > PWM_PULSE_MAX ||
             arguments[MIDDLE] < arguments[MIN] || arguments[MIDDLE] > arguments[MAX] ||
             arguments[MIN] > arguments[MAX] || arguments[MAX] < arguments[MIN] ||
-            arguments[RATE] < 100 || arguments[RATE] > 100 ||
+            arguments[RATE] < -100 || arguments[RATE] > 100 ||
             arguments[FORWARD] >= MAX_SUPPORTED_RC_CHANNEL_COUNT ||
             arguments[ANGLE_AT_MIN] < 0 || arguments[ANGLE_AT_MIN] > 180 ||
             arguments[ANGLE_AT_MAX] < 0 || arguments[ANGLE_AT_MAX] > 180


### PR DESCRIPTION
I think this is an error in the limits of RATE in "servo" command, so should be -100 instead 100
