### PR TITLE
Accelerometer and attitude computation in independent tasks

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -373,9 +373,6 @@ extern uint32_t currentTime;
 //From rx.c:
 extern uint16_t rssi;
 
-//From gyro.c
-extern uint32_t targetLooptime;
-
 static BlackboxState blackboxState = BLACKBOX_STATE_DISABLED;
 
 static uint32_t blackboxLastArmingBeep = 0;
@@ -1284,7 +1281,7 @@ static bool blackboxWriteSysinfo()
             }
             );
 
-        BLACKBOX_PRINT_HEADER_LINE("looptime:%d",                           targetLooptime);
+        BLACKBOX_PRINT_HEADER_LINE("looptime:%d",                           getLooptime());
         BLACKBOX_PRINT_HEADER_LINE("rcExpo:%d",                             masterConfig.controlRateProfiles[masterConfig.current_profile_index].rcExpo8);
         BLACKBOX_PRINT_HEADER_LINE("rcYawExpo:%d",                          masterConfig.controlRateProfiles[masterConfig.current_profile_index].rcYawExpo8);
         BLACKBOX_PRINT_HEADER_LINE("thrMid:%d",                             masterConfig.controlRateProfiles[masterConfig.current_profile_index].thrMid8);

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -524,8 +524,6 @@ void blackboxWriteFloat(float value)
 
 /**
  * If there is data waiting to be written to the blackbox device, attempt to write (a portion of) that now.
- * 
- * Intended to be called regularly for the blackbox device to perform housekeeping.
  */
 void blackboxDeviceFlush(void)
 {
@@ -617,7 +615,8 @@ bool blackboxDeviceOpen(void)
                  *                              = floor((looptime_ns * 3) / 500.0)
                  *                              = (looptime_ns * 3) / 500
                  */
-                blackboxMaxHeaderBytesPerIteration = constrain((targetLooptime * 3) / 500, 1, BLACKBOX_TARGET_HEADER_BUDGET_PER_ITERATION);
+                 //FIXME here we store hardcoded 2000us looptime
+                blackboxMaxHeaderBytesPerIteration = constrain((2000 * 3) / 500, 1, BLACKBOX_TARGET_HEADER_BUDGET_PER_ITERATION);
 
                 return blackboxPort != NULL;
             }

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -25,6 +25,7 @@
 #include "common/maths.h"
 
 #include "drivers/gyro_sync.h"
+#include "config/config.h"
 
 #define BIQUAD_Q    (1.0f / 1.41421356f)     /* quality factor - butterworth (1 / sqrt(2)) */
 #define M_PI_FLOAT  3.14159265358979323846f
@@ -37,8 +38,7 @@ void biquadFilterInit(biquadFilter_t *newState, uint8_t filterCutFreq, int16_t s
 
     /* If sampling rate == 0 - use main loop target rate */
     if (!samplingRate) {
-        //FIXME here we use hardcoded 2000us looptime
-        samplingRate = 1000000 / 2000;
+        samplingRate = 1000000 / getLooptime();
     }
 
     /* setup variables */

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -37,7 +37,8 @@ void biquadFilterInit(biquadFilter_t *newState, uint8_t filterCutFreq, int16_t s
 
     /* If sampling rate == 0 - use main loop target rate */
     if (!samplingRate) {
-        samplingRate = 1000000 / targetLooptime;
+        //FIXME here we use hardcoded 2000us looptime
+        samplingRate = 1000000 / 2000;
     }
 
     /* setup variables */

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -30,50 +30,6 @@
 #define BIQUAD_Q    (1.0f / 1.41421356f)     /* quality factor - butterworth (1 / sqrt(2)) */
 #define M_PI_FLOAT  3.14159265358979323846f
 
-void decimalBiquadFilterInit(decimalBiquadFilter_t *newState, uint8_t filterCutFreq, int16_t samplingRate) {
-    float omega, sn, cs, alpha;
-    float a0, a1, a2, b0, b1, b2;
-
-    /* If sampling rate == 0 - use main loop target rate */
-    if (!samplingRate) {
-        samplingRate = 1000000 / getLooptime();
-    }
-
-    /* setup variables */
-    omega = 2 * M_PIf * (float)filterCutFreq / (float)samplingRate;
-    sn = sin_approx(omega);
-    cs = cos_approx(omega);
-    alpha = sn / (2 * BIQUAD_Q);
-
-    b0 = (1 - cs) / 2;
-    b1 = 1 - cs;
-    b2 = (1 - cs) / 2;
-    a0 = 1 + alpha;
-    a1 = -2 * cs;
-    a2 = 1 - alpha;
-
-    /* precompute the coefficients */
-    newState->b0 = lrintf((b0 / a0) * 100);
-    newState->b1 = lrintf((b1 / a0) * 100);
-    newState->b2 = lrintf((b2 / a0) * 100);
-    newState->a1 = lrintf((a1 / a0) * 100);
-    newState->a2 = lrintf((a2 / a0) * 100);
-
-    /* zero initial samples */
-    newState->d1 = newState->d2 = 1;
-}
-
-int32_t decimalBiquadFilterApply(decimalBiquadFilter_t *state, int32_t sample)
-{
-    int32_t result;
-
-    result = state->b0 * sample + state->d1;
-    state->d1 = state->b1 * sample - state->a1 * result + state->d2;
-    state->d2 = state->b2 * sample - state->a2 * result;
-
-    return result / 100;
-}
-
 /* sets up a biquad Filter */
 void biquadFilterInit(biquadFilter_t *newState, uint8_t filterCutFreq, int16_t samplingRate)
 {

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -29,6 +29,11 @@ typedef struct biquadFilter_s {
     float d1, d2;
 } biquadFilter_t;
 
+typedef struct decimalBiquadFilter_s {
+    int32_t b0, b1, b2, a1, a2;
+    int32_t d1, d2;
+} decimalBiquadFilter_t;
+
 typedef struct firFilter_s {
     float *buf;
     const float *coeffs;
@@ -49,3 +54,5 @@ void firFilterInit2(firFilter_t *filter, float *buf, uint8_t bufLength, const fl
 void firFilterUpdate(firFilter_t *filter, float input);
 float firFilterApply(firFilter_t *filter);
 
+void decimalBiquadFilterInit(decimalBiquadFilter_t *newState, uint8_t filterCutFreq, int16_t samplingRate);
+int32_t decimalBiquadFilterApply(decimalBiquadFilter_t *state, int32_t sample);

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -29,11 +29,6 @@ typedef struct biquadFilter_s {
     float d1, d2;
 } biquadFilter_t;
 
-typedef struct decimalBiquadFilter_s {
-    int32_t b0, b1, b2, a1, a2;
-    int32_t d1, d2;
-} decimalBiquadFilter_t;
-
 typedef struct firFilter_s {
     float *buf;
     const float *coeffs;
@@ -41,6 +36,7 @@ typedef struct firFilter_s {
     uint8_t coeffsLength;
 } firFilter_t;
 
+void pt1FilterInit(pt1Filter_t *filter, uint8_t f_cut, float dT);
 float pt1FilterApply(pt1Filter_t *filter, float input);
 float pt1FilterApply4(pt1Filter_t *filter, float input, float f_cut, float dt);
 float pt1FilterApplyWithRateLimit(pt1Filter_t *filter, float input, float f_cut, float rate_limit, float dT);
@@ -53,6 +49,3 @@ void firFilterInit(firFilter_t *filter, float *buf, uint8_t bufLength, const flo
 void firFilterInit2(firFilter_t *filter, float *buf, uint8_t bufLength, const float *coeffs, uint8_t coeffsLength);
 void firFilterUpdate(firFilter_t *filter, float input);
 float firFilterApply(firFilter_t *filter);
-
-void decimalBiquadFilterInit(decimalBiquadFilter_t *newState, uint8_t filterCutFreq, int16_t samplingRate);
-int32_t decimalBiquadFilterApply(decimalBiquadFilter_t *state, int32_t sample);

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -429,6 +429,14 @@ uint32_t getLooptime(void) {
     return masterConfig.looptime;
 }
 
+uint32_t getAccUpdateFrequency(void) {
+    if (feature(FEATURE_RACE)) {
+        return ACC_TASK_FREQUENCY;
+    } else {
+        return 1000000 / getLooptime();
+    }
+}
+
 uint8_t getCurrentProfile(void)
 {
     return masterConfig.current_profile_index;

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -425,6 +425,10 @@ void resetMixerConfig(mixerConfig_t *mixerConfig) {
 #endif
 }
 
+uint32_t getLooptime(void) {
+    return masterConfig.looptime;
+}
+
 uint8_t getCurrentProfile(void)
 {
     return masterConfig.current_profile_index;
@@ -997,7 +1001,7 @@ static void validateAndFixConfig(void)
 
     //FIXME this is only override for separated gyro/pid loop, has to be fixed at one point
     masterConfig.gyroSync = 1;
-    masterConfig.gyroSyncDenominator = 8; //Run at 1000Hz
+    // masterConfig.gyroSyncDenominator = 8; //Run at 1000Hz
     masterConfig.gyro_lpf = 0; //Force 256Hz LPF on gyro
 
     useRxConfig(&masterConfig.rxConfig);

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -997,7 +997,7 @@ static void validateAndFixConfig(void)
 
     //FIXME this is only override for separated gyro/pid loop, has to be fixed at one point
     masterConfig.gyroSync = 1;
-    masterConfig.gyroSyncDenominator = 4; //Run at 2000Hz
+    masterConfig.gyroSyncDenominator = 8; //Run at 1000Hz
     masterConfig.gyro_lpf = 0; //Force 256Hz LPF on gyro
 
     useRxConfig(&masterConfig.rxConfig);

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -571,7 +571,7 @@ static void resetConf(void)
     masterConfig.emf_avoidance = 0;
     masterConfig.i2c_overclock = 0;
     masterConfig.gyroSync = 0;
-    masterConfig.gyroSyncDenominator = 2;
+    masterConfig.gyroSyncDenominator = 8;
 
     resetPidProfile(&currentProfile->pidProfile);
 
@@ -923,8 +923,8 @@ static void validateAndFixConfig(void)
 
 #ifdef STM32F10X
     // avoid overloading the CPU on F1 targets when using gyro sync and GPS.
-    if (masterConfig.gyroSync && masterConfig.gyroSyncDenominator < 2 && featureConfigured(FEATURE_GPS)) {
-        masterConfig.gyroSyncDenominator = 2;
+    if (masterConfig.gyroSyncDenominator < 8 && featureConfigured(FEATURE_GPS)) {
+        masterConfig.gyroSyncDenominator = 8;
     }
 
     // avoid overloading the CPU when looptime < 2000 and GPS

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -431,7 +431,7 @@ uint32_t getLooptime(void) {
 
 uint32_t getAccUpdateFrequency(void) {
     if (feature(FEATURE_RACE)) {
-        return ACC_TASK_FREQUENCY;
+        return masterConfig.accTaskFrequency;
     } else {
         return 1000000 / getLooptime();
     }
@@ -580,6 +580,7 @@ static void resetConf(void)
     masterConfig.i2c_overclock = 0;
     masterConfig.gyroSync = 0;
     masterConfig.gyroSyncDenominator = 8;
+    masterConfig.accTaskFrequency = ACC_TASK_FREQUENCY;
 
     resetPidProfile(&currentProfile->pidProfile);
 

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -158,7 +158,7 @@ size_t custom_flash_memory_address = 0;
 #define CONFIG_START_FLASH_ADDRESS (custom_flash_memory_address)
 #else
 // use the last flash pages for storage
-#ifndef CONFIG_START_FLASH_ADDRESS 
+#ifndef CONFIG_START_FLASH_ADDRESS
 #define CONFIG_START_FLASH_ADDRESS (0x08000000 + (uint32_t)((FLASH_PAGE_SIZE * FLASH_PAGE_COUNT) - FLASH_TO_RESERVE_FOR_CONFIG))
 #endif
 #endif
@@ -994,6 +994,11 @@ static void validateAndFixConfig(void)
 	    masterConfig.serialConfig.portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
     }
 #endif
+
+    //FIXME this is only override for separated gyro/pid loop, has to be fixed at one point
+    masterConfig.gyroSync = 1;
+    masterConfig.gyroSyncDenominator = 4; //Run at 2000Hz
+    masterConfig.gyro_lpf = 0; //Force 256Hz LPF on gyro
 
     useRxConfig(&masterConfig.rxConfig);
 

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -20,7 +20,7 @@
 #define MAX_PROFILE_COUNT 3
 #define MAX_CONTROL_RATE_PROFILE_COUNT 3
 #define ONESHOT_FEATURE_CHANGED_DELAY_ON_BOOT_MS 1500
-
+#define ACC_TASK_FREQUENCY 120;
 
 typedef enum {
     FEATURE_RX_PPM = 1 << 0,
@@ -51,6 +51,7 @@ typedef enum {
     FEATURE_VTX = 1 << 25,
     FEATURE_RX_NRF24 = 1 << 26,
     FEATURE_SOFTSPI = 1 << 27,
+    FEATURE_RACE = 1 << 28,
 } features_e;
 
 typedef enum {
@@ -100,3 +101,4 @@ void applyAndSaveBoardAlignmentDelta(int16_t roll, int16_t pitch);
 uint16_t getCurrentMinthrottle(void);
 
 uint32_t getLooptime(void);
+uint32_t getAccUpdateFrequency(void);

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -98,3 +98,5 @@ bool canSoftwareSerialBeUsed(void);
 void applyAndSaveBoardAlignmentDelta(int16_t roll, int16_t pitch);
 
 uint16_t getCurrentMinthrottle(void);
+
+uint32_t getLooptime(void);

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -32,6 +32,8 @@ typedef struct master_t {
     uint8_t gyroSync;                       // Enable interrupt based loop
     uint8_t gyroSyncDenominator;            // Gyro sync Denominator
 
+    uint16_t accTaskFrequency;
+
     motorMixer_t customMotorMixer[MAX_SUPPORTED_MOTORS];
 #ifdef USE_SERVOS
     servoMixer_t customServoMixer[MAX_SERVO_RULES];

--- a/src/main/drivers/gyro_sync.c
+++ b/src/main/drivers/gyro_sync.c
@@ -33,7 +33,7 @@
 
 extern gyro_t gyro;
 
-uint32_t targetLooptime;
+uint32_t targetGyroLooptime;
 static uint8_t mpuDividerDrops;
 
 bool getMpuDataStatus(gyro_t *gyro)
@@ -55,16 +55,15 @@ void gyroSetSampleRate(uint32_t looptime, uint8_t lpf, uint8_t gyroSync, uint8_t
         int gyroSamplePeriod;
         if (lpf == 0) {
             gyroSamplePeriod = 125;
-
         } else {
             gyroSamplePeriod = 1000;
         }
 
         mpuDividerDrops  = gyroSyncDenominator - 1;
-        targetLooptime = gyroSyncDenominator * gyroSamplePeriod;
+        targetGyroLooptime = gyroSyncDenominator * gyroSamplePeriod;
     } else {
         mpuDividerDrops = 0;
-        targetLooptime = looptime;
+        targetGyroLooptime = looptime;
     }
 }
 

--- a/src/main/drivers/gyro_sync.h
+++ b/src/main/drivers/gyro_sync.h
@@ -17,7 +17,7 @@
 
 #define INTERRUPT_WAIT_TIME 10
 
-extern uint32_t targetLooptime;
+extern uint32_t targetGyroLooptime;
 
 bool gyroSyncCheckUpdate(void);
 uint8_t gyroMPU6xxxCalculateDivider(void);

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -493,20 +493,17 @@ void imuHILUpdate(void)
 void imuUpdateAccelerometer(void)
 {
 #ifdef HIL
-    if (sensors(SENSOR_ACC) && !hilActive) {
+    if (!hilActive) {
         updateAccelerationReadings();
         isAccelUpdatedAtLeastOnce = true;
     }
 #else
-    if (sensors(SENSOR_ACC)) {
-        updateAccelerationReadings();
-        isAccelUpdatedAtLeastOnce = true;
-    }
+    updateAccelerationReadings();
+    isAccelUpdatedAtLeastOnce = true;
 #endif
 }
 
-//TODO rename it, since its not updating gyro anymore
-void imuUpdateGyroAndAttitude(void)
+void imuUpdateAttitude(void)
 {
     /* Calculate dT */
     static uint32_t previousIMUUpdateTime;
@@ -514,11 +511,7 @@ void imuUpdateGyroAndAttitude(void)
     float dT = (currentTime - previousIMUUpdateTime) * 1e-6;
     previousIMUUpdateTime = currentTime;
 
-    /* Update gyroscope */
-    //No, we do not, gyro is updated somewhere else
-    // gyroUpdate();
-
-    if (sensors(SENSOR_ACC) && isAccelUpdatedAtLeastOnce) {
+    if (isAccelUpdatedAtLeastOnce) {
 #ifdef HIL
         if (!hilActive) {
             imuUpdateMeasuredRotationRate();    // Calculate gyro rate in body frame in rad/s

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -94,7 +94,7 @@ STATIC_UNIT_TESTED void imuComputeRotationMatrix(void)
     float q1q1 = q1 * q1;
     float q2q2 = q2 * q2;
     float q3q3 = q3 * q3;
-    
+
     float q0q1 = q0 * q1;
     float q0q2 = q0 * q2;
     float q0q3 = q0 * q3;
@@ -154,7 +154,7 @@ void imuTransformVectorEarthToBody(t_fp_vector * v)
     float x,y,z;
 
     v->V.Y = -v->V.Y;
-    
+
     /* From earth frame to body frame */
     x = rMat[0][0] * v->V.X + rMat[1][0] * v->V.Y + rMat[2][0] * v->V.Z;
     y = rMat[0][1] * v->V.X + rMat[1][1] * v->V.Y + rMat[2][1] * v->V.Z;
@@ -300,8 +300,8 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
     if (accWeight > 0) {
         float kpAcc = imuRuntimeConfig->dcm_kp_acc * imuGetPGainScaleFactor();
 
-        // Just scale by 1G length - That's our vector adjustment. Rather than 
-        // using one-over-exact length (which needs a costly square root), we already 
+        // Just scale by 1G length - That's our vector adjustment. Rather than
+        // using one-over-exact length (which needs a costly square root), we already
         // know the vector is enough "roughly unit length" and since it is only weighted
         // in by a certain amount anyway later, having that exact is meaningless. (c) MasterZap
         recipNorm = 1.0f / GRAVITY_CMSS;
@@ -505,6 +505,7 @@ void imuUpdateAccelerometer(void)
 #endif
 }
 
+//TODO rename it, since its not updating gyro anymore
 void imuUpdateGyroAndAttitude(void)
 {
     /* Calculate dT */
@@ -514,7 +515,8 @@ void imuUpdateGyroAndAttitude(void)
     previousIMUUpdateTime = currentTime;
 
     /* Update gyroscope */
-    gyroUpdate();
+    //No, we do not, gyro is updated somewhere else
+    // gyroUpdate();
 
     if (sensors(SENSOR_ACC) && isAccelUpdatedAtLeastOnce) {
 #ifdef HIL

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -50,7 +50,7 @@ typedef struct imuRuntimeConfig_s {
 
 void imuConfigure(imuRuntimeConfig_t *initialImuRuntimeConfig, pidProfile_t *initialPidProfile);
 
-void imuUpdateGyroAndAttitude(void);
+void imuUpdateAttitude(void);
 void imuUpdateAccelerometer(void);
 float calculateThrottleTiltCompensationFactor(uint8_t throttleTiltCompensationStrength);
 float calculateCosTiltAngle(void);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -192,7 +192,7 @@ static const char * const featureNames[] = {
     "SONAR", "TELEMETRY", "CURRENT_METER", "3D", "RX_PARALLEL_PWM",
     "RX_MSP", "RSSI_ADC", "LED_STRIP", "DISPLAY", "ONESHOT125",
     "BLACKBOX", "CHANNEL_FORWARDING", "TRANSPONDER", "AIRMODE",
-    "SUPEREXPO", "OSD", "VTX", "RX_NRF24", "SOFTSPI", NULL
+    "SUPEREXPO", "OSD", "VTX", "RX_NRF24", "SOFTSPI", "RACE", NULL
 };
 
 // sync this with rxFailsafeChannelMode_e

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -560,6 +560,7 @@ const clivalue_t valueTable[] = {
     { "i2c_overclock",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.i2c_overclock, .config.lookup = { TABLE_OFF_ON }, 0 },
     { "gyro_sync",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.gyroSync, .config.lookup = { TABLE_OFF_ON } },
     { "gyro_sync_denom",            VAR_UINT8  | MASTER_VALUE,  &masterConfig.gyroSyncDenominator, .config.minmax = { 1,  32 } },
+    { "acc_task_frequency",         VAR_UINT16 | MASTER_VALUE,  &masterConfig.accTaskFrequency, .config.minmax = { 15,  1000 } },
 
     { "mid_rc",                     VAR_UINT16 | MASTER_VALUE,  &masterConfig.rxConfig.midrc, .config.minmax = { 1200,  1700 }, 0 },
     { "min_check",                  VAR_UINT16 | MASTER_VALUE,  &masterConfig.rxConfig.mincheck, .config.minmax = { PWM_RANGE_ZERO,  PWM_RANGE_MAX }, 0 },

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -578,12 +578,14 @@ int main(void)
     /* Setup scheduler */
     schedulerInit();
 
-    rescheduleTask(TASK_PID, masterConfig.looptime);
+    rescheduleTask(TASK_PID, getLooptime());
     setTaskEnabled(TASK_PID, true);
 
     rescheduleTask(TASK_GYRO, targetGyroLooptime);
     setTaskEnabled(TASK_GYRO, true);
-    setTaskEnabled(TASK_ACC, true);
+
+    rescheduleTask(TASK_ACC, 1000000 / getAccUpdateFrequency());
+    setTaskEnabled(TASK_ACC, feature(FEATURE_RACE) && sensors(SENSOR_ACC));
 
     setTaskEnabled(TASK_SERIAL, true);
 #ifdef BEEPER

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -578,10 +578,10 @@ int main(void)
     /* Setup scheduler */
     schedulerInit();
 
-    //FIXME right now we want to run with looptime 2000, so no rescheduling is required
-    // rescheduleTask(TASK_PID, targetLooptime);
+    rescheduleTask(TASK_PID, masterConfig.looptime);
     setTaskEnabled(TASK_PID, true);
 
+    rescheduleTask(TASK_GYRO, targetGyroLooptime);
     setTaskEnabled(TASK_GYRO, true);
 
     setTaskEnabled(TASK_SERIAL, true);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -578,8 +578,11 @@ int main(void)
     /* Setup scheduler */
     schedulerInit();
 
-    rescheduleTask(TASK_GYROPID, targetLooptime);
-    setTaskEnabled(TASK_GYROPID, true);
+    //FIXME right now we want to run with looptime 2000, so no rescheduling is required
+    // rescheduleTask(TASK_PID, targetLooptime);
+    setTaskEnabled(TASK_PID, true);
+
+    setTaskEnabled(TASK_GYRO, true);
 
     setTaskEnabled(TASK_SERIAL, true);
 #ifdef BEEPER

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -583,6 +583,7 @@ int main(void)
 
     rescheduleTask(TASK_GYRO, targetGyroLooptime);
     setTaskEnabled(TASK_GYRO, true);
+    setTaskEnabled(TASK_ACC, true);
 
     setTaskEnabled(TASK_SERIAL, true);
 #ifdef BEEPER

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -586,6 +586,7 @@ int main(void)
 
     rescheduleTask(TASK_ACC, 1000000 / getAccUpdateFrequency());
     setTaskEnabled(TASK_ACC, feature(FEATURE_RACE) && sensors(SENSOR_ACC));
+    setTaskEnabled(TASK_ATTI, feature(FEATURE_RACE) && sensors(SENSOR_ACC));
 
     setTaskEnabled(TASK_SERIAL, true);
 #ifdef BEEPER

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -626,18 +626,6 @@ void taskMainPidLoop(void)
 
 // Function for loop trigger
 void taskMainPidLoopChecker(void) {
-    // getTaskDeltaTime() returns delta time freezed at the moment of entering the scheduler. currentTime is freezed at the very same point.
-    // To make busy-waiting timeout work we need to account for time spent within busy-waiting loop
-    // uint32_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
-
-    // if (masterConfig.gyroSync) {
-    //     while (1) {
-    //         if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (targetLooptime + GYRO_WATCHDOG_DELAY))) {
-    //             break;
-    //         }
-    //     }
-    // }
-
     /*
      * Right now we run it with much lower precission since we do not do gyro here
      */
@@ -650,9 +638,11 @@ void taskMainPidLoopChecker(void) {
 void taskGyro(void) {
     uint32_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
 
+    debug[0] = currentDeltaTime;
+
     if (masterConfig.gyroSync) {
         while (1) {
-            if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (1000 + GYRO_WATCHDOG_DELAY))) {
+            if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (targetGyroLooptime + GYRO_WATCHDOG_DELAY))) {
                 break;
             }
         }

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -652,7 +652,7 @@ void taskGyro(void) {
 
     if (masterConfig.gyroSync) {
         while (1) {
-            if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (500 + GYRO_WATCHDOG_DELAY))) {
+            if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (1000 + GYRO_WATCHDOG_DELAY))) {
                 break;
             }
         }

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -523,9 +523,13 @@ void taskMainPidLoop(void)
     cycleTime = getTaskDeltaTime(TASK_SELF);
     dT = (float)cycleTime * 0.000001f;
 
-    //Acc and IMU moved to separate task
-    // imuUpdateAccelerometer();
-    // imuUpdateGyroAndAttitude();
+    /*
+     * Acc update is run in sync with PID loop only when RACE mode is not enabled
+     */
+    if (!feature(FEATURE_RACE) && sensors(SENSOR_ACC)) {
+        imuUpdateAccelerometer();
+        imuUpdateAttitude();
+    }
 
     annexCode();
 
@@ -631,8 +635,6 @@ void taskMainPidLoop(void)
 void taskGyro(void) {
     uint32_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
 
-    // debug[0] = currentDeltaTime;
-
     if (masterConfig.gyroSync) {
         while (1) {
             if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (targetGyroLooptime + GYRO_WATCHDOG_DELAY))) {
@@ -645,10 +647,8 @@ void taskGyro(void) {
 }
 
 void taskAcc(void) {
-    // debug[1] = getTaskDeltaTime(TASK_SELF);
-
     imuUpdateAccelerometer();
-    imuUpdateGyroAndAttitude();
+    imuUpdateAttitude();
 }
 
 void taskHandleSerial(void)

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -631,7 +631,7 @@ void taskMainPidLoop(void)
 void taskGyro(void) {
     uint32_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
 
-    debug[0] = currentDeltaTime;
+    // debug[0] = currentDeltaTime;
 
     if (masterConfig.gyroSync) {
         while (1) {
@@ -645,7 +645,7 @@ void taskGyro(void) {
 }
 
 void taskAcc(void) {
-    debug[1] = getTaskDeltaTime(TASK_SELF);
+    // debug[1] = getTaskDeltaTime(TASK_SELF);
 
     imuUpdateAccelerometer();
     imuUpdateGyroAndAttitude();

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -646,9 +646,12 @@ void taskGyro(void) {
     gyroUpdate();
 }
 
+void taskAttitude(void) {
+    imuUpdateAttitude();
+}
+
 void taskAcc(void) {
     imuUpdateAccelerometer();
-    imuUpdateAttitude();
 }
 
 void taskHandleSerial(void)

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -628,17 +628,37 @@ void taskMainPidLoop(void)
 void taskMainPidLoopChecker(void) {
     // getTaskDeltaTime() returns delta time freezed at the moment of entering the scheduler. currentTime is freezed at the very same point.
     // To make busy-waiting timeout work we need to account for time spent within busy-waiting loop
+    // uint32_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
+
+    // if (masterConfig.gyroSync) {
+    //     while (1) {
+    //         if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (targetLooptime + GYRO_WATCHDOG_DELAY))) {
+    //             break;
+    //         }
+    //     }
+    // }
+
+    /*
+     * Right now we run it with much lower precission since we do not do gyro here
+     */
+    taskMainPidLoop();
+}
+
+/*
+ * This task does only gyro reading and filtering
+ */
+void taskGyro(void) {
     uint32_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
 
     if (masterConfig.gyroSync) {
         while (1) {
-            if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (targetLooptime + GYRO_WATCHDOG_DELAY))) {
+            if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (500 + GYRO_WATCHDOG_DELAY))) {
                 break;
             }
         }
     }
 
-    taskMainPidLoop();
+    gyroUpdate();
 }
 
 void taskHandleSerial(void)

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -523,8 +523,9 @@ void taskMainPidLoop(void)
     cycleTime = getTaskDeltaTime(TASK_SELF);
     dT = (float)cycleTime * 0.000001f;
 
-    imuUpdateAccelerometer();
-    imuUpdateGyroAndAttitude();
+    //Acc and IMU moved to separate task
+    // imuUpdateAccelerometer();
+    // imuUpdateGyroAndAttitude();
 
     annexCode();
 
@@ -624,14 +625,6 @@ void taskMainPidLoop(void)
 #endif
 }
 
-// Function for loop trigger
-void taskMainPidLoopChecker(void) {
-    /*
-     * Right now we run it with much lower precission since we do not do gyro here
-     */
-    taskMainPidLoop();
-}
-
 /*
  * This task does only gyro reading and filtering
  */
@@ -649,6 +642,13 @@ void taskGyro(void) {
     }
 
     gyroUpdate();
+}
+
+void taskAcc(void) {
+    debug[1] = getTaskDeltaTime(TASK_SELF);
+
+    imuUpdateAccelerometer();
+    imuUpdateGyroAndAttitude();
 }
 
 void taskHandleSerial(void)

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -42,7 +42,8 @@ typedef struct {
 typedef enum {
     /* Actual tasks */
     TASK_SYSTEM = 0,
-    TASK_GYROPID,
+    TASK_PID,
+    TASK_GYRO,
     TASK_SERIAL,
     TASK_BEEPER,
     TASK_BATTERY,

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -44,6 +44,7 @@ typedef enum {
     TASK_SYSTEM = 0,
     TASK_PID,
     TASK_GYRO,
+    TASK_ACC,
     TASK_SERIAL,
     TASK_BEEPER,
     TASK_BATTERY,

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -45,6 +45,7 @@ typedef enum {
     TASK_PID,
     TASK_GYRO,
     TASK_ACC,
+    TASK_ATTI,
     TASK_SERIAL,
     TASK_BEEPER,
     TASK_BATTERY,

--- a/src/main/scheduler/scheduler_tasks.c
+++ b/src/main/scheduler/scheduler_tasks.c
@@ -31,11 +31,18 @@ cfTask_t cfTasks[TASK_COUNT] = {
         .staticPriority = TASK_PRIORITY_HIGH,
     },
 
-    [TASK_GYROPID] = {
-        .taskName = "GYRO/PID",
+    [TASK_PID] = {
+        .taskName = "PID",
         .taskFunc = taskMainPidLoopChecker,
-        .desiredPeriod = 1000,
+        .desiredPeriod = 1000000 / 500, // Run at 500Hz
         .staticPriority = TASK_PRIORITY_REALTIME,
+    },
+
+    [TASK_GYRO] = {
+        .taskName = "GYRO",
+        .taskFunc = taskGyro,
+        .desiredPeriod = 1000000 / 2000, //Run at 2000Hz
+        .staticPriority = TASK_PRIORITY_REALTIME
     },
 
     [TASK_SERIAL] = {

--- a/src/main/scheduler/scheduler_tasks.c
+++ b/src/main/scheduler/scheduler_tasks.c
@@ -48,7 +48,14 @@ cfTask_t cfTasks[TASK_COUNT] = {
     [TASK_ACC] = {
         .taskName = "ACC",
         .taskFunc = taskAcc,
-        .desiredPeriod = 1000000 / 120, //Run at 120Hz, with LPF at 15Hz this is even too much
+        .desiredPeriod = 1000000 / 520, //520Hz is ACC bandwidth (260Hz) * 2
+        .staticPriority = TASK_PRIORITY_HIGH,
+    },
+
+    [TASK_ATTI] = {
+        .taskName = "ATTITUDE",
+        .taskFunc = taskAttitude,
+        .desiredPeriod = 1000000 / 60, //With acc LPF at 15Hz 60Hz attitude refresh should be enough
         .staticPriority = TASK_PRIORITY_HIGH,
     },
 

--- a/src/main/scheduler/scheduler_tasks.c
+++ b/src/main/scheduler/scheduler_tasks.c
@@ -41,8 +41,8 @@ cfTask_t cfTasks[TASK_COUNT] = {
     [TASK_GYRO] = {
         .taskName = "GYRO",
         .taskFunc = taskGyro,
-        .desiredPeriod = 1000000 / 2000, //Run at 2000Hz
-        .staticPriority = TASK_PRIORITY_REALTIME
+        .desiredPeriod = 1000000 / 1000, //Run at 1000Hz
+        .staticPriority = TASK_PRIORITY_HIGH
     },
 
     [TASK_SERIAL] = {

--- a/src/main/scheduler/scheduler_tasks.c
+++ b/src/main/scheduler/scheduler_tasks.c
@@ -33,7 +33,7 @@ cfTask_t cfTasks[TASK_COUNT] = {
 
     [TASK_PID] = {
         .taskName = "PID",
-        .taskFunc = taskMainPidLoopChecker,
+        .taskFunc = taskMainPidLoop,
         .desiredPeriod = 1000000 / 500, // Run at 500Hz
         .staticPriority = TASK_PRIORITY_REALTIME,
     },
@@ -42,7 +42,14 @@ cfTask_t cfTasks[TASK_COUNT] = {
         .taskName = "GYRO",
         .taskFunc = taskGyro,
         .desiredPeriod = 1000000 / 1000, //Run at 1000Hz
-        .staticPriority = TASK_PRIORITY_REALTIME
+        .staticPriority = TASK_PRIORITY_REALTIME,
+    },
+
+    [TASK_ACC] = {
+        .taskName = "ACC",
+        .taskFunc = taskAcc,
+        .desiredPeriod = 1000000 / 120, //Run at 120Hz, with LPF at 15Hz this is even too much
+        .staticPriority = TASK_PRIORITY_HIGH,
     },
 
     [TASK_SERIAL] = {

--- a/src/main/scheduler/scheduler_tasks.c
+++ b/src/main/scheduler/scheduler_tasks.c
@@ -42,7 +42,7 @@ cfTask_t cfTasks[TASK_COUNT] = {
         .taskName = "GYRO",
         .taskFunc = taskGyro,
         .desiredPeriod = 1000000 / 1000, //Run at 1000Hz
-        .staticPriority = TASK_PRIORITY_HIGH
+        .staticPriority = TASK_PRIORITY_REALTIME
     },
 
     [TASK_SERIAL] = {

--- a/src/main/scheduler/scheduler_tasks.h
+++ b/src/main/scheduler/scheduler_tasks.h
@@ -19,7 +19,7 @@
 
 #include <stdint.h>
 
-void taskMainPidLoopChecker(void);
+void taskMainPidLoop(void);
 void taskHandleSerial(void);
 void taskUpdateBeeper(void);
 void taskUpdateBattery(void);
@@ -34,3 +34,4 @@ void taskTelemetry(void);
 void taskLedStrip(void);
 void taskSystem(void);
 void taskGyro(void);
+void taskAcc(void);

--- a/src/main/scheduler/scheduler_tasks.h
+++ b/src/main/scheduler/scheduler_tasks.h
@@ -35,3 +35,4 @@ void taskLedStrip(void);
 void taskSystem(void);
 void taskGyro(void);
 void taskAcc(void);
+void taskAttitude(void);

--- a/src/main/scheduler/scheduler_tasks.h
+++ b/src/main/scheduler/scheduler_tasks.h
@@ -33,4 +33,4 @@ void taskUpdateDisplay(void);
 void taskTelemetry(void);
 void taskLedStrip(void);
 void taskSystem(void);
-
+void taskGyro(void);

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -91,7 +91,7 @@ int getPrimaryAxisIndex(int32_t sample[3])
         //Y-axis
         return (sample[Y] > 0) ? 4 : 5;
     }
-    else 
+    else
         return -1;
 }
 
@@ -181,14 +181,13 @@ void updateAccelerationReadings(void)
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) accADC[axis] = accADCRaw[axis];
 
     if (accLpfCutHz) {
-        if (!accFilterInitialised) {
-            if (targetLooptime) {  /* Initialisation needs to happen once sample rate is known */
-                for (int axis = 0; axis < 3; axis++) {
-                    biquadFilterInit(&accFilterState[axis], accLpfCutHz, 0);
-                }
-
-                accFilterInitialised = true;
+        /* Initialisation needs to happen once sample rate is known */
+        if (!accFilterInitialised && targetGyroLooptime) {
+            for (int axis = 0; axis < 3; axis++) {
+                biquadFilterInit(&accFilterState[axis], accLpfCutHz, 1000000 / getLooptime());
             }
+
+            accFilterInitialised = true;
         }
 
         if (accFilterInitialised) {

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -52,7 +52,7 @@ static flightDynamicsTrims_t * accGain;
 
 static int8_t accLpfCutHz = 0;
 static biquadFilter_t accFilterState[XYZ_AXIS_COUNT];
-static decimalBiquadFilter_t decimalAccFilterState[XYZ_AXIS_COUNT];
+static pt1Filter_t fastAccFilterState[XYZ_AXIS_COUNT];
 static bool accFilterInitialised = false;
 
 void accSetCalibrationCycles(uint16_t calibrationCyclesRequired)
@@ -185,25 +185,29 @@ void updateAccelerationReadings(void)
 
     if (accLpfCutHz) {
         /* Initialisation needs to happen once sample rate is known */
-        if (!accFilterInitialised && targetGyroLooptime) {
+        if (!accFilterInitialised) {
             for (int axis = 0; axis < 3; axis++) {
-                biquadFilterInit(&accFilterState[axis], accLpfCutHz, 1000000 / getLooptime());
-                decimalBiquadFilterInit(&decimalAccFilterState[axis], accLpfCutHz, 1000000 / getLooptime());
+                // if (feature(FEATURE_RACE)) {
+                    double dT = 1 / getAccUpdateFrequency();
+                    pt1FilterInit(&fastAccFilterState[axis], accLpfCutHz, dT);
+                // } else {
+                    biquadFilterInit(&accFilterState[axis], accLpfCutHz, getAccUpdateFrequency());
+                // }
             }
 
             accFilterInitialised = true;
-        }
-
-        if (accFilterInitialised) {
+        } else {
             for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                accADC[axis] = lrintf(biquadFilterApply(&accFilterState[axis], (float) accADC[axis]));
-
-                if (axis == 0) {
-                    debug[0] = accADC[0];
-                    debug[1] = decimalBiquadFilterApply(&decimalAccFilterState[axis], accADC[axis]);
-                    debug[2] = debug[0] - debug[1];
-                }
-
+                // if (feature(FEATURE_RACE)) {
+                    // accADC[axis] = lrintf(pt1FilterApply(&fastAccFilterState[axis], (float) accADC[axis]));
+                // } else {
+                    accADC[axis] = lrintf(biquadFilterApply(&accFilterState[axis], (float) accADC[axis]));
+                    if (axis == 0) {
+                        debug[0] = accADC[0];
+                        debug[1] = lrintf(pt1FilterApply(&fastAccFilterState[axis], (float) accADC[0]));
+                        debug[2] = debug[0] - debug[1];
+                    }
+                // }
             }
         }
     }

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -137,7 +137,8 @@ void gyroUpdate(void)
         if (!gyroFilterInitialised) {
             if (targetLooptime) {  /* Initialisation needs to happen once sample rate is known */
                 for (int axis = 0; axis < 3; axis++) {
-                    biquadFilterInit(&gyroFilterState[axis], gyroLpfCutHz, 0);
+                    //FIXME hardcoded 500us = 2kHz
+                    biquadFilterInit(&gyroFilterState[axis], gyroLpfCutHz, 1000000 / 500);
                 }
 
                 gyroFilterInitialised = true;

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -134,15 +134,13 @@ void gyroUpdate(void)
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) gyroADC[axis] = gyroADCRaw[axis];
 
     if (gyroLpfCutHz) {
-        if (!gyroFilterInitialised) {
-            if (targetLooptime) {  /* Initialisation needs to happen once sample rate is known */
-                for (int axis = 0; axis < 3; axis++) {
-                    //FIXME hardcoded 1000us = 1kHz
-                    biquadFilterInit(&gyroFilterState[axis], gyroLpfCutHz, 1000000 / 1000);
-                }
-
-                gyroFilterInitialised = true;
+        /* Initialisation needs to happen once sample rate is known */
+        if (!gyroFilterInitialised && targetGyroLooptime) {
+            for (int axis = 0; axis < 3; axis++) {
+                biquadFilterInit(&gyroFilterState[axis], gyroLpfCutHz, 1000000 / targetGyroLooptime);
             }
+
+            gyroFilterInitialised = true;
         }
 
         if (gyroFilterInitialised) {

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -137,8 +137,8 @@ void gyroUpdate(void)
         if (!gyroFilterInitialised) {
             if (targetLooptime) {  /* Initialisation needs to happen once sample rate is known */
                 for (int axis = 0; axis < 3; axis++) {
-                    //FIXME hardcoded 500us = 2kHz
-                    biquadFilterInit(&gyroFilterState[axis], gyroLpfCutHz, 1000000 / 500);
+                    //FIXME hardcoded 1000us = 1kHz
+                    biquadFilterInit(&gyroFilterState[axis], gyroLpfCutHz, 1000000 / 1000);
                 }
 
                 gyroFilterInitialised = true;

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -113,7 +113,7 @@
 
 #define MAG_HMC5883_ALIGN CW180_DEG
 
-#define SONAR
+// #define SONAR
 //#define USE_SONAR_SRF10
 #define SONAR_PWM_TRIGGER_PIN       Pin_8   // PWM5 (PB8) - 5v tolerant
 #define SONAR_PWM_TRIGGER_GPIO      GPIOB


### PR DESCRIPTION
This is continuation of #369 in order to squeeze as much as possible from gyro and acro modes.
It uses the same approach as Betaflight for ACC computations

This PR introduces feature "RACE" that, when activated does the following:
1. ACC reading is done at 520Hz that should be enough not to have aliasing problems (260Hz ACC bandwidth
1. Attitude computation is done at 60Hz that should be enough not to have aliasing problems (ACC LPF has cutoff at 15Hz)
1. Acc BiQuad filter replaced with PT1 filter -> not done yet!!

When RACE feature is disabled, ACC and ATTITUDE are done in sync with PID loop, gyro loop is still independent just like in #369  

Did not flight tested yet, should be flyable. Or at least I hope so. Any volunteers?
