### PR TITLE
LTM AUTO serial port speed lowered to 4800 bps

### DIFF
--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -80,6 +80,7 @@
 
 #define TELEMETRY_LTM_INITIAL_PORT_MODE MODE_TX
 #define LTM_CYCLETIME   100
+#define LTM_AUTO_BAUD_RATE 4800
 
 extern uint16_t rssi;           // FIXME dependency on mw.c
 static serialPort_t *ltmPort;
@@ -331,14 +332,22 @@ void initLtmTelemetry(telemetryConfig_t *initialTelemetryConfig)
 
 void configureLtmTelemetryPort(void)
 {
+
     if (!portConfig) {
         return;
     }
+
+    uint32_t bps;
+
     baudRate_e baudRateIndex = portConfig->telemetry_baudrateIndex;
+
     if (baudRateIndex == BAUD_AUTO) {
-        baudRateIndex = BAUD_19200;
+        bps = LTM_AUTO_BAUD_RATE;
+    } else {
+        bps = baudRates[baudRateIndex];
     }
-    ltmPort = openSerialPort(portConfig->identifier, FUNCTION_TELEMETRY_LTM, NULL, baudRates[baudRateIndex], TELEMETRY_LTM_INITIAL_PORT_MODE, SERIAL_NOT_INVERTED);
+
+    ltmPort = openSerialPort(portConfig->identifier, FUNCTION_TELEMETRY_LTM, NULL, bps, TELEMETRY_LTM_INITIAL_PORT_MODE, SERIAL_NOT_INVERTED);
     if (!ltmPort)
         return;
     ltmEnabled = true;


### PR DESCRIPTION
This is proof of concept for issue #183 .
If LTM serial speed is set to AUTO, port is initialized with 4800pbs. I was considering going down to 2400 but lets first check how it behaves at 4800. Unfortunately I'm unable to test it in any reasonable future (days) so maybe one of you can do it @sppnk @stronnag @digitalentity 
