### PR TITLE
Turn assistant - turn on parallel to ground plane

### DIFF
--- a/src/main/config/runtime_config.h
+++ b/src/main/config/runtime_config.h
@@ -46,6 +46,7 @@ typedef enum {
     NAV_WP_MODE     = (1 << 12),
     HEADING_LOCK    = (1 << 13),
     FLAPERON        = (1 << 14),
+    TURN_ASSISTANT  = (1 << 15),
 } flightModeFlags_e;
 
 extern uint16_t flightModeFlags;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -495,7 +495,8 @@ void pidController(const pidProfile_t *pidProfile, const controlRateConfig_t *co
         pidApplyHeadingLock(pidProfile, &pidState[FD_YAW]);
     }
 
-    if (FLIGHT_MODE(TURN_ASSISTANT)) {
+    // Turn assistant is enabled explicitly in HANGLE/HORIZON mode to improve yaw stability
+    if (FLIGHT_MODE(TURN_ASSISTANT) || ((FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)) && !STATE(FIXED_WING))) {
         pidTurnAssistant(pidState);
     }
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -495,8 +495,7 @@ void pidController(const pidProfile_t *pidProfile, const controlRateConfig_t *co
         pidApplyHeadingLock(pidProfile, &pidState[FD_YAW]);
     }
 
-    // Turn assistant is enabled explicitly in HANGLE/HORIZON mode to improve yaw stability
-    if (FLIGHT_MODE(TURN_ASSISTANT) || ((FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)) && !STATE(FIXED_WING))) {
+    if (FLIGHT_MODE(TURN_ASSISTANT)) {
         pidTurnAssistant(pidState);
     }
 

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -52,6 +52,7 @@ typedef enum {
     BOXHEADINGLOCK,
     BOXSURFACE,
     BOXFLAPERON,
+    BOXTURNASSIST,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -149,6 +149,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXHEADINGLOCK, "HEADING LOCK;", 32 },
     { BOXSURFACE, "SURFACE;", 33 },
     { BOXFLAPERON, "FLAPERON;", 34 },
+    { BOXTURNASSIST, "TURN ASSIST;", 35 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -479,6 +480,7 @@ void mspInit(void)
     if (sensors(SENSOR_ACC)) {
         activeBoxIds[activeBoxIdCount++] = BOXANGLE;
         activeBoxIds[activeBoxIdCount++] = BOXHORIZON;
+        activeBoxIds[activeBoxIdCount++] = BOXTURNASSIST;
     }
 
     activeBoxIds[activeBoxIdCount++] = BOXAIRMODE;
@@ -595,6 +597,7 @@ static uint32_t packFlightModeFlags(void)
         IS_ENABLED(FLIGHT_MODE(HEADING_LOCK)) << BOXHEADINGLOCK |
         IS_ENABLED(IS_RC_MODE_ACTIVE(BOXSURFACE)) << BOXSURFACE |
         IS_ENABLED(FLIGHT_MODE(FLAPERON)) << BOXFLAPERON |
+        IS_ENABLED(FLIGHT_MODE(TURN_ASSISTANT)) << BOXTURNASSIST |
         IS_ENABLED(IS_RC_MODE_ACTIVE(BOXHOMERESET)) << BOXHOMERESET;
 
     for (i = 0; i < activeBoxIdCount; i++) {

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -383,15 +383,22 @@ void processRx(void)
         DISABLE_FLIGHT_MODE(HEADING_LOCK);
     }
 
-    /*
-    Flaperon mode
-    */
+    /* Flaperon mode */
     if (IS_RC_MODE_ACTIVE(BOXFLAPERON) && STATE(FLAPERON_AVAILABLE)) {
         if (!FLIGHT_MODE(FLAPERON)) {
             ENABLE_FLIGHT_MODE(FLAPERON);
         }
     } else {
         DISABLE_FLIGHT_MODE(FLAPERON);
+    }
+
+    /* Turn assistant mode */
+    if (IS_RC_MODE_ACTIVE(BOXTURNASSIST)) {
+        if (!FLIGHT_MODE(TURN_ASSISTANT)) {
+            ENABLE_FLIGHT_MODE(TURN_ASSISTANT);
+        }
+    } else {
+        DISABLE_FLIGHT_MODE(TURN_ASSISTANT);
     }
 
 #if defined(MAG)


### PR DESCRIPTION
This PR introduces a new flight mode TURN ASSIST that makes copter do Yaw turns on parallel to the ground plane regardless of tilt.
