### PR TITLE
I2C bus fixes for F1 and F4 targets

### DIFF
--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -51,6 +51,7 @@ typedef struct i2cDevice_s {
 typedef struct i2cState_s {
     volatile bool initialised;
     volatile bool error;
+    volatile bool unstick;
     volatile bool busy;
     volatile uint8_t addr;
     volatile uint8_t reg;

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -51,7 +51,7 @@ typedef struct i2cDevice_s {
 typedef struct i2cState_s {
     volatile bool initialised;
     volatile bool error;
-    volatile bool unstick;
+    volatile bool busError;
     volatile bool busy;
     volatile uint8_t addr;
     volatile uint8_t reg;

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -19,6 +19,7 @@
 
 #define I2C1_OVERCLOCK false
 #define I2C2_OVERCLOCK false
+#define USE_I2C_PULLUP          // Enable built-in pullups on all boards in case external ones are too week
 
 #define USE_SERVOS
 #define SERIAL_RX


### PR DESCRIPTION
9ff56d3 introduced very aggressive error handling, even a NAK (a normal bus event) was treated as a bus error and resulted in "unstick" procedute. Additionally, unstick was only clocking out 8 bits, while in most cases it should be 9 (8 bit data and ACK/NAK) and clock was followed by an empty trasnaction (START-STOP with no clock).

 Some of chips were stunned by these events and stopped responding to normal transactions - #665. Compass errors might be related as well - #632 (CC3D), #594 (NAZE)
