### PR TITLE
RTH: Fix slow RTH when home is reset

### DIFF
--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -827,7 +827,7 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_INITIALIZE(navig
             // If close to home - reset home position and land
             if (posControl.homeDistance < posControl.navConfig->min_rth_distance) {
                 setHomePosition(&posControl.actualState.pos, posControl.actualState.yaw, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_HEADING);
-                setDesiredPosition(&posControl.actualState.pos, 0, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_Z);
+                setDesiredPosition(&posControl.actualState.pos, posControl.actualState.yaw, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_Z | NAV_POS_UPDATE_HEADING);
 
                 return NAV_FSM_EVENT_SWITCH_TO_RTH_3D_LANDING;   // NAV_STATE_RTH_3D_HOVER_PRIOR_TO_LANDING
             }
@@ -842,7 +842,7 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_INITIALIZE(navig
                     calculateFarAwayTarget(&targetHoldPos, posControl.actualState.yaw, 100000.0f);  // 1km away
                 }
 
-                setDesiredPosition(&targetHoldPos, 0, NAV_POS_UPDATE_XY);
+                setDesiredPosition(&targetHoldPos, posControl.actualState.yaw, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_HEADING);
 
                 return NAV_FSM_EVENT_SUCCESS;   // NAV_STATE_RTH_3D_CLIMB_TO_SAFE_ALT
             }

--- a/src/main/flight/navigation_rewrite_private.h
+++ b/src/main/flight/navigation_rewrite_private.h
@@ -41,8 +41,8 @@
 
 typedef enum {
     NAV_POS_UPDATE_NONE                 = 0,
-    NAV_POS_UPDATE_XY                   = 1 << 0,
     NAV_POS_UPDATE_Z                    = 1 << 1,
+    NAV_POS_UPDATE_XY                   = 1 << 0,
     NAV_POS_UPDATE_HEADING              = 1 << 2,
     NAV_POS_UPDATE_BEARING              = 1 << 3,
     NAV_POS_UPDATE_BEARING_TAIL_FIRST   = 1 << 4,
@@ -292,7 +292,7 @@ bool isLandingDetected(void);
 
 navigationFSMStateFlags_t navGetCurrentStateFlags(void);
 
-void setHomePosition(t_fp_vector * pos, int32_t yaw);
+void setHomePosition(t_fp_vector * pos, int32_t yaw, navSetWaypointFlags_t useMask);
 void setDesiredPosition(t_fp_vector * pos, int32_t yaw, navSetWaypointFlags_t useMask);
 void setDesiredSurfaceOffset(float surfaceOffset);
 void setDesiredPositionToFarAwayTarget(int32_t yaw, int32_t distance, navSetWaypointFlags_t useMask);


### PR DESCRIPTION
A fix for #245. Please review and comment.

Now home altitude is not reset in some cases (one case is being within `nav_min_rth_distance` to previous home position).
