### PR TITLE
SDCard & I2C bugfixes

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -680,6 +680,8 @@ static void writeIntraframe(void)
     blackboxHistory[2] = blackboxHistory[0];
     //And advance the current state over to a blank space ready to be filled
     blackboxHistory[0] = ((blackboxHistory[0] - blackboxHistoryRing + 1) % 3) + blackboxHistoryRing;
+
+    blackboxLoggedAnyFrames = true;
 }
 
 static void blackboxWriteMainStateArrayUsingAveragePredictor(int arrOffsetInHistory, int count)
@@ -831,6 +833,8 @@ static void writeInterframe(void)
     blackboxHistory[2] = blackboxHistory[1];
     blackboxHistory[1] = blackboxHistory[0];
     blackboxHistory[0] = ((blackboxHistory[0] - blackboxHistoryRing + 1) % 3) + blackboxHistoryRing;
+
+    blackboxLoggedAnyFrames = true;
 }
 
 /* Write the contents of the global "slowHistory" to the log as an "S" frame. Because this data is logged so

--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -65,6 +65,11 @@ static i2cDevice_t i2cHardwareMap[] = {
     { .dev = I2C2, .scl = IO_TAG(I2C2_SCL), .sda = IO_TAG(I2C2_SDA), .rcc = RCC_APB1(I2C2), .overClock = I2C2_OVERCLOCK }
 };
 
+static bool deviceInitialised[] = {
+    false,
+    false
+};
+
 static bool i2cOverClock;
 
 void i2cSetOverclock(uint8_t overClock)
@@ -90,7 +95,7 @@ void i2cInit(I2CDevice device)
 
     I2C_TypeDef *I2Cx;
     I2Cx = i2c->dev;
-  
+
     IO_t scl = IOGetByTag(i2c->scl);
     IO_t sda = IOGetByTag(i2c->sda);
 
@@ -116,8 +121,10 @@ void i2cInit(I2CDevice device)
     I2C_Init(I2Cx, &i2cInit);
 
     I2C_StretchClockCmd(I2Cx, ENABLE);
- 
+
     I2C_Cmd(I2Cx, ENABLE);
+
+    deviceInitialised[device] = true;
 }
 
 uint16_t i2cGetErrorCounter(void)
@@ -127,6 +134,9 @@ uint16_t i2cGetErrorCounter(void)
 
 bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data)
 {
+    if (!deviceInitialised[device])
+        return false;
+
     addr_ <<= 1;
 
     I2C_TypeDef *I2Cx;
@@ -193,6 +203,9 @@ bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data)
 
 bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf)
 {
+    if (!deviceInitialised[device])
+        return false;
+
     addr_ <<= 1;
 
     I2C_TypeDef *I2Cx;

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -123,9 +123,16 @@ void spiInitDevice(SPIDevice device)
     IOInit(IOGetByTag(spi->mosi), OWNER_SPI, RESOURCE_SPI_MOSI, device + 1);
 
 #if defined(STM32F3) || defined(STM32F4)
-    IOConfigGPIOAF(IOGetByTag(spi->sck),  SPI_IO_AF_CFG, spi->af);
-    IOConfigGPIOAF(IOGetByTag(spi->miso), SPI_IO_AF_CFG, spi->af);
-    IOConfigGPIOAF(IOGetByTag(spi->mosi), SPI_IO_AF_CFG, spi->af);
+    if (spi->sdcard || spi->nrf24l01) {
+        IOConfigGPIOAF(IOGetByTag(spi->sck),  SPI_IO_AF_SCK_CFG, spi->af);
+        IOConfigGPIOAF(IOGetByTag(spi->miso), SPI_IO_AF_MISO_CFG, spi->af);
+        IOConfigGPIOAF(IOGetByTag(spi->mosi), SPI_IO_AF_CFG, spi->af);
+    }
+    else {
+        IOConfigGPIOAF(IOGetByTag(spi->sck),  SPI_IO_AF_CFG, spi->af);
+        IOConfigGPIOAF(IOGetByTag(spi->miso), SPI_IO_AF_CFG, spi->af);
+        IOConfigGPIOAF(IOGetByTag(spi->mosi), SPI_IO_AF_CFG, spi->af);
+    }
 
     if (spi->nss) {
         IOConfigGPIOAF(IOGetByTag(spi->nss), SPI_IO_CS_CFG, spi->af);

--- a/src/main/drivers/dma.c
+++ b/src/main/drivers/dma.c
@@ -69,6 +69,21 @@ void dmaInit(void)
     // TODO: Do we need this?
 }
 
+#ifdef STM32F4
+dmaHandlerIdentifier_e dmaFindHandlerIdentifier(DMA_Stream_TypeDef* stream)
+{
+    dmaHandlerIdentifier_e i;
+
+    for (i = 0; i < (sizeof(dmaDescriptors) / sizeof(dmaDescriptors[0])); i++) {
+        if (stream == dmaDescriptors[i].stream) {
+            return i;
+        }
+    }
+
+    // Shouldn't get here
+    return 0;
+}
+#else
 dmaHandlerIdentifier_e dmaFindHandlerIdentifier(DMA_Channel_TypeDef* channel)
 {
     dmaHandlerIdentifier_e i;
@@ -82,6 +97,7 @@ dmaHandlerIdentifier_e dmaFindHandlerIdentifier(DMA_Channel_TypeDef* channel)
     // Shouldn't get here
     return 0;
 }
+#endif
 
 void dmaEnableClock(dmaHandlerIdentifier_e identifier)
 {

--- a/src/main/drivers/dma.c
+++ b/src/main/drivers/dma.c
@@ -69,11 +69,31 @@ void dmaInit(void)
     // TODO: Do we need this?
 }
 
+dmaHandlerIdentifier_e dmaFindHandlerIdentifier(DMA_Channel_TypeDef* channel)
+{
+    dmaHandlerIdentifier_e i;
+
+    for (i = 0; i < (sizeof(dmaDescriptors) / sizeof(dmaDescriptors[0])); i++) {
+        if (channel == dmaDescriptors[i].channel) {
+            return i;
+        }
+    }
+
+    // Shouldn't get here
+    return 0;
+}
+
+void dmaEnableClock(dmaHandlerIdentifier_e identifier)
+{
+    RCC_AHBPeriphClockCmd(dmaDescriptors[identifier].rcc, ENABLE);
+}
+
 void dmaSetHandler(dmaHandlerIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
 {
     NVIC_InitTypeDef NVIC_InitStructure;
 
-    RCC_AHBPeriphClockCmd(dmaDescriptors[identifier].rcc, ENABLE);
+    dmaEnableClock(identifier);
+
     dmaDescriptors[identifier].irqHandlerCallback = callback;
     dmaDescriptors[identifier].userParam = userParam;
 

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -108,8 +108,13 @@ typedef struct dmaChannelDescriptor_s {
 
 #endif
 
-void dmaInit(void);
+#ifdef STM32F4
+dmaHandlerIdentifier_e dmaFindHandlerIdentifier(DMA_Stream_TypeDef* stream);
+#else
 dmaHandlerIdentifier_e dmaFindHandlerIdentifier(DMA_Channel_TypeDef* channel);
+#endif
+
+void dmaInit(void);
 void dmaEnableClock(dmaHandlerIdentifier_e identifier);
 void dmaSetHandler(dmaHandlerIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam);
 

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -109,5 +109,7 @@ typedef struct dmaChannelDescriptor_s {
 #endif
 
 void dmaInit(void);
+dmaHandlerIdentifier_e dmaFindHandlerIdentifier(DMA_Channel_TypeDef* channel);
+void dmaEnableClock(dmaHandlerIdentifier_e identifier);
 void dmaSetHandler(dmaHandlerIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam);
 

--- a/src/main/drivers/sdcard.c
+++ b/src/main/drivers/sdcard.c
@@ -24,12 +24,15 @@
 
 #include "nvic.h"
 #include "io.h"
+#include "dma.h"
 
 #include "bus_spi.h"
 #include "system.h"
 
 #include "sdcard.h"
 #include "sdcard_standard.h"
+
+#include "build/debug.h"
 
 #ifdef AFATFS_USE_INTROSPECTIVE_LOGGING
     #define SDCARD_PROFILING
@@ -414,9 +417,6 @@ static void sdcard_sendDataBlockBegin(uint8_t *buffer, bool multiBlockWrite)
     if (useDMAForTx) {
 #ifdef SDCARD_DMA_CHANNEL_TX
         // Queue the transmission of the sector payload
-#ifdef SDCARD_DMA_CLK
-        RCC_AHB1PeriphClockCmd(SDCARD_DMA_CLK, ENABLE);
-#endif
         DMA_InitTypeDef DMA_InitStructure;
 
         DMA_StructInit(&DMA_InitStructure);
@@ -544,6 +544,8 @@ void sdcard_init(bool useDMA)
 {
 #ifdef SDCARD_DMA_CHANNEL_TX
     useDMAForTx = useDMA;
+    dmaEnableClock(dmaFindHandlerIdentifier(SDCARD_DMA_CHANNEL_TX));
+    DMA_Cmd(SDCARD_DMA_CHANNEL_TX, DISABLE);
 #else
     // DMA is not available
     (void) useDMA;


### PR DESCRIPTION
1. Fix uninitialised I2C usage on F3
2. Fix incorrect SPI pullup init when using SDCard
3. Fix DMA clock not being enabled for SDCard
4. Fix Blackbox deleting the file after finishing the log

Closes #507
