### PR TITLE
Flight stability improvements

### DIFF
--- a/src/main/config/runtime_config.h
+++ b/src/main/config/runtime_config.h
@@ -60,6 +60,7 @@ typedef enum {
     SMALL_ANGLE     = (1 << 3),
     FIXED_WING      = (1 << 4),                   // set when in flying_wing or airplane mode. currently used by althold selection code
     ANTI_WINDUP     = (1 << 5),
+    PID_ATTENUATE   = (1 << 6),
 } stateFlags_t;
 
 #define DISABLE_STATE(mask) (stateFlags &= ~(mask))

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -859,6 +859,7 @@ void mixTable(void)
 
     throttleRange = throttleMax - throttleMin;
 
+    #define THROTTLE_CLIPPING_FACTOR    0.33f
     if (rpyMixRange > throttleRange) {
         motorLimitReached = true;
         float mixReduction = (float)throttleRange / rpyMixRange;
@@ -867,12 +868,13 @@ void mixTable(void)
             rpyMix[i] =  mixReduction  * rpyMix[i];
         }
 
-        // Get the maximum correction by setting offset to center
-        throttleMin = throttleMax = throttleMin + (throttleRange / 2);
+        // Allow some clipping on edges to soften correction response
+        throttleMin = throttleMin + (throttleRange / 2) - (throttleRange * THROTTLE_CLIPPING_FACTOR / 2);
+        throttleMax = throttleMin + (throttleRange / 2) + (throttleRange * THROTTLE_CLIPPING_FACTOR / 2);
     } else {
         motorLimitReached = false;
-        throttleMin = throttleMin + (rpyMixRange / 2);
-        throttleMax = throttleMax - (rpyMixRange / 2);
+        throttleMin = MIN(throttleMin + (rpyMixRange / 2), throttleMin + (throttleRange / 2) - (throttleRange * THROTTLE_CLIPPING_FACTOR / 2));
+        throttleMax = MAX(throttleMax - (rpyMixRange / 2), throttleMin + (throttleRange / 2) + (throttleRange * THROTTLE_CLIPPING_FACTOR / 2);
     }
 
     // Now add in the desired throttle, but keep in a range that doesn't clip adjusted

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -874,7 +874,7 @@ void mixTable(void)
     } else {
         motorLimitReached = false;
         throttleMin = MIN(throttleMin + (rpyMixRange / 2), throttleMin + (throttleRange / 2) - (throttleRange * THROTTLE_CLIPPING_FACTOR / 2));
-        throttleMax = MAX(throttleMax - (rpyMixRange / 2), throttleMin + (throttleRange / 2) + (throttleRange * THROTTLE_CLIPPING_FACTOR / 2);
+        throttleMax = MAX(throttleMax - (rpyMixRange / 2), throttleMin + (throttleRange / 2) + (throttleRange * THROTTLE_CLIPPING_FACTOR / 2));
     }
 
     // Now add in the desired throttle, but keep in a range that doesn't clip adjusted

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -55,6 +55,11 @@ typedef enum mixerMode
 
 #define DEFAULT_MIXER MIXER_QUADX
 
+typedef struct motorAxisCorrectionLimits_s {
+    int16_t min;
+    int16_t max;
+} motorAxisCorrectionLimits_t;
+
 // Custom mixer data per motor
 typedef struct motorMixer_s {
     float throttle;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -82,7 +82,6 @@ extern float dT;
 
 // Thrust PID Attenuation factor. 0.0f means fully attenuated, 1.0f no attenuation is applied
 static float tpaFactor;
-
 int16_t axisPID[FLIGHT_DYNAMICS_INDEX_COUNT];
 
 #ifdef BLACKBOX
@@ -124,7 +123,9 @@ float pidRcCommandToRate(int16_t stick, uint8_t rate)
 #define FP_PID_LEVEL_P_MULTIPLIER   40.0f       // betaflight - 10.0
 #define FP_PID_YAWHOLD_P_MULTIPLIER 80.0f
 
-void updatePIDCoefficients(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig)
+#define KD_ATTENUATION_BREAK        0.25f
+
+void updatePIDCoefficients(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig, const rxConfig_t *rxConfig)
 {
     // TPA should be updated only when TPA is actually set
     if (controlRateConfig->dynThrPID == 0 || rcData[THROTTLE] < controlRateConfig->tpa_breakpoint) {
@@ -133,6 +134,16 @@ void updatePIDCoefficients(const pidProfile_t *pidProfile, const controlRateConf
         tpaFactor = (100 - (uint16_t)controlRateConfig->dynThrPID * (rcData[THROTTLE] - controlRateConfig->tpa_breakpoint) / (2000 - controlRateConfig->tpa_breakpoint)) / 100.0f;
     } else {
         tpaFactor = (100 - controlRateConfig->dynThrPID) / 100.0f;
+    }
+
+    // Additional throttle-based KD attenuation (kudos to RS2K & Raceflight)
+    float relThrottle = constrainf( ((float)rcData[THROTTLE] - (float)rxConfig->mincheck) / ((float)rxConfig->maxcheck - (float)rxConfig->mincheck), 0.0f, 1.0f);
+    float kdAttenuationFactor;
+
+    if (relThrottle < KD_ATTENUATION_BREAK) {
+        kdAttenuationFactor = constrainf((relThrottle / KD_ATTENUATION_BREAK) + 0.50f, 0.0f, 1.0f);
+    } else {
+        kdAttenuationFactor = 1.0f;
     }
 
     // PID coefficients can be update only with THROTTLE and TPA or inflight PID adjustments
@@ -145,7 +156,7 @@ void updatePIDCoefficients(const pidProfile_t *pidProfile, const controlRateConf
         // Apply TPA to ROLL and PITCH axes
         if (axis != FD_YAW) {
             pidState[axis].kP *= tpaFactor;
-            pidState[axis].kD *= tpaFactor;
+            pidState[axis].kD *= tpaFactor * kdAttenuationFactor;
         }
 
         if ((pidProfile->P8[axis] != 0) && (pidProfile->I8[axis] != 0)) {
@@ -257,10 +268,7 @@ static void pidApplyRateController(const pidProfile_t *pidProfile, pidState_t *p
 
     // TODO: Get feedback from mixer on available correction range for each axis
     const float newOutput = newPTerm + pidState->errorGyroIf + newDTerm;
-    const float newOutputLimited = constrainf(newOutput, -PID_MAX_OUTPUT, +PID_MAX_OUTPUT);
-
-    if (STATE(PID_ATTENUATE))
-        newOutputLimited *= 0.33f;
+    const float newOutputLimited = constrainf(newOutput, -PID_MAX_OUTPUT, +PID_MAX_OUTPUT) * (STATE(PID_ATTENUATE) ? 0.33f : 1.0f);
 
     // Integrate only if we can do backtracking
     pidState->errorGyroIf += (rateError * pidState->kI * dT) + ((newOutputLimited - newOutput) * pidState->kT * dT);
@@ -299,6 +307,7 @@ void pidController(const pidProfile_t *pidProfile, const controlRateConfig_t *co
         pidLevel(pidProfile, &pidState[FD_ROLL], FD_ROLL, horizonLevelStrength);
         pidLevel(pidProfile, &pidState[FD_PITCH], FD_PITCH, horizonLevelStrength);
     }
+
     if (FLIGHT_MODE(HEADING_LOCK)) {
         pidApplyHeadingLock(pidProfile, &pidState[FD_YAW]);
     }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -259,6 +259,9 @@ static void pidApplyRateController(const pidProfile_t *pidProfile, pidState_t *p
     const float newOutput = newPTerm + pidState->errorGyroIf + newDTerm;
     const float newOutputLimited = constrainf(newOutput, -PID_MAX_OUTPUT, +PID_MAX_OUTPUT);
 
+    if (STATE(PID_ATTENUATE))
+        newOutputLimited *= 0.33f;
+
     // Integrate only if we can do backtracking
     pidState->errorGyroIf += (rateError * pidState->kI * dT) + ((newOutputLimited - newOutput) * pidState->kT * dT);
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -61,9 +61,6 @@ extern int16_t axisPID[];
 extern int32_t axisPID_P[], axisPID_I[], axisPID_D[], axisPID_Setpoint[];
 
 void pidResetErrorAccumulators(void);
-
-void updatePIDCoefficients(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig);
-
+void updatePIDCoefficients(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig, const rxConfig_t *rxConfig);
 int16_t pidAngleToRcCommand(float angleDeciDegrees);
-
 void pidController(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig, const rxConfig_t *rxConfig);

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -489,8 +489,11 @@ void processRx(void)
             else {
                 pidResetErrorAccumulators();
             }
+
+            ENABLE_STATE(PID_ATTENUATE);
         }
         else {
+            DISABLE_STATE(PID_ATTENUATE);
             DISABLE_STATE(ANTI_WINDUP);
         }
     }

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -718,7 +718,7 @@ bool taskUpdateRxCheck(uint32_t currentDeltaTime)
 void taskUpdateRxMain(void)
 {
     processRx();
-    updatePIDCoefficients(&currentProfile->pidProfile, currentControlRateProfile);
+    updatePIDCoefficients(&currentProfile->pidProfile, currentControlRateProfile, &masterConfig.rxConfig);
     isRXDataNew = true;
 }
 


### PR DESCRIPTION
Currently if PID controller requests more than motors can handle, mixer will force throttle to 50%. At overpowered machines this may lead to jumps, especially on the ground.
The PR makes two changes:
1) Reduce PID output at zero throttle. This allows stabilisation in flight but effectively prevents jumping on the ground
2) Don't allow mixer to force throttle to 50% anymore. Mixer now only forces throttle to 33-67% range, depending on actual throttle stick position. This slightly reduces mixer authority at low and high throttle but effectively prevents overreacting to external interference at low throttle.

There is certainly way for improvement here, but this one makes my mini more controllable on takeoffs and landings.
