### PR TITLE
PWM output disable/enable feature

### DIFF
--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -72,6 +72,7 @@ typedef enum {
     FEATURE_RX_SPI = 1 << 25,
     FEATURE_SOFTSPI = 1 << 26,
     FEATURE_PWM_SERVO_DRIVER = 1 << 27,
+    FEATURE_PWM_OUTPUT_ENABLE = 1 << 28,
 } features_e;
 
 typedef enum {

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -32,8 +32,8 @@
 #include "pwm_rx.h"
 #include "pwm_mapping.h"
 
-void pwmMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint16_t idlePulse, motorPwmProtocolTypes_e proto);
-void pwmServoConfig(const timerHardware_t *timerHardware, uint8_t servoIndex, uint16_t servoPwmRate, uint16_t servoCenterPulse);
+void pwmMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, uint16_t idlePulse, motorPwmProtocolTypes_e proto, bool enableOutput);
+void pwmServoConfig(const timerHardware_t *timerHardware, uint8_t servoIndex, uint16_t servoPwmRate, uint16_t servoCenterPulse, bool enableOutput);
 
 /*
     Configuration maps
@@ -370,7 +370,7 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
             }
 #endif
 
-            pwmMotorConfig(timerHardwarePtr, pwmIOConfiguration.motorCount, init->motorPwmRate, init->idlePulse, init->pwmProtocolType);
+            pwmMotorConfig(timerHardwarePtr, pwmIOConfiguration.motorCount, init->motorPwmRate, init->idlePulse, init->pwmProtocolType, init->enablePWMOutput);
             if (init->useFastPwm) {
                 pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].flags = PWM_PF_MOTOR | PWM_PF_OUTPUT_PROTOCOL_FASTPWM | PWM_PF_OUTPUT_PROTOCOL_PWM;
             } else if (init->pwmProtocolType == PWM_TYPE_BRUSHED) {
@@ -392,7 +392,7 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
             }
 
 #ifdef USE_SERVOS
-            pwmServoConfig(timerHardwarePtr, pwmIOConfiguration.servoCount, init->servoPwmRate, init->servoCenterPulse);
+            pwmServoConfig(timerHardwarePtr, pwmIOConfiguration.servoCount, init->servoPwmRate, init->servoCenterPulse, init->enablePWMOutput);
 
             pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].flags = PWM_PF_SERVO | PWM_PF_OUTPUT_PROTOCOL_PWM;
             pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].index = pwmIOConfiguration.servoCount;

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -50,6 +50,7 @@ typedef struct sonarIOConfig_s {
 } sonarIOConfig_t;
 
 typedef struct drv_pwm_config_s {
+    bool enablePWMOutput;
     bool useParallelPWM;
     bool usePPM;
     bool useSerialRx;

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -289,6 +289,8 @@ void init(void)
         pwm_params.idlePulse = 0; // brushed motors
     }
 
+    pwm_params.enablePWMOutput = feature(FEATURE_PWM_OUTPUT_ENABLE);
+
 #ifndef SKIP_RX_PWM_PPM
     pwmRxInit(masterConfig.inputFilteringMode);
 #endif

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -219,7 +219,7 @@ static const char * const featureNames[] = {
     "SONAR", "TELEMETRY", "CURRENT_METER", "3D", "RX_PARALLEL_PWM",
     "RX_MSP", "RSSI_ADC", "LED_STRIP", "DISPLAY", "UNUSED_2",
     "BLACKBOX", "CHANNEL_FORWARDING", "TRANSPONDER", "AIRMODE",
-    "SUPEREXPO", "VTX", "RX_SPI", "SOFTSPI", "PWM_SERVO_DRIVER", NULL
+    "SUPEREXPO", "VTX", "RX_SPI", "SOFTSPI", "PWM_SERVO_DRIVER", "PWM_OUTPUT_ENABLE", NULL
 };
 
 // sync this with rxFailsafeChannelMode_e


### PR DESCRIPTION
When updating FC, the default configuration reverts to multicopter. If there are servos attached to the FC the high frequency outputs can damage them before being able to configure all the setup as airplane.

This PR adds a new feature `PWM_OUTPUT_ENABLE` that is a flag to actually allow anything to be output to motors and servos. If the feature is disabled all outputs are pulled low.

Feature `PWM_OUTPUT_ENABLE` is disabled by default so nothing will fly or move before user decides so.

At the moment this feature can only be enabled via CLI, configurator support required for easier configuration.

Fixes #208
