### PR TITLE
Allow ANDing of multiple channel ranges in mode activation conditions

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -491,6 +491,8 @@ static void resetConf(void)
     masterConfig.auto_disarm_delay = 5;
     masterConfig.small_angle = 25;
 
+    masterConfig.and_mode_conditions = 0; // default is to OR multiple-channel mode activation conditions
+
     resetMixerConfig(&masterConfig.mixerConfig);
 
     // Motor/ESC/Servo

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -79,6 +79,8 @@ typedef struct master_t {
     uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
     uint8_t small_angle;
 
+    uint8_t and_mode_conditions;            // When using multiple AUX channels to activate modes, the default is to OR the activation conditions. This allows the conditions to be ANDed instead.
+
     // mixer-related configuration
     mixerConfig_t mixerConfig;
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -534,6 +534,8 @@ const clivalue_t valueTable[] = {
 
     { "reboot_character",           VAR_UINT8  | MASTER_VALUE,  &masterConfig.serialConfig.reboot_character, .config.minmax = { 48,  126 }, 0 },
 
+    { "and_mode_conditions",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.and_mode_conditions, .config.lookup = { TABLE_OFF_ON }, 0 },
+
 #ifdef GPS
     { "gps_provider",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.gpsConfig.provider, .config.lookup = { TABLE_GPS_PROVIDER }, 0 },
     { "gps_sbas_mode",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.gpsConfig.sbasMode, .config.lookup = { TABLE_GPS_SBAS_MODE }, 0 },


### PR DESCRIPTION
Enter "set and_mode_conditions=ON" in the CLI to use AND logic between channel ranges, so that all range conditions of a mode must be met for that mode to be activated. Default is and_mode_conditions=OFF which leaves current behavior unchanged.
