### PR TITLE
Prefer GPS heading on airplanes, fallback to MAG if available

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -73,7 +73,7 @@
 
 #define SPIN_RATE_LIMIT             20
 #define MAX_ACC_SQ_NEARNESS         25      // 25% or G^2, accepted acceleration of (0.87 - 1.12G)
-#define MAX_GPS_HEADING_ERROR_DEG   15      // Amount of error between GPS CoG and estimated Yaw at witch we stop trusting GPS and fallback to MAG
+#define MAX_GPS_HEADING_ERROR_DEG   60      // Amount of error between GPS CoG and estimated Yaw at witch we stop trusting GPS and fallback to MAG
 
 t_fp_vector imuAccelInBodyFrame;
 t_fp_vector imuMeasuredGravityBF;


### PR DESCRIPTION
A follow up for #165.
IMU will fallback to MAG if GPS CoG is significatly different (>15 deg)  from estimated heading. 
If GPS is the only source of heading it will be used regardless.
