### PR TITLE
Increase timeout for I2C bus transfer

### DIFF
--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -19,7 +19,7 @@
 
 #define I2C_SHORT_TIMEOUT            ((uint32_t)0x1000)
 #define I2C_LONG_TIMEOUT             ((uint32_t)(10 * I2C_SHORT_TIMEOUT))
-#define I2C_DEFAULT_TIMEOUT          I2C_SHORT_TIMEOUT
+#define I2C_DEFAULT_TIMEOUT          I2C_LONG_TIMEOUT
 
 #include "drivers/io.h"
 #include "drivers/rcc.h"


### PR DESCRIPTION
Increase timeout for I2C transter. 
BMP280 is reading 24 bytes as a single I2C transaction and hits the timeout which causes the i2c driver to get stuck on sending START when doing the next transaction.
