### PR TITLE
Fixes to initialisation procedure

### DIFF
--- a/src/main/drivers/system_stm32f10x.c
+++ b/src/main/drivers/system_stm32f10x.c
@@ -28,7 +28,7 @@
 #define AIRCR_VECTKEY_MASK    ((uint32_t)0x05FA0000)
 
 // from system_stm32f10x.c
-void SetSysClock(bool overclock);
+void SetSysClock(void);
 
 void systemReset(void)
 {
@@ -70,7 +70,7 @@ void systemInit(void)
 {
     checkForBootLoaderRequest();
 
-    SetSysClock(false);
+    SetSysClock();
 
 #ifdef CC3D
     /* Accounts for OP Bootloader, set the Vector Table base address as specified in .ld file */

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -49,6 +49,8 @@
 #include "drivers/sonar_hcsr04.h"
 #include "drivers/sdcard.h"
 #include "drivers/gyro_sync.h"
+#include "drivers/io.h"
+#include "drivers/exti.h"
 
 #include "rx/rx.h"
 
@@ -167,13 +169,6 @@ void init(void)
     // initialize IO (needed for all IO operations)
     IOInitGlobal();
 
-#ifdef STM32F303
-    // start fpu
-    SCB->CPACR = (0x3 << (10*2)) | (0x3 << (11*2));
-#endif
-
-    SetSysClock();
-
     i2cSetOverclock(masterConfig.i2c_overclock);
 
 #ifdef USE_HARDWARE_REVISION_DETECTION
@@ -189,6 +184,10 @@ void init(void)
     ledInit(hardwareRevision == AFF3_REV_1 ? false : true);
 #else
     ledInit(false);
+#endif
+
+#ifdef USE_EXTI
+    EXTIInit();
 #endif
 
 #ifdef SPEKTRUM_BIND

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -83,9 +83,9 @@
 #define GYRO_MPU6500_ALIGN      CW0_DEG
 
 #define ACC
-#define USE_ACC_ADXL345
-#define USE_ACC_BMA280
-#define USE_ACC_MMA8452
+//#define USE_ACC_ADXL345
+//#define USE_ACC_BMA280
+//#define USE_ACC_MMA8452
 #define USE_ACC_MPU6050
 #define USE_ACC_MPU6500
 #define USE_ACC_SPI_MPU6500
@@ -97,7 +97,7 @@
 #define ACC_MPU6500_ALIGN       CW0_DEG
 
 #define BARO
-//#define USE_BARO_MS5611
+#define USE_BARO_MS5611
 #define USE_BARO_BMP085
 #define USE_BARO_BMP280
 


### PR DESCRIPTION
1. Add missing call to `EXTIInit()`
2. Remove duplicated call to `SetSysClock()`
3. Remove duplicated FPU init on F3 targets
4. Re-enable MS5611 baro on NAZE target

Fixes #425
