### PR TITLE
range of yaw_p_limit increased to 100-500

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -187,7 +187,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->dterm_lpf_hz = 40;
     pidProfile->yaw_lpf_hz = 30;
 
-    pidProfile->yaw_p_limit = YAW_P_LIMIT_MAX;
+    pidProfile->yaw_p_limit = YAW_P_LIMIT_DEFAULT;
     pidProfile->mag_hold_rate_limit = MAG_HOLD_RATE_LIMIT_DEFAULT;
 
     pidProfile->max_angle_inclination[FD_ROLL] = 300;    // 30 degrees

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -26,7 +26,8 @@
 #define GYRO_SATURATION_LIMIT   1800        // 1800dps
 #define PID_MAX_OUTPUT          1000
 #define YAW_P_LIMIT_MIN 100                 // Maximum value for yaw P limiter
-#define YAW_P_LIMIT_MAX 300                 // Maximum value for yaw P limiter
+#define YAW_P_LIMIT_MAX 500                 // Maximum value for yaw P limiter
+#define YAW_P_LIMIT_DEFAULT 300             // Default value for yaw P limiter
 
 #define MAG_HOLD_RATE_LIMIT_MIN 10
 #define MAG_HOLD_RATE_LIMIT_MAX 250


### PR DESCRIPTION
Comparing to CF and BF, INAV yaw_p_limit is capped at 300. My 600mm quad would not mind having this value slightly higher. 
Default is kept at 300, only upper limit rised to 500
