### PR TITLE
Adding spracing F3 mini

### DIFF
--- a/src/main/target/SPRACINGF3MINI/target.c
+++ b/src/main/target/SPRACINGF3MINI/target.c
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+const uint16_t multiPPM[] = {
+    PWM1  | (MAP_TO_PPM_INPUT    << 8),  // PPM input
+
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM11 | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const uint16_t multiPWM[] = {
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM11 | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const uint16_t airPPM[] = {
+    PWM1  | (MAP_TO_PPM_INPUT << 8),     // PPM input
+    PWM2  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #1
+    PWM3  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #2
+    PWM4  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #1
+    PWM5  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM6  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM7  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM8  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM9  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM10 | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM11 | (MAP_TO_SERVO_OUTPUT  << 8), // servo #8
+    0xFFFF
+};
+
+const uint16_t airPWM[] = {
+    PWM2  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #1
+    PWM3  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #2
+    PWM4  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #1
+    PWM5  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM6  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM7  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM8  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM9  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM10 | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM11 | (MAP_TO_SERVO_OUTPUT  << 8), // servo #8
+    0xFFFF
+};
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    // PPM Pad
+#ifdef SPRACINGF3MINI_MKII_REVA
+    { TIM3,  IO_TAG(PB5),  TIM_Channel_2, TIM3_IRQn,               0, IOCFG_AF_PP, GPIO_AF_2 }, // PPM - PB5
+    // PB4 / TIM3 CH1 is connected to USBPresent
+#else
+    { TIM3,  IO_TAG(PB4),  TIM_Channel_1, TIM3_IRQn,               0, IOCFG_AF_PP, GPIO_AF_2 }, // PPM - PB4
+    // PB5 / TIM3 CH2 is connected to USBPresent
+#endif
+
+    { TIM16, IO_TAG(PA6),  TIM_Channel_1, TIM1_UP_TIM16_IRQn,      1, IOCFG_AF_PP, GPIO_AF_1 },  // PWM1 - PA6
+    { TIM17, IO_TAG(PA7),  TIM_Channel_1, TIM1_TRG_COM_TIM17_IRQn, 1, IOCFG_AF_PP, GPIO_AF_1 },  // PWM2 - PA7
+    { TIM4,  IO_TAG(PB8),  TIM_Channel_3, TIM4_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2 },  // PWM3 - PB8
+    { TIM4,  IO_TAG(PB9),  TIM_Channel_4, TIM4_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2 },  // PWM4 - PB9
+    { TIM15, IO_TAG(PA2),  TIM_Channel_1, TIM1_BRK_TIM15_IRQn,     1, IOCFG_AF_PP, GPIO_AF_9 },  // PWM5 - PA2
+    { TIM15, IO_TAG(PA3),  TIM_Channel_2, TIM1_BRK_TIM15_IRQn,     1, IOCFG_AF_PP, GPIO_AF_9 },  // PWM6 - PA3
+    { TIM2,  IO_TAG(PA0),  TIM_Channel_1, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1 },  // PWM7 - PA0
+    { TIM2,  IO_TAG(PA1),  TIM_Channel_2, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1 },  // PWM8 - PA1
+
+    // UART3 RX/TX
+    { TIM2,  IO_TAG(PB10), TIM_Channel_3, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1 }, // PWM9  - PB10 - TIM2_CH3 / UART3_TX (AF7)
+    { TIM2,  IO_TAG(PB11), TIM_Channel_4, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1 }, // PWM10 - PB11 - TIM2_CH4 / UART3_RX (AF7)
+
+    // LED Strip Pad
+    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM1_CC_IRQn,            1, IOCFG_AF_PP, GPIO_AF_6 },  // GPIO_TIMER / LED_STRIP
+};
+

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -28,9 +28,6 @@
 #define BEEPER                  PC15
 #define BEEPER_INVERTED
 
-#define USE_EXTI
-#define MPU_INT_EXTI            PC13
-#define EXTI15_10_CALLBACK_HANDLER_COUNT 2 // MPU_INT, SDCardDetect
 #define USE_MPU_DATA_READY_SIGNAL
 #define ENSURE_MPU_DATA_READY_IS_LOW
 

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -1,0 +1,184 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "SRFM"
+
+
+// early prototype had slightly different pin mappings.
+//#define SPRACINGF3MINI_MKII_REVA
+
+#define LED0                    PB3
+
+#define BEEPER                  PC15
+#define BEEPER_INVERTED
+
+#define USE_EXTI
+#define MPU_INT_EXTI            PC13
+#define EXTI15_10_CALLBACK_HANDLER_COUNT 2 // MPU_INT, SDCardDetect
+#define USE_MPU_DATA_READY_SIGNAL
+#define ENSURE_MPU_DATA_READY_IS_LOW
+
+#define USE_MAG_DATA_READY_SIGNAL
+#define ENSURE_MAG_DATA_READY_IS_HIGH
+
+#define GYRO
+//#define USE_FAKE_GYRO
+#define USE_GYRO_MPU6500
+#define GYRO_MPU6500_ALIGN      CW180_DEG
+
+#define ACC
+//#define USE_FAKE_ACC
+#define USE_ACC_MPU6500
+#define ACC_MPU6500_ALIGN       CW180_DEG
+
+#define BARO
+#define USE_BARO_BMP280
+
+#define MAG
+#define USE_MPU9250_MAG // Enables bypass configuration
+#define USE_MAG_AK8975
+#define USE_MAG_HMC5883 // External
+#define MAG_AK8975_ALIGN        CW90_DEG_FLIP
+
+#define SONAR
+#define SONAR_ECHO_PIN          PB1
+#define SONAR_TRIGGER_PIN       PB0
+
+#define USB_IO
+#define USB_CABLE_DETECTION
+
+#define USB_DETECT_PIN          PB5
+
+#define USE_VCP
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_SOFTSERIAL1
+#define SERIAL_PORT_COUNT       5
+
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define UART2_TX_PIN            PA14 // PA14 / SWCLK
+#define UART2_RX_PIN            PA15
+
+#define UART3_TX_PIN            PB10 // PB10 (AF7)
+#define UART3_RX_PIN            PB11 // PB11 (AF7)
+
+#define SOFTSERIAL_1_TIMER TIM2
+#define SOFTSERIAL_1_TIMER_RX_HARDWARE 9 // PA0 / PAD3
+#define SOFTSERIAL_1_TIMER_TX_HARDWARE 10 // PA1 / PAD4
+
+#define USE_I2C
+#define I2C_DEVICE              (I2CDEV_1) // PB6/SCL, PB7/SDA
+
+#define USE_SPI
+#define USE_SPI_DEVICE_2 // PB12,13,14,15 on AF5
+
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_SDCARD
+#define USE_SDCARD_SPI2
+
+#define SDCARD_DETECT_INVERTED
+
+#define SDCARD_DETECT_PIN                   PC14
+#define SDCARD_SPI_INSTANCE                 SPI2
+#define SDCARD_SPI_CS_PIN                   SPI2_NSS_PIN
+
+// SPI2 is on the APB1 bus whose clock runs at 36MHz. Divide to under 400kHz for init:
+#define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 128
+// Divide to under 25MHz for normal operation:
+#define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER     2
+
+// Note, this is the same DMA channel as UART1_RX. Luckily we don't use DMA for USART Rx.
+#define SDCARD_DMA_CHANNEL_TX               DMA1_Channel5
+#define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG DMA1_FLAG_TC5
+
+// Performance logging for SD card operations:
+// #define AFATFS_USE_INTROSPECTIVE_LOGGING
+
+#define BOARD_HAS_VOLTAGE_DIVIDER
+#define USE_ADC
+#define ADC_INSTANCE                ADC2
+#define VBAT_ADC_PIN                PA4
+#define CURRENT_METER_ADC_PIN       PA5
+#define RSSI_ADC_PIN                PB2
+
+#define LED_STRIP
+#define WS2811_PIN                      PA8
+#define WS2811_TIMER                    TIM1
+#define WS2811_DMA_CHANNEL              DMA1_Channel2
+#define WS2811_IRQ                      DMA1_Channel2_IRQn
+#define WS2811_DMA_TC_FLAG              DMA1_FLAG_TC2
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
+
+#define TRANSPONDER
+#define TRANSPONDER_GPIO                     GPIOA
+#define TRANSPONDER_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
+#define TRANSPONDER_GPIO_AF                  GPIO_AF_6
+#define TRANSPONDER_PIN                      GPIO_Pin_8
+#define TRANSPONDER_PIN_SOURCE               GPIO_PinSource8
+#define TRANSPONDER_TIMER                    TIM1
+#define TRANSPONDER_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM1
+#define TRANSPONDER_DMA_CHANNEL              DMA1_Channel2
+#define TRANSPONDER_IRQ                      DMA1_Channel2_IRQn
+#define TRANSPONDER_DMA_TC_FLAG              DMA1_FLAG_TC2
+#define TRANSPONDER_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
+
+#define REDUCE_TRANSPONDER_CURRENT_DRAW_WHEN_USB_CABLE_PRESENT
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_PPM
+#define DEFAULT_FEATURES        FEATURE_BLACKBOX
+
+#define BUTTONS
+#define BUTTON_A_PORT           GPIOB
+#define BUTTON_A_PIN            Pin_1
+#define BUTTON_B_PORT           GPIOB
+#define BUTTON_B_PIN            Pin_0
+
+#define SPEKTRUM_BIND
+// USART3,
+#define BIND_PIN                PB11
+
+#define HARDWARE_BIND_PLUG
+#define BINDPLUG_PIN            PB0
+#define NAV
+#define NAV_AUTO_MAG_DECLINATION
+#define NAV_GPS_GLITCH_DETECTION
+#define NAV_MAX_WAYPOINTS       60
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+// Number of available PWM outputs
+#define MAX_PWM_OUTPUT_PORTS    10
+
+// IO - stm32f303cc in 48pin package
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         (BIT(13)|BIT(14)|BIT(15))
+#define TARGET_IO_PORTF         (BIT(0)|BIT(1)|BIT(4))
+
+#define USABLE_TIMER_CHANNEL_COUNT 12 // 8 Outputs; PPM; LED Strip; 2 additional PWM pins also on UART3 RX/TX pins.
+#define USED_TIMERS             (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(15) | TIM_N(16) |TIM_N(17))
+

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -52,9 +52,9 @@
 
 #define MAG
 #define USE_MPU9250_MAG // Enables bypass configuration
-#define USE_MAG_AK8975
+#define USE_MAG_AK8963
 #define USE_MAG_HMC5883 // External
-#define MAG_AK8975_ALIGN        CW90_DEG_FLIP
+#define MAG_AK8963_ALIGN        CW90_DEG_FLIP
 
 #define SONAR
 #define SONAR_ECHO_PIN          PB1

--- a/src/main/target/SPRACINGF3MINI/target.mk
+++ b/src/main/target/SPRACINGF3MINI/target.mk
@@ -1,0 +1,15 @@
+F3_TARGETS  += $(TARGET)
+FEATURES    = VCP SDCARD 
+
+TARGET_SRC = \
+            drivers/accgyro_mpu.c \
+            drivers/accgyro_mpu6500.c \
+            drivers/barometer_bmp280.c \
+            drivers/compass_ak8975.c \
+            drivers/compass_hmc5883l.c \
+            drivers/flash_m25p16.c \
+            drivers/light_ws2811strip.c \
+            drivers/light_ws2811strip_stm32f30x.c \
+            drivers/serial_softserial.c \
+            drivers/serial_usb_vcp.c \
+            drivers/sonar_hcsr04.c \

--- a/src/main/target/SPRACINGF3MINI/target.mk
+++ b/src/main/target/SPRACINGF3MINI/target.mk
@@ -5,7 +5,7 @@ TARGET_SRC = \
             drivers/accgyro_mpu.c \
             drivers/accgyro_mpu6500.c \
             drivers/barometer_bmp280.c \
-            drivers/compass_ak8975.c \
+            drivers/compass_ak8963.c \
             drivers/compass_hmc5883l.c \
             drivers/flash_m25p16.c \
             drivers/light_ws2811strip.c \


### PR DESCRIPTION
Pulled files from betaflight. 

Added timer in target.c 

And some NAV specific found from regular spracing build with inav. 

Removed transponder ( iNav does have it in drivers,  maybe it should be added as well) 

Also removed #define CONFIG_FASTLOOP_PREFERRED_ACC ACC_NONE from target.h. I guess this is betaflight specific? 

It builds and runs on hardware, but I have not testing any esc or servos or simular on it.. 

Need someone to go over it. 
