### PR TITLE
CLI: give help when trying to set invalid value

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2396,7 +2396,7 @@ static void cliSet(char *cmdline)
                 int_float_value_t tmp;
                 switch (valueTable[i].type & VALUE_MODE_MASK) {
                     case MODE_DIRECT: {
-                            if(strspn(eqptr, "0123456789.+-") == strlen(eqptr)) {
+                            if(strlen(eqptr) > 0 && strspn(eqptr, "0123456789.+-") == strlen(eqptr)) {
                                 int32_t value = 0;
                                 float valuef = 0;
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2291,27 +2291,30 @@ static void cliPrintVar(const clivalue_t *var, uint32_t full)
             break;
 
         case VAR_FLOAT:
-            cliPrintf("%s", ftoa(*(float *)ptr, ftoaBuffer));
             if (full && (var->type & VALUE_MODE_MASK) == MODE_DIRECT) {
-                cliPrintf(" %s", ftoa((float)var->config.minmax.min, ftoaBuffer));
-                cliPrintf(" %s", ftoa((float)var->config.minmax.max, ftoaBuffer));
+                cliPrintf("%s", ftoa((float)var->config.minmax.min, ftoaBuffer));
+                cliPrintf(" - %s", ftoa((float)var->config.minmax.max, ftoaBuffer));
+            } else {
+                cliPrintf("%s", ftoa(*(float *)ptr, ftoaBuffer));
             }
             return; // return from case for float only
     }
 
     switch(var->type & VALUE_MODE_MASK) {
         case MODE_DIRECT:
-            cliPrintf("%d", value);
             if (full) {
-                cliPrintf(" %d %d", var->config.minmax.min, var->config.minmax.max);
+                cliPrintf("%d - %d", var->config.minmax.min, var->config.minmax.max);
+            } else {
+                cliPrintf("%d", value);
             }
             break;
         case MODE_LOOKUP:
-            cliPrintf(lookupTables[var->config.lookup.tableIndex].values[value]);
             if (full) {
                 for (int i=0; i<lookupTables[var->config.lookup.tableIndex].valueCount; i++) {
-                    cliPrintf(" %s", lookupTables[var->config.lookup.tableIndex].values[i]);
+                    cliPrintf("%s ", lookupTables[var->config.lookup.tableIndex].values[i]);
                 }
+            } else {
+                cliPrintf(lookupTables[var->config.lookup.tableIndex].values[value]);
             }
             break;
     }

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2308,6 +2308,11 @@ static void cliPrintVar(const clivalue_t *var, uint32_t full)
             break;
         case MODE_LOOKUP:
             cliPrintf(lookupTables[var->config.lookup.tableIndex].values[value]);
+            if (full) {
+                for (int i=0; i<lookupTables[var->config.lookup.tableIndex].valueCount; i++) {
+                    cliPrintf(" %s", lookupTables[var->config.lookup.tableIndex].values[i]);
+                }
+            }
             break;
     }
 }
@@ -2426,7 +2431,9 @@ static void cliSet(char *cmdline)
                     cliPrintf("%s set to ", valueTable[i].name);
                     cliPrintVar(val, 0);
                 } else {
-                    cliPrint("Invalid value\r\n");
+                    cliPrint("Invalid value. Allowed values are: ");
+                    cliPrintVar(val, 1); // print out min/max/table values
+                    cliPrint("\r\n");
                 }
 
                 return;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2396,7 +2396,7 @@ static void cliSet(char *cmdline)
                 int_float_value_t tmp;
                 switch (valueTable[i].type & VALUE_MODE_MASK) {
                     case MODE_DIRECT: {
-                            if(strlen(eqptr) > 0 && strspn(eqptr, "0123456789.+-") == strlen(eqptr)) {
+                            if(*eqptr != 0 && strspn(eqptr, "0123456789.+-") == strlen(eqptr)) {
                                 int32_t value = 0;
                                 float valuef = 0;
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2396,20 +2396,22 @@ static void cliSet(char *cmdline)
                 int_float_value_t tmp;
                 switch (valueTable[i].type & VALUE_MODE_MASK) {
                     case MODE_DIRECT: {
-                            int32_t value = 0;
-                            float valuef = 0;
+                            if(strspn(eqptr, "0123456789.+-") == strlen(eqptr)) {
+                                int32_t value = 0;
+                                float valuef = 0;
 
-                            value = atoi(eqptr);
-                            valuef = fastA2F(eqptr);
+                                value = atoi(eqptr);
+                                valuef = fastA2F(eqptr);
 
-                            if (valuef >= valueTable[i].config.minmax.min && valuef <= valueTable[i].config.minmax.max) { // note: compare float value
+                                if (valuef >= valueTable[i].config.minmax.min && valuef <= valueTable[i].config.minmax.max) { // note: compare float value
 
-                                if ((valueTable[i].type & VALUE_TYPE_MASK) == VAR_FLOAT)
-                                    tmp.float_value = valuef;
-                                else
-                                    tmp.int_value = value;
+                                    if ((valueTable[i].type & VALUE_TYPE_MASK) == VAR_FLOAT)
+                                        tmp.float_value = valuef;
+                                    else
+                                        tmp.int_value = value;
 
-                                changeValue = true;
+                                    changeValue = true;
+                                }
                             }
                         }
                         break;


### PR DESCRIPTION
As discussed in #198 
This is just a working prototype, it works but the formatting is ugly and it also prints the current value.

Output:

```
# set mid_rc=
Invalid value. Allowed values are: 1500 1200 1700

# set rc_smoothing=
Invalid value. Allowed values are: ON OFF ON

# set gps_sbas_mode=
Invalid value. Allowed values are: EGNOS AUTO EGNOS WAAS MSAS GAGAN NONE

# set gps_sbas_mode=meh
Invalid value. Allowed values are: EGNOS AUTO EGNOS WAAS MSAS GAGAN NONE
```
