### PR TITLE
Bugfix initial GPS baudrate

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -209,7 +209,7 @@ void gpsInit(serialConfig_t *initialSerialConfig, gpsConfig_t *initialGpsConfig)
             portMode_t mode = gpsProviders[gpsState.gpsConfig->provider].portMode;
 
             // no callback - buffer will be consumed in gpsThread()
-            gpsState.gpsPort = openSerialPort(gpsPortConfig->identifier, FUNCTION_GPS, NULL, gpsToSerialBaudRate[gpsState.baudrateIndex], mode, SERIAL_NOT_INVERTED);
+            gpsState.gpsPort = openSerialPort(gpsPortConfig->identifier, FUNCTION_GPS, NULL, baudRates[gpsToSerialBaudRate[gpsState.baudrateIndex]], mode, SERIAL_NOT_INVERTED);
 
             if (!gpsState.gpsPort) {
                 featureClear(FEATURE_GPS);


### PR DESCRIPTION
Originally passed the index not the baudspeed into openSerialPort. gps_auto_baud = OFF might have been broken before
