### PR TITLE
Failsafe beeper only when armed once

### DIFF
--- a/src/main/config/runtime_config.h
+++ b/src/main/config/runtime_config.h
@@ -21,7 +21,8 @@
 typedef enum {
     OK_TO_ARM       = (1 << 0),
     PREVENT_ARMING  = (1 << 1),
-    ARMED           = (1 << 2)
+    ARMED           = (1 << 2),
+	WAS_EVER_ARMED  = (1 << 3)
 } armingFlag_e;
 
 extern uint8_t armingFlags;

--- a/src/main/config/runtime_config.h
+++ b/src/main/config/runtime_config.h
@@ -22,7 +22,7 @@ typedef enum {
     OK_TO_ARM       = (1 << 0),
     PREVENT_ARMING  = (1 << 1),
     ARMED           = (1 << 2),
-	WAS_EVER_ARMED  = (1 << 3)
+    WAS_EVER_ARMED  = (1 << 3)
 } armingFlag_e;
 
 extern uint8_t armingFlags;

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -186,7 +186,8 @@ void failsafeUpdateState(void)
     bool failsafeSwitchIsOn = IS_RC_MODE_ACTIVE(BOXFAILSAFE);
     beeperMode_e beeperMode = BEEPER_SILENCE;
 
-    if (!receivingRxData) {
+    // Beep RX lost only if we are not seeing data and we have been armed earlier
+    if (!receivingRxData && ARMING_FLAG(WAS_EVER_ARMED)) {
         beeperMode = BEEPER_RX_LOST;
     }
 

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -303,7 +303,7 @@ void mwArm(void)
         }
         if (!ARMING_FLAG(PREVENT_ARMING)) {
             ENABLE_ARMING_FLAG(ARMED);
-			ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
+            ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
             headFreeModeHold = DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 
 #ifdef BLACKBOX
@@ -690,7 +690,7 @@ void taskMainPidLoop(void)
 
 // Function for loop trigger
 void taskMainPidLoopChecker(void) {
-    // getTaskDeltaTime() returns delta time freezed at the moment of entering the scheduler. currentTime is freezed at the very same point. 
+    // getTaskDeltaTime() returns delta time freezed at the moment of entering the scheduler. currentTime is freezed at the very same point.
     // To make busy-waiting timeout work we need to account for time spent within busy-waiting loop
     uint32_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
 

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -303,6 +303,7 @@ void mwArm(void)
         }
         if (!ARMING_FLAG(PREVENT_ARMING)) {
             ENABLE_ARMING_FLAG(ARMED);
+			ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
             headFreeModeHold = DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 
 #ifdef BLACKBOX


### PR DESCRIPTION
Great little feature I'v found in betaflight: buzzer will beep of missing RX failsafe only if FC was armed at least once. So, you can power drone up, but do not turn on transmitter and buzzer will not annoy everyone around. I'm kind of tired of disconnecting buzzer during configurations and connecting it again before flight
