### PR TITLE
Force no PWM pulses on soft reset

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -1134,9 +1134,6 @@ void changeControlRateProfile(uint8_t profileIndex)
 
 void handleOneshotFeatureChangeOnRestart(void)
 {
-    // Shutdown PWM on all motors prior to soft restart
-    StopPwmAllMotors();
-    delay(50);
     // Apply additional delay when OneShot125 feature changed from on to off state
     if (feature(FEATURE_ONESHOT125) && !featureConfigured(FEATURE_ONESHOT125)) {
         delay(ONESHOT_FEATURE_CHANGED_DELAY_ON_BOOT_MS);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -659,13 +659,13 @@ void writeAllMotors(int16_t mc)
 void stopMotors(void)
 {
     writeAllMotors(feature(FEATURE_3D) ? flight3DConfig->neutral3d : escAndServoConfig->mincommand);
-
     delay(50); // give the timers and ESCs a chance to react.
 }
 
-void StopPwmAllMotors()
+void stopPwmAllMotors()
 {
     pwmShutdownPulsesForAllMotors(motorCount);
+    delay(500);
 }
 
 void mixTable(void)

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -238,6 +238,6 @@ void writeMotors(void);
 void servoMixer(void);
 void processServoTilt(void);
 void stopMotors(void);
-void StopPwmAllMotors(void);
+void stopPwmAllMotors(void);
 
 bool isMixerEnabled(mixerMode_e mixerMode);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2248,7 +2248,7 @@ static void cliReboot(void) {
     cliPrint("\r\nRebooting");
     bufWriterFlush(cliWriter);
     waitForSerialPortToFinishTransmitting(cliPort);
-    stopMotors();
+    stopPwmAllMotors();
     handleOneshotFeatureChangeOnRestart();
     systemReset();
 }

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1703,7 +1703,7 @@ void mspProcess(void)
 
         if (isRebootScheduled) {
             waitForSerialPortToFinishTransmitting(candidatePort->port);
-            stopMotors();
+            stopPwmAllMotors();
             handleOneshotFeatureChangeOnRestart();
             systemReset();
         }


### PR DESCRIPTION
A fix for brief motor spinup on reboot.
