### PR TITLE
RTH: Wait until descend speed has been over 25cm/s before starting to detect landing

### DIFF
--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -948,7 +948,9 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_LANDING(navigati
         // A safeguard - if sonar is available and it is reading < 50cm altitude - drop to low descend speed
         if (posControl.flags.hasValidSurfaceSensor && posControl.actualState.surface >= 0 && posControl.actualState.surface < 50.0f) {
             // land_descent_rate == 200 : descend speed = 30 cm/s, gentle touchdown
-            updateAltitudeTargetFromClimbRate(-0.15f * posControl.navConfig->land_descent_rate, CLIMB_RATE_RESET_SURFACE_TARGET);
+            // Do not allow descent velocity slower than -30cm/s so the landing detector works.
+            float descentVelLimited = MIN(-0.15f * posControl.navConfig->land_descent_rate, -30.0f);
+            updateAltitudeTargetFromClimbRate(descentVelLimited, CLIMB_RATE_RESET_SURFACE_TARGET);
         }
         else {
             // Ramp down descent velocity from 100% at maxAlt altitude to 25% from minAlt to 0cm.

--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -956,7 +956,10 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_LANDING(navigati
                                         / (posControl.navConfig->land_slowdown_maxalt - posControl.navConfig->land_slowdown_minalt) * 0.75f + 0.25f;  // Yield 1.0 at 2000 alt and 0.25 at 500 alt
 
             descentVelScaling = constrainf(descentVelScaling, 0.25f, 1.0f);
-            updateAltitudeTargetFromClimbRate(-descentVelScaling * posControl.navConfig->land_descent_rate, CLIMB_RATE_RESET_SURFACE_TARGET);
+            
+            // Do not allow descent velocity slower than -50cm/s so the landing detector works.
+            float descentVelLimited = MIN(-descentVelScaling * posControl.navConfig->land_descent_rate, -50.0f);
+            updateAltitudeTargetFromClimbRate(descentVelLimited, CLIMB_RATE_RESET_SURFACE_TARGET);
         }
 
         return NAV_FSM_EVENT_NONE;

--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -1605,10 +1605,12 @@ void calculateFarAwayTarget(t_fp_vector * farAwayPos, int32_t yaw, int32_t dista
  * NAV land detector
  *-----------------------------------------------------------*/
 static uint32_t landingTimer;
+static bool hasHadSomeVelocity;
 
 void resetLandingDetector(void)
 {
     landingTimer = micros();
+    hasHadSomeVelocity = false;
 }
 
 bool isLandingDetected(void)
@@ -1619,7 +1621,7 @@ bool isLandingDetected(void)
         landingDetected = isFixedWingLandingDetected(&landingTimer);
     }
     else {
-        landingDetected = isMulticopterLandingDetected(&landingTimer);
+        landingDetected = isMulticopterLandingDetected(&landingTimer, &hasHadSomeVelocity);
     }
 
     return landingDetected;

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -485,16 +485,17 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelo
     // We use rcCommandAdjustedThrottle to keep track of NAV corrected throttle (isLandingDetected is executed
     // from processRx() and rcCommand at that moment holds rc input, not adjusted values from NAV core)
     bool minimalThrust = rcCommandAdjustedThrottle < posControl.navConfig->mc_min_fly_throttle;
-
-    /*
-    Do not trust the sonar, it wants to kill you!
-    // If we have surface sensor - use it to detect touchdown (surfaceMin is our ground reference. If we are less than 5cm above the ground - we are likely landed)
-    bool surfaceDetected = (posControl.flags.hasValidSurfaceSensor && posControl.actualState.surface >= 0 && posControl.actualState.surfaceMin >= 0)
-                                && (posControl.actualState.surface <= (posControl.actualState.surfaceMin + 5.0f));
-
-    bool possibleLandingDetected = (surfaceDetected) || (minimalThrust && !verticalMovement && !horizontalMovement);
-    */
+    
     bool possibleLandingDetected = hasHadSomeVelocity && minimalThrust && !verticalMovement && !horizontalMovement;
+    
+    // If we have surface sensor (for example sonar) - use it to detect touchdown
+    if (posControl.flags.hasValidSurfaceSensor && posControl.actualState.surface >= 0 && posControl.actualState.surfaceMin >= 0) {
+        // TODO: Come up with a clever way to let sonar increase detection performance, not just add extra safety.
+        // TODO: Out of range sonar may give reading that looks like we landed, find a way to check if sonar is healthy.
+        // surfaceMin is our ground reference. If we are less than 5cm above the ground - we are likely landed
+        possibleLandingDetected = possibleLandingDetected && posControl.actualState.surface <= (posControl.actualState.surfaceMin + 5.0f);
+    }
+    
     navDebug[0] = *hasHadSomeVelocity;
     navDebug[1] = rcCommandAdjustedThrottle;
     navDebug[2] = !verticalMovement;

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -502,14 +502,13 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer)
     navDebug[0] = hasHadSomeVelocity;
     navDebug[1] = rcCommandAdjustedThrottle;
     navDebug[2] = !verticalMovement;
+    navDebug[3] = (currentTime - *landingTimer) / 1000;
 
     if (!possibleLandingDetected) {
         *landingTimer = currentTime;
-        navDebug[3] = (currentTime - *landingTimer) / 1000;
         return false;
     }
     else {
-        navDebug[3] = (currentTime - *landingTimer) / 1000;
         return ((currentTime - *landingTimer) > (LAND_DETECTOR_TRIGGER_TIME_MS * 1000)) ? true : false;
     }
 }

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -472,8 +472,9 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer)
 {
     uint32_t currentTime = micros();
     
-    // TODO: Do we need to reset this? How?
     static bool hasHadSomeVelocity = false;
+    // TODO: hasHadSomeVelocity needs to be reset when rth restarts, ugly hack used for now.
+    if ((currentTime - *landingTimer) > 1000000) hasHadSomeVelocity = false;
     
     // When descend stage is activated velocity is ~0, so wait until we have descended faster than -25cm/s
     if (!hasHadSomeVelocity && posControl.actualState.vel.V.Z < -25.0f) hasHadSomeVelocity = true;
@@ -501,13 +502,14 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer)
     navDebug[0] = hasHadSomeVelocity;
     navDebug[1] = rcCommandAdjustedThrottle;
     navDebug[2] = !verticalMovement;
-    navDebug[3] = (currentTime - *landingTimer) / 1000;
 
     if (!possibleLandingDetected) {
         *landingTimer = currentTime;
+        navDebug[3] = (currentTime - *landingTimer) / 1000;
         return false;
     }
     else {
+        navDebug[3] = (currentTime - *landingTimer) / 1000;
         return ((currentTime - *landingTimer) > (LAND_DETECTOR_TRIGGER_TIME_MS * 1000)) ? true : false;
     }
 }

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -477,7 +477,6 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer)
     
     // When descend stage is activated velocity is ~0, so wait until we have descended faster than -25cm/s
     if (!hasHadSomeVelocity && posControl.actualState.vel.V.Z < -25.0f) hasHadSomeVelocity = true;
-    navDebug[0] = hasHadSomeVelocity;
 
     // Average climb rate should be low enough
     bool verticalMovement = fabsf(posControl.actualState.vel.V.Z) > 25.0f;
@@ -489,7 +488,6 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer)
     // We use rcCommandAdjustedThrottle to keep track of NAV corrected throttle (isLandingDetected is executed
     // from processRx() and rcCommand at that moment holds rc input, not adjusted values from NAV core)
     bool minimalThrust = rcCommandAdjustedThrottle < posControl.navConfig->mc_min_fly_throttle;
-    navDebug[1] = posControl.navConfig->mc_min_fly_throttle;
     
     /*
     Do not trust the sonar, it want to kill you!
@@ -500,7 +498,9 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer)
     bool possibleLandingDetected = (surfaceDetected) || (minimalThrust && !verticalMovement && !horizontalMovement);
     */
     bool possibleLandingDetected = hasHadSomeVelocity && minimalThrust && !verticalMovement && !horizontalMovement;
-    navDebug[2] = possibleLandingDetected;
+    navDebug[0] = hasHadSomeVelocity;
+    navDebug[1] = rcCommandAdjustedThrottle;
+    navDebug[2] = !verticalMovement;
     navDebug[3] = (currentTime - *landingTimer) / 1000;
 
     if (!possibleLandingDetected) {

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -495,11 +495,6 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelo
         // surfaceMin is our ground reference. If we are less than 5cm above the ground - we are likely landed
         possibleLandingDetected = possibleLandingDetected && posControl.actualState.surface <= (posControl.actualState.surfaceMin + 5.0f);
     }
-    
-    navDebug[0] = *hasHadSomeVelocity;
-    navDebug[1] = rcCommandAdjustedThrottle;
-    navDebug[2] = !verticalMovement;
-    navDebug[3] = (currentTime - *landingTimer) / 1000;
 
     if (!possibleLandingDetected) {
         *landingTimer = currentTime;

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -474,7 +474,7 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer)
     
     static bool hasHadSomeVelocity = false;
     // TODO: hasHadSomeVelocity needs to be reset when rth restarts, ugly hack used for now.
-    if ((currentTime - *landingTimer) > 1000000) hasHadSomeVelocity = false;
+    if ((currentTime - *landingTimer) > 2500000) hasHadSomeVelocity = false;
     
     // When descend stage is activated velocity is ~0, so wait until we have descended faster than -25cm/s
     if (!hasHadSomeVelocity && posControl.actualState.vel.V.Z < -25.0f) hasHadSomeVelocity = true;

--- a/src/main/flight/navigation_rewrite_private.h
+++ b/src/main/flight/navigation_rewrite_private.h
@@ -324,7 +324,7 @@ bool adjustMulticopterPositionFromRCInput(void);
 
 void applyMulticopterNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTime);
 
-bool isMulticopterLandingDetected(uint32_t * landingTimer);
+bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelocity);
 void calculateMulticopterInitialHoldPosition(t_fp_vector * pos);
 
 /* Fixed-wing specific functions */


### PR DESCRIPTION
As discussed in #219 
Work in progress, not ready for merging!

This have been flight tested and it looks like it works great.
hasHadSomeVelocity and !verticalMovement are never true at the same time during the beginning of the descent, this should make things safer, reduce the need for a long timeout and make having a to high min_fly setting less dangerous.

Thoughts, ideas for improvement and other feedback are welcome!

EDIT: I also removed the code that only relied on the sonar, that's to dangerous. The commit named "Fixed landingTimer reset" is about hasHadSomeVelocity, i have not fixed the bug i talked about in the issue, sorry for making a bit of a mess here.
