### PR TITLE
Rename ref protocol to inav. Tidied function names.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ COMMON_SRC = \
             rx/msp.c \
             rx/nrf24.c \
             rx/nrf24_cx10.c \
-            rx/nrf24_ref.c \
+            rx/nrf24_inav.c \
             rx/nrf24_h8_3d.c \
             rx/nrf24_syma.c \
             rx/nrf24_v202.c \

--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #define ARRAYLEN(x) (sizeof(x) / sizeof((x)[0]))
+#define ARRAYEND(x) (&(x)[ARRAYLEN(x)])
 
 #define CONCAT_HELPER(x,y) x ## y
 #define CONCAT(x,y) CONCAT_HELPER(x, y)

--- a/src/main/drivers/rx_nrf24l01.h
+++ b/src/main/drivers/rx_nrf24l01.h
@@ -88,6 +88,13 @@ enum {
     NRF24L01_17_FIFO_STATUS_RX_FULL     = 1,
     NRF24L01_17_FIFO_STATUS_RX_EMPTY    = 0,
 
+    NRF24L01_1C_DYNPD_DPL_P5            = 5,
+    NRF24L01_1C_DYNPD_DPL_P4            = 4,
+    NRF24L01_1C_DYNPD_DPL_P3            = 3,
+    NRF24L01_1C_DYNPD_DPL_P2            = 2,
+    NRF24L01_1C_DYNPD_DPL_P1            = 1,
+    NRF24L01_1C_DYNPD_DPL_P0            = 0,
+
     NRF24L01_1D_FEATURE_EN_DPL          = 2,
     NRF24L01_1D_FEATURE_EN_ACK_PAY      = 1,
     NRF24L01_1D_FEATURE_EN_DYN_ACK      = 0,
@@ -116,6 +123,16 @@ enum {
     NRF24L01_1C_DYNPD_ALL_PIPES         = 0x3F,
 };
 
+// Pipes
+enum {
+    NRF24L01_PIPE0 = 0,
+    NRF24L01_PIPE1 = 1,
+    NRF24L01_PIPE2 = 2,
+    NRF24L01_PIPE3 = 3,
+    NRF24L01_PIPE4 = 4,
+    NRF24L01_PIPE5 = 5
+};
+
 typedef enum {
     NFR24L01_SOFTSPI,
     NFR24L01_SPI,
@@ -125,10 +142,11 @@ void NRF24L01_SpiInit(nfr24l01_spi_type_e spiType);
 void NRF24L01_Initialize(uint8_t baseConfig);
 uint8_t NRF24L01_WriteReg(uint8_t reg, uint8_t data);
 uint8_t NRF24L01_WriteRegisterMulti(uint8_t reg, const uint8_t *data, uint8_t length);
-uint8_t NRF24L01_WritePayload(const uint8_t *data, uint8_t len);
+uint8_t NRF24L01_WritePayload(const uint8_t *data, uint8_t length);
+uint8_t NRF24L01_WriteAckPayload(const uint8_t *data, uint8_t length, uint8_t pipe);
 uint8_t NRF24L01_ReadReg(uint8_t reg);
 uint8_t NRF24L01_ReadRegisterMulti(uint8_t reg, uint8_t *data, uint8_t length);
-uint8_t NRF24L01_ReadPayload(uint8_t *data, uint8_t len);
+uint8_t NRF24L01_ReadPayload(uint8_t *data, uint8_t length);
 
 void NRF24L01_FlushTx(void);
 void NRF24L01_FlushRx(void);
@@ -136,7 +154,7 @@ void NRF24L01_FlushRx(void);
 
 // Utility functions
 
-void NRF24L01_Setup(void);
+void NRF24L01_SetupBasic(void);
 void NRF24L01_SetStandbyMode(void);
 void NRF24L01_SetRxMode(void);
 void NRF24L01_SetTxMode(void);

--- a/src/main/rx/nrf24.c
+++ b/src/main/rx/nrf24.c
@@ -30,7 +30,7 @@
 #include "rx/nrf24_syma.h"
 #include "rx/nrf24_v202.h"
 #include "rx/nrf24_h8_3d.h"
-#include "rx/nrf24_ref.h"
+#include "rx/nrf24_inav.h"
 
 
 uint16_t nrf24RcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
@@ -64,39 +64,39 @@ STATIC_UNIT_TESTED bool rxNrf24SetProtocol(nrf24_protocol_t protocol)
 #ifdef USE_RX_V202
     case NRF24RX_V202_250K:
     case NRF24RX_V202_1M:
-        protocolInit = v202Init;
-        protocolDataReceived = v202DataReceived;
-        protocolSetRcDataFromPayload = v202SetRcDataFromPayload;
+        protocolInit = v202Nrf24Init;
+        protocolDataReceived = v202Nrf24DataReceived;
+        protocolSetRcDataFromPayload = v202Nrf24SetRcDataFromPayload;
         break;
 #endif
 #ifdef USE_RX_SYMA
     case NRF24RX_SYMA_X:
     case NRF24RX_SYMA_X5C:
-        protocolInit = symaInit;
-        protocolDataReceived = symaDataReceived;
-        protocolSetRcDataFromPayload = symaSetRcDataFromPayload;
+        protocolInit = symaNrf24Init;
+        protocolDataReceived = symaNrf24DataReceived;
+        protocolSetRcDataFromPayload = symaNrf24SetRcDataFromPayload;
         break;
 #endif
 #ifdef USE_RX_CX10
     case NRF24RX_CX10:
     case NRF24RX_CX10A:
-        protocolInit = cx10Init;
-        protocolDataReceived = cx10DataReceived;
-        protocolSetRcDataFromPayload = cx10SetRcDataFromPayload;
+        protocolInit = cx10Nrf24Init;
+        protocolDataReceived = cx10Nrf24DataReceived;
+        protocolSetRcDataFromPayload = cx10Nrf24SetRcDataFromPayload;
         break;
 #endif
 #ifdef USE_RX_H8_3D
     case NRF24RX_H8_3D:
-        protocolInit = h8_3dInit;
-        protocolDataReceived = h8_3dDataReceived;
-        protocolSetRcDataFromPayload = h8_3dSetRcDataFromPayload;
+        protocolInit = h8_3dNrf24Init;
+        protocolDataReceived = h8_3dNrf24DataReceived;
+        protocolSetRcDataFromPayload = h8_3dNrf24SetRcDataFromPayload;
         break;
 #endif
-#ifdef USE_RX_REF
-    case NRF24RX_REF:
-        protocolInit = refInit;
-        protocolDataReceived = refDataReceived;
-        protocolSetRcDataFromPayload = refSetRcDataFromPayload;
+#ifdef USE_RX_INAV
+    case NRF24RX_INAV:
+        protocolInit = inavNrf24Init;
+        protocolDataReceived = inavNrf24DataReceived;
+        protocolSetRcDataFromPayload = inavNrf24SetRcDataFromPayload;
         break;
 #endif
     }

--- a/src/main/rx/nrf24.h
+++ b/src/main/rx/nrf24.h
@@ -30,7 +30,7 @@ typedef enum {
     NRF24RX_CX10,
     NRF24RX_CX10A,
     NRF24RX_H8_3D,
-    NRF24RX_REF,
+    NRF24RX_INAV,
     NRF24RX_PROTOCOL_COUNT
 } nrf24_protocol_t;
 
@@ -68,7 +68,9 @@ typedef enum {
 #define RC_CHANNEL_PICTURE     NRF24_AUX3
 #define RC_CHANNEL_VIDEO       NRF24_AUX4
 #define RC_CHANNEL_HEADLESS    NRF24_AUX5
-#define RC_CHANNEL_RTH         NRF24_AUX6
+#define RC_CHANNEL_RTH         NRF24_AUX6 // return to home
 
 bool rxNrf24DataReceived(void);
-bool rxNrf24Init(nfr24l01_spi_type_e spiType, const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcReadRawDataPtr *callback);
+struct rxConfig_s;
+struct rxRuntimeConfig_s;
+bool rxNrf24Init(nfr24l01_spi_type_e spiType, const struct rxConfig_s *rxConfig, struct rxRuntimeConfig_s *rxRuntimeConfig, rcReadRawDataPtr *callback);

--- a/src/main/rx/nrf24_cx10.c
+++ b/src/main/rx/nrf24_cx10.c
@@ -125,7 +125,7 @@ STATIC_UNIT_TESTED uint16_t cx10ConvertToPwmUnsigned(const uint8_t *pVal)
     return ret;
 }
 
-void cx10SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload)
+void cx10Nrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload)
 {
     const uint8_t offset = (cx10Protocol == NRF24RX_CX10) ? 0 : 4;
     rcData[NRF24_ROLL] = (PWM_RANGE_MAX + PWM_RANGE_MIN) - cx10ConvertToPwmUnsigned(&payload[5 + offset]);  // aileron
@@ -194,7 +194,7 @@ static bool cx10ReadPayloadIfAvailable(uint8_t *payload)
  * This is called periodically by the scheduler.
  * Returns NRF24_RECEIVED_DATA if a data packet was received.
  */
-nrf24_received_t cx10DataReceived(uint8_t *payload)
+nrf24_received_t cx10Nrf24DataReceived(uint8_t *payload)
 {
     static uint8_t ackCount;
     nrf24_received_t ret = NRF24_RECEIVED_NONE;
@@ -268,7 +268,7 @@ nrf24_received_t cx10DataReceived(uint8_t *payload)
     return ret;
 }
 
-void cx10Nrf24Init(nrf24_protocol_t protocol)
+static void cx10Nrf24Setup(nrf24_protocol_t protocol)
 {
     cx10Protocol = protocol;
     protocolState = STATE_BIND;
@@ -276,7 +276,7 @@ void cx10Nrf24Init(nrf24_protocol_t protocol)
     hopTimeout = (protocol == NRF24RX_CX10) ? CX10_PROTOCOL_HOP_TIMEOUT : CX10A_PROTOCOL_HOP_TIMEOUT;
 
     NRF24L01_Initialize(0); // sets PWR_UP, no CRC
-    NRF24L01_Setup();
+    NRF24L01_SetupBasic();
 
     NRF24L01_SetChannel(CX10_RF_BIND_CHANNEL);
 
@@ -291,10 +291,10 @@ void cx10Nrf24Init(nrf24_protocol_t protocol)
     NRF24L01_SetRxMode(); // enter receive mode to start listening for packets
 }
 
-void cx10Init(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+void cx10Nrf24Init(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     rxRuntimeConfig->channelCount = RC_CHANNEL_COUNT;
-    cx10Nrf24Init((nrf24_protocol_t)rxConfig->nrf24rx_protocol);
+    cx10Nrf24Setup((nrf24_protocol_t)rxConfig->nrf24rx_protocol);
 }
 #endif
 

--- a/src/main/rx/nrf24_cx10.h
+++ b/src/main/rx/nrf24_cx10.h
@@ -20,7 +20,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void cx10Init(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
-void cx10SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
-nrf24_received_t cx10DataReceived(uint8_t *payload);
+struct rxConfig_s;
+struct rxRuntimeConfig_s;
+void cx10Nrf24Init(const struct rxConfig_s *rxConfig, struct rxRuntimeConfig_s *rxRuntimeConfig);
+void cx10Nrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
+nrf24_received_t cx10Nrf24DataReceived(uint8_t *payload);
 

--- a/src/main/rx/nrf24_h8_3d.h
+++ b/src/main/rx/nrf24_h8_3d.h
@@ -20,6 +20,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void h8_3dInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
-void h8_3dSetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
-nrf24_received_t h8_3dDataReceived(uint8_t *payload);
+struct rxConfig_s;
+struct rxRuntimeConfig_s;
+void h8_3dNrf24Init(const struct rxConfig_s *rxConfig, struct rxRuntimeConfig_s *rxRuntimeConfig);
+void h8_3dNrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
+nrf24_received_t h8_3dNrf24DataReceived(uint8_t *payload);

--- a/src/main/rx/nrf24_inav.h
+++ b/src/main/rx/nrf24_inav.h
@@ -20,7 +20,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void refInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
-void refSetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
-nrf24_received_t refDataReceived(uint8_t *payload);
+struct rxConfig_s;
+struct rxRuntimeConfig_s;
+void inavNrf24Init(const struct rxConfig_s *rxConfig, struct rxRuntimeConfig_s *rxRuntimeConfig);
+void inavNrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
+nrf24_received_t inavNrf24DataReceived(uint8_t *payload);
 

--- a/src/main/rx/nrf24_syma.c
+++ b/src/main/rx/nrf24_syma.c
@@ -156,7 +156,7 @@ STATIC_UNIT_TESTED uint16_t symaConvertToPwmSigned(uint8_t val)
     return (uint16_t)(PWM_RANGE_MIDDLE + ret);
 }
 
-void symaSetRcDataFromPayload(uint16_t *rcData, const uint8_t *packet)
+void symaNrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *packet)
 {
     rcData[NRF24_THROTTLE] = symaConvertToPwmUnsigned(packet[0]); // throttle
     rcData[NRF24_ROLL] = symaConvertToPwmSigned(packet[3]); // aileron
@@ -200,7 +200,7 @@ static void symaHopToNextChannel(void)
 }
 
 // The SymaX hopping channels are determined by the low bits of rxTxAddress
-void setSymaXHoppingChannels(uint32_t addr)
+static void setSymaXHoppingChannels(uint32_t addr)
 {
     addr = addr & 0x1f;
     if (addr == 0x06) {
@@ -221,7 +221,7 @@ void setSymaXHoppingChannels(uint32_t addr)
     }
 }
 
-void symaSetBound(const uint8_t* rxTxAddr)
+static void symaSetBound(const uint8_t* rxTxAddr)
 {
     protocolState = STATE_DATA;
     // using protocol NRF24L01_SYMA_X, since NRF24L01_SYMA_X5C went straight into data mode
@@ -239,7 +239,7 @@ void symaSetBound(const uint8_t* rxTxAddr)
  * This is called periodically by the scheduler.
  * Returns NRF24_RECEIVED_DATA if a data packet was received.
  */
-nrf24_received_t symaDataReceived(uint8_t *payload)
+nrf24_received_t symaNrf24DataReceived(uint8_t *payload)
 {
     nrf24_received_t ret = NRF24_RECEIVED_NONE;
     uint32_t timeNowUs;
@@ -268,7 +268,7 @@ nrf24_received_t symaDataReceived(uint8_t *payload)
     return ret;
 }
 
-void symaNrf24Init(nrf24_protocol_t protocol)
+static void symaNrf24Setup(nrf24_protocol_t protocol)
 {
     symaProtocol = protocol;
     NRF24L01_Initialize(BV(NRF24L01_00_CONFIG_EN_CRC) | BV( NRF24L01_00_CONFIG_CRCO)); // sets PWR_UP, EN_CRC, CRCO - 2 byte CRC
@@ -302,10 +302,10 @@ void symaNrf24Init(nrf24_protocol_t protocol)
     NRF24L01_SetRxMode(); // enter receive mode to start listening for packets
 }
 
-void symaInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+void symaNrf24Init(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     rxRuntimeConfig->channelCount = RC_CHANNEL_COUNT;
-    symaNrf24Init((nrf24_protocol_t)rxConfig->nrf24rx_protocol);
+    symaNrf24Setup((nrf24_protocol_t)rxConfig->nrf24rx_protocol);
 }
 #endif
 

--- a/src/main/rx/nrf24_syma.h
+++ b/src/main/rx/nrf24_syma.h
@@ -20,7 +20,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void symaInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
-void symaSetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
-nrf24_received_t symaDataReceived(uint8_t *payload);
+struct rxConfig_s;
+struct rxRuntimeConfig_s;
+void symaNrf24Init(const struct rxConfig_s *rxConfig, struct rxRuntimeConfig_s *rxRuntimeConfig);
+void symaNrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
+nrf24_received_t symaNrf24DataReceived(uint8_t *payload);
 

--- a/src/main/rx/nrf24_v202.c
+++ b/src/main/rx/nrf24_v202.c
@@ -98,7 +98,7 @@ STATIC_UNIT_TESTED uint8_t txid[TXIDSIZE];
 static uint32_t rx_timeout;
 extern uint16_t nrf24RcData[];
 
-const unsigned char v2x2_channelindex[] = {NRF24_THROTTLE,NRF24_YAW,NRF24_PITCH,NRF24_ROLL,
+static const unsigned char v2x2_channelindex[] = {NRF24_THROTTLE,NRF24_YAW,NRF24_PITCH,NRF24_ROLL,
         NRF24_AUX1,NRF24_AUX2,NRF24_AUX3,NRF24_AUX4,NRF24_AUX5,NRF24_AUX6,NRF24_AUX7};
 
 static void prepare_to_bind(void)
@@ -116,7 +116,7 @@ static void switch_channel(void)
     if (++rf_ch_num >= V2X2_NFREQCHANNELS) rf_ch_num = 0;
 }
 
-void v2x2_set_tx_id(uint8_t *id)
+static void v2x2_set_tx_id(uint8_t *id)
 {
     uint8_t sum;
     txid[0] = id[0];
@@ -183,14 +183,14 @@ static nrf24_received_t decode_packet(uint8_t *packet)
     return NRF24_RECEIVED_DATA;
 }
 
-void v202SetRcDataFromPayload(uint16_t *rcData, const uint8_t *packet)
+void v202Nrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *packet)
 {
     UNUSED(rcData);
     UNUSED(packet);
     // Ideally the decoding of the packet should be moved into here, to reduce the overhead of v202DataReceived function.
 }
 
-nrf24_received_t readrx(uint8_t *packet)
+static nrf24_received_t readrx(uint8_t *packet)
 {
     if (!(NRF24L01_ReadReg(NRF24L01_07_STATUS) & BV(NRF24L01_07_STATUS_RX_DR))) {
         uint32_t t = micros() - packet_timer;
@@ -213,12 +213,12 @@ nrf24_received_t readrx(uint8_t *packet)
  * This is called periodically by the scheduler.
  * Returns NRF24_RECEIVED_DATA if a data packet was received.
  */
-nrf24_received_t v202DataReceived(uint8_t *packet)
+nrf24_received_t v202Nrf24DataReceived(uint8_t *packet)
 {
     return readrx(packet);
 }
 
-void v202Nrf24Init(nrf24_protocol_t protocol)
+static void v202Nrf24Setup(nrf24_protocol_t protocol)
 {
     NRF24L01_Initialize(BV(NRF24L01_00_CONFIG_EN_CRC) | BV(NRF24L01_00_CONFIG_CRCO)); // 2-bytes CRC
 
@@ -249,10 +249,10 @@ void v202Nrf24Init(nrf24_protocol_t protocol)
     NRF24L01_SetRxMode(); // enter receive mode to start listening for packets
 }
 
-void v202Init(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+void v202Nrf24Init(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     rxRuntimeConfig->channelCount = V2X2_RC_CHANNEL_COUNT;
-    v202Nrf24Init((nrf24_protocol_t)rxConfig->nrf24rx_protocol);
+    v202Nrf24Setup((nrf24_protocol_t)rxConfig->nrf24rx_protocol);
 }
 
 #endif

--- a/src/main/rx/nrf24_v202.h
+++ b/src/main/rx/nrf24_v202.h
@@ -20,6 +20,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void v202Init(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
-nrf24_received_t v202DataReceived(uint8_t *payload);
-void v202SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
+struct rxConfig_s;
+struct rxRuntimeConfig_s;
+void v202Nrf24Init(const struct rxConfig_s *rxConfig, struct rxRuntimeConfig_s *rxRuntimeConfig);
+nrf24_received_t v202Nrf24DataReceived(uint8_t *payload);
+void v202Nrf24SetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);


### PR DESCRIPTION
Renamed the reference protocol to be the iNav protocol.

Minor tidy of function names.
