### PR TITLE
new default I gain for roll and pitch

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -150,10 +150,10 @@ static void resetAccelerometerTrims(flightDynamicsTrims_t * accZero, flightDynam
 void resetPidProfile(pidProfile_t *pidProfile)
 {
     pidProfile->P8[ROLL] = 56;
-    pidProfile->I8[ROLL] = 30;
+    pidProfile->I8[ROLL] = 60;
     pidProfile->D8[ROLL] = 80;
     pidProfile->P8[PITCH] = 56;
-    pidProfile->I8[PITCH] = 30;
+    pidProfile->I8[PITCH] = 60;
     pidProfile->D8[PITCH] = 80;
     pidProfile->P8[YAW] = 140;      // 3.5 * 40
     pidProfile->I8[YAW] = 40;      // 4.0 * 40


### PR DESCRIPTION
With every flight I'm more and more sure that default I gain is way too low. This increases default by factor of 2. To be honest, I think that it even should be more, around 80. But let's wait for other users input on this
