### PR TITLE
Servo mixer refactoring

### DIFF
--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -170,6 +170,8 @@ typedef struct servoMixer_s {
 // Custom mixer configuration
 typedef struct mixerRules_s {
     uint8_t servoRuleCount;
+    uint8_t minServoIndex;
+    uint8_t maxServoIndex;
     const servoMixer_t *rule;
 } mixerRules_t;
 
@@ -189,6 +191,7 @@ struct escAndServoConfig_s;
 struct rxConfig_s;
 
 extern int16_t servo[MAX_SUPPORTED_SERVOS];
+bool isServoOutputEnabled(void);
 bool isMixerUsingServos(void);
 void writeServos(void);
 void filterServos(void);
@@ -221,6 +224,8 @@ int servoDirection(int servoIndex, int fromChannel);
 void mixerResetDisarmedMotors(void);
 void mixTable(void);
 void writeMotors(void);
+void servoMixer(void);
+void processServoTilt(void);
 void stopMotors(void);
 void StopPwmAllMotors(void);
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -268,7 +268,7 @@ void init(void)
 #endif
 
 #ifdef USE_SERVOS
-    pwm_params.useServos = isMixerUsingServos();
+    pwm_params.useServos = isServoOutputEnabled();
     pwm_params.useChannelForwarding = feature(FEATURE_CHANNEL_FORWARDING);
     pwm_params.servoCenterPulse = masterConfig.escAndServoConfig.servoCenterPulse;
     pwm_params.servoPwmRate = masterConfig.servo_pwm_rate;
@@ -495,9 +495,6 @@ void init(void)
     initBlackbox();
 #endif
 
-    if (masterConfig.mixerMode == MIXER_GIMBAL) {
-        accSetCalibrationCycles(CALIBRATING_ACC_CYCLES);
-    }
     gyroSetCalibrationCycles(CALIBRATING_GYRO_CYCLES);
 #ifdef BARO
     baroSetCalibrationCycles(CALIBRATING_BARO_CYCLES);

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -643,8 +643,20 @@ void taskMainPidLoop(void)
     mixTable();
 
 #ifdef USE_SERVOS
-    filterServos();
-    writeServos();
+
+    if (isMixerUsingServos()) {
+        servoMixer();
+    }
+
+    if (feature(FEATURE_SERVO_TILT)) {
+        processServoTilt();
+    }
+
+    //Servos should be filtered or written only when mixer is using servos or special feaures are enabled
+    if (isServoOutputEnabled()) {
+        filterServos();
+        writeServos();
+    }
 #endif
 
     if (motorControlEnable) {

--- a/src/test/unit/flight_mixer_unittest.cc
+++ b/src/test/unit/flight_mixer_unittest.cc
@@ -45,7 +45,6 @@ extern "C" {
     #include "io/gimbal.h"
     #include "io/rc_controls.h"
 
-    extern uint8_t servoCount;
     void forwardAuxChannelsToServos(uint8_t firstServoIndex);
 
     void mixerInit(mixerMode_e mixerMode, motorMixer_t *initialCustomMixers, servoMixer_t *initialCustomServoMixers);
@@ -90,8 +89,6 @@ protected:
 
 TEST_F(ChannelForwardingTest, TestForwardAuxChannelsToServosWithNoServos)
 {
-    // given
-    servoCount = 0;
 
     rcData[AUX1] = TEST_RC_MID;
     rcData[AUX2] = TEST_RC_MID;
@@ -110,7 +107,6 @@ TEST_F(ChannelForwardingTest, TestForwardAuxChannelsToServosWithNoServos)
 TEST_F(ChannelForwardingTest, TestForwardAuxChannelsToServosWithMaxServos)
 {
     // given
-    servoCount = MAX_SUPPORTED_SERVOS;
 
     rcData[AUX1] = 1000;
     rcData[AUX2] = 1250;
@@ -130,7 +126,6 @@ TEST_F(ChannelForwardingTest, TestForwardAuxChannelsToServosWithMaxServos)
 TEST_F(ChannelForwardingTest, TestForwardAuxChannelsToServosWithLessRemainingServosThanAuxChannelsToForward)
 {
     // given
-    servoCount = MAX_SUPPORTED_SERVOS - 2;
 
     rcData[AUX1] = 1000;
     rcData[AUX2] = 1250;


### PR DESCRIPTION
This is a continuation of #143 started in #141 
Changes:
- servo mixer is no longer called in motor mixer
- servo handling is executed independently from motors
- PWM write for servos is now generic and does not relay on mixer type, only on mixer parameters
- mixer CUSTOM can now read and use custom servo rules (still up to 2 servos will be handled). That allows to use Dualcopter and Bicopter even when mixer preset is no longer available
- some variables renamed so that now they really describe their role
- Singlecopter, Dualcopter and Bicopter presets removed (can be implemented with new CUSTOM)
- PPM to PWM disabled
- MXIER_GIMBAL disabled, servo tilt feature can be used instead

@digitalentity milestone 1.2 might be reasonable for this
