### PR TITLE
ledstrip: blue warning on compass failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,6 +446,7 @@ COMMON_SRC = \
             sensors/compass.c \
             sensors/gyro.c \
             sensors/initialisation.c \
+            sensors/diagnostics.c \
             $(CMSIS_SRC) \
             $(DEVICE_STDPERIPH_SRC)
 

--- a/docs/LedStrip.md
+++ b/docs/LedStrip.md
@@ -163,6 +163,7 @@ This mode simply uses the LEDs to flash when warnings occur.
 |---------|-------------|-------|
 | Arm-lock enabled | flash between green and off | occurs calibration or when unarmed and the aircraft is tilted too much |
 | Low Battery | flash red and off | battery monitoring must be enabled.  May trigger temporarily under high-throttle due to voltage drop |
+| Hardware Error | flash blue and off | indicates that at least one of hardware components is not working correctly |
 | Failsafe | flash between light blue and yellow | Failsafe must be enabled |
 
 Flash patterns appear in order, so that it's clear which warnings are enabled.

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -398,11 +398,6 @@ static int imuCalculateAccelerometerConfidence(void)
     return (nearness > MAX_ACC_SQ_NEARNESS) ? 0 : MAX_ACC_SQ_NEARNESS - nearness;
 }
 
-static bool isMagnetometerHealthy(void)
-{
-    return (magADC[X] != 0) && (magADC[Y] != 0) && (magADC[Z] != 0);
-}
-
 static void imuCalculateEstimatedAttitude(float dT)
 {
     float courseOverGround = 0;
@@ -413,7 +408,7 @@ static void imuCalculateEstimatedAttitude(float dT)
 
     accWeight = imuCalculateAccelerometerConfidence();
 
-    if (sensors(SENSOR_MAG) && isMagnetometerHealthy()) {
+    if (sensors(SENSOR_MAG) && isCompassHealthy()) {
         useMag = true;
     }
 #if defined(GPS)

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -52,6 +52,7 @@
 #include "sensors/gyro.h"
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
+#include "sensors/compass.h"
 
 #include "io/ledstrip.h"
 #include "io/beeper.h"
@@ -515,6 +516,7 @@ typedef enum {
     WARNING_ARMING_DISABLED,
     WARNING_LOW_BATTERY,
     WARNING_FAILSAFE,
+    WARNING_HW_ERROR,
 } warningFlags_e;
 
 static void applyLedWarningLayer(bool updateNow, uint32_t *timer)
@@ -535,6 +537,10 @@ static void applyLedWarningLayer(bool updateNow, uint32_t *timer)
                 warningFlags |= 1 << WARNING_FAILSAFE;
             if (!ARMING_FLAG(ARMED) && !ARMING_FLAG(OK_TO_ARM))
                 warningFlags |= 1 << WARNING_ARMING_DISABLED;
+#ifdef MAG
+            if (masterConfig.mag_hardware != MAG_NONE && !compassIsWorking())
+                warningFlags |= 1 << WARNING_HW_ERROR;
+#endif
         }
         *timer += LED_STRIP_HZ(10);
     }
@@ -554,6 +560,9 @@ static void applyLedWarningLayer(bool updateNow, uint32_t *timer)
                     break;
                 case WARNING_FAILSAFE:
                     warningColor = colorOn ? &HSV(YELLOW) : &HSV(BLUE);
+                    break;
+                case WARNING_HW_ERROR:
+                    warningColor = colorOn ? &HSV(BLUE) : &HSV(BLACK);
                     break;
                 default:;
             }

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -52,7 +52,7 @@
 #include "sensors/gyro.h"
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
-#include "sensors/compass.h"
+#include "sensors/diagnostics.h"
 
 #include "io/ledstrip.h"
 #include "io/beeper.h"
@@ -537,10 +537,8 @@ static void applyLedWarningLayer(bool updateNow, uint32_t *timer)
                 warningFlags |= 1 << WARNING_FAILSAFE;
             if (!ARMING_FLAG(ARMED) && !ARMING_FLAG(OK_TO_ARM))
                 warningFlags |= 1 << WARNING_ARMING_DISABLED;
-#ifdef MAG
-            if (masterConfig.mag_hardware != MAG_NONE && !compassIsWorking())
+            if (!isHardwareHealthy())
                 warningFlags |= 1 << WARNING_HW_ERROR;
-#endif
         }
         *timer += LED_STRIP_HZ(10);
     }

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -70,9 +70,9 @@ bool compassInit(int16_t magDeclinationFromConfig)
     return ret;
 }
 
-bool compassIsWorking(void)
+bool isCompassHealthy(void)
 {
-	return (magADC[X] | magADC[Y] | magADC[Z]) != 0;
+    return (magADC[X] != 0) && (magADC[Y] != 0) && (magADC[Z] != 0);
 }
 
 bool isCompassReady(void)

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -70,6 +70,11 @@ bool compassInit(int16_t magDeclinationFromConfig)
     return ret;
 }
 
+bool compassIsWorking(void)
+{
+	return (magADC[X] | magADC[Y] | magADC[Z]) != 0;
+}
+
 bool isCompassReady(void)
 {
     return magUpdatedAtLeastOnce;

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -35,7 +35,7 @@ typedef enum {
 bool compassInit(int16_t magDeclinationFromConfig);
 void updateCompass(flightDynamicsTrims_t *magZero);
 bool isCompassReady(void);
-bool compassIsWorking(void);
+bool isCompassHealthy(void);
 #endif
 
 extern int32_t magADC[XYZ_AXIS_COUNT];

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -35,6 +35,7 @@ typedef enum {
 bool compassInit(int16_t magDeclinationFromConfig);
 void updateCompass(flightDynamicsTrims_t *magZero);
 bool isCompassReady(void);
+bool compassIsWorking(void);
 #endif
 
 extern int32_t magADC[XYZ_AXIS_COUNT];

--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -1,0 +1,27 @@
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+#include "build/debug.h"
+
+#include "common/axis.h"
+#include "common/maths.h"
+
+#include "flight/navigation_rewrite.h"
+
+#include "config/config.h"
+#include "config/config_master.h"
+
+#include "sensors/sensors.h"
+#include "sensors/compass.h"
+
+
+bool isHardwareHealthy(void)
+{
+#ifdef MAG
+	if (masterConfig.mag_hardware != MAG_NONE && !isCompassHealthy())
+		return false;
+#endif
+
+	return true;
+}

--- a/src/main/sensors/diagnostics.h
+++ b/src/main/sensors/diagnostics.h
@@ -1,0 +1,8 @@
+
+/**
+ * Collects hardware failure information from devices.
+ * No hardware checking should be actually performed,
+ * rather already known hardware status should be returned.
+ */
+bool isHardwareHealthy(void);
+


### PR DESCRIPTION
- added new generic ledstrip warning: HW_ERROR (BLUE-BLACK)
- HW_ERROR warning set on compass failure (on init or in runtime)

fixes #650.
