### PR TITLE
Increase GPIO speed to 50MHz for I2C pins

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -53,19 +53,23 @@ static void i2cUnstick(IO_t scl, IO_t sda);
 #ifndef I2C1_SDA
 #define I2C1_SDA PB9
 #endif
+
 #else
+
 #ifndef I2C1_SCL
 #define I2C1_SCL PB6
 #endif
 #ifndef I2C1_SDA
 #define I2C1_SDA PB7
 #endif
+#define IOCFG_I2C   IO_CONFIG(GPIO_Mode_AF_OD, GPIO_Speed_50MHz)
 
 #endif
 
 #ifndef I2C2_SCL
 #define I2C2_SCL PB10
 #endif
+
 #ifndef I2C2_SDA
 #define I2C2_SDA PB11
 #endif
@@ -414,8 +418,8 @@ void i2cInit(I2CDevice device)
     IOConfigGPIOAF(scl, IOCFG_I2C, GPIO_AF_I2C);
     IOConfigGPIOAF(sda, IOCFG_I2C, GPIO_AF_I2C);
 #else
-    IOConfigGPIO(scl, IOCFG_AF_OD);
-    IOConfigGPIO(sda, IOCFG_AF_OD);
+    IOConfigGPIO(scl, IOCFG_I2C);
+    IOConfigGPIO(sda, IOCFG_I2C);
 #endif
 
     I2C_DeInit(i2c->dev);

--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -30,9 +30,9 @@
 #ifndef SOFT_I2C
 
 #if defined(USE_I2C_PULLUP)
-#define IOCFG_I2C IO_CONFIG(GPIO_Mode_AF, 0, GPIO_OType_OD, GPIO_PuPd_UP)
+#define IOCFG_I2C IO_CONFIG(GPIO_Mode_AF, GPIO_Speed_50MHz, GPIO_OType_OD, GPIO_PuPd_UP)
 #else
-#define IOCFG_I2C IOCFG_AF_OD
+#define IOCFG_I2C IO_CONFIG(GPIO_Mode_AF, GPIO_Speed_50MHz, GPIO_OType_OD, GPIO_PuPd_NOPULL)
 #endif
 
 #define I2C_HIGHSPEED_TIMING  0x00500E30  // 1000 Khz, 72Mhz Clock, Analog Filter Delay ON, Setup 40, Hold 4.


### PR DESCRIPTION
With new IO drivers SCL and SDA pins are initialised as IOCFG_AF_OD. 
On both F1 and F3 boards this result in GPIO port output speed register being set to zero (2MHz clock).
Prioir to new IO I2C pins were clocked at 50MHz and this PR sets it back to 50MHz.
