### PR TITLE
Airplane PID attenuation and more TPA fixes

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1131,6 +1131,7 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_PID:
+        signalRequiredPIDCoefficientsUpdate();
         for (i = 0; i < PID_ITEM_COUNT; i++) {
             currentProfile->pidProfile.P8[i] = sbufReadU8(src);
             currentProfile->pidProfile.I8[i] = sbufReadU8(src);
@@ -1200,6 +1201,8 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
             if (dataSize >= 11) {
                 currentControlRateProfile->rcYawExpo8 = sbufReadU8(src);
             }
+
+            signalRequiredPIDCoefficientsUpdate();
         } else {
             return MSP_RESULT_ERROR;
         }

--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -583,7 +583,14 @@ void taskMainPidLoop(void)
                                             masterConfig.motorConfig.maxthrottle);
         }
     }
+    else {
+        // FIXME: throttle pitch comp for FW
+    }
 
+    // Update PID coefficients
+    updatePIDCoefficients(&currentProfile->pidProfile, currentControlRateProfile, &masterConfig.motorConfig);
+
+    // Calculate stabilisation
     pidController(&currentProfile->pidProfile, currentControlRateProfile, &masterConfig.rxConfig);
 
 #ifdef HIL
@@ -655,6 +662,5 @@ bool taskUpdateRxCheck(uint32_t currentDeltaTime)
 void taskUpdateRxMain(void)
 {
     processRx();
-    updatePIDCoefficients(&currentProfile->pidProfile, currentControlRateProfile, &masterConfig.rxConfig);
     isRXDataNew = true;
 }

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -527,6 +527,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             controlRateConfig->rates[FD_PITCH] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_RATE, newValue);
             if (adjustmentFunction == ADJUSTMENT_PITCH_RATE) {
+                signalRequiredPIDCoefficientsUpdate();
                 break;
             }
             // follow though for combined ADJUSTMENT_PITCH_ROLL_RATE
@@ -534,11 +535,13 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             newValue = constrain((int)controlRateConfig->rates[FD_ROLL] + delta, CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MIN, CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
             controlRateConfig->rates[FD_ROLL] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_RATE, newValue);
+            signalRequiredPIDCoefficientsUpdate();
             break;
         case ADJUSTMENT_YAW_RATE:
             newValue = constrain((int)controlRateConfig->rates[FD_YAW] + delta, CONTROL_RATE_CONFIG_YAW_RATE_MIN, CONTROL_RATE_CONFIG_YAW_RATE_MAX);
             controlRateConfig->rates[FD_YAW] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_RATE, newValue);
+            signalRequiredPIDCoefficientsUpdate();
             break;
         case ADJUSTMENT_PITCH_ROLL_P:
         case ADJUSTMENT_PITCH_P:
@@ -546,6 +549,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             pidProfile->P8[PIDPITCH] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_P, newValue);
             if (adjustmentFunction == ADJUSTMENT_PITCH_P) {
+                signalRequiredPIDCoefficientsUpdate();
                 break;
             }
             // follow though for combined ADJUSTMENT_PITCH_ROLL_P
@@ -553,6 +557,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             newValue = constrain((int)pidProfile->P8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
             pidProfile->P8[PIDROLL] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_P, newValue);
+            signalRequiredPIDCoefficientsUpdate();
             break;
         case ADJUSTMENT_PITCH_ROLL_I:
         case ADJUSTMENT_PITCH_I:
@@ -560,6 +565,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             pidProfile->I8[PIDPITCH] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_I, newValue);
             if (adjustmentFunction == ADJUSTMENT_PITCH_I) {
+                signalRequiredPIDCoefficientsUpdate();
                 break;
             }
             // follow though for combined ADJUSTMENT_PITCH_ROLL_I
@@ -567,6 +573,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             newValue = constrain((int)pidProfile->I8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
             pidProfile->I8[PIDROLL] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_I, newValue);
+            signalRequiredPIDCoefficientsUpdate();
             break;
         case ADJUSTMENT_PITCH_ROLL_D:
         case ADJUSTMENT_PITCH_D:
@@ -574,6 +581,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             pidProfile->D8[PIDPITCH] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_D, newValue);
             if (adjustmentFunction == ADJUSTMENT_PITCH_D) {
+                signalRequiredPIDCoefficientsUpdate();
                 break;
             }
             // follow though for combined ADJUSTMENT_PITCH_ROLL_D
@@ -581,21 +589,25 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             newValue = constrain((int)pidProfile->D8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
             pidProfile->D8[PIDROLL] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_D, newValue);
+            signalRequiredPIDCoefficientsUpdate();
             break;
         case ADJUSTMENT_YAW_P:
             newValue = constrain((int)pidProfile->P8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
             pidProfile->P8[PIDYAW] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_P, newValue);
+            signalRequiredPIDCoefficientsUpdate();
             break;
         case ADJUSTMENT_YAW_I:
             newValue = constrain((int)pidProfile->I8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
             pidProfile->I8[PIDYAW] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_I, newValue);
+            signalRequiredPIDCoefficientsUpdate();
             break;
         case ADJUSTMENT_YAW_D:
             newValue = constrain((int)pidProfile->D8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
             pidProfile->D8[PIDYAW] = newValue;
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_D, newValue);
+            signalRequiredPIDCoefficientsUpdate();
             break;
         default:
             break;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -187,7 +187,7 @@ void updatePIDCoefficients(const pidProfile_t *pidProfile, const controlRateConf
         // tpa_breakpoint for fixed wing is cruise throttle value (value at which PIDs were tuned)
         if (controlRateConfig->dynThrPID != 0 && controlRateConfig->tpa_breakpoint > motorConfig->minthrottle) {
             if (rcCommand[THROTTLE] > motorConfig->minthrottle) {
-                tpaFactor = 0.5f + ((controlRateConfig->tpa_breakpoint - motorConfig->minthrottle) / (rcCommand[THROTTLE] - motorConfig->minthrottle) / 2.0f);
+                tpaFactor = 0.5f + ((float)(controlRateConfig->tpa_breakpoint - motorConfig->minthrottle) / (rcCommand[THROTTLE] - motorConfig->minthrottle) / 2.0f);
                 tpaFactor = constrainf(tpaFactor, 0.6f, 1.67f);
             }
             else {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -85,6 +85,7 @@ struct controlRateConfig_s;
 struct motorConfig_s;
 struct rxConfig_s;
 
+void signalRequiredPIDCoefficientsUpdate(void);
 void updatePIDCoefficients(const pidProfile_t *pidProfile, const struct controlRateConfig_s *controlRateConfig, const struct motorConfig_s *motorConfig);
 void pidController(const pidProfile_t *pidProfile, const struct controlRateConfig_s *controlRateConfig, const struct rxConfig_s *rxConfig);
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -80,9 +80,12 @@ extern int32_t axisPID_P[], axisPID_I[], axisPID_D[], axisPID_Setpoint[];
 
 void pidInit(void);
 void pidResetErrorAccumulators(void);
+
 struct controlRateConfig_s;
+struct motorConfig_s;
 struct rxConfig_s;
-void updatePIDCoefficients(const pidProfile_t *pidProfile, const struct controlRateConfig_s *controlRateConfig, const struct rxConfig_s *rxConfig);
+
+void updatePIDCoefficients(const pidProfile_t *pidProfile, const struct controlRateConfig_s *controlRateConfig, const struct motorConfig_s *motorConfig);
 void pidController(const pidProfile_t *pidProfile, const struct controlRateConfig_s *controlRateConfig, const struct rxConfig_s *rxConfig);
 
 float pidRateToRcCommand(float rateDPS, uint8_t rate);


### PR DESCRIPTION
In general one should tune the airplane to fly good at cruise throttle. Control surface response should be increased when throttle is below cruise and decreased otherwise. Code is adapted from ArduPlane. See https://github.com/iNavFlight/inav/issues/684

Changed TPA to respect rcCommand[THROTTLE] not rcData[THROTTLE] - we have modes where motor throttle is disconnected from the stick (AltHold, Waypoint, RTH).

Also removed extra kD scaling - useless.
