### PR TITLE
Converted ltm telemetry to use streambuf serialisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,7 @@ COMMON_SRC = \
             common/maths.c \
             common/printf.c \
             common/typeconversion.c \
+            common/streambuf.c \
             config/config.c \
             config/runtime_config.c \
             drivers/adc.c \

--- a/src/main/common/streambuf.c
+++ b/src/main/common/streambuf.c
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+#include <stdint.h>
+
+#include "streambuf.h"
+
+void sbufWriteU8(sbuf_t *dst, uint8_t val)
+{
+    *dst->ptr++ = val;
+}
+
+void sbufWriteU16(sbuf_t *dst, uint16_t val)
+{
+    sbufWriteU8(dst, val >> 0);
+    sbufWriteU8(dst, val >> 8);
+}
+
+void sbufWriteU32(sbuf_t *dst, uint32_t val)
+{
+    sbufWriteU8(dst, val >> 0);
+    sbufWriteU8(dst, val >> 8);
+    sbufWriteU8(dst, val >> 16);
+    sbufWriteU8(dst, val >> 24);
+}
+
+void sbufWriteData(sbuf_t *dst, const void *data, int len)
+{
+    memcpy(dst->ptr, data, len);
+    dst->ptr += len;
+}
+
+void sbufWriteString(sbuf_t *dst, const char *string)
+{
+    sbufWriteData(dst, string, strlen(string));
+}
+
+uint8_t sbufReadU8(sbuf_t *src)
+{
+    return *src->ptr++;
+}
+
+uint16_t sbufReadU16(sbuf_t *src)
+{
+    uint16_t ret;
+    ret = sbufReadU8(src);
+    ret |= sbufReadU8(src) << 8;
+    return ret;
+}
+
+uint32_t sbufReadU32(sbuf_t *src)
+{
+    uint32_t ret;
+    ret = sbufReadU8(src);
+    ret |= sbufReadU8(src) <<  8;
+    ret |= sbufReadU8(src) << 16;
+    ret |= sbufReadU8(src) << 24;
+    return ret;
+}
+
+void sbufReadData(sbuf_t *src, void *data, int len)
+{
+    memcpy(data, src->ptr, len);
+}
+
+// reader - return bytes remaining in buffer
+// writer - return available space
+int sbufBytesRemaining(sbuf_t *buf)
+{
+    return buf->end - buf->ptr;
+}
+
+uint8_t* sbufPtr(sbuf_t *buf)
+{
+    return buf->ptr;
+}
+
+// advance buffer pointer
+// reader - skip data
+// writer - commit written data
+void sbufAdvance(sbuf_t *buf, int size)
+{
+    buf->ptr += size;
+}
+
+// modifies streambuf so that written data are prepared for reading
+void sbufSwitchToReader(sbuf_t *buf, uint8_t *base)
+{
+    buf->end = buf->ptr;
+    buf->ptr = base;
+}

--- a/src/main/common/streambuf.h
+++ b/src/main/common/streambuf.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+// simple buffer-based serializer/deserializer without implicit size check
+// little-endian encoding implemneted now
+
+typedef struct sbuf_s {
+    uint8_t *ptr;          // data pointer must be first (sbuff_t* is equivalent to uint8_t **)
+    uint8_t *end;
+} sbuf_t;
+
+void sbufWriteU8(sbuf_t *dst, uint8_t val);
+void sbufWriteU16(sbuf_t *dst, uint16_t val);
+void sbufWriteU32(sbuf_t *dst, uint32_t val);
+void sbufWriteData(sbuf_t *dst, const void *data, int len);
+void sbufWriteString(sbuf_t *dst, const char *string);
+
+uint8_t sbufReadU8(sbuf_t *src);
+uint16_t sbufReadU16(sbuf_t *src);
+uint32_t sbufReadU32(sbuf_t *src);
+void sbufReadData(sbuf_t *dst, void *data, int len);
+
+int sbufBytesRemaining(sbuf_t *buf);
+uint8_t* sbufPtr(sbuf_t *buf);
+void sbufAdvance(sbuf_t *buf, int size);
+
+void sbufSwitchToReader(sbuf_t *buf, uint8_t * base);

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -95,8 +95,8 @@ static void ltm_initialise_packet(sbuf_t *dst)
     dst->ptr = ltmPayload;
     dst->end = ARRAYEND(ltmPayload);
 
-    serialWrite(ltmPort, '$');
-    serialWrite(ltmPort, 'T');
+    sbufWriteU8(dst, '$');
+    sbufWriteU8(dst, 'T');
 }
 
 static void ltm_serialise_8(sbuf_t *dst, uint8_t v)
@@ -123,9 +123,9 @@ static void ltm_serialise_32(sbuf_t *dst, uint32_t v)
 
 static void ltm_finalise(sbuf_t *dst)
 {
+    sbufWriteU8(dst, ltm_crc);
     sbufSwitchToReader(dst, ltmPayload);
     serialWriteBuf(ltmPort, sbufPtr(dst), sbufBytesRemaining(dst));
-    serialWrite(ltmPort, ltm_crc);
 }
 
 #if defined(GPS)

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -157,7 +157,7 @@ void ltm_gframe(sbuf_t *dst)
     ltm_alt = sensors(SENSOR_GPS) ? gpsSol.llh.alt : 0; // cm
 #endif
 
-    ltm_serialise_8(dst, 'G');
+    sbufWriteU8(dst, 'G');
     ltm_serialise_32(dst, ltm_lat);
     ltm_serialise_32(dst, ltm_lon);
     ltm_serialise_8(dst, (uint8_t)ltm_gs);
@@ -203,7 +203,7 @@ void ltm_sframe(sbuf_t *dst)
     uint8_t lt_statemode = (ARMING_FLAG(ARMED)) ? 1 : 0;
     if (failsafeIsActive())
         lt_statemode |= 2;
-    ltm_serialise_8(dst, 'S');
+    sbufWriteU8(dst, 'S');
     ltm_serialise_16(dst, vbat * 100);    //vbat converted to mv
     ltm_serialise_16(dst, 0);             //  current, not implemented
     ltm_serialise_8(dst, (uint8_t)((rssi * 254) / 1023));        // scaled RSSI (uchar)
@@ -217,7 +217,7 @@ void ltm_sframe(sbuf_t *dst)
  */
 void ltm_aframe(sbuf_t *dst)
 {
-    ltm_serialise_8(dst, 'A');
+    sbufWriteU8(dst, 'A');
     ltm_serialise_16(dst, DECIDEGREES_TO_DEGREES(attitude.values.pitch));
     ltm_serialise_16(dst, DECIDEGREES_TO_DEGREES(attitude.values.roll));
     ltm_serialise_16(dst, DECIDEGREES_TO_DEGREES(attitude.values.yaw));
@@ -231,7 +231,7 @@ void ltm_aframe(sbuf_t *dst)
  */
 void ltm_oframe(sbuf_t *dst)
 {
-    ltm_serialise_8(dst, 'O');
+    sbufWriteU8(dst, 'O');
     ltm_serialise_32(dst, GPS_home.lat);
     ltm_serialise_32(dst, GPS_home.lon);
     ltm_serialise_32(dst, GPS_home.alt);
@@ -245,7 +245,7 @@ void ltm_oframe(sbuf_t *dst)
  */
 void ltm_xframe(sbuf_t *dst)
 {
-    ltm_serialise_8(dst, 'X');
+    sbufWriteU8(dst, 'X');
     ltm_serialise_16(dst, gpsSol.hdop);
     ltm_serialise_8(dst, 0);
     ltm_serialise_8(dst, 0);
@@ -259,7 +259,7 @@ void ltm_xframe(sbuf_t *dst)
  */
 void ltm_nframe(sbuf_t *dst)
 {
-    ltm_serialise_8(dst, 'N');
+    sbufWriteU8(dst, 'N');
     ltm_serialise_8(dst, NAV_Status.mode);
     ltm_serialise_8(dst, NAV_Status.state);
     ltm_serialise_8(dst, NAV_Status.activeWpAction);

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -18,7 +18,7 @@
 /*
  * LightTelemetry from KipK
  *
- * Minimal one way telemetry protocol for really bitrates (1200/2400 bauds).
+ * Minimal one way telemetry protocol for really low bitrates (1200/2400 bauds).
  * Effective for ground OSD, groundstation HUD and Antenna tracker
  * http://www.wedontneednasa.com/2014/02/lighttelemetry-v2-en-route-to-ground-osd.html
  *
@@ -33,13 +33,15 @@
 
 #include "platform.h"
 
-#include "build_config.h"
-
 #if defined(TELEMETRY_LTM)
+
+#include "build_config.h"
 
 #include "common/maths.h"
 #include "common/axis.h"
 #include "common/color.h"
+#include "common/streambuf.h"
+#include "common/utils.h"
 
 #include "drivers/system.h"
 #include "drivers/sensor.h"
@@ -85,39 +87,44 @@ static telemetryConfig_t *telemetryConfig;
 static bool ltmEnabled;
 static portSharing_e ltmPortSharing;
 static uint8_t ltm_crc;
+static uint8_t ltmPayload[LTM_MAX_MESSAGE_SIZE];
 
-static void ltm_initialise_packet(uint8_t ltm_id)
+static void ltm_initialise_packet(sbuf_t *dst)
 {
     ltm_crc = 0;
+    dst->ptr = ltmPayload;
+    dst->end = ARRAYEND(ltmPayload);
+
     serialWrite(ltmPort, '$');
     serialWrite(ltmPort, 'T');
-    serialWrite(ltmPort, ltm_id);
 }
 
-static void ltm_serialise_8(uint8_t v)
+static void ltm_serialise_8(sbuf_t *dst, uint8_t v)
 {
-    serialWrite(ltmPort, v);
+    sbufWriteU8(dst, v);
     ltm_crc ^= v;
 }
 
-static void ltm_serialise_16(uint16_t v)
+static void ltm_serialise_16(sbuf_t *dst, uint16_t v)
 {
-    ltm_serialise_8((uint8_t)v);
-    ltm_serialise_8((v >> 8));
+    ltm_serialise_8(dst, (uint8_t)v);
+    ltm_serialise_8(dst,  (v >> 8));
 }
 
 #if defined(GPS)
-static void ltm_serialise_32(uint32_t v)
+static void ltm_serialise_32(sbuf_t *dst, uint32_t v)
 {
-    ltm_serialise_8((uint8_t)v);
-    ltm_serialise_8((v >> 8));
-    ltm_serialise_8((v >> 16));
-    ltm_serialise_8((v >> 24));
+    ltm_serialise_8(dst, (uint8_t)v);
+    ltm_serialise_8(dst, (v >> 8));
+    ltm_serialise_8(dst, (v >> 16));
+    ltm_serialise_8(dst, (v >> 24));
 }
 #endif
 
-static void ltm_finalise(void)
+static void ltm_finalise(sbuf_t *dst)
 {
+    sbufSwitchToReader(dst, ltmPayload);
+    serialWriteBuf(ltmPort, sbufPtr(dst), sbufBytesRemaining(dst));
     serialWrite(ltmPort, ltm_crc);
 }
 
@@ -126,7 +133,7 @@ static void ltm_finalise(void)
  * GPS G-frame 5Hhz at > 2400 baud
  * LAT LON SPD ALT SAT/FIX
  */
-static void ltm_gframe(void)
+void ltm_gframe(sbuf_t *dst)
 {
     uint8_t gps_fix_type = 0;
     int32_t ltm_lat = 0, ltm_lon = 0, ltm_alt = 0, ltm_gs = 0;
@@ -150,13 +157,12 @@ static void ltm_gframe(void)
     ltm_alt = sensors(SENSOR_GPS) ? gpsSol.llh.alt : 0; // cm
 #endif
 
-    ltm_initialise_packet('G');
-    ltm_serialise_32(ltm_lat);
-    ltm_serialise_32(ltm_lon);
-    ltm_serialise_8((uint8_t)ltm_gs);
-    ltm_serialise_32(ltm_alt);
-    ltm_serialise_8((gpsSol.numSat << 2) | gps_fix_type);
-    ltm_finalise();
+    ltm_serialise_8(dst, 'G');
+    ltm_serialise_32(dst, ltm_lat);
+    ltm_serialise_32(dst, ltm_lon);
+    ltm_serialise_8(dst, (uint8_t)ltm_gs);
+    ltm_serialise_32(dst, ltm_alt);
+    ltm_serialise_8(dst, (gpsSol.numSat << 2) | gps_fix_type);
 }
 #endif
 
@@ -171,10 +177,10 @@ static void ltm_gframe(void)
  *     15: LAND, 16:FlybyWireA, 17: FlybywireB, 18: Cruise, 19: Unknown
  */
 
-static void ltm_sframe(void)
+void ltm_sframe(sbuf_t *dst)
 {
     uint8_t lt_flightmode;
-    uint8_t lt_statemode;
+
     if (FLIGHT_MODE(PASSTHRU_MODE))
         lt_flightmode = 0;
     else if (FLIGHT_MODE(NAV_WP_MODE))
@@ -194,29 +200,27 @@ static void ltm_sframe(void)
     else
         lt_flightmode = 1;      // Rate mode
 
-    lt_statemode = (ARMING_FLAG(ARMED)) ? 1 : 0;
+    uint8_t lt_statemode = (ARMING_FLAG(ARMED)) ? 1 : 0;
     if (failsafeIsActive())
         lt_statemode |= 2;
-    ltm_initialise_packet('S');
-    ltm_serialise_16(vbat * 100);    //vbat converted to mv
-    ltm_serialise_16(0);             //  current, not implemented
-    ltm_serialise_8((uint8_t)((rssi * 254) / 1023));        // scaled RSSI (uchar)
-    ltm_serialise_8(0);              // no airspeed
-    ltm_serialise_8((lt_flightmode << 2) | lt_statemode);
-    ltm_finalise();
+    ltm_serialise_8(dst, 'S');
+    ltm_serialise_16(dst, vbat * 100);    //vbat converted to mv
+    ltm_serialise_16(dst, 0);             //  current, not implemented
+    ltm_serialise_8(dst, (uint8_t)((rssi * 254) / 1023));        // scaled RSSI (uchar)
+    ltm_serialise_8(dst, 0);              // no airspeed
+    ltm_serialise_8(dst, (lt_flightmode << 2) | lt_statemode);
 }
 
 /*
  * Attitude A-frame - 10 Hz at > 2400 baud
  *  PITCH ROLL HEADING
  */
-static void ltm_aframe()
+void ltm_aframe(sbuf_t *dst)
 {
-    ltm_initialise_packet('A');
-    ltm_serialise_16(DECIDEGREES_TO_DEGREES(attitude.values.pitch));
-    ltm_serialise_16(DECIDEGREES_TO_DEGREES(attitude.values.roll));
-    ltm_serialise_16(DECIDEGREES_TO_DEGREES(attitude.values.yaw));
-    ltm_finalise();
+    ltm_serialise_8(dst, 'A');
+    ltm_serialise_16(dst, DECIDEGREES_TO_DEGREES(attitude.values.pitch));
+    ltm_serialise_16(dst, DECIDEGREES_TO_DEGREES(attitude.values.roll));
+    ltm_serialise_16(dst, DECIDEGREES_TO_DEGREES(attitude.values.yaw));
 }
 
 #if defined(GPS)
@@ -225,46 +229,43 @@ static void ltm_aframe()
  *  This frame will be ignored by Ghettostation, but processed by GhettOSD if it is used as standalone onboard OSD
  *  home pos, home alt, direction to home
  */
-static void ltm_oframe()
+void ltm_oframe(sbuf_t *dst)
 {
-    ltm_initialise_packet('O');
-    ltm_serialise_32(GPS_home.lat);
-    ltm_serialise_32(GPS_home.lon);
-    ltm_serialise_32(GPS_home.alt);
-    ltm_serialise_8(1);                 // OSD always ON
-    ltm_serialise_8(STATE(GPS_FIX_HOME) ? 1 : 0);
-    ltm_finalise();
+    ltm_serialise_8(dst, 'O');
+    ltm_serialise_32(dst, GPS_home.lat);
+    ltm_serialise_32(dst, GPS_home.lon);
+    ltm_serialise_32(dst, GPS_home.alt);
+    ltm_serialise_8(dst, 1);                 // OSD always ON
+    ltm_serialise_8(dst, STATE(GPS_FIX_HOME) ? 1 : 0);
 }
 
 /*
  * Extended information data frame, 1 Hz rate
  *  This frame is intended to report extended GPS and NAV data, however at the moment it contains only HDOP value
  */
-static void ltm_xframe()
+void ltm_xframe(sbuf_t *dst)
 {
-    ltm_initialise_packet('X');
-    ltm_serialise_16(gpsSol.hdop);
-    ltm_serialise_8(0);
-    ltm_serialise_8(0);
-    ltm_serialise_8(0);
-    ltm_serialise_8(0);
-    ltm_finalise();
+    ltm_serialise_8(dst, 'X');
+    ltm_serialise_16(dst, gpsSol.hdop);
+    ltm_serialise_8(dst, 0);
+    ltm_serialise_8(dst, 0);
+    ltm_serialise_8(dst, 0);
+    ltm_serialise_8(dst, 0);
 }
 #endif
 
 #if defined(NAV)
 /** OSD additional data frame, ~4 Hz rate, navigation system status
  */
-static void ltm_nframe(void)
+void ltm_nframe(sbuf_t *dst)
 {
-    ltm_initialise_packet('N');
-    ltm_serialise_8(NAV_Status.mode);
-    ltm_serialise_8(NAV_Status.state);
-    ltm_serialise_8(NAV_Status.activeWpAction);
-    ltm_serialise_8(NAV_Status.activeWpNumber);
-    ltm_serialise_8(NAV_Status.error);
-    ltm_serialise_8(NAV_Status.flags);
-    ltm_finalise();
+    ltm_serialise_8(dst, 'N');
+    ltm_serialise_8(dst, NAV_Status.mode);
+    ltm_serialise_8(dst, NAV_Status.state);
+    ltm_serialise_8(dst, NAV_Status.activeWpAction);
+    ltm_serialise_8(dst, NAV_Status.activeWpNumber);
+    ltm_serialise_8(dst, NAV_Status.error);
+    ltm_serialise_8(dst, NAV_Status.flags);
 }
 #endif
 
@@ -304,29 +305,50 @@ static uint8_t ltm_schedule[10] = {
 
 static void process_ltm(void)
 {
-    static uint8_t ltm_scheduler;
+    static uint8_t ltm_scheduler = 0;
     uint8_t current_schedule = ltm_schedule[ltm_scheduler];
 
-    if (current_schedule & LTM_BIT_AFRAME)
-        ltm_aframe();
+    sbuf_t ltmPayloadBuf;
+    sbuf_t *dst = &ltmPayloadBuf;
+
+    if (current_schedule & LTM_BIT_AFRAME) {
+        ltm_initialise_packet(dst);
+        ltm_aframe(dst);
+        ltm_finalise(dst);
+    }
 
 #if defined(GPS)
-    if (current_schedule & LTM_BIT_GFRAME)
-        ltm_gframe();
+    if (current_schedule & LTM_BIT_GFRAME) {
+        ltm_initialise_packet(dst);
+        ltm_gframe(dst);
+        ltm_finalise(dst);
+    }
 
-    if (current_schedule & LTM_BIT_OFRAME)
-        ltm_oframe();
+    if (current_schedule & LTM_BIT_OFRAME) {
+        ltm_initialise_packet(dst);
+        ltm_oframe(dst);
+        ltm_finalise(dst);
+    }
 
-    if (current_schedule & LTM_BIT_XFRAME && ltm_shouldSendXFrame())
-        ltm_xframe();
+    if (current_schedule & LTM_BIT_XFRAME && ltm_shouldSendXFrame()) {
+        ltm_initialise_packet(dst);
+        ltm_xframe(dst);
+        ltm_finalise(dst);
+    }
 #endif
 
-    if (current_schedule & LTM_BIT_SFRAME)
-        ltm_sframe();
+    if (current_schedule & LTM_BIT_SFRAME) {
+        ltm_initialise_packet(dst);
+        ltm_sframe(dst);
+        ltm_finalise(dst);
+    }
 
 #if defined(NAV)
-    if (current_schedule & LTM_BIT_NFRAME)
-        ltm_nframe();
+    if (current_schedule & LTM_BIT_NFRAME) {
+        ltm_initialise_packet(dst);
+        ltm_nframe(dst);
+        ltm_finalise(dst);
+    }
 #endif
 
     ltm_scheduler = (ltm_scheduler + 1) % 10;

--- a/src/main/telemetry/ltm.h
+++ b/src/main/telemetry/ltm.h
@@ -17,14 +17,47 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TELEMETRY_LTM_H_
-#define TELEMETRY_LTM_H_
+#pragma once
 
-void initLtmTelemetry(telemetryConfig_t *initialTelemetryConfig);
+struct telemetryConfig_s;
+void initLtmTelemetry(struct telemetryConfig_s *initialTelemetryConfig);
 void handleLtmTelemetry(void);
 void checkLtmTelemetryState(void);
 
 void freeLtmTelemetryPort(void);
 void configureLtmTelemetryPort(void);
 
-#endif /* TELEMETRY_LTM_H_ */
+typedef enum {
+    LTM_FRAME_START = 0,
+    LTM_AFRAME = LTM_FRAME_START, // Attitude Frame
+    LTM_SFRAME, // Status Frame
+#if defined(GPS)
+    LTM_GFRAME, // GPS Frame
+    LTM_OFRAME, // Origin Frame
+    LTM_XFRAME, // Extended information data frame
+#endif
+#if defined(NAV)
+    LTM_NFRAME, // Navigation Frame (inav extension)
+#endif
+    LTM_FRAME_COUNT
+} ltm_frame_e;
+
+// payload size does not include the '$T' header, the frame type byte or the checksum byte
+#define LTM_GFRAME_PAYLOAD_SIZE 14
+#define LTM_AFRAME_PAYLOAD_SIZE  6
+#define LTM_SFRAME_PAYLOAD_SIZE  7
+#define LTM_OFRAME_PAYLOAD_SIZE 14
+#define LTM_NFRAME_PAYLOAD_SIZE  6
+#define LTM_XFRAME_PAYLOAD_SIZE  6
+
+#define LTM_MAX_PAYLOAD_SIZE 14
+#define LTM_MAX_MESSAGE_SIZE (LTM_MAX_PAYLOAD_SIZE+4)
+
+struct sbuf_s;
+void ltm_gframe(struct sbuf_s *dst);
+void ltm_sframe(struct sbuf_s *dst);
+void ltm_aframe(struct sbuf_s *dst);
+void ltm_oframe(struct sbuf_s *dst);
+void ltm_xframe(struct sbuf_s *dst);
+void ltm_nframe(struct sbuf_s *dst);
+


### PR DESCRIPTION
@digitalentity , I've converted the LTM telemetry to use `streambuf`s.

The reason for this is so that the serialisation code can be reused to implement telemetry for the iNav NRF24 protocol.

`streambuf`s will be added for parameter groups, so there will be no ROM overhead in using them once parameter groups are implemented.

I'm fairly confident that the code works, but I don't have any means to test it. Can you test it?

@DzikuVx , I'm not sure what setup you have, but if you could find time to test this, it would be great.
