### PR TITLE
PID: Use full stick in ANGLE/HORIZON

### DIFF
--- a/src/main/flight/navigation_rewrite_fixedwing.c
+++ b/src/main/flight/navigation_rewrite_fixedwing.c
@@ -420,12 +420,12 @@ void applyFixedWingPitchRollThrottleController(navigationFSMStateFlags_t navStat
     if (isPitchAdjustmentValid && (navStateFlags & NAV_CTL_ALT)) {
         // PITCH angle is measured in opposite direction ( >0 - dive, <0 - climb)
         pitchCorrection = constrain(pitchCorrection, -DEGREES_TO_CENTIDEGREES(posControl.navConfig->fw_max_dive_angle), DEGREES_TO_CENTIDEGREES(posControl.navConfig->fw_max_climb_angle));
-        rcCommand[PITCH] = -pidAngleToRcCommand(pitchCorrection);
+        rcCommand[PITCH] = -pidAngleToRcCommand(pitchCorrection, posControl.pidProfile->max_angle_inclination[FD_PITCH]);
     }
 
     if (isRollAdjustmentValid && (navStateFlags & NAV_CTL_POS)) {
         rollCorrection = constrain(rollCorrection, -DEGREES_TO_CENTIDEGREES(posControl.navConfig->fw_max_bank_angle), DEGREES_TO_CENTIDEGREES(posControl.navConfig->fw_max_bank_angle));
-        rcCommand[ROLL] = pidAngleToRcCommand(rollCorrection);
+        rcCommand[ROLL] = pidAngleToRcCommand(rollCorrection, posControl.pidProfile->max_angle_inclination[FD_ROLL]);
 
         // Calculate coordinated turn rate based on velocity and banking angle
         if (posControl.actualState.velXY >= 300.0f) {

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -461,8 +461,8 @@ static void applyMulticopterPositionController(uint32_t currentTime)
     }
 
     if (!bypassPositionController) {
-        rcCommand[PITCH] = pidAngleToRcCommand(posControl.rcAdjustment[PITCH]);
-        rcCommand[ROLL] = pidAngleToRcCommand(posControl.rcAdjustment[ROLL]);
+        rcCommand[PITCH] = pidAngleToRcCommand(posControl.rcAdjustment[PITCH], posControl.pidProfile->max_angle_inclination[FD_PITCH]);
+        rcCommand[ROLL] = pidAngleToRcCommand(posControl.rcAdjustment[ROLL], posControl.pidProfile->max_angle_inclination[FD_ROLL]);
     }
 }
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -251,7 +251,8 @@ static void pidLevel(const pidProfile_t *pidProfile, const controlRateConfig_t *
     // This is ROLL/PITCH, run ANGLE/HORIZON controllers
     const float angleTarget = pidRcCommandToAngle(rcCommand[axis], pidProfile->max_angle_inclination[axis]);
     const float angleError = angleTarget - attitude.raw[axis];
-    const float angleRateTarget = constrainf(angleError * (pidProfile->P8[PIDLEVEL] / FP_PID_LEVEL_P_MULTIPLIER), -controlRateConfig->rates[axis] * 10.0f, controlRateConfig->rates[axis] * 10.0f);
+
+    float angleRateTarget = constrainf(angleError * (pidProfile->P8[PIDLEVEL] / FP_PID_LEVEL_P_MULTIPLIER), -controlRateConfig->rates[axis] * 10.0f, controlRateConfig->rates[axis] * 10.0f);
 
     // Apply simple LPF to angleRateTarget to make response less jerky
     // Ideas behind this:

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -72,11 +72,10 @@ extern int32_t axisPID_P[], axisPID_I[], axisPID_D[], axisPID_Setpoint[];
 void pidInit(void);
 void pidResetErrorAccumulators(void);
 void updatePIDCoefficients(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig, const rxConfig_t *rxConfig);
-
-int16_t pidAngleToRcCommand(float angleDeciDegrees);
-float pidRateToRcCommand(float rateDPS, uint8_t rate);
-
 void pidController(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig, const rxConfig_t *rxConfig);
+
+float pidRateToRcCommand(float rateDPS, uint8_t rate);
+int16_t pidAngleToRcCommand(float angleDeciDegrees, int16_t maxInclination);
 
 enum {
     MAG_HOLD_DISABLED = 0,


### PR DESCRIPTION
Currently formula for targetAngle is this:
`targetAngle = 2 * rcCommand`
this is latter constrained to `max_inclination` therefore if your max_inclination is set to something smaller than 100 deg you won't be using full stick in ANGLE mode.

This PR changes the logic in such way that full stick deflection will result in `max_inclination`.
