### PR TITLE
OLED Display debug page readded

### DIFF
--- a/src/main/io/display.h
+++ b/src/main/io/display.h
@@ -15,7 +15,7 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define ENABLE_DEBUG_OLED_PAGE
+// #define ENABLE_DEBUG_OLED_PAGE
 
 typedef enum {
     PAGE_WELCOME,

--- a/src/main/io/display.h
+++ b/src/main/io/display.h
@@ -15,10 +15,16 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define ENABLE_DEBUG_OLED_PAGE
+
 typedef enum {
     PAGE_WELCOME,
     PAGE_ARMED,
+    #ifndef ENABLE_DEBUG_OLED_PAGE
     PAGE_STATUS
+    #else
+    PAGE_DEBUG
+    #endif
 } pageId_e;
 
 void updateDisplay(void);


### PR DESCRIPTION
Since I'm not using any ARM specific IDE, I find OLED display debug quite useful and this option got somehow lost lately with changes to display.c
