### PR TITLE
Added BLUEJAYF4 target

### DIFF
--- a/src/main/target/BLUEJAYF4/config.c
+++ b/src/main/target/BLUEJAYF4/config.c
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "build/build_config.h"
+
+#include "blackbox/blackbox_io.h"
+
+#include "common/color.h"
+#include "common/axis.h"
+#include "common/filter.h"
+
+#include "drivers/sensor.h"
+#include "drivers/accgyro.h"
+#include "drivers/compass.h"
+#include "drivers/system.h"
+#include "drivers/timer.h"
+#include "drivers/pwm_rx.h"
+#include "drivers/serial.h"
+#include "drivers/pwm_output.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+
+#include "sensors/sensors.h"
+#include "sensors/gyro.h"
+#include "sensors/compass.h"
+#include "sensors/acceleration.h"
+#include "sensors/barometer.h"
+#include "sensors/boardalignment.h"
+#include "sensors/battery.h"
+
+#include "io/beeper.h"
+#include "io/serial.h"
+#include "io/gimbal.h"
+#include "io/escservo.h"
+#include "fc/rc_controls.h"
+#include "fc/rc_curves.h"
+#include "io/ledstrip.h"
+#include "io/gps.h"
+
+#include "rx/rx.h"
+
+#include "telemetry/telemetry.h"
+
+#include "flight/mixer.h"
+#include "flight/pid.h"
+#include "flight/failsafe.h"
+
+#include "fc/runtime_config.h"
+
+#include "config/config.h"
+
+#include "config/config_profile.h"
+#include "config/config_master.h"
+
+#include "hardware_revision.h"
+
+// alternative defaults settings for BlueJayF4 targets
+void targetConfiguration(void) 
+{
+    if (hardwareRevision == BJF4_REV1 || hardwareRevision == BJF4_REV2) {
+        masterConfig.sensorAlignmentConfig.gyro_align = CW180_DEG;
+        masterConfig.sensorAlignmentConfig.acc_align  = CW180_DEG;
+    }
+}

--- a/src/main/target/BLUEJAYF4/hardware_revision.c
+++ b/src/main/target/BLUEJAYF4/hardware_revision.c
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "platform.h"
+
+#include "build/build_config.h"
+
+#include "drivers/system.h"
+#include "drivers/bus_spi.h"
+#include "drivers/io.h"
+#include "drivers/flash_m25p16.h"
+#include "hardware_revision.h"
+
+static const char * const hardwareRevisionNames[] = {
+    "Unknown",
+    "BlueJay rev1",
+    "BlueJay rev2",
+    "BlueJay rev3",
+    "BlueJay rev3a"
+};
+
+uint8_t hardwareRevision = UNKNOWN;
+
+void detectHardwareRevision(void)
+{
+    IO_t pin1 = IOGetByTag(IO_TAG(PB12));
+    IOInit(pin1, OWNER_SYSTEM, RESOURCE_INPUT, 1);
+    IOConfigGPIO(pin1, IOCFG_IPU);
+
+    IO_t pin2 = IOGetByTag(IO_TAG(PB13));
+    IOInit(pin2, OWNER_SYSTEM, RESOURCE_INPUT, 2);
+    IOConfigGPIO(pin2, IOCFG_IPU);
+
+    // Check hardware revision
+    delayMicroseconds(10);  // allow configuration to settle
+
+    /* 
+        if both PB12 and 13 are tied to GND then it is Rev3A (mini)
+        if only PB12 is tied to GND then it is a Rev3 (full size) 
+    */
+    if (!IORead(pin1)) {
+        if (!IORead(pin2)) {
+            hardwareRevision = BJF4_REV3A;
+        }
+        hardwareRevision = BJF4_REV3;
+    }
+
+    if (hardwareRevision == UNKNOWN) {
+        hardwareRevision = BJF4_REV2;
+        return;
+    }
+    
+    /* 
+        enable the UART1 inversion PC9
+        
+        TODO: once param groups are in place, inverter outputs
+        can be moved to be simple IO outputs, and merely set them
+        HI or LO in configuration.
+    */
+    IO_t uart1invert = IOGetByTag(IO_TAG(PC9));
+    IOInit(uart1invert, OWNER_INVERTER, RESOURCE_OUTPUT, 2);
+    IOConfigGPIO(uart1invert, IOCFG_AF_PP);
+    IOLo(uart1invert);    
+}
+
+void updateHardwareRevision(void)
+{
+    if (hardwareRevision != BJF4_REV2) {
+        return;
+    }
+    
+    /* 
+        if flash exists on PB3 then Rev1
+    */
+    if (m25p16_init(IO_TAG(PB3))) {
+        hardwareRevision = BJF4_REV1;
+    } else {
+        IOInit(IOGetByTag(IO_TAG(PB3)), OWNER_FREE, RESOURCE_NONE, 0);
+    }
+}
+
+

--- a/src/main/target/BLUEJAYF4/hardware_revision.h
+++ b/src/main/target/BLUEJAYF4/hardware_revision.h
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+typedef enum bjf4HardwareRevision_t {
+    UNKNOWN = 0,
+    BJF4_REV1,  // Flash
+    BJF4_REV2,  // SDCard
+    BJF4_REV3,  // SDCard + Flash
+    BJF4_REV3A, // Flash (20x20 mini format)
+} bjf4HardwareRevision_e;
+
+extern uint8_t hardwareRevision;
+
+void updateHardwareRevision(void);
+void detectHardwareRevision(void);

--- a/src/main/target/BLUEJAYF4/target.c
+++ b/src/main/target/BLUEJAYF4/target.c
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+const uint16_t multiPPM[] = {
+    PWM1  | (MAP_TO_PPM_INPUT << 8),     // PPM input
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const uint16_t multiPWM[] = {
+    PWM1  | (MAP_TO_PWM_INPUT << 8),
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT  << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT  << 8),
+    0xFFFF
+};
+
+const uint16_t airPPM[] = {
+    PWM1  | (MAP_TO_PPM_INPUT << 8),      // PPM input
+    PWM2  | (MAP_TO_MOTOR_OUTPUT  << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT  << 8),
+    PWM4  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM5  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM6  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM7  | (MAP_TO_SERVO_OUTPUT  << 8),
+    0xFFFF
+};
+
+const uint16_t airPWM[] = {
+    PWM1  | (MAP_TO_PWM_INPUT << 8),
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT  << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT  << 8),
+    0xFFFF
+};
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    { TIM8, IO_TAG(PC7), TIM_Channel_2, TIM8_CC_IRQn,       0, IOCFG_IPD,    GPIO_AF_TIM8 }, // PPM IN
+    { TIM5, IO_TAG(PA0), TIM_Channel_1, TIM5_IRQn,          1, IOCFG_AF_PP,  GPIO_AF_TIM5 }, // S1_OUT
+    { TIM5, IO_TAG(PA1), TIM_Channel_2, TIM5_IRQn,          1, IOCFG_AF_PP,  GPIO_AF_TIM5 }, // S2_OUT
+    { TIM2, IO_TAG(PA2), TIM_Channel_3, TIM2_IRQn,          1, IOCFG_AF_PP,  GPIO_AF_TIM2 }, // S3_OUT
+    { TIM9, IO_TAG(PA3), TIM_Channel_2, TIM1_BRK_TIM9_IRQn, 1, IOCFG_AF_PP,  GPIO_AF_TIM9 }, // S4_OUT
+    { TIM3, IO_TAG(PB1), TIM_Channel_4, TIM3_IRQn,          1, IOCFG_AF_PP,  GPIO_AF_TIM3 }, // S5_OUT
+    { TIM3, IO_TAG(PB0), TIM_Channel_3, TIM3_IRQn,          1, IOCFG_AF_PP,  GPIO_AF_TIM3 }, // S6_OUT
+};
+

--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -1,0 +1,174 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#define TARGET_BOARD_IDENTIFIER "BJF4"
+#define TARGET_CONFIG
+
+#define CONFIG_START_FLASH_ADDRESS (0x08080000) //0x08080000 to 0x080A0000 (FLASH_Sector_8)
+
+#define USBD_PRODUCT_STRING     "BlueJayF4"
+
+#define USE_HARDWARE_REVISION_DETECTION
+#define HW_PIN                  PB2
+
+#define BOARD_HAS_VOLTAGE_DIVIDER
+#define USE_EXTI
+
+#define LED0                    PB6
+#define LED1                    PB5
+#define LED2                    PB4
+
+#define BEEPER                  PC1
+#define BEEPER_OPT              PB7
+#define BEEPER_INVERTED
+
+#define INVERTER                PB15
+#define INVERTER_USART          USART6
+
+// MPU6500 interrupt
+//#define DEBUG_MPU_DATA_READY_INTERRUPT
+#define USE_MPU_DATA_READY_SIGNAL
+#define ENSURE_MPU_DATA_READY_IS_LOW
+//#define EXTI_CALLBACK_HANDLER_COUNT 1 // MPU data ready
+#define MPU_INT_EXTI PC5
+#define MPU6500_CS_PIN          PC4
+#define MPU6500_SPI_INSTANCE    SPI1
+
+#define ACC
+#define USE_ACC_MPU6500
+#define USE_ACC_SPI_MPU6500
+#define ACC_MPU6500_ALIGN       CW0_DEG
+
+#define GYRO
+#define USE_GYRO_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define GYRO_MPU6500_ALIGN      CW0_DEG
+
+//#define MAG
+//#define USE_MAG_AK8963
+
+#define BARO
+#define USE_BARO_MS5611
+#define MS5611_I2C_INSTANCE     I2CDEV_1
+
+#define USE_SDCARD
+
+#define SDCARD_DETECT_INVERTED
+
+#define SDCARD_DETECT_PIN                   PD2
+#define SDCARD_SPI_INSTANCE                 SPI3
+#define SDCARD_SPI_CS_PIN                   PA15
+
+// SPI2 is on the APB1 bus whose clock runs at 84MHz. Divide to under 400kHz for init:
+#define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 256 // 328kHz
+// Divide to under 25MHz for normal operation:
+#define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER     4 // 21MHz
+
+#define SDCARD_DMA_CHANNEL_TX               DMA1_Stream5
+#define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG DMA_FLAG_TCIF5
+#define SDCARD_DMA_CLK                      RCC_AHB1Periph_DMA1
+#define SDCARD_DMA_CHANNEL                  DMA_Channel_0
+
+// Performance logging for SD card operations:
+// #define AFATFS_USE_INTROSPECTIVE_LOGGING
+
+#define M25P16_CS_PIN           PB7
+#define M25P16_SPI_INSTANCE     SPI3
+
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+
+#define USE_VCP
+//#define VBUS_SENSING_PIN PA8
+//#define VBUS_SENSING_ENABLED
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define USE_SOFTSERIAL1
+#define SERIAL_PORT_COUNT       5
+
+#define SOFTSERIAL_1_TIMER      TIM3
+#define SOFTSERIAL_1_TIMER_RX_HARDWARE 4 // PWM 5
+#define SOFTSERIAL_1_TIMER_TX_HARDWARE 5 // PWM 6
+
+
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_HARDWARE 0
+
+#define USE_SPI
+
+#define USE_SPI_DEVICE_1
+#define SPI1_NSS_PIN            PC4
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_SPI_DEVICE_3
+#define SPI3_NSS_PIN            PB3
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PC12
+
+#define USE_I2C
+#define I2C_DEVICE              (I2CDEV_1)
+#define USE_I2C_PULLUP
+
+#define USE_ADC
+#define VBAT_ADC_PIN            PC3
+
+#define LED_STRIP
+// LED Strip can run off Pin 6 (PB1) of the ESC outputs.
+#define WS2811_PIN                      PB1
+#define WS2811_TIMER                    TIM3
+#define WS2811_TIMER_CHANNEL            TIM_Channel_4
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST2_HANDLER
+#define WS2811_DMA_STREAM               DMA1_Stream2
+#define WS2811_DMA_FLAG                 DMA_FLAG_TCIF2
+#define WS2811_DMA_IT                   DMA_IT_TCIF2
+#define WS2811_DMA_CHANNEL              DMA_Channel_5
+#define WS2811_DMA_IRQ                  DMA1_Stream2_IRQn
+
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_PPM
+#define DEFAULT_FEATURES        FEATURE_BLACKBOX
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define SPEKTRUM_BIND
+#define BIND_PIN                PB11
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define USABLE_TIMER_CHANNEL_COUNT 7
+#define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(8) | TIM_N(9))
+

--- a/src/main/target/BLUEJAYF4/target.mk
+++ b/src/main/target/BLUEJAYF4/target.mk
@@ -1,0 +1,10 @@
+F405_TARGETS    += $(TARGET)
+FEATURES        += SDCARD VCP ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro_spi_mpu6500.c \
+            drivers/accgyro_mpu6500.c \
+            drivers/barometer_ms5611.c \
+            drivers/light_ws2811strip.c \
+            drivers/light_ws2811strip_stm32f4xx.c
+


### PR DESCRIPTION
I actually have one of these boards, so I can test it. This works, or at least it connects to the iNav configuration and shows sensor output. Not built into a quad, so no motor outputs etc tested.

So more testing required, but this shows we have at least a working F4 target.

Target files are just copied over from betaflight, with a minor edit of the `config.c` file.

@blckmn , I think you'd like to know that iNav is now ported to BLUEJAYF4.
