### PR TITLE
Change baro detect order to prevent MS5611 misdetection

### DIFF
--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -506,14 +506,6 @@ static bool detectBaro(baroSensor_e baroHardwareToUse)
         case BARO_DEFAULT:
             ; // fallthough
 
-        case BARO_MS5611:
-#ifdef USE_BARO_MS5611
-            if (ms5611Detect(&baro)) {
-                baroHardware = BARO_MS5611;
-                break;
-            }
-#endif
-            ; // fallthough
         case BARO_BMP085:
 #ifdef USE_BARO_BMP085
             if (bmp085Detect(bmp085Config, &baro)) {
@@ -522,6 +514,14 @@ static bool detectBaro(baroSensor_e baroHardwareToUse)
             }
 #endif
         ; // fallthough
+        case BARO_MS5611:
+#ifdef USE_BARO_MS5611
+            if (ms5611Detect(&baro)) {
+                baroHardware = BARO_MS5611;
+                break;
+            }
+#endif
+            ; // fallthough
         case BARO_BMP280:
 #ifdef USE_BARO_BMP280
             if (bmp280Detect(&baro)) {


### PR DESCRIPTION
Probe BMP085/BMP180 before MS5611, because BMP085 can be misdetected as a MS5611. 
https://github.com/betaflight/betaflight/pull/1101
