### PR TITLE
reset heading lock on arm

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -191,6 +191,10 @@ static void pidOuterLoop(pidProfile_t *pidProfile, rxConfig_t *rxConfig)
     }
 }
 
+void resetHeadingLock(void) {
+    pidState[FD_YAW].axisLockAccum = 0;
+}
+
 static void pidApplyRateController(pidProfile_t *pidProfile, pidState_t *pidState, int axis)
 {
     int n;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -61,6 +61,7 @@ extern int16_t axisPID[XYZ_AXIS_COUNT];
 extern int32_t axisPID_P[3], axisPID_I[3], axisPID_D[3], axisPID_Setpoint[3];
 
 void pidResetErrorGyro(void);
+void resetHeadingLock(void);
 
 float pidRcCommandToAngle(int16_t stick);
 int16_t pidAngleToRcCommand(float angleDeciDegrees);

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -267,6 +267,8 @@ void mwArm(void)
             ENABLE_ARMING_FLAG(ARMED);
             headFreeModeHold = DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 
+            resetHeadingLock();
+
 #ifdef BLACKBOX
             if (feature(FEATURE_BLACKBOX)) {
                 serialPort_t *sharedBlackboxAndMspPort = findSharedSerialPort(FUNCTION_BLACKBOX, FUNCTION_MSP);


### PR DESCRIPTION
This bug probably happens only when using switches to arm / disarm.
If one lands with **_Heading lock**_ enabled, disarmes with a switch, and then arms again, there is a visible jump on YAW axis. It was quite scary when I experienced that for a first time :) . Probably this is due to accumulated yaw error that was not "zeroed" with YAW stick movement during disarm 
