### PR TITLE
CC3D: Allow all 6 PWM RX inputs to be used

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -826,6 +826,19 @@ void validateAndFixConfig(void)
         if (masterConfig.batteryConfig.currentMeterType == CURRENT_SENSOR_ADC) {
             featureClear(FEATURE_CURRENT_METER);
         }
+
+#if defined(CC3D)
+        // There is a timer clash between PWM RX pins and motor output pins - this forces us to have same timer tick rate for these timers
+        // which is only possible when using brushless motors w/o oneshot (timer tick rate is PWM_TIMER_MHZ)
+
+        // On CC3D OneShot is incompatible with PWM RX
+        featureClear(FEATURE_ONESHOT125);
+
+        // Brushed motors on CC3D are not possible when using PWM RX
+        if (masterConfig.motor_pwm_rate > BRUSHLESS_MOTORS_PWM_RATE) {
+            masterConfig.motor_pwm_rate = BRUSHLESS_MOTORS_PWM_RATE;
+        }
+#endif
 #endif
 
 #if defined(STM32F10X) || defined(CHEBUZZ) || defined(STM32F3DISCOVERY)

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -248,6 +248,9 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
 #endif
 
 #ifdef CC3D
+        // This part of code is unnecessary and can be removed - timer clash is resolved by forcing configuration with the same
+        // timer tick rate - PWM_TIMER_MHZ
+        /*
         if (init->useParallelPWM) {
             // Skip PWM inputs that conflict with timers used outputs.
             if ((type == MAP_TO_SERVO_OUTPUT || type == MAP_TO_MOTOR_OUTPUT) && (timerHardwarePtr->tim == TIM2 || timerHardwarePtr->tim == TIM3)) {
@@ -258,6 +261,7 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
             }
 
         }
+        */
 #endif
 
         if (type == MAP_TO_PPM_INPUT) {


### PR DESCRIPTION
Resolves #267 
Config validation on boot now prohibits brushless motors and OneShot if PWM RX is selected. This ensures conflicting timers will have the same tick rate (PWM_TIMER_MHZ) which makes it possible to have all 6 PWM RX inputs and all 6 PWM outputs (motor/servo).
