### PR TITLE
FuryF3 Initial support

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -33,6 +33,7 @@
 #define I2C_SHORT_TIMEOUT             ((uint32_t)0x1000)
 #define I2C_LONG_TIMEOUT             ((uint32_t)(10 * I2C_SHORT_TIMEOUT))
 
+#if !defined(I2C1_SCL_GPIO)
 #define I2C1_SCL_GPIO        GPIOB
 #define I2C1_SCL_GPIO_AF     GPIO_AF_4
 #define I2C1_SCL_PIN         GPIO_Pin_6
@@ -43,6 +44,7 @@
 #define I2C1_SDA_PIN         GPIO_Pin_7
 #define I2C1_SDA_PIN_SOURCE  GPIO_PinSource7
 #define I2C1_SDA_CLK_SOURCE  RCC_AHBPeriph_GPIOB
+#endif
 
 #if !defined(I2C2_SCL_GPIO)
 #define I2C2_SCL_GPIO        GPIOF
@@ -55,7 +57,6 @@
 #define I2C2_SDA_PIN         GPIO_Pin_10
 #define I2C2_SDA_PIN_SOURCE  GPIO_PinSource10
 #define I2C2_SDA_CLK_SOURCE  RCC_AHBPeriph_GPIOA
-
 #endif
 
 static uint32_t i2cTimeout;

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -83,8 +83,8 @@ void EXTI15_10_IRQHandler(void)
     extiHandler(EXTI15_10_IRQn);
 }
 
-#if defined(CC3D)
- void EXTI3_IRQHandler(void)
+#if defined(CC3D) || defined(FURYF3)
+void EXTI3_IRQHandler(void)
 {
     extiHandler(EXTI3_IRQn);
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -343,6 +343,11 @@ void init(void)
     }
 #endif
 
+#if defined(FURYF3) && defined(SONAR) && defined(USE_SOFTSERIAL1)
+    if (feature(FEATURE_SONAR) && feature(FEATURE_SOFTSERIAL)) {
+        serialRemovePort(SERIAL_PORT_SOFTSERIAL1);
+    }
+#endif
 
 #ifdef USE_I2C
 #if defined(NAZE)

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -171,6 +171,19 @@ const extiConfig_t *selectMPUIntExtiConfig(void)
     return &colibriRaceMPUIntExtiConfig;
 #endif
 
+#if defined(FURYF3)
+    static const extiConfig_t FURYF3MPUIntExtiConfig = {
+            .gpioAHBPeripherals = RCC_AHBPeriph_GPIOA,
+            .gpioPort = GPIOA,
+            .gpioPin = Pin_3,
+            .exti_port_source = EXTI_PortSourceGPIOA,
+            .exti_pin_source = EXTI_PinSource3,
+            .exti_line = EXTI_Line3,
+            .exti_irqn = EXTI3_IRQn
+    };
+    return &FURYF3MPUIntExtiConfig;
+#endif
+
     return NULL;
 }
 

--- a/src/main/target/FURYF3/target.c
+++ b/src/main/target/FURYF3/target.c
@@ -1,0 +1,66 @@
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/pwm_mapping.h"
+
+const uint16_t multiPPM[] = {
+    PWM1  | (MAP_TO_PPM_INPUT << 8), // PPM input
+    
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const uint16_t multiPWM[] = {
+    PWM1  | (MAP_TO_PWM_INPUT << 8),
+    PWM2  | (MAP_TO_PWM_INPUT << 8),
+    PWM3  | (MAP_TO_PWM_INPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const uint16_t airPPM[] = {
+    PWM1  | (MAP_TO_PPM_INPUT << 8), // PPM input
+    
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_SERVO_OUTPUT << 8),
+    PWM7  | (MAP_TO_SERVO_OUTPUT << 8),
+    PWM2  | (MAP_TO_SERVO_OUTPUT << 8),
+    PWM3  | (MAP_TO_SERVO_OUTPUT << 8),   
+    0xFFFF
+};
+
+const uint16_t airPWM[] = {
+    PWM1  | (MAP_TO_PWM_INPUT << 8),
+    PWM2  | (MAP_TO_PWM_INPUT << 8),
+    PWM3  | (MAP_TO_PWM_INPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    { TIM2,  GPIOB, Pin_3,  TIM_Channel_2, TIM2_IRQn,               0, Mode_AF_PP,      GPIO_PinSource3,  GPIO_AF_1}, // PPM IN
+    { TIM3,  GPIOB, Pin_0,  TIM_Channel_3, TIM3_IRQn,               0, Mode_AF_PP,      GPIO_PinSource0,  GPIO_AF_2}, // SS1 - PB0  - *TIM3_CH3, TIM1_CH2N, TIM8_CH2N
+    { TIM3,  GPIOB, Pin_1,  TIM_Channel_4, TIM3_IRQn,               0, Mode_AF_PP,      GPIO_PinSource1,  GPIO_AF_2}, // SS1 - PB1  - *TIM3_CH4, TIM1_CH3N, TIM8_CH3N
+
+    { TIM4,  GPIOB, Pin_7,  TIM_Channel_2, TIM4_IRQn,               1, Mode_AF_PP,      GPIO_PinSource7,  GPIO_AF_2}, // PWM4 - S1
+    { TIM4,  GPIOB, Pin_6,  TIM_Channel_1, TIM4_IRQn,               1, Mode_AF_PP,      GPIO_PinSource6,  GPIO_AF_2}, // PWM5 - S2
+    { TIM17, GPIOB, Pin_5,  TIM_Channel_1, TIM1_TRG_COM_TIM17_IRQn, 1, Mode_AF_PP,      GPIO_PinSource5,  GPIO_AF_10}, // PWM6 - S3
+    { TIM16, GPIOB, Pin_4,  TIM_Channel_1, TIM1_UP_TIM16_IRQn,      1, Mode_AF_PP,      GPIO_PinSource4,  GPIO_AF_1}, // PWM7 - S4
+ 
+    { TIM1,  GPIOA, Pin_8,  TIM_Channel_1, TIM1_CC_IRQn,            1, Mode_AF_PP,      GPIO_PinSource8,  GPIO_AF_6}, // GPIO TIMER - LED_STRIP
+
+};

--- a/src/main/target/FURYF3/target.c
+++ b/src/main/target/FURYF3/target.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include <platform.h>
+#include "drivers/io.h"
 #include "drivers/pwm_mapping.h"
 
 const uint16_t multiPPM[] = {
@@ -52,15 +53,15 @@ const uint16_t airPWM[] = {
 };
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM2,  GPIOB, Pin_3,  TIM_Channel_2, TIM2_IRQn,               0, Mode_AF_PP,      GPIO_PinSource3,  GPIO_AF_1}, // PPM IN
-    { TIM3,  GPIOB, Pin_0,  TIM_Channel_3, TIM3_IRQn,               0, Mode_AF_PP,      GPIO_PinSource0,  GPIO_AF_2}, // SS1 - PB0  - *TIM3_CH3, TIM1_CH2N, TIM8_CH2N
-    { TIM3,  GPIOB, Pin_1,  TIM_Channel_4, TIM3_IRQn,               0, Mode_AF_PP,      GPIO_PinSource1,  GPIO_AF_2}, // SS1 - PB1  - *TIM3_CH4, TIM1_CH3N, TIM8_CH3N
+    { TIM2,  IO_TAG(PB3), TIM_Channel_2, TIM2_IRQn,               0, IOCFG_AF_PP,  GPIO_AF_1, 0}, // PPM IN
+    { TIM3,  IO_TAG(PB0), TIM_Channel_3, TIM3_IRQn,               1, IOCFG_AF_PP,  GPIO_AF_2, 0}, // SS1 - PB0  - *TIM3_CH3, TIM1_CH2N, TIM8_CH2N
+    { TIM3,  IO_TAG(PB1), TIM_Channel_4, TIM3_IRQn,               1, IOCFG_AF_PP,  GPIO_AF_2, 0}, // SS1 - PB1  - *TIM3_CH4, TIM1_CH3N, TIM8_CH3N
 
-    { TIM4,  GPIOB, Pin_7,  TIM_Channel_2, TIM4_IRQn,               1, Mode_AF_PP,      GPIO_PinSource7,  GPIO_AF_2}, // PWM4 - S1
-    { TIM4,  GPIOB, Pin_6,  TIM_Channel_1, TIM4_IRQn,               1, Mode_AF_PP,      GPIO_PinSource6,  GPIO_AF_2}, // PWM5 - S2
-    { TIM17, GPIOB, Pin_5,  TIM_Channel_1, TIM1_TRG_COM_TIM17_IRQn, 1, Mode_AF_PP,      GPIO_PinSource5,  GPIO_AF_10}, // PWM6 - S3
-    { TIM16, GPIOB, Pin_4,  TIM_Channel_1, TIM1_UP_TIM16_IRQn,      1, Mode_AF_PP,      GPIO_PinSource4,  GPIO_AF_1}, // PWM7 - S4
+    { TIM4,  IO_TAG(PB7), TIM_Channel_2, TIM4_IRQn,               1, IOCFG_AF_PP,  GPIO_AF_2, 0}, // PWM4 - S1
+    { TIM4,  IO_TAG(PB6), TIM_Channel_1, TIM4_IRQn,               1, IOCFG_AF_PP,  GPIO_AF_2, 0}, // PWM5 - S2
+    { TIM17, IO_TAG(PB5), TIM_Channel_1, TIM1_TRG_COM_TIM17_IRQn, 1, IOCFG_AF_PP,  GPIO_AF_10, 0}, // PWM6 - S3
+    { TIM16, IO_TAG(PB4), TIM_Channel_1, TIM1_UP_TIM16_IRQn,      1, IOCFG_AF_PP,  GPIO_AF_1, 0}, // PWM7 - S4
  
-    { TIM1,  GPIOA, Pin_8,  TIM_Channel_1, TIM1_CC_IRQn,            1, Mode_AF_PP,      GPIO_PinSource8,  GPIO_AF_6}, // GPIO TIMER - LED_STRIP
+    { TIM1,  IO_TAG(PA8), TIM_Channel_1, TIM1_CC_IRQn,            1, IOCFG_AF_PP,  GPIO_AF_6, 0}, // GPIO TIMER - LED_STRIP
 
 };

--- a/src/main/target/FURYF3/target.h
+++ b/src/main/target/FURYF3/target.h
@@ -85,8 +85,11 @@
 #define SPI2_MOSI_PIN           Pin_15
 #define SPI2_MOSI_PIN_SOURCE    GPIO_PinSource15
 
+#ifdef FURYF3_SPIFLASH
 #define USE_FLASHFS
-//#define USE_SDCARD
+#else
+#define USE_SDCARD
+#endif
 
 #ifdef USE_FLASHFS
 #define USE_FLASH_M25P16

--- a/src/main/target/FURYF3/target.h
+++ b/src/main/target/FURYF3/target.h
@@ -87,6 +87,7 @@
 
 #ifdef FURYF3_SPIFLASH
 #define USE_FLASHFS
+#undef BEEPER_INVERTED
 #else
 #define USE_SDCARD
 #endif

--- a/src/main/target/FURYF3/target.h
+++ b/src/main/target/FURYF3/target.h
@@ -1,0 +1,248 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "FURY"
+
+#define LED0
+
+#define LED0_GPIO   GPIOC
+#define LED0_PIN    Pin_14
+#define LED0_PERIPHERAL RCC_AHBPeriph_GPIOC
+
+#define BEEPER
+#define BEEP_GPIO   GPIOC
+#define BEEP_PIN    Pin_15
+#define BEEP_PERIPHERAL RCC_AHBPeriph_GPIOC
+#define BEEPER_INVERTED
+
+//#define EXTI_CALLBACK_HANDLER_COUNT 2 // MPU INT, SDCardDetect
+#define EXTI_CALLBACK_HANDLER_COUNT 1 // MPU INT
+
+#define USE_MPU_DATA_READY_SIGNAL
+#define ENSURE_MPU_DATA_READY_IS_LOW
+
+#define GYRO
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_MPU6000_ALIGN CW180_DEG  // changedkb 270
+#define USE_GYRO_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define GYRO_MPU6500_ALIGN CW90_DEG  // changedkb 270
+
+#define ACC
+#define USE_ACC_SPI_MPU6000
+#define ACC_MPU6000_ALIGN CW180_DEG  // changedkb 270
+#define USE_ACC_MPU6500
+#define USE_ACC_SPI_MPU6500
+#define ACC_MPU6500_ALIGN CW90_DEG  // changedkb 270
+
+#define MPU6000_CS_GPIO_CLK_PERIPHERAL   RCC_AHBPeriph_GPIOA
+#define MPU6000_CS_GPIO                  GPIOA
+#define MPU6000_CS_PIN                   GPIO_Pin_4
+#define MPU6000_SPI_INSTANCE             SPI1
+
+#define MPU6500_CS_GPIO_CLK_PERIPHERAL   RCC_AHBPeriph_GPIOA
+#define MPU6500_CS_GPIO                  GPIOA
+#define MPU6500_CS_PIN                   GPIO_Pin_4
+#define MPU6500_SPI_INSTANCE             SPI1
+
+#define MAG
+#define USE_MAG_AK8975
+#define USE_MAG_HMC5883
+#define USE_MAG_MAG3110
+
+#define BARO
+#define USE_BARO_MS5611
+#define USE_BARO_BMP280
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define USE_SPI_DEVICE_2 // PB12,13,14,15 on AF5
+
+#define SPI2_GPIO               GPIOB
+#define SPI2_GPIO_PERIPHERAL    RCC_AHBPeriph_GPIOB
+#define SPI2_NSS_PIN            Pin_12
+#define SPI2_NSS_PIN_SOURCE     GPIO_PinSource12
+#define SPI2_SCK_PIN            Pin_13
+#define SPI2_SCK_PIN_SOURCE     GPIO_PinSource13
+#define SPI2_MISO_PIN           Pin_14
+#define SPI2_MISO_PIN_SOURCE    GPIO_PinSource14
+#define SPI2_MOSI_PIN           Pin_15
+#define SPI2_MOSI_PIN_SOURCE    GPIO_PinSource15
+
+#define USE_FLASHFS
+//#define USE_SDCARD
+
+#ifdef USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_CS_GPIO          GPIOB
+#define M25P16_CS_PIN           GPIO_Pin_12
+#define M25P16_SPI_INSTANCE     SPI2
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#endif
+
+#ifdef USE_SDCARD
+#define USE_SDCARD_SPI2
+
+#define SDCARD_DETECT_INVERTED
+
+#define SDCARD_DETECT_PIN                   GPIO_Pin_2
+#define SDCARD_DETECT_EXTI_LINE             EXTI_Line2
+#define SDCARD_DETECT_EXTI_PIN_SOURCE       EXTI_PinSource2
+#define SDCARD_DETECT_GPIO_PORT             GPIOB
+#define SDCARD_DETECT_GPIO_CLK              RCC_AHBPeriph_GPIOB
+#define SDCARD_DETECT_EXTI_PORT_SOURCE      EXTI_PortSourceGPIOB
+#define SDCARD_DETECT_EXTI_IRQn             EXTI15_10_IRQn
+
+#define SDCARD_SPI_INSTANCE                 SPI2
+#define SDCARD_SPI_CS_GPIO                  SPI2_GPIO
+#define SDCARD_SPI_CS_PIN                   SPI2_NSS_PIN
+
+// SPI2 is on the APB1 bus whose clock runs at 36MHz. Divide to under 400kHz for init:
+#define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 128
+// Divide to under 25MHz for normal operation:
+#define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER     2
+
+// Note, this is the same DMA channel as USART1_RX. Luckily we don't use DMA for USART Rx.
+#define SDCARD_DMA_CHANNEL_TX               DMA1_Channel5
+#define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG DMA1_FLAG_TC5
+#endif
+
+#define USABLE_TIMER_CHANNEL_COUNT 8
+
+#define USB_IO
+
+#define USE_VCP
+#define USE_USART1
+#define USE_USART2
+#define USE_USART3
+#define USE_SOFTSERIAL1
+#define SERIAL_PORT_COUNT 5
+
+#ifndef UART1_GPIO
+#define UART1_TX_PIN        GPIO_Pin_9  // PA9
+#define UART1_RX_PIN        GPIO_Pin_10 // PA10
+#define UART1_GPIO          GPIOA
+#define UART1_GPIO_AF       GPIO_AF_7
+#define UART1_TX_PINSOURCE  GPIO_PinSource9
+#define UART1_RX_PINSOURCE  GPIO_PinSource10
+#endif
+
+#define UART2_TX_PIN        GPIO_Pin_14 // PA14
+#define UART2_RX_PIN        GPIO_Pin_15 // PA15
+#define UART2_GPIO          GPIOA
+#define UART2_GPIO_AF       GPIO_AF_7
+#define UART2_TX_PINSOURCE  GPIO_PinSource14
+#define UART2_RX_PINSOURCE  GPIO_PinSource15
+
+#ifndef UART3_GPIO
+#define UART3_TX_PIN        GPIO_Pin_10 // PB10 (AF7)
+#define UART3_RX_PIN        GPIO_Pin_11 // PB11 (AF7)
+#define UART3_GPIO_AF       GPIO_AF_7
+#define UART3_GPIO          GPIOB
+#define UART3_TX_PINSOURCE  GPIO_PinSource10
+#define UART3_RX_PINSOURCE  GPIO_PinSource11
+#endif
+
+#define SOFTSERIAL_1_TIMER TIM3
+#define SOFTSERIAL_1_TIMER_RX_HARDWARE 1
+#define SOFTSERIAL_1_TIMER_TX_HARDWARE 2
+
+#define USE_I2C
+#define I2C_DEVICE (I2CDEV_1) // SDA (PB9/AF4), SCL (PB8/AF4)
+
+#define I2C1_SCL_GPIO        GPIOB
+#define I2C1_SCL_GPIO_AF     GPIO_AF_4
+#define I2C1_SCL_PIN         GPIO_Pin_8
+#define I2C1_SCL_PIN_SOURCE  GPIO_PinSource8
+#define I2C1_SCL_CLK_SOURCE  RCC_AHBPeriph_GPIOB
+#define I2C1_SDA_GPIO        GPIOB
+#define I2C1_SDA_GPIO_AF     GPIO_AF_4
+#define I2C1_SDA_PIN         GPIO_Pin_9
+#define I2C1_SDA_PIN_SOURCE  GPIO_PinSource9
+#define I2C1_SDA_CLK_SOURCE  RCC_AHBPeriph_GPIOB
+
+#define USE_ADC
+#define BOARD_HAS_VOLTAGE_DIVIDER
+
+#define ADC_INSTANCE                ADC1
+#define ADC_DMA_CHANNEL             DMA1_Channel1
+#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA1
+
+#define VBAT_ADC_GPIO               GPIOA
+#define VBAT_ADC_GPIO_PIN           GPIO_Pin_0
+#define VBAT_ADC_CHANNEL            ADC_Channel_1
+
+#define RSSI_ADC_GPIO               GPIOA
+#define RSSI_ADC_GPIO_PIN           GPIO_Pin_1
+#define RSSI_ADC_CHANNEL            ADC_Channel_2
+
+#define CURRENT_METER_ADC_GPIO      GPIOA
+#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_2
+#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_3
+
+#define SONAR
+#define SONAR_TRIGGER_PIN           Pin_0   // RC_CH7 (PB0) - only 3.3v ( add a 1K Ohms resistor )
+#define SONAR_TRIGGER_GPIO          GPIOB
+#define SONAR_ECHO_PIN              Pin_1   // RC_CH8 (PB1) - only 3.3v ( add a 1K Ohms resistor )
+#define SONAR_ECHO_GPIO             GPIOB
+#define SONAR_EXTI_LINE             EXTI_Line1
+#define SONAR_EXTI_PIN_SOURCE       EXTI_PinSource1
+#define SONAR_EXTI_IRQN             EXTI1_IRQn
+
+#define LED_STRIP
+#define LED_STRIP_TIMER TIM1
+
+#define USE_LED_STRIP_ON_DMA1_CHANNEL2
+#define WS2811_GPIO                     GPIOA
+#define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
+#define WS2811_GPIO_AF                  GPIO_AF_6
+#define WS2811_PIN                      GPIO_Pin_8
+#define WS2811_PIN_SOURCE               GPIO_PinSource8
+#define WS2811_TIMER                    TIM1
+#define WS2811_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM1
+#define WS2811_DMA_CHANNEL              DMA1_Channel2
+#define WS2811_IRQ                      DMA1_Channel2_IRQn
+#define WS2811_DMA_TC_FLAG              DMA1_FLAG_TC2
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
+
+#define NAV
+#define NAV_AUTO_MAG_DECLINATION
+#define NAV_GPS_GLITCH_DETECTION
+
+#define DEFAULT_RX_FEATURE FEATURE_RX_PPM
+#define DEFAULT_FEATURES FEATURE_BLACKBOX
+
+#define SPEKTRUM_BIND
+// USART3,
+#define BIND_PORT  GPIOB
+#define BIND_PIN   Pin_11
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+// IO - stm32f303cc in 48pin package
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC (BIT(13)|BIT(14)|BIT(15))
+#define TARGET_IO_PORTF (BIT(0)|BIT(1)|BIT(3)|BIT(4))
+
+#define USED_TIMERS  (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(16) |TIM_N(17))
+
+#define TIMER_APB1_PERIPHERALS (RCC_APB1Periph_TIM2 | RCC_APB1Periph_TIM3 | RCC_APB1Periph_TIM4)
+#define TIMER_APB2_PERIPHERALS (RCC_APB2Periph_TIM1 | RCC_APB2Periph_TIM16 | RCC_APB2Periph_TIM17)
+#define TIMER_AHB_PERIPHERALS (RCC_AHBPeriph_GPIOA | RCC_AHBPeriph_GPIOB)

--- a/src/main/target/FURYF3/target.mk
+++ b/src/main/target/FURYF3/target.mk
@@ -1,0 +1,20 @@
+F3_TARGETS  += $(TARGET)
+FEATURES    = VCP ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro_mpu.c \
+            drivers/accgyro_spi_mpu6000.c \
+            drivers/accgyro_mpu6500.c \
+            drivers/accgyro_spi_mpu6500.c \
+            drivers/barometer_bmp085.c \
+            drivers/barometer_bmp280.c \
+            drivers/barometer_ms5611.c \
+            drivers/compass_ak8975.c \
+            drivers/compass_hmc5883l.c \
+            drivers/compass_mag3110.c \
+            drivers/light_ws2811strip.c \
+            drivers/light_ws2811strip_stm32f30x.c \
+            drivers/serial_softserial.c \
+            drivers/sonar_hcsr04.c \
+            drivers/sonar_srf10.c
+


### PR DESCRIPTION
Adding support for new FuryF3 board by @kc10kevin (available in July from http://www.2dogrc.com/furyf3-board.html)

Final board has SD-Card socket but I only have a prototype of FuryF3 board with SPIFLASH (no SD-Card). I'm making two targets available - FURY and FURY_SPIFLASH. 

When #266 gets merged (SPRacingF3 EVO + final SD-Card support) this target will be updated as well and will have full support for SD-Card logging.
