### PR TITLE
BLHeli4wayif timing improvement

### DIFF
--- a/src/main/io/serial_4way_avrootloader.c
+++ b/src/main/io/serial_4way_avrootloader.c
@@ -70,7 +70,8 @@
 
 #define BIT_TIME          52                       // 52uS
 #define BIT_TIME_HALVE    (BIT_TIME >> 1)          // 26uS
-#define START_BIT_TIME    (BIT_TIME_HALVE + 1)
+#define BIT_TIME_3_4      (BIT_TIME_HALVE + (BIT_TIME_HALVE >> 1))   // 39uS
+#define START_BIT_TIME    (BIT_TIME_3_4)
 
 static int suart_getc(void)
 {


### PR DESCRIPTION
https://github.com/cleanflight/cleanflight/pull/2225

Bit state reading timed later to improve connection for ESC with higher
capacities at input pin.
