### PR TITLE
Landing detector: replace mc_min_fly_throttle with average throttle

### DIFF
--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -1611,11 +1611,15 @@ void calculateFarAwayTarget(t_fp_vector * farAwayPos, int32_t yaw, int32_t dista
  *-----------------------------------------------------------*/
 static uint32_t landingTimer;
 static bool hasHadSomeVelocity;
+static int32_t landingThrSum;
+static int16_t landingThrSamples;
 
 void resetLandingDetector(void)
 {
     landingTimer = micros();
     hasHadSomeVelocity = false;
+    landingThrSum = 0;
+    landingThrSamples = 0;
 }
 
 bool isLandingDetected(void)
@@ -1626,7 +1630,7 @@ bool isLandingDetected(void)
         landingDetected = isFixedWingLandingDetected(&landingTimer);
     }
     else {
-        landingDetected = isMulticopterLandingDetected(&landingTimer, &hasHadSomeVelocity);
+        landingDetected = isMulticopterLandingDetected(&landingTimer, &hasHadSomeVelocity, &landingThrSum, &landingThrSamples);
     }
 
     return landingDetected;

--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -1618,8 +1618,11 @@ void resetLandingDetector(void)
 {
     landingTimer = micros();
     hasHadSomeVelocity = false;
-    landingThrSum = 0;
-    landingThrSamples = 0;
+    
+    // When descent starts the throttle is at hover and quickly drops to gain descend velocity,
+    // Start with a fake low throttle average to avoid passing the test on that throttle drop.
+    landingThrSum = 10 * 1000;
+    landingThrSamples = 10;
 }
 
 bool isLandingDetected(void)

--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -1612,7 +1612,7 @@ void calculateFarAwayTarget(t_fp_vector * farAwayPos, int32_t yaw, int32_t dista
 static uint32_t landingTimer;
 static bool hasHadSomeVelocity;
 static int32_t landingThrSum;
-static int16_t landingThrSamples;
+static int32_t landingThrSamples;
 
 void resetLandingDetector(void)
 {

--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -1621,8 +1621,8 @@ void resetLandingDetector(void)
     
     // When descent starts the throttle is at hover and quickly drops to gain descend velocity,
     // Start with a fake low throttle average to avoid passing the test on that throttle drop.
-    landingThrSum = 10 * 1000;
-    landingThrSamples = 10;
+    landingThrSum = 8 * 1000;
+    landingThrSamples = 8;
 }
 
 bool isLandingDetected(void)

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -488,11 +488,10 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelo
     bool minimalThrust = rcCommandAdjustedThrottle < posControl.navConfig->mc_min_fly_throttle;
     */
 
-    // We have likely landed if throttle is 100 units below average throttle
-    // TODO: rcCommandAdjustedThrottle never goes below min_throttle+1, so replace 1040+1 with min_throttle+1
-    *landingThrSum += rcCommandAdjustedThrottle;
+    // We have likely landed if throttle is 50 units below average descend throttle
     *landingThrSamples += 1;
-    bool minimalThrust= rcCommandAdjustedThrottle <= MAX(*landingThrSum / *landingThrSamples - 50, 1040+1);
+    *landingThrSum += rcCommandAdjustedThrottle;
+    bool minimalThrust= rcCommandAdjustedThrottle < *landingThrSum / *landingThrSamples - 50;
 
     bool possibleLandingDetected = hasHadSomeVelocity && minimalThrust && !verticalMovement && !horizontalMovement;
     

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -481,17 +481,15 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelo
     // check if we are moving horizontally
     bool horizontalMovement = sqrtf(sq(posControl.actualState.vel.V.X) + sq(posControl.actualState.vel.V.Y)) > 100.0f;
 
-    /*
-    // Throttle should be low enough
+    // We have likely landed if throttle is 40 units below average descend throttle
     // We use rcCommandAdjustedThrottle to keep track of NAV corrected throttle (isLandingDetected is executed
     // from processRx() and rcCommand at that moment holds rc input, not adjusted values from NAV core)
-    bool minimalThrust = rcCommandAdjustedThrottle < posControl.navConfig->mc_min_fly_throttle;
-    */
-
-    // We have likely landed if throttle is 50 units below average descend throttle
     *landingThrSamples += 1;
     *landingThrSum += rcCommandAdjustedThrottle;
-    bool minimalThrust= rcCommandAdjustedThrottle < *landingThrSum / *landingThrSamples - 50;
+    bool minimalThrust= rcCommandAdjustedThrottle < *landingThrSum / *landingThrSamples - 40;
+
+    // TODO: This setting is no longer needed, remove or reuse it for LAND_DETECTOR_TRIGGER_TIME_MS
+    //posControl.navConfig->mc_min_fly_throttle;
 
     bool possibleLandingDetected = hasHadSomeVelocity && minimalThrust && !verticalMovement && !horizontalMovement;
     

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -468,7 +468,7 @@ static void applyMulticopterPositionController(uint32_t currentTime)
 /*-----------------------------------------------------------
  * Multicopter land detector
  *-----------------------------------------------------------*/
-bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelocity, int32_t * landingThrSum, int16_t * landingThrSamples)
+bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelocity, int32_t * landingThrSum, int32_t * landingThrSamples)
 {
     uint32_t currentTime = micros();
 

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -492,12 +492,12 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelo
     // TODO: rcCommandAdjustedThrottle never goes below min_throttle+1, so replace 1040+1 with min_throttle+1
     *landingThrSum += rcCommandAdjustedThrottle;
     *landingThrSamples += 1;
-    bool minimalThrust= rcCommandAdjustedThrottle <= MAX(*landingThrSum / *landingThrSamples - 100, 1040+1);
+    bool minimalThrust= rcCommandAdjustedThrottle <= MAX(*landingThrSum / *landingThrSamples - 50, 1040+1);
 
     bool possibleLandingDetected = hasHadSomeVelocity && minimalThrust && !verticalMovement && !horizontalMovement;
     
     navDebug[0] = *hasHadSomeVelocity*1000 + minimalThrust*100 + !verticalMovement*10 + !horizontalMovement*1;
-    navDebug[1] = (*landingThrSum / *landingThrSamples - 100) - rcCommandAdjustedThrottle;
+    navDebug[1] = (*landingThrSum / *landingThrSamples) - rcCommandAdjustedThrottle;
     navDebug[2] = (currentTime - *landingTimer) / 1000;
 
     // If we have surface sensor (for example sonar) - use it to detect touchdown

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -489,7 +489,6 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelo
     */
 
     // We have likely landed if throttle is 100 units below average throttle
-    // TODO: We could use "((throttle - min_throttle) / acc[z] + min_throttle)" to get a more accurate hover throttle.
     // TODO: rcCommandAdjustedThrottle never goes below min_throttle+1, so replace 1040+1 with min_throttle+1
     *landingThrSum += rcCommandAdjustedThrottle;
     *landingThrSamples += 1;
@@ -497,14 +496,9 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelo
 
     bool possibleLandingDetected = hasHadSomeVelocity && minimalThrust && !verticalMovement && !horizontalMovement;
     
-    int landingDebug;
-    if (hasHadSomeVelocity) landingDebug += 1;
-    if (minimalThrust) landingDebug += 2;
-    if (!verticalMovement) landingDebug += 4;
-    if (!horizontalMovement) landingDebug += 8;
-    navDebug[0] = landingDebug;
-    navDebug[1] = *landingThrSum / *landingThrSamples;
-    navDebug[2] = *landingThrSamples;
+    navDebug[0] = *hasHadSomeVelocity*1000 + minimalThrust*100 + !verticalMovement*10 + !horizontalMovement*1;
+    navDebug[1] = (*landingThrSum / *landingThrSamples - 100) - rcCommandAdjustedThrottle;
+    navDebug[2] = (currentTime - *landingTimer) / 1000;
 
     // If we have surface sensor (for example sonar) - use it to detect touchdown
     if (posControl.flags.hasValidSurfaceSensor && posControl.actualState.surface >= 0 && posControl.actualState.surfaceMin >= 0) {

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -486,14 +486,14 @@ bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelo
     // from processRx() and rcCommand at that moment holds rc input, not adjusted values from NAV core)
     *landingThrSamples += 1;
     *landingThrSum += rcCommandAdjustedThrottle;
-    bool minimalThrust= rcCommandAdjustedThrottle < *landingThrSum / *landingThrSamples - 40;
+    bool isAtMinimalThrust= rcCommandAdjustedThrottle < *landingThrSum / *landingThrSamples - 40;
 
     // TODO: This setting is no longer needed, remove or reuse it for LAND_DETECTOR_TRIGGER_TIME_MS
     //posControl.navConfig->mc_min_fly_throttle;
 
-    bool possibleLandingDetected = hasHadSomeVelocity && minimalThrust && !verticalMovement && !horizontalMovement;
+    bool possibleLandingDetected = hasHadSomeVelocity && isAtMinimalThrust && !verticalMovement && !horizontalMovement;
     
-    navDebug[0] = *hasHadSomeVelocity*1000 + minimalThrust*100 + !verticalMovement*10 + !horizontalMovement*1;
+    navDebug[0] = *hasHadSomeVelocity*1000 + isAtMinimalThrust*100 + !verticalMovement*10 + !horizontalMovement*1;
     navDebug[1] = (*landingThrSum / *landingThrSamples) - rcCommandAdjustedThrottle;
     navDebug[2] = (currentTime - *landingTimer) / 1000;
 

--- a/src/main/flight/navigation_rewrite_private.h
+++ b/src/main/flight/navigation_rewrite_private.h
@@ -324,7 +324,7 @@ bool adjustMulticopterPositionFromRCInput(void);
 
 void applyMulticopterNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTime);
 
-bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelocity);
+bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelocity, int32_t * landingThrSum, int16_t * landingThrSamples);
 void calculateMulticopterInitialHoldPosition(t_fp_vector * pos);
 
 /* Fixed-wing specific functions */

--- a/src/main/flight/navigation_rewrite_private.h
+++ b/src/main/flight/navigation_rewrite_private.h
@@ -324,7 +324,7 @@ bool adjustMulticopterPositionFromRCInput(void);
 
 void applyMulticopterNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTime);
 
-bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelocity, int32_t * landingThrSum, int16_t * landingThrSamples);
+bool isMulticopterLandingDetected(uint32_t * landingTimer, bool * hasHadSomeVelocity, int32_t * landingThrSum, int32_t * landingThrSamples);
 void calculateMulticopterInitialHoldPosition(t_fp_vector * pos);
 
 /* Fixed-wing specific functions */


### PR DESCRIPTION
Improving one aspect of issue: #219 

Currently we are using  `mc_min_fly_throttle` to set a throttle value to compare current throttle to. This has a few problems IMHO:
1. Stupid users (like me) may set it wrong (look at me, i had it too high and got a disarm-in-air!).
2. In one of @stronnag logs it looked like the hover throttle went from ~1550 to ~1650 with full to empty battery, this gives inconsistent behavior no matter how well tuned mc_min_fly_throttle is.
3. What if one uses a heaver or light battery? Add or remove a gimbal or change the weigth in any other way?
4. Impossible to set good default. Either to high so racing quads risk disarming in air, or to low so it takes forever to disarm big quads.
5. It requires tuning.

I got an idea that may solve all of those problems. I have started playing around with measuring the average throttle during descent and comparing the current throttle to that. I have flown with just a 40ms timeout, and my quad disarms instantly on touchdown, before the landing legs has even settled in to the grass, but the throttle check has never passed in-air! Not even close actually.

This needs a little bit more testing and cleanup before it's ready to merge, but i'm really happy with the results so far, better than i expected :smiley: Comments and feedback are welcome as usual!
