### PR TITLE
import cleanflight fix for SPRF3-EVO servo

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -242,6 +242,12 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
             }
 #endif
 
+#if defined(SPRACINGF3EVO)
+            // remap PWM6+7 as servos
+            if ((timerIndex == PWM8 || timerIndex == PWM9) && timerHardwarePtr->tim == TIM3)
+                type = MAP_TO_SERVO_OUTPUT;
+#endif
+
 #if (defined(STM32F3DISCOVERY) && !defined(CHEBUZZF3))
             // remap PWM 5+6 or 9+10 as servos - softserial pin pairs require timer ports that use the same timer
             if (init->useSoftSerial) {


### PR DESCRIPTION
Adds servo support to SPRF3 EVO. Bench tested. 

Same as https://github.com/cleanflight/cleanflight/pull/2252
