### PR TITLE
OLED Display status page

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -249,12 +249,14 @@ static const blackboxDeltaFieldDefinition_t blackboxMainFields[] = {
 // GPS position/vel frame
 static const blackboxConditionalFieldDefinition_t blackboxGpsGFields[] = {
     {"time",              -1, UNSIGNED, PREDICT(LAST_MAIN_FRAME_TIME), ENCODING(UNSIGNED_VB), CONDITION(NOT_LOGGING_EVERY_FRAME)},
+    {"GPS_fixType",       -1, UNSIGNED, PREDICT(0),          ENCODING(UNSIGNED_VB), CONDITION(ALWAYS)},
     {"GPS_numSat",        -1, UNSIGNED, PREDICT(0),          ENCODING(UNSIGNED_VB), CONDITION(ALWAYS)},
     {"GPS_coord",          0, SIGNED,   PREDICT(HOME_COORD), ENCODING(SIGNED_VB),   CONDITION(ALWAYS)},
     {"GPS_coord",          1, SIGNED,   PREDICT(HOME_COORD), ENCODING(SIGNED_VB),   CONDITION(ALWAYS)},
     {"GPS_altitude",      -1, UNSIGNED, PREDICT(0),          ENCODING(UNSIGNED_VB), CONDITION(ALWAYS)},
     {"GPS_speed",         -1, UNSIGNED, PREDICT(0),          ENCODING(UNSIGNED_VB), CONDITION(ALWAYS)},
     {"GPS_ground_course", -1, UNSIGNED, PREDICT(0),          ENCODING(UNSIGNED_VB), CONDITION(ALWAYS)},
+    {"GPS_hdop",          -1, UNSIGNED, PREDICT(0),          ENCODING(UNSIGNED_VB), CONDITION(ALWAYS)},
     {"GPS_eph",           -1, UNSIGNED, PREDICT(0),          ENCODING(UNSIGNED_VB), CONDITION(ALWAYS)},
     {"GPS_epv",           -1, UNSIGNED, PREDICT(0),          ENCODING(UNSIGNED_VB), CONDITION(ALWAYS)}
 };
@@ -970,12 +972,14 @@ static void writeGPSFrame()
         blackboxWriteUnsignedVB(currentTime - blackboxHistory[1]->time);
     }
 
+    blackboxWriteUnsignedVB(gpsSol.fixType);
     blackboxWriteUnsignedVB(gpsSol.numSat);
     blackboxWriteSignedVB(gpsSol.llh.lat - gpsHistory.GPS_home[0]);
     blackboxWriteSignedVB(gpsSol.llh.lon - gpsHistory.GPS_home[1]);
     blackboxWriteUnsignedVB(gpsSol.llh.alt / 100); // meters
     blackboxWriteUnsignedVB(gpsSol.groundSpeed);
     blackboxWriteUnsignedVB(gpsSol.groundCourse);
+    blackboxWriteUnsignedVB(gpsSol.hdop);
     blackboxWriteUnsignedVB(gpsSol.eph);
     blackboxWriteUnsignedVB(gpsSol.epv);
 

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -345,7 +345,7 @@ void resetSerialConfig(serialConfig_t *serialConfig)
     for (index = 0; index < SERIAL_PORT_COUNT; index++) {
         serialConfig->portConfigs[index].identifier = serialPortIdentifiers[index];
         serialConfig->portConfigs[index].msp_baudrateIndex = BAUD_115200;
-        serialConfig->portConfigs[index].gps_baudrateIndex = BAUD_57600;
+        serialConfig->portConfigs[index].gps_baudrateIndex = BAUD_38400;
         serialConfig->portConfigs[index].telemetry_baudrateIndex = BAUD_AUTO;
         serialConfig->portConfigs[index].blackbox_baudrateIndex = BAUD_115200;
     }

--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -338,8 +338,6 @@ void showProfilePage(void)
     i2c_OLED_set_line(rowIndex++);
     i2c_OLED_send_string(lineBuffer);
 }
-#define SATELLITE_COUNT (sizeof(gpsSol.svInfo) / sizeof(gpsSol.svInfo[0]))
-#define SATELLITE_GRAPH_LEFT_OFFSET ((SCREEN_CHARACTER_COLUMN_COUNT - SATELLITE_COUNT) / 2)
 
 #ifdef GPS
 void showGpsPage() {
@@ -355,16 +353,6 @@ void showGpsPage() {
 
     i2c_OLED_set_xy(0, rowIndex);
     i2c_OLED_send_char(tickerCharacters[gpsTicker]);
-
-    i2c_OLED_set_xy(MAX(0, SATELLITE_GRAPH_LEFT_OFFSET), rowIndex++);
-
-    uint32_t index;
-    for (index = 0; index < SATELLITE_COUNT && index < SCREEN_CHARACTER_COLUMN_COUNT; index++) {
-        uint8_t bargraphOffset = ((uint16_t) gpsSol.svInfo[index].cno * VERTICAL_BARGRAPH_CHARACTER_COUNT) / (GPS_DBHZ_MAX - 1);
-        bargraphOffset = MIN(bargraphOffset, VERTICAL_BARGRAPH_CHARACTER_COUNT - 1);
-        i2c_OLED_send_char(VERTICAL_BARGRAPH_ZERO_CHARACTER + bargraphOffset);
-    }
-
 
     char fixChar = STATE(GPS_FIX) ? 'Y' : 'N';
     tfp_sprintf(lineBuffer, "Sats: %d Fix: %c", gpsSol.numSat, fixChar);

--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -108,13 +108,6 @@ static const char* const gpsFixTypeText[] = {
 
 const pageId_e cyclePageIds[] = {
     PAGE_STATUS
-    ,PAGE_PROFILE
-#ifdef GPS
-    ,PAGE_GPS
-#endif
-    ,PAGE_RX
-    ,PAGE_BATTERY
-    ,PAGE_SENSORS
 #ifdef ENABLE_DEBUG_OLED_PAGE
     ,PAGE_DEBUG
 #endif

--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -85,16 +85,9 @@ static char lineBuffer[SCREEN_CHARACTER_COLUMN_COUNT + 1];
 #define IS_SCREEN_CHARACTER_COLUMN_COUNT_ODD (SCREEN_CHARACTER_COLUMN_COUNT & 1)
 
 static const char* const pageTitles[] = {
-    "CLEANFLIGHT"
+    FC_NAME
     ,"ARMED"
-    ,"BATTERY"
-    ,"SENSORS"
-    ,"RX"
-    ,"PROFILE"
     ,"STATUS"
-#ifdef GPS
-    ,"GPS"
-#endif
 #ifdef ENABLE_DEBUG_OLED_PAGE
     ,"DEBUG"
 #endif
@@ -182,19 +175,6 @@ void drawHorizonalPercentageBar(uint8_t width,uint8_t percent) {
         LCDprint(154); // empty
 }
 
-#if 0
-void fillScreenWithCharacters()
-{
-    for (uint8_t row = 0; row < SCREEN_CHARACTER_ROW_COUNT; row++) {
-        for (uint8_t column = 0; column < SCREEN_CHARACTER_COLUMN_COUNT; column++) {
-            i2c_OLED_set_xy(column, row);
-            i2c_OLED_send_char('A' + column);
-        }
-    }
-}
-#endif
-
-
 void updateTicker(void)
 {
     static uint8_t tickerIndex = 0;
@@ -254,37 +234,6 @@ void showTitle()
     i2c_OLED_send_string(pageTitles[pageState.pageId]);
 }
 
-void drawRxChannel(uint8_t channelIndex, uint8_t width)
-{
-    uint32_t percentage;
-
-    LCDprint(rcChannelLetters[channelIndex]);
-
-    percentage = (constrain(rcData[channelIndex], PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN);
-    drawHorizonalPercentageBar(width - 1, percentage);
-}
-
-#define RX_CHANNELS_PER_PAGE_COUNT 14
-void showRxPage(void)
-{
-
-    for (uint8_t channelIndex = 0; channelIndex < rxRuntimeConfig.channelCount && channelIndex < RX_CHANNELS_PER_PAGE_COUNT; channelIndex += 2) {
-        i2c_OLED_set_line((channelIndex / 2) + PAGE_TITLE_LINE_COUNT);
-
-        drawRxChannel(channelIndex, HALF_SCREEN_CHARACTER_COLUMN_COUNT);
-
-        if (channelIndex >= rxRuntimeConfig.channelCount) {
-            continue;
-        }
-
-        if (IS_SCREEN_CHARACTER_COLUMN_COUNT_ODD) {
-            LCDprint(' ');
-        }
-
-        drawRxChannel(channelIndex + PAGE_TITLE_LINE_COUNT, HALF_SCREEN_CHARACTER_COLUMN_COUNT);
-    }
-}
-
 void showWelcomePage(void)
 {
     uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
@@ -299,179 +248,6 @@ void showWelcomePage(void)
 
 void showArmedPage(void)
 {
-}
-
-void showProfilePage(void)
-{
-    uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
-
-    tfp_sprintf(lineBuffer, "Profile: %d", getCurrentProfile());
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-
-    uint8_t currentRateProfileIndex = getCurrentControlRateProfile();
-    tfp_sprintf(lineBuffer, "Rate profile: %d", currentRateProfileIndex);
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-
-    controlRateConfig_t *controlRateConfig = getControlRateConfig(currentRateProfileIndex);
-
-    tfp_sprintf(lineBuffer, "RCE: %d, RCR: %d",
-        controlRateConfig->rcExpo8,
-        controlRateConfig->rcRate8
-    );
-    padLineBuffer();
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-
-    tfp_sprintf(lineBuffer, "RR:%d PR:%d YR:%d",
-        controlRateConfig->rates[FD_ROLL],
-        controlRateConfig->rates[FD_PITCH],
-        controlRateConfig->rates[FD_YAW]
-    );
-    padLineBuffer();
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-}
-
-#ifdef GPS
-void showGpsPage() {
-    uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
-
-    static uint8_t gpsTicker = 0;
-    static uint8_t lastGPSHeartbeat = 0;
-    if (gpsSol.flags.gpsHeartbeat != lastGPSHeartbeat) {
-        lastGPSHeartbeat = gpsSol.flags.gpsHeartbeat;
-        gpsTicker++;
-        gpsTicker = gpsTicker % TICKER_CHARACTER_COUNT;
-    }
-
-    i2c_OLED_set_xy(0, rowIndex);
-    i2c_OLED_send_char(tickerCharacters[gpsTicker]);
-        
-    tfp_sprintf(lineBuffer, "Sats: %d Fix: %s", gpsSol.numSat, gpsFixTypeText[gpsSol.fixType]);
-    padLineBuffer();
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-
-    tfp_sprintf(lineBuffer, "HDOP: %d", gpsSol.hdop);
-    padLineBuffer();
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-
-    tfp_sprintf(lineBuffer, "La/Lo: %d/%d", gpsSol.llh.lat / GPS_DEGREES_DIVIDER, gpsSol.llh.lon / GPS_DEGREES_DIVIDER);
-    padLineBuffer();
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-
-    tfp_sprintf(lineBuffer, "Spd: %d", gpsSol.groundSpeed);
-    padHalfLineBuffer();
-    i2c_OLED_set_line(rowIndex);
-    i2c_OLED_send_string(lineBuffer);
-
-    tfp_sprintf(lineBuffer, "GC: %d", gpsSol.groundCourse);
-    padHalfLineBuffer();
-    i2c_OLED_set_xy(HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-
-    tfp_sprintf(lineBuffer, "RX: %d", gpsStats.packetCount);
-    padHalfLineBuffer();
-    i2c_OLED_set_line(rowIndex);
-    i2c_OLED_send_string(lineBuffer);
-
-    tfp_sprintf(lineBuffer, "ERRs: %d", gpsStats.errors);
-    padHalfLineBuffer();
-    i2c_OLED_set_xy(HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-
-    tfp_sprintf(lineBuffer, "Dt: %d", gpsStats.lastMessageDt);
-    padHalfLineBuffer();
-    i2c_OLED_set_line(rowIndex);
-    i2c_OLED_send_string(lineBuffer);
-
-    tfp_sprintf(lineBuffer, "TOs: %d", gpsStats.timeouts);
-    padHalfLineBuffer();
-    i2c_OLED_set_xy(HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-
-#ifdef GPS_PH_DEBUG
-    tfp_sprintf(lineBuffer, "Angles: P:%d R:%d", GPS_angle[PITCH], GPS_angle[ROLL]);
-    padLineBuffer();
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-#endif
-
-#if 0
-    tfp_sprintf(lineBuffer, "%d %d %d %d", debug[0], debug[1], debug[2], debug[3]);
-    padLineBuffer();
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
-#endif
-}
-#endif
-
-void showBatteryPage(void)
-{
-    uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
-
-    if (feature(FEATURE_VBAT)) {
-        tfp_sprintf(lineBuffer, "Volts: %d.%1d Cells: %d", vbat / 10, vbat % 10, batteryCellCount);
-        padLineBuffer();
-        i2c_OLED_set_line(rowIndex++);
-        i2c_OLED_send_string(lineBuffer);
-
-        uint8_t batteryPercentage = calculateBatteryPercentage();
-        i2c_OLED_set_line(rowIndex++);
-        drawHorizonalPercentageBar(SCREEN_CHARACTER_COLUMN_COUNT, batteryPercentage);
-    }
-
-    if (feature(FEATURE_CURRENT_METER)) {
-        tfp_sprintf(lineBuffer, "Amps: %d.%2d mAh: %d", amperage / 100, amperage % 100, mAhDrawn);
-        padLineBuffer();
-        i2c_OLED_set_line(rowIndex++);
-        i2c_OLED_send_string(lineBuffer);
-
-        uint8_t capacityPercentage = calculateBatteryCapacityRemainingPercentage();
-        i2c_OLED_set_line(rowIndex++);
-        drawHorizonalPercentageBar(SCREEN_CHARACTER_COLUMN_COUNT, capacityPercentage);
-    }
-}
-
-void showSensorsPage(void)
-{
-    uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
-    static const char *format = "%s %5d %5d %5d";
-
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string("        X     Y     Z");
-
-    if (sensors(SENSOR_ACC)) {
-        tfp_sprintf(lineBuffer, format, "ACC", accADC[X], accADC[Y], accADC[Z]);
-        padLineBuffer();
-        i2c_OLED_set_line(rowIndex++);
-        i2c_OLED_send_string(lineBuffer);
-    }
-
-    if (sensors(SENSOR_GYRO)) {
-        tfp_sprintf(lineBuffer, format, "GYR", gyroADC[X], gyroADC[Y], gyroADC[Z]);
-        padLineBuffer();
-        i2c_OLED_set_line(rowIndex++);
-        i2c_OLED_send_string(lineBuffer);
-    }
-
-#ifdef MAG
-    if (sensors(SENSOR_MAG)) {
-        tfp_sprintf(lineBuffer, format, "MAG", magADC[X], magADC[Y], magADC[Z]);
-        padLineBuffer();
-        i2c_OLED_set_line(rowIndex++);
-        i2c_OLED_send_string(lineBuffer);
-    }
-#endif
-
-    tfp_sprintf(lineBuffer, format, "I&H", attitude.values.roll, attitude.values.pitch, DECIDEGREES_TO_DEGREES(attitude.values.yaw));
-    padLineBuffer();
-    i2c_OLED_set_line(rowIndex++);
-    i2c_OLED_send_string(lineBuffer);
 }
 
 void showStatusPage(void)
@@ -595,13 +371,14 @@ void updateDisplay(void)
                 (((int32_t)(now - pageState.nextPageAt) >= 0L && (pageState.pageFlags & PAGE_STATE_FLAG_CYCLE_ENABLED)));
                 
         uint8_t prevCycleIndex = pageState.cycleIndex;
+        uint8_t pageId = pageState.pageId;
                 
         if (pageState.pageChanging && (pageState.pageFlags & PAGE_STATE_FLAG_CYCLE_ENABLED)) {
             pageState.cycleIndex++;
             pageState.cycleIndex = pageState.cycleIndex % CYCLE_PAGE_ID_COUNT;
             pageState.pageId = cyclePageIds[pageState.cycleIndex];
             
-            if (prevCycleIndex == pageState.cycleIndex) {
+            if (prevCycleIndex == pageState.cycleIndex && pageId != PAGE_WELCOME) {
                 pageState.pageChanging = false;
             }
             
@@ -639,30 +416,9 @@ void updateDisplay(void)
         case PAGE_ARMED:
             showArmedPage();
             break;
-        case PAGE_BATTERY:
-            showBatteryPage();
-            break;
-        case PAGE_SENSORS:
-            showSensorsPage();
-            break;
-        case PAGE_RX:
-            showRxPage();
-            break;
-        case PAGE_PROFILE:
-            showProfilePage();
-            break;
         case PAGE_STATUS:
             showStatusPage();
             break;
-#ifdef GPS
-        case PAGE_GPS:
-            if (feature(FEATURE_GPS)) {
-                showGpsPage();
-            } else {
-                pageState.pageFlags |= PAGE_STATE_FLAG_FORCE_PAGE_CHANGE;
-            }
-            break;
-#endif
 #ifdef ENABLE_DEBUG_OLED_PAGE
         case PAGE_DEBUG:
             showDebugPage();

--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -98,8 +98,6 @@ static const char* const pageTitles[] = {
 #endif
 };
 
-#define PAGE_COUNT (PAGE_RX + 1)
-
 const pageId_e cyclePageIds[] = {
     PAGE_PROFILE,
 #ifdef GPS
@@ -353,9 +351,21 @@ void showGpsPage() {
 
     i2c_OLED_set_xy(0, rowIndex);
     i2c_OLED_send_char(tickerCharacters[gpsTicker]);
+    
+    char *fixChar = "NO";
+    
+    if (gpsSol.fixType == 2) {
+        fixChar = "3D";
+    } else if (gpsSol.fixType == 1) {
+        fixChar = "2D";
+    } 
+    
+    tfp_sprintf(lineBuffer, "Sats: %d Fix: %s", gpsSol.numSat, fixChar);
+    padLineBuffer();
+    i2c_OLED_set_line(rowIndex++);
+    i2c_OLED_send_string(lineBuffer);
 
-    char fixChar = STATE(GPS_FIX) ? 'Y' : 'N';
-    tfp_sprintf(lineBuffer, "Sats: %d Fix: %c", gpsSol.numSat, fixChar);
+    tfp_sprintf(lineBuffer, "HDOP: %d", gpsSol.hdop);
     padLineBuffer();
     i2c_OLED_set_line(rowIndex++);
     i2c_OLED_send_string(lineBuffer);

--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -98,6 +98,12 @@ static const char* const pageTitles[] = {
 #endif
 };
 
+static const char* const gpsFixTypeText[] = {
+    "NO",
+    "2D",
+    "3D"
+};
+
 const pageId_e cyclePageIds[] = {
     PAGE_PROFILE,
 #ifdef GPS
@@ -351,16 +357,8 @@ void showGpsPage() {
 
     i2c_OLED_set_xy(0, rowIndex);
     i2c_OLED_send_char(tickerCharacters[gpsTicker]);
-    
-    char *fixChar = "NO";
-    
-    if (gpsSol.fixType == 2) {
-        fixChar = "3D";
-    } else if (gpsSol.fixType == 1) {
-        fixChar = "2D";
-    } 
-    
-    tfp_sprintf(lineBuffer, "Sats: %d Fix: %s", gpsSol.numSat, fixChar);
+        
+    tfp_sprintf(lineBuffer, "Sats: %d Fix: %s", gpsSol.numSat, gpsFixTypeText[gpsSol.fixType]);
     padLineBuffer();
     i2c_OLED_set_line(rowIndex++);
     i2c_OLED_send_string(lineBuffer);

--- a/src/main/io/display.h
+++ b/src/main/io/display.h
@@ -20,14 +20,7 @@
 typedef enum {
     PAGE_WELCOME
     ,PAGE_ARMED
-    ,PAGE_BATTERY
-    ,PAGE_SENSORS
-    ,PAGE_RX
-    ,PAGE_PROFILE
     ,PAGE_STATUS
-#ifdef GPS
-    ,PAGE_GPS
-#endif
 #ifdef ENABLE_DEBUG_OLED_PAGE
     ,PAGE_DEBUG
 #endif

--- a/src/main/io/display.h
+++ b/src/main/io/display.h
@@ -18,17 +18,18 @@
 //#define ENABLE_DEBUG_OLED_PAGE
 
 typedef enum {
-    PAGE_WELCOME,
-    PAGE_ARMED,
-    PAGE_BATTERY,
-    PAGE_SENSORS,
-    PAGE_RX,
-    PAGE_PROFILE,
+    PAGE_WELCOME
+    ,PAGE_ARMED
+    ,PAGE_BATTERY
+    ,PAGE_SENSORS
+    ,PAGE_RX
+    ,PAGE_PROFILE
+    ,PAGE_STATUS
 #ifdef GPS
-    PAGE_GPS,
+    ,PAGE_GPS
 #endif
 #ifdef ENABLE_DEBUG_OLED_PAGE
-    PAGE_DEBUG,
+    ,PAGE_DEBUG
 #endif
 } pageId_e;
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -147,15 +147,6 @@ static void gpsHandleProtocol(void)
 
 static void gpsResetSolution(void)
 {
-    // Clear satellites in view information, if we use I2C driver this is not used
-    gpsSol.numCh = 0;
-    for (int i = 0; i < GPS_SV_MAXSATS; i++){
-        gpsSol.svInfo[i].chn = 0;
-        gpsSol.svInfo[i].svid = 0;
-        gpsSol.svInfo[i].quality = 0;
-        gpsSol.svInfo[i].cno = 0;
-    }
-
     gpsSol.eph = 9999;
     gpsSol.epv = 9999;
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -260,7 +260,12 @@ void gpsFinalizeChangeBaud(void)
 
 uint16_t gpsConstrainEPE(uint32_t epe)
 {
-    return (epe > 9999) ? 9999 : epe;
+    return (epe > 99999) ? 9999 : epe; // max 99.99m error
+}
+
+uint16_t gpsConstrainHDOP(uint32_t hdop)
+{
+    return (hdop > 99999) ? 9999 : hdop; // max 99.99m error
 }
 
 void gpsThread(void)

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -20,8 +20,6 @@
 #define GPS_DBHZ_MIN 0
 #define GPS_DBHZ_MAX 55
 
-#define GPS_SV_MAXSATS   16
-
 #define LAT 0
 #define LON 1
 
@@ -84,13 +82,6 @@ typedef struct gpsCoordinateDDDMMmmmm_s {
     int16_t mmmm;
 } gpsCoordinateDDDMMmmmm_t;
 
-typedef struct {
-    uint8_t chn;     // Channel number
-    uint8_t svid;    // Satellite ID
-    uint8_t quality; // Bitfield Qualtity
-    uint8_t cno;     // Carrier to Noise Ratio (Signal Strength)
-} gpsSVChannel_t;
-
 /* LLH Location in NEU axis system */
 typedef struct gpsLocation_s {
     int32_t lat;    // Lattitude * 1e+7
@@ -109,9 +100,6 @@ typedef struct gpsSolutionData_s {
     } flags;
 
     uint8_t numSat;
-
-    uint8_t numCh;
-    gpsSVChannel_t svInfo[GPS_SV_MAXSATS];
 
     gpsLocation_t llh;
     int16_t       magData[3];

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -110,6 +110,8 @@ typedef struct gpsSolutionData_s {
 
     uint16_t eph;   // horizontal accuracy (cm)
     uint16_t epv;   // vertical accuracy (cm)
+
+    uint16_t hdop;  // generic HDOP value (*100)
 } gpsSolutionData_t;
 
 typedef struct {

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -67,6 +67,12 @@ typedef enum {
     GPS_MODEL_HIGH_G,
 } gpsNavModel_e;
 
+typedef enum {
+    GPS_NO_FIX = 0,
+    GPS_FIX_2D,
+    GPS_FIX_3D
+} gpsFixType_e;
+
 #define GPS_BAUDRATE_MAX GPS_BAUDRATE_9600
 
 typedef struct gpsConfig_s {
@@ -92,13 +98,13 @@ typedef struct gpsLocation_s {
 typedef struct gpsSolutionData_s {
     struct {
         unsigned gpsHeartbeat   : 1;     // Toggle each update
-        unsigned fix3D          : 1;     // gps fix status
         unsigned validVelNE     : 1;
         unsigned validVelD      : 1;
         unsigned validMag       : 1;
         unsigned validEPE       : 1;    // EPH/EPV values are valid - actual accuracy
     } flags;
 
+    uint8_t fixType;
     uint8_t numSat;
 
     gpsLocation_t llh;

--- a/src/main/io/gps_i2cnav.c
+++ b/src/main/io/gps_i2cnav.c
@@ -74,8 +74,9 @@ bool gpsPollI2CNAV(void)
         // Other data
         if (gpsMsg.flags.newData) {
             if (gpsMsg.flags.fix3D) {
-                gpsSol.eph = gpsConstrainEPE(gpsMsg.hdop);
-                gpsSol.epv = gpsConstrainEPE(gpsMsg.hdop);  // i2c-nav doesn't give vdop data, fake it using hdop
+                gpsSol.hdop = gpsConstrainHDOP(gpsMsg.hdop);
+                gpsSol.eph = gpsConstrainEPE(gpsMsg.hdop * GPS_HDOP_TO_EPH_MULTIPLIER);
+                gpsSol.epv = gpsConstrainEPE(gpsMsg.hdop * GPS_HDOP_TO_EPH_MULTIPLIER);  // i2c-nav doesn't give vdop data, fake it using hdop
                 gpsSol.groundSpeed = gpsMsg.speed;
                 gpsSol.groundCourse = gpsMsg.ground_course;
                 gpsSol.llh.lat = gpsMsg.latitude;

--- a/src/main/io/gps_i2cnav.c
+++ b/src/main/io/gps_i2cnav.c
@@ -66,7 +66,13 @@ bool gpsPollI2CNAV(void)
     i2cnavGPSModuleRead(&gpsMsg);
 
     if (gpsMsg.flags.gpsOk) {
-        gpsSol.flags.fix3D = gpsMsg.flags.fix3D;
+        if (gpsMsg.flags.fix3D) {
+            // No fix type available - assume 3D
+            gpsSol.fixType = GPS_FIX_3D;
+        }
+        else {
+            gpsSol.fixType = GPS_NO_FIX;
+        }
 
         // sat count
         gpsSol.numSat = gpsMsg.numSat;

--- a/src/main/io/gps_naza.c
+++ b/src/main/io/gps_naza.c
@@ -181,13 +181,14 @@ static bool NAZA_parse_gps(void)
         gpsSol.velNED[2] = decodeLong(_buffernaza.nav.ned_down, mask);   // cm/s
 
 
-        //uint16_t pdop = decodeShort(_buffernaza.nav.pdop, mask); // pdop
+        uint16_t pdop = decodeShort(_buffernaza.nav.pdop, mask); // pdop
         //uint16_t vdop = decodeShort(_buffernaza.nav.vdop, mask); // vdop
         //uint16_t ndop = decodeShort(_buffernaza.nav.ndop, mask);
         //uint16_t edop = decodeShort(_buffernaza.nav.edop, mask);
         //gpsSol.hdop = sqrtf(powf(ndop,2)+powf(edop,2));
         //gpsSol.vdop = decodeShort(_buffernaza.nav.vdop, mask); // vdop
 
+        gpsSol.hdop = gpsConstrainEPE(pdop);        // PDOP
         gpsSol.eph = gpsConstrainEPE(h_acc / 10);   // hAcc in cm
         gpsSol.epv = gpsConstrainEPE(v_acc / 10);   // vAcc in cm
         gpsSol.numSat = _buffernaza.nav.satellites;

--- a/src/main/io/gps_naza.c
+++ b/src/main/io/gps_naza.c
@@ -97,7 +97,7 @@ typedef enum {
     NO_FIX = 0,
     FIX_2D = 2,
     FIX_3D = 3,
-    FIX_DGPS = 4 
+    FIX_DGPS = 4
 } fixType_t;
 
 // Receive buffer
@@ -170,7 +170,12 @@ static bool NAZA_parse_gps(void)
         //uint8_t r5 = _buffernaza.nav.reserved5 ^ mask;
         //uint8_t r6 = _buffernaza.nav.reserved6 ^ mask;
 
-        gpsSol.flags.fix3D = (fixType == FIX_3D) ? 1 : 0;
+        if (fixType == FIX_2D)
+            gpsSol.fixType = GPS_FIX_2D;
+        else if (fixType == FIX_3D)
+            gpsSol.fixType = GPS_FIX_3D;
+        else
+            gpsSol.fixType = GPS_NO_FIX;
 
         uint32_t h_acc = decodeLong(_buffernaza.nav.h_acc, mask); // mm
         uint32_t v_acc = decodeLong(_buffernaza.nav.v_acc, mask); // mm
@@ -350,7 +355,7 @@ bool gpsHandleNAZA(void)
 
     case GPS_CHECK_VERSION:
     case GPS_CONFIGURE:
-        // No autoconfig, switch straight to receiving data 
+        // No autoconfig, switch straight to receiving data
         gpsSetState(GPS_RECEIVING_DATA);
         return false;
 

--- a/src/main/io/gps_nmea.c
+++ b/src/main/io/gps_nmea.c
@@ -62,7 +62,6 @@
 #define NO_FRAME   0
 #define FRAME_GGA  1
 #define FRAME_RMC  2
-#define FRAME_GSV  3
 
 static uint32_t grab_fields(char *src, uint8_t mult)
 {                               // convert string to uint32
@@ -104,8 +103,6 @@ static bool gpsNewFrameNMEA(char c)
     static uint8_t param = 0, offset = 0, parity = 0;
     static char string[15];
     static uint8_t checksum_param, gps_frame = NO_FRAME;
-    static uint8_t svMessageNum = 0;
-    uint8_t svSatNum = 0, svPacketIdx = 0, svSatParam = 0;
 
     switch (c) {
         case '$':
@@ -122,8 +119,6 @@ static bool gpsNewFrameNMEA(char c)
                     gps_frame = FRAME_GGA;
                 if (string[0] == 'G' && string[1] == 'P' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C')
                     gps_frame = FRAME_RMC;
-                if (string[0] == 'G' && string[1] == 'P' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V')
-                    gps_frame = FRAME_GSV;
             }
 
             switch (gps_frame) {
@@ -170,49 +165,6 @@ static bool gpsNewFrameNMEA(char c)
                             break;
                         case 8:
                             gps_Msg.ground_course = (grab_fields(string, 1));      // ground course deg * 10
-                            break;
-                    }
-                    break;
-                case FRAME_GSV:
-                    switch(param) {
-                      /*case 1:
-                            // Total number of messages of this type in this cycle
-                            break; */
-                        case 2:
-                            // Message number
-                            svMessageNum = grab_fields(string, 0);
-                            break;
-                        case 3:
-                            // Total number of SVs visible
-                            gpsSol.numCh = grab_fields(string, 0);
-                            break;
-                    }
-                    if(param < 4)
-                        break;
-
-                    svPacketIdx = (param - 4) / 4 + 1; // satellite number in packet, 1-4
-                    svSatNum    = svPacketIdx + (4 * (svMessageNum - 1)); // global satellite number
-                    svSatParam  = param - 3 - (4 * (svPacketIdx - 1)); // parameter number for satellite
-
-                    if(svSatNum > GPS_SV_MAXSATS)
-                        break;
-
-                    switch(svSatParam) {
-                        case 1:
-                            // SV PRN number
-                            gpsSol.svInfo[svSatNum - 1].chn = svSatNum;
-                            gpsSol.svInfo[svSatNum - 1].svid = grab_fields(string, 0);
-                            break;
-                      /*case 2:
-                            // Elevation, in degrees, 90 maximum
-                            break;
-                        case 3:
-                            // Azimuth, degrees from True North, 000 through 359
-                            break; */
-                        case 4:
-                            // SNR, 00 through 99 dB (null when not tracking)
-                            gpsSol.svInfo[svSatNum - 1].cno = grab_fields(string, 0);
-                            gpsSol.svInfo[svSatNum - 1].quality = 0; // only used by ublox
                             break;
                     }
                     break;

--- a/src/main/io/gps_nmea.c
+++ b/src/main/io/gps_nmea.c
@@ -151,7 +151,7 @@ static bool gpsNewFrameNMEA(char c)
                             gps_Msg.numSat = grab_fields(string, 0);
                             break;
                         case 8:
-                            gps_Msg.hdop = grab_fields(string, 1) * 10;         // hdop (assume GPS is reporting it in meters)
+                            gps_Msg.hdop = grab_fields(string, 1) * 10;          // hdop
                             break;
                         case 9:
                             gps_Msg.altitude = grab_fields(string, 1) * 10;     // altitude in cm
@@ -194,8 +194,9 @@ static bool gpsNewFrameNMEA(char c)
                             gpsSol.llh.alt = gps_Msg.altitude;
 
                             // EPH/EPV are unreliable for NMEA as they are not real accuracy
-                            gpsSol.eph = gpsConstrainEPE(gps_Msg.hdop);
-                            gpsSol.epv = gpsConstrainEPE(gps_Msg.hdop);
+                            gpsSol.hdop = gpsConstrainHDOP(gps_Msg.hdop);
+                            gpsSol.eph = gpsConstrainEPE(gps_Msg.hdop * GPS_HDOP_TO_EPH_MULTIPLIER);
+                            gpsSol.epv = gpsConstrainEPE(gps_Msg.hdop * GPS_HDOP_TO_EPH_MULTIPLIER);
                             gpsSol.flags.validEPE = 0;
                         }
                         else {

--- a/src/main/io/gps_nmea.c
+++ b/src/main/io/gps_nmea.c
@@ -188,7 +188,8 @@ static bool gpsNewFrameNMEA(char c)
                         frameOK = 1;
                         gpsSol.numSat = gps_Msg.numSat;
                         if (gps_Msg.fix) {
-                            gpsSol.flags.fix3D = 1;
+                            gpsSol.fixType = GPS_FIX_3D;    // NMEA doesn't report fix type, assume 3D
+
                             gpsSol.llh.lat = gps_Msg.latitude;
                             gpsSol.llh.lon = gps_Msg.longitude;
                             gpsSol.llh.alt = gps_Msg.altitude;
@@ -200,7 +201,7 @@ static bool gpsNewFrameNMEA(char c)
                             gpsSol.flags.validEPE = 0;
                         }
                         else {
-                            gpsSol.flags.fix3D = 0;
+                            gpsSol.fixType = GPS_NO_FIX;
                         }
 
                         // NMEA does not report VELNED
@@ -278,7 +279,7 @@ bool gpsHandleNMEA(void)
 
     case GPS_CHECK_VERSION:
     case GPS_CONFIGURE:
-        // No autoconfig, switch straight to receiving data 
+        // No autoconfig, switch straight to receiving data
         gpsSetState(GPS_RECEIVING_DATA);
         return false;
 

--- a/src/main/io/gps_private.h
+++ b/src/main/io/gps_private.h
@@ -19,6 +19,8 @@
 
 #ifdef GPS
 
+#define GPS_HDOP_TO_EPH_MULTIPLIER      2   // empirical value
+
 typedef enum {
     GPS_UNKNOWN,                // 0
     GPS_INITIALIZING,           // 1
@@ -53,7 +55,9 @@ extern baudRate_e gpsToSerialBaudRate[GPS_BAUDRATE_COUNT];
 
 extern void gpsSetState(gpsState_e state);
 extern void gpsFinalizeChangeBaud(void);
+
 extern uint16_t gpsConstrainEPE(uint32_t epe);
+extern uint16_t gpsConstrainHDOP(uint32_t hdop);
 
 extern bool gpsHandleNMEA(void);
 extern bool gpsHandleUBLOX(void);

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -96,7 +96,7 @@ static const uint8_t ubloxInit_MSG_UBX_POSLLH[] = {
     0xB5, 0x62, 0x06, 0x01, 0x03, 0x00, 0x01, 0x02, 0x01, 0x0E, 0x47,           // set POSLLH MSG rate
     0xB5, 0x62, 0x06, 0x01, 0x03, 0x00, 0x01, 0x03, 0x01, 0x0F, 0x49,           // set STATUS MSG rate
     0xB5, 0x62, 0x06, 0x01, 0x03, 0x00, 0x01, 0x06, 0x01, 0x12, 0x4F,           // set SOL MSG rate
-    0xB5, 0x62, 0x06, 0x01, 0x03, 0x00, 0x01, 0x30, 0x05, 0x40, 0xA7,           // set SVINFO MSG rate (evey 5 cycles - low bandwidth)
+    0xB5, 0x62, 0x06, 0x01, 0x03, 0x00, 0x01, 0x30, 0x00, 0x3B, 0xA2,           // disable SVINFO
     0xB5, 0x62, 0x06, 0x01, 0x03, 0x00, 0x01, 0x12, 0x01, 0x1E, 0x67            // set VELNED MSG rate
 };
 
@@ -105,7 +105,7 @@ static const uint8_t ubloxInit_MSG_UBX_PVT[] = {
     0xB5, 0x62, 0x06, 0x01, 0x08, 0x00, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0xB9, // disable POSLLH
     0xB5, 0x62, 0x06, 0x01, 0x08, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0xC0, // disable STATUS
     0xB5, 0x62, 0x06, 0x01, 0x08, 0x00, 0x01, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0xD5, // disable SOL
-    0xB5, 0x62, 0x06, 0x01, 0x08, 0x00, 0x01, 0x30, 0x00, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x4A, 0x2D, // enable SVINFO 10 cycle
+    0xB5, 0x62, 0x06, 0x01, 0x08, 0x00, 0x01, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0xFB, // disable SVINFO
     0xB5, 0x62, 0x06, 0x01, 0x08, 0x00, 0x01, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x29, // disable VELNED
     0xB5, 0x62, 0x06, 0x01, 0x08, 0x00, 0x01, 0x07, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x18, 0xE1  // enable PVT 1 cycle
 };
@@ -327,9 +327,7 @@ static bool _new_speed;
 //15:17:55  R -> UBX NAV,  Size 100,  'Navigation'
 //15:17:55  R -> UBX NAV-SVINFO,  Size 328,  'Satellite Status and Information'
 
-// from the UBlox6 document, the largest payout we receive i the NAV-SVINFO and the payload size
-// is calculated as 8 + 12*numCh.  numCh in the case of a Glonass receiver is 28.
-#define MAX_UBLOX_PAYLOAD_SIZE 344
+#define MAX_UBLOX_PAYLOAD_SIZE 100  // 100 bytes should be enough for all used messages
 #define UBLOX_BUFFER_SIZE MAX_UBLOX_PAYLOAD_SIZE
 
 // Receive buffer
@@ -353,11 +351,8 @@ void _update_checksum(uint8_t *data, uint8_t len, uint8_t *ck_a, uint8_t *ck_b)
     }
 }
 
-
 static bool gpsParceFrameUBLOX(void)
 {
-    uint32_t i;
-
     switch (_msg_id) {
     case MSG_POSLLH:
         //i2c_dataset.time                = _buffer.posllh.time;
@@ -366,7 +361,8 @@ static bool gpsParceFrameUBLOX(void)
         gpsSol.llh.alt = _buffer.posllh.altitude_msl / 10;  //alt in cm
         gpsSol.eph = gpsConstrainEPE(_buffer.posllh.horizontal_accuracy / 10);
         gpsSol.epv = gpsConstrainEPE(_buffer.posllh.vertical_accuracy / 10);
-        gpsSol.flags.fix3D = next_fix ? 1 : 0;
+        if (next_fix)
+            gpsSol.flags.fix3D = 1;
         _new_position = true;
         break;
     case MSG_STATUS:
@@ -418,17 +414,6 @@ static bool gpsParceFrameUBLOX(void)
         }
         break;
 #endif
-    case MSG_SVINFO:
-        gpsSol.numCh = _buffer.svinfo.numCh;
-        if (gpsSol.numCh > 16)
-            gpsSol.numCh = 16;
-        for (i = 0; i < gpsSol.numCh; i++){
-            gpsSol.svInfo[i].chn = _buffer.svinfo.channel[i].chn;
-            gpsSol.svInfo[i].svid = _buffer.svinfo.channel[i].svid;
-            gpsSol.svInfo[i].quality = _buffer.svinfo.channel[i].quality;
-            gpsSol.svInfo[i].cno =  _buffer.svinfo.channel[i].cno;
-        }
-        break;
     default:
         return false;
     }
@@ -509,6 +494,7 @@ static bool gpsNewFrameUBLOX(uint8_t data)
             if (_ck_a != data) {
                 _skip_packet = true;          // bad checksum
                 gpsStats.errors++;
+                _step = 0;
             }
             break;
         case 8:

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -375,6 +375,7 @@ static bool gpsParceFrameUBLOX(void)
         if (!next_fix)
             gpsSol.flags.fix3D = 0;
         gpsSol.numSat = _buffer.solution.satellites;
+        gpsSol.hdop = gpsConstrainHDOP(_buffer.solution.position_DOP);
         break;
     case MSG_VELNED:
         gpsSol.groundSpeed = _buffer.velned.speed_2d;    // cm/s
@@ -401,6 +402,7 @@ static bool gpsParceFrameUBLOX(void)
         gpsSol.numSat = _buffer.pvt.satellites;
         gpsSol.eph = gpsConstrainEPE(_buffer.pvt.horizontal_accuracy / 10);
         gpsSol.epv = gpsConstrainEPE(_buffer.pvt.vertical_accuracy / 10);
+        gpsSol.hdop = gpsConstrainHDOP(_buffer.pvt.position_DOP);
         gpsSol.flags.validVelNE = 1;
         gpsSol.flags.validVelD = 1;
         gpsSol.flags.validEPE = 1;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2459,7 +2459,8 @@ static void cliVersion(char *cmdline)
 {
     UNUSED(cmdline);
 
-    cliPrintf("# iNav/%s %s %s / %s (%s)",
+    cliPrintf("# %s/%s %s %s / %s (%s)",
+        FC_NAME,
         targetName,
         FC_VERSION_STRING,
         buildDate,

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1109,7 +1109,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         break;
 #ifdef GPS
     case MSP_RAW_GPS:
-        headSerialReply(16);
+        headSerialReply(18);
         serialize8(STATE(GPS_FIX));
         serialize8(gpsSol.numSat);
         serialize32(gpsSol.llh.lat);
@@ -1117,6 +1117,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize16(gpsSol.llh.alt/100); // meters
         serialize16(gpsSol.groundSpeed);
         serialize16(gpsSol.groundCourse);
+        serialize16(gpsSol.hdop);
         break;
     case MSP_COMP_GPS:
         headSerialReply(5);
@@ -1152,8 +1153,14 @@ static bool processOutCommand(uint8_t cmdMSP)
 #endif
     case MSP_GPSSVINFO:
         /* Compatibility stub - return zero SVs */
-        headSerialReply(1 + (0 * 4));
+        headSerialReply(1 + (1 * 4));
+        serialize8(1);
+
+        // HDOP
         serialize8(0);
+        serialize8(0);
+        serialize8(gpsSol.hdop / 100);
+        serialize8(gpsSol.hdop / 100);
         break;
     case MSP_GPSSTATISTICS:
         headSerialReply(1);
@@ -1161,6 +1168,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize32(gpsStats.errors);
         serialize32(gpsStats.timeouts);
         serialize32(gpsStats.packetCount);
+        serialize16(gpsSol.hdop);
         serialize16(gpsSol.eph);
         serialize16(gpsSol.epv);
         break;

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -327,7 +327,7 @@ static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 #define MSP_SET_ACC_TRIM         239    //in message          set acc angle trim values
 #define MSP_SERVO_MIX_RULES      241    //out message         Returns servo mixer configuration
 #define MSP_SET_SERVO_MIX_RULE   242    //in message          Sets servo mixer configuration
-#define MSP_SET_1WIRE            243    //in message          Sets 1Wire paththrough 
+#define MSP_SET_1WIRE            243    //in message          Sets 1Wire paththrough
 
 #define INBUF_SIZE 64
 
@@ -765,7 +765,7 @@ static uint32_t packFlightModeFlags(void)
         if (flag)
             junk |= 1 << i;
     }
-    
+
     return junk;
 }
 
@@ -972,7 +972,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         break;
     case MSP_ARMING_CONFIG:
         headSerialReply(2);
-        serialize8(masterConfig.auto_disarm_delay); 
+        serialize8(masterConfig.auto_disarm_delay);
         serialize8(masterConfig.disarm_kill_switch);
         break;
     case MSP_LOOP_TIME:
@@ -1163,7 +1163,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize8(gpsSol.hdop / 100);
         break;
     case MSP_GPSSTATISTICS:
-        headSerialReply(1);
+        headSerialReply(32);
         serialize16(gpsStats.lastMessageDt);
         serialize32(gpsStats.errors);
         serialize32(gpsStats.timeouts);
@@ -1575,7 +1575,7 @@ static bool processInCommand(void)
         }
 #endif
         break;
-        
+
     case MSP_SET_SERVO_MIX_RULE:
 #ifdef USE_SERVOS
         i = read8();
@@ -1609,14 +1609,14 @@ static bool processInCommand(void)
 
     case MSP_SET_RESET_CURR_PID:
         resetPidProfile(&currentProfile->pidProfile);
-        break;    
+        break;
 
     case MSP_SET_SENSOR_ALIGNMENT:
         masterConfig.sensorAlignmentConfig.gyro_align = read8();
         masterConfig.sensorAlignmentConfig.acc_align = read8();
         masterConfig.sensorAlignmentConfig.mag_align = read8();
         break;
-        
+
     case MSP_RESET_CONF:
         if (!ARMING_FLAG(ARMED)) {
             resetEEPROM();
@@ -1883,7 +1883,7 @@ static bool processInCommand(void)
                 waitForSerialPortToFinishTransmitting(currentPort->port);
                 // Start to activate here
                 // motor 1 => index 0
-                
+
                 // search currentPort portIndex
                 /* next lines seems to be unnecessary, because the currentPort always point to the same mspPorts[portIndex]
                 uint8_t portIndex;	
@@ -1902,7 +1902,7 @@ static bool processInCommand(void)
                 mspAllocateSerialPorts(&masterConfig.serialConfig);
                 /* restore currentPort and mspSerialPort
                 setCurrentPort(&mspPorts[portIndex]); // not needed same index will be restored
-                */ 
+                */
                 // former used MSP uart is active again
                 // restore MSP_SET_1WIRE as current command for correct headSerialReply(0)
                 currentPort->cmdMSP = MSP_SET_1WIRE;

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -322,6 +322,7 @@ static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 #define MSP_STATUS_EX            150    //out message         cycletime, errors_count, CPU load, sensor present etc
 #define MSP_UID                  160    //out message         Unique device ID
 #define MSP_GPSSVINFO            164    //out message         get Signal Strength (only U-Blox)
+#define MSP_GPSSTATISTICS        166    //out message         get GPS debugging data
 #define MSP_ACC_TRIM             240    //out message         get acc angle trim values
 #define MSP_SET_ACC_TRIM         239    //in message          set acc angle trim values
 #define MSP_SERVO_MIX_RULES      241    //out message         Returns servo mixer configuration
@@ -1150,14 +1151,18 @@ static bool processOutCommand(uint8_t cmdMSP)
         break;
 #endif
     case MSP_GPSSVINFO:
-        headSerialReply(1 + (gpsSol.numCh * 4));
-        serialize8(gpsSol.numCh);
-           for (i = 0; i < gpsSol.numCh; i++){
-               serialize8(gpsSol.svInfo[i].chn);
-               serialize8(gpsSol.svInfo[i].svid);
-               serialize8(gpsSol.svInfo[i].quality);
-               serialize8(gpsSol.svInfo[i].cno);
-           }
+        /* Compatibility stub - return zero SVs */
+        headSerialReply(1 + (0 * 4));
+        serialize8(0);
+        break;
+    case MSP_GPSSTATISTICS:
+        headSerialReply(1);
+        serialize16(gpsStats.lastMessageDt);
+        serialize32(gpsStats.errors);
+        serialize32(gpsStats.timeouts);
+        serialize32(gpsStats.packetCount);
+        serialize16(gpsSol.eph);
+        serialize16(gpsSol.epv);
         break;
 #endif
     case MSP_DEBUG:

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -222,8 +222,8 @@ static void sendTemperature1(void)
 static void sendSatalliteSignalQualityAsTemperature2(void)
 {
     uint16_t satellite = gpsSol.numSat;
-    if (gpsSol.eph > GPS_BAD_QUALITY && ( (cycleNum % 16 ) < 8)) {//Every 1s
-        satellite = constrain(gpsSol.eph, 0, GPS_MAX_HDOP_VAL);
+    if (gpsSol.hdop > GPS_BAD_QUALITY && ( (cycleNum % 16 ) < 8)) {//Every 1s
+        satellite = constrain(gpsSol.hdop, 0, GPS_MAX_HDOP_VAL);
     }
     sendDataHead(ID_TEMPRATURE2);
 

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -135,11 +135,11 @@ static void ltm_gframe(void)
     if (!sensors(SENSOR_GPS))
         return;
 
-    if (!STATE(GPS_FIX))
+    if (gpsSol.fixType == GPS_NO_FIX)
         gps_fix_type = 1;
-    else if (gpsSol.numSat < 5)
+    else if (gpsSol.fixType == GPS_FIX_2D)
         gps_fix_type = 2;
-    else
+    else if (gpsSol.fixType == GPS_FIX_3D)
         gps_fix_type = 3;
 
     ltm_initialise_packet('G');

--- a/src/main/version.h
+++ b/src/main/version.h
@@ -22,6 +22,7 @@
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
+#define FC_NAME "iNav"
 
 #define MW_VERSION              231
 


### PR DESCRIPTION
CF inherited OLED Display support had a flaw that was making its real life usage very hard: it was trying to display all available data. Even data that has little usage in real life. Do I really need raw gyro? Or RX sticks position? If there was something useful like MAG heading or battery level, it was cycling every 5 seconds and you would have to wait another 20 or 30 seconds to see it again.

This is why I got rid of most of the display pages and combined useful data into one screen that stays on all the time UAV is not armed. It shows:
- RX status (channel width within borders)
- Battery voltage if available
- Remaining battery current is current monitoring available
- GPS status: 
  - Number of sats
  - Fix: No/2D/3D
  - HDOP
  - Lat/Lon
- Heading if MAG available
- Altitude (relative) if BARO available

Additional benefit is that code running OLED display has been reduced in size by approx. 800 bytes. 

Since it depends on `gpsSol.hdop` has to be merged into `gps-remove-svinfo` or into `master` after dependency has been merged there (#84).

New display page looks like this:
![display](https://quadmeup.shtr.eu/wp-content/uploads/2016/03/oled_display.jpg) 
