### PR TITLE
Reduced and rationalised #includes

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -31,12 +31,10 @@
 #include "common/encoding.h"
 #include "common/utils.h"
 
-#include "drivers/gpio.h"
 #include "drivers/sensor.h"
 #include "drivers/system.h"
 #include "drivers/serial.h"
 #include "drivers/compass.h"
-#include "drivers/timer.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/accgyro.h"
 #include "drivers/light_led.h"

--- a/src/main/build/build_config.c
+++ b/src/main/build/build_config.c
@@ -20,8 +20,6 @@
 
 #include "platform.h"
 
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
 #include "drivers/pwm_mapping.h"
 #include "flight/mixer.h"
 

--- a/src/main/common/printf.c
+++ b/src/main/common/printf.c
@@ -38,11 +38,9 @@
 
 #include "build/build_config.h"
 
-
 #include "drivers/serial.h"
-#include "io/serial.h"
 
-#include "build/build_config.h"
+#include "io/serial.h"
 
 #include "printf.h"
 

--- a/src/main/common/printf.h
+++ b/src/main/common/printf.h
@@ -107,8 +107,6 @@ regs Kusti, 23.10.2004
 
 #include <stdarg.h>
 
-#include "drivers/serial.h"
-
 void init_printf(void *putp, void (*putf) (void *, char));
 
 int tfp_printf(const char *fmt, ...);
@@ -120,6 +118,7 @@ int tfp_format(void *putp, void (*putf) (void *, char), const char *fmt, va_list
 #define sprintf tfp_sprintf
 
 void printfSupportInit(void);
-void setPrintfSerialPort(serialPort_t *serialPort);
+struct serialPort_s;
+void setPrintfSerialPort(struct serialPort_s *serialPort);
 
 #endif

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -30,15 +30,9 @@
 #include "common/maths.h"
 #include "common/filter.h"
 
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
 #include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
 #include "drivers/rx_spi.h"
 #include "drivers/pwm_output.h"
-#include "drivers/rx_nrf24l01.h"
 #include "drivers/serial.h"
 
 #include "sensors/sensors.h"

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -26,12 +26,7 @@
 #include "common/color.h"
 #include "common/axis.h"
 
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
 #include "drivers/system.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
 #include "drivers/serial.h"
 
 #include "sensors/sensors.h"

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -52,6 +52,7 @@
 
 #include "flight/mixer.h"
 #include "flight/servos.h"
+#include "flight/navigation_rewrite.h"
 #include "flight/pid.h"
 #include "flight/imu.h"
 #include "flight/failsafe.h"

--- a/src/main/config/feature.c
+++ b/src/main/config/feature.c
@@ -17,62 +17,11 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
 
 #include "platform.h"
 
-#include "common/axis.h"
-#include "common/color.h"
-#include "common/maths.h"
-
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
-#include "drivers/system.h"
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/rx_spi.h"
-#include "drivers/serial.h"
-
-#include "sensors/sensors.h"
-#include "sensors/gyro.h"
-#include "sensors/compass.h"
-#include "sensors/acceleration.h"
-#include "sensors/barometer.h"
-#include "sensors/boardalignment.h"
-#include "sensors/battery.h"
-
-#include "io/beeper.h"
-#include "io/serial.h"
-#include "io/gimbal.h"
-#include "io/motors.h"
-#include "io/servos.h"
-#include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "io/ledstrip.h"
-#include "io/gps.h"
-
-#include "rx/rx.h"
-#include "rx/rx_spi.h"
-
-#include "blackbox/blackbox_io.h"
-
-#include "telemetry/telemetry.h"
-
-#include "flight/mixer.h"
-#include "flight/servos.h"
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/failsafe.h"
-#include "flight/navigation_rewrite.h"
-
-#include "fc/runtime_config.h"
-
-#include "config/config.h"
-
-#include "config/config_profile.h"
 #include "config/config_master.h"
+#include "config/feature.h"
 
 static uint32_t activeFeaturesLatch = 0;
 

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -21,8 +21,8 @@
 #define I2C_LONG_TIMEOUT             ((uint32_t)(10 * I2C_SHORT_TIMEOUT))
 #define I2C_DEFAULT_TIMEOUT          I2C_LONG_TIMEOUT
 
-#include "drivers/io.h"
-#include "drivers/rcc.h"
+#include "drivers/io_types.h"
+#include "drivers/rcc_types.h"
 
 #ifndef I2C_DEVICE
 #define I2C_DEVICE I2CINVALID

--- a/src/main/fc/fc_hardfaults.c
+++ b/src/main/fc/fc_hardfaults.c
@@ -21,7 +21,10 @@
 #include "platform.h"
 
 #include "drivers/light_led.h"
+#include "drivers/system.h"
+
 #include "fc/fc_init.h"
+
 #include "flight/mixer.h"
 
 #ifdef DEBUG_HARDFAULTS

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -35,15 +35,11 @@
 
 #include "drivers/system.h"
 
-#include "drivers/sensor.h"
 #include "drivers/accgyro.h"
 #include "drivers/compass.h"
 #include "drivers/pwm_mapping.h"
-
 #include "drivers/serial.h"
 #include "drivers/bus_i2c.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
 #include "drivers/sdcard.h"
 
 #include "fc/fc_msp.h"

--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -31,14 +31,10 @@
 #include "common/utils.h"
 #include "common/filter.h"
 
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 #include "drivers/light_led.h"
-
-#include "drivers/system.h"
-#include "drivers/serial.h"
-#include "drivers/pwm_rx.h"
 #include "drivers/gyro_sync.h"
+#include "drivers/serial.h"
+#include "drivers/system.h"
 
 #include "sensors/sensors.h"
 #include "sensors/boardalignment.h"

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -25,41 +25,36 @@
 
 #include "build/build_config.h"
 
+#include "blackbox/blackbox.h"
+
 #include "common/axis.h"
 #include "common/maths.h"
 
+#include "config/config.h"
+#include "config/feature.h"
+
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
+
+#include "fc/mw.h"
+#include "fc/rc_controls.h"
+#include "fc/rc_curves.h"
+#include "fc/runtime_config.h"
+
+#include "flight/pid.h"
+#include "flight/navigation_rewrite.h"
+#include "flight/failsafe.h"
+
+#include "io/gps.h"
+#include "io/beeper.h"
+#include "io/motors.h"
+
+#include "rx/rx.h"
 
 #include "sensors/barometer.h"
 #include "sensors/battery.h"
 #include "sensors/sensors.h"
 #include "sensors/gyro.h"
 #include "sensors/acceleration.h"
-
-#include "rx/rx.h"
-
-#include "io/gps.h"
-#include "io/beeper.h"
-#include "io/motors.h"
-
-#include "fc/rc_controls.h"
-#include "fc/rc_curves.h"
-#include "fc/runtime_config.h"
-
-#include "io/display.h"
-
-#include "flight/pid.h"
-#include "flight/navigation_rewrite.h"
-#include "flight/failsafe.h"
-
-#include "config/config.h"
-#include "config/feature.h"
-
-#include "blackbox/blackbox.h"
-
-#include "mw.h"
 
 #define AIRMODE_DEADBAND 25
 

--- a/src/main/flight/hil.c
+++ b/src/main/flight/hil.c
@@ -32,8 +32,6 @@
 #include "common/filter.h"
 
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -35,9 +35,6 @@
 #include "common/filter.h"
 
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
 
 #include "sensors/sensors.h"
 #include "sensors/gyro.h"

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -34,20 +34,18 @@
 #include "drivers/system.h"
 #include "drivers/pwm_output.h"
 #include "drivers/pwm_mapping.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/system.h"
 
 #include "rx/rx.h"
 
 #include "io/gimbal.h"
 #include "io/motors.h"
-#include "fc/rc_controls.h"
-
 
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"
 #include "sensors/gyro.h"
+
+#include "fc/rc_controls.h"
+#include "fc/runtime_config.h"
 
 #include "flight/mixer.h"
 #include "flight/servos.h"
@@ -55,8 +53,6 @@
 #include "flight/pid.h"
 #include "flight/imu.h"
 #include "flight/navigation_rewrite.h"
-
-#include "fc/runtime_config.h"
 
 #include "config/config.h"
 #include "config/config_profile.h"

--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -30,8 +30,6 @@
 #include "common/filter.h"
 
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"

--- a/src/main/flight/navigation_rewrite_fixedwing.c
+++ b/src/main/flight/navigation_rewrite_fixedwing.c
@@ -31,8 +31,6 @@
 #include "common/filter.h"
 
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"

--- a/src/main/flight/navigation_rewrite_geo.c
+++ b/src/main/flight/navigation_rewrite_geo.c
@@ -29,10 +29,6 @@
 #include "common/axis.h"
 #include "common/maths.h"
 
-#include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"
 #include "sensors/boardalignment.h"

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -26,13 +26,11 @@
 #include "build/build_config.h"
 #include "build/debug.h"
 
+#include "drivers/system.h"
+
 #include "common/axis.h"
 #include "common/maths.h"
 #include "common/filter.h"
-
-#include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"

--- a/src/main/flight/navigation_rewrite_pos_estimator.c
+++ b/src/main/flight/navigation_rewrite_pos_estimator.c
@@ -31,8 +31,6 @@
 #include "common/maths.h"
 
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 
 #include "sensors/sensors.h"
 #include "sensors/rangefinder.h"

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -22,34 +22,27 @@
 #include <platform.h>
 
 #include "build/build_config.h"
-
 #include "build/debug.h"
 
+#include "common/axis.h"
+#include "common/filter.h"
+#include "common/maths.h"
 
+#include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
 
+#include "flight/pid.h"
+#include "flight/imu.h"
+#include "flight/navigation_rewrite.h"
 
-#include "common/axis.h"
-#include "common/maths.h"
-#include "common/filter.h"
+#include "io/gps.h"
 
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/gyro_sync.h"
+#include "rx/rx.h"
 
 #include "sensors/sensors.h"
 #include "sensors/gyro.h"
 #include "sensors/acceleration.h"
 
-#include "rx/rx.h"
-
-#include "fc/rc_controls.h"
-
-#include "io/gps.h"
-
-#include "flight/pid.h"
-#include "flight/imu.h"
-#include "flight/navigation_rewrite.h"
 
 #define MAG_HOLD_ERROR_LPF_FREQ 2
 

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -31,21 +31,21 @@
 #include "common/maths.h"
 #include "common/filter.h"
 
-#include "drivers/system.h"
 #include "drivers/pwm_output.h"
 #include "drivers/pwm_mapping.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 #include "drivers/system.h"
-
-#include "rx/rx.h"
 
 #include "io/gimbal.h"
 #include "io/servos.h"
-#include "fc/rc_controls.h"
+
+#include "rx/rx.h"
+
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"
 #include "sensors/gyro.h"
+
+#include "fc/rc_controls.h"
+#include "fc/runtime_config.h"
 
 #include "flight/mixer.h"
 #include "flight/servos.h"
@@ -54,11 +54,10 @@
 #include "flight/imu.h"
 #include "flight/navigation_rewrite.h"
 
-#include "fc/runtime_config.h"
-
 #include "config/config.h"
 #include "config/config_profile.h"
 #include "config/feature.h"
+
 
 extern mixerMode_e currentMixerMode;
 extern const mixer_t mixers[];

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -23,14 +23,13 @@
 #include "build/build_config.h"
 
 
-#include "drivers/gpio.h"
 #include "drivers/sound_beeper.h"
 #include "drivers/system.h"
+
 #include "sensors/battery.h"
 #include "sensors/sensors.h"
 
 #include "rx/rx.h"
-#include "fc/rc_controls.h"
 
 #include "io/statusindicator.h"
 
@@ -38,6 +37,7 @@
 #include "io/gps.h"
 #endif
 
+#include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
 
 #include "config/config.h"

--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -27,12 +27,8 @@
 #include "build/version.h"
 #include "build/build_config.h"
 
-#include "drivers/serial.h"
 #include "drivers/system.h"
 #include "drivers/display_ug2864hsweg01.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
 
 #include "common/printf.h"
 #include "common/maths.h"

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -28,18 +28,14 @@
 
 #include "build/debug.h"
 
-
 #include "common/maths.h"
 #include "common/axis.h"
 #include "common/utils.h"
 
-#include "drivers/system.h"
-#include "drivers/serial.h"
-#include "drivers/serial_uart.h"
-#include "drivers/gpio.h"
-#include "drivers/light_led.h"
-#include "drivers/sensor.h"
 #include "drivers/compass.h"
+#include "drivers/light_led.h"
+#include "drivers/serial.h"
+#include "drivers/system.h"
 
 #include "sensors/sensors.h"
 #include "sensors/compass.h"

--- a/src/main/io/gps_i2cnav.c
+++ b/src/main/io/gps_i2cnav.c
@@ -26,13 +26,13 @@
 #include "build/build_config.h"
 #include "build/debug.h"
 
-#include "common/maths.h"
 #include "common/axis.h"
+#include "common/maths.h"
 #include "common/utils.h"
 
-#include "drivers/system.h"
-#include "drivers/serial.h"
 #include "drivers/gps_i2cnav.h"
+#include "drivers/serial.h"
+#include "drivers/system.h"
 
 #include "io/serial.h"
 #include "io/gps.h"

--- a/src/main/io/gps_naza.c
+++ b/src/main/io/gps_naza.c
@@ -29,14 +29,12 @@
 
 #include "build/debug.h"
 
-
 #include "common/maths.h"
 #include "common/axis.h"
 #include "common/utils.h"
 
-#include "drivers/system.h"
 #include "drivers/serial.h"
-#include "drivers/serial_uart.h"
+#include "drivers/system.h"
 
 #include "io/serial.h"
 #include "io/gps.h"

--- a/src/main/io/gps_nmea.c
+++ b/src/main/io/gps_nmea.c
@@ -29,14 +29,12 @@
 
 #include "build/debug.h"
 
-
 #include "common/maths.h"
 #include "common/axis.h"
 #include "common/utils.h"
 
-#include "drivers/system.h"
 #include "drivers/serial.h"
-#include "drivers/serial_uart.h"
+#include "drivers/system.h"
 
 #include "io/serial.h"
 #include "io/gps.h"

--- a/src/main/io/gps_private.h
+++ b/src/main/io/gps_private.h
@@ -19,6 +19,8 @@
 
 #ifdef GPS
 
+#include "io/serial.h"
+
 #define GPS_HDOP_TO_EPH_MULTIPLIER      2   // empirical value
 
 typedef enum {

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -35,9 +35,8 @@
 #include "common/axis.h"
 #include "common/utils.h"
 
-#include "drivers/system.h"
 #include "drivers/serial.h"
-#include "drivers/serial_uart.h"
+#include "drivers/system.h"
 
 #include "io/serial.h"
 #include "io/gps.h"

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -32,26 +32,22 @@
 #include "common/typeconversion.h"
 
 #include "drivers/light_ws2811strip.h"
-#include "drivers/system.h"
 #include "drivers/serial.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
+#include "drivers/system.h"
 
-#include <common/printf.h>
 #include "common/axis.h"
+#include "common/printf.h"
 #include "common/utils.h"
 
 #include "fc/rc_controls.h"
+#include "fc/runtime_config.h"
 
-#include "sensors/battery.h"
-#include "sensors/sensors.h"
-#include "sensors/boardalignment.h"
-#include "sensors/gyro.h"
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
+#include "sensors/battery.h"
+#include "sensors/boardalignment.h"
+#include "sensors/gyro.h"
+#include "sensors/sensors.h"
 
 #include "io/ledstrip.h"
 #include "io/beeper.h"
@@ -63,6 +59,8 @@
 
 #include "rx/rx.h"
 
+#include "telemetry/telemetry.h"
+
 #include "flight/failsafe.h"
 #include "flight/mixer.h"
 #include "flight/servos.h"
@@ -70,14 +68,11 @@
 #include "flight/imu.h"
 #include "flight/navigation_rewrite.h"
 
-#include "telemetry/telemetry.h"
-
-#include "fc/runtime_config.h"
-
 #include "config/config.h"
-#include "config/config_profile.h"
 #include "config/config_master.h"
+#include "config/config_profile.h"
 #include "config/feature.h"
+
 
 /*
 PG_REGISTER_ARR_WITH_RESET_FN(ledConfig_t, LED_MAX_STRIP_LENGTH, ledConfigs, PG_LED_STRIP_CONFIG, 0);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -43,10 +43,8 @@
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
 #include "drivers/compass.h"
-
 #include "drivers/serial.h"
 #include "drivers/bus_i2c.h"
-#include "drivers/gpio.h"
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
 #include "drivers/timer.h"

--- a/src/main/io/statusindicator.c
+++ b/src/main/io/statusindicator.c
@@ -21,9 +21,7 @@
 #include "platform.h"
 
 #include "drivers/system.h"
-#include "drivers/gpio.h"
 #include "drivers/light_led.h"
-#include "drivers/sound_beeper.h"
 
 #include "statusindicator.h"
 

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -29,11 +29,9 @@
 
 #include "build/build_config.h"
 
-
+#include "drivers/serial.h"
 #include "drivers/system.h"
 
-#include "drivers/serial.h"
-#include "drivers/serial_uart.h"
 #include "io/serial.h"
 
 #include "rx/rx.h"

--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -42,10 +42,12 @@
 #include "common/utils.h"
 #include "build/build_config.h"
 
-#include "drivers/system.h"
 #include "drivers/serial.h"
 #include "drivers/serial_uart.h"
+#include "drivers/system.h"
+
 #include "io/serial.h"
+
 #include "rx/rx.h"
 #include "rx/jetiexbus.h"
 
@@ -57,6 +59,7 @@
 #include "sensors/sensors.h"
 #include "sensors/battery.h"
 #include "sensors/barometer.h"
+
 #include "telemetry/telemetry.h"
 #include "telemetry/jetiexbus.h"
 
@@ -611,6 +614,6 @@ void sendJetiExBusTelemetry(uint8_t packetID)
     requestLoop++;
 }
 
-#endif //TELEMETRY
+#endif // TELEMETRY
 
-#endif //SKIP_SERIALRX_JETIEXBUS
+#endif // USE_SERIALRX_JETIEXBUS

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -25,10 +25,6 @@
 
 #ifndef SKIP_RX_MSP
 
-#include "drivers/system.h"
-#include "drivers/serial.h"
-#include "drivers/serial_uart.h"
-
 #include "rx/rx.h"
 #include "rx/msp.h"
 

--- a/src/main/rx/pwm.c
+++ b/src/main/rx/pwm.c
@@ -28,8 +28,6 @@
 
 #ifndef SKIP_RX_PWM_PPM
 
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
 #include "drivers/pwm_rx.h"
 
 #include "config/config.h"

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -31,12 +31,10 @@
 #include "config/config.h"
 #include "config/feature.h"
 
-#include "drivers/serial.h"
 #include "drivers/adc.h"
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
 #include "drivers/pwm_rx.h"
 #include "drivers/rx_spi.h"
+#include "drivers/serial.h"
 #include "drivers/system.h"
 
 #include "fc/rc_controls.h"

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -23,14 +23,9 @@
 
 #include "build/build_config.h"
 
-
+#include "drivers/serial.h"
 #include "drivers/system.h"
 
-#include "drivers/gpio.h"
-#include "drivers/inverter.h"
-
-#include "drivers/serial.h"
-#include "drivers/serial_uart.h"
 #include "io/serial.h"
 
 #include "rx/rx.h"

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -20,17 +20,15 @@
 #include <stdlib.h>
 
 #include "platform.h"
-#include "build/debug.h"
 
+#include "build/debug.h"
 
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
+#include "drivers/light_led.h"
+#include "drivers/serial.h"
 #include "drivers/system.h"
 
-#include "drivers/light_led.h"
-
-#include "drivers/serial.h"
-#include "drivers/serial_uart.h"
 #include "io/serial.h"
 
 #include "config/config.h"

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -23,11 +23,9 @@
 
 #include "build/build_config.h"
 
-
+#include "drivers/serial.h"
 #include "drivers/system.h"
 
-#include "drivers/serial.h"
-#include "drivers/serial_uart.h"
 #include "io/serial.h"
 
 #include "rx/rx.h"

--- a/src/main/rx/sumh.c
+++ b/src/main/rx/sumh.c
@@ -29,11 +29,9 @@
 
 #include "build/build_config.h"
 
-
+#include "drivers/serial.h"
 #include "drivers/system.h"
 
-#include "drivers/serial.h"
-#include "drivers/serial_uart.h"
 #include "io/serial.h"
 
 #include "rx/rx.h"

--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -21,10 +21,9 @@
 
 #include "platform.h"
 
+#include "drivers/serial.h"
 #include "drivers/system.h"
 
-#include "drivers/serial.h"
-#include "drivers/serial_uart.h"
 #include "io/serial.h"
 
 #include "rx/rx.h"

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -26,8 +26,6 @@
 #include "common/filter.h"
 
 #include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/gyro_sync.h"
 
 #include "sensors/battery.h"
 #include "sensors/sensors.h"

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#include "drivers/accgyro.h"
+
+#include "sensors/sensors.h"
+
 // Type of accelerometer used/detected
 typedef enum {
     ACC_DEFAULT = 0,

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -25,17 +25,14 @@
 #include "common/axis.h"
 #include "common/maths.h"
 
-#include "drivers/sensor.h"
-#include "drivers/compass.h"
-#include "drivers/compass_hmc5883l.h"
-#include "drivers/gpio.h"
-#include "drivers/light_led.h"
-
-#include "sensors/boardalignment.h"
-#include "fc/runtime_config.h"
-
 #include "config/config.h"
 
+#include "drivers/compass.h"
+#include "drivers/light_led.h"
+
+#include "fc/runtime_config.h"
+
+#include "sensors/boardalignment.h"
 #include "sensors/sensors.h"
 #include "sensors/compass.h"
 

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "sensors/sensors.h"
+
 // Type of magnetometer used/detected
 typedef enum {
     MAG_DEFAULT = 0,
@@ -33,7 +35,8 @@ typedef enum {
 
 #ifdef MAG
 bool compassInit(int16_t magDeclinationFromConfig);
-void updateCompass(flightDynamicsTrims_t *magZero);
+union flightDynamicsTrims_u;
+void updateCompass(union flightDynamicsTrims_u *magZero);
 bool isCompassReady(void);
 #endif
 

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -25,10 +25,6 @@
 #include "common/maths.h"
 #include "common/filter.h"
 
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/gyro_sync.h"
-
 #include "io/beeper.h"
 #include "io/statusindicator.h"
 

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "drivers/accgyro.h"
+
 typedef enum {
     GYRO_NONE = 0,
     GYRO_DEFAULT,

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -32,12 +32,7 @@
 #include "common/axis.h"
 
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
 #include "drivers/serial.h"
-
 
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"

--- a/src/main/telemetry/ibus.c
+++ b/src/main/telemetry/ibus.c
@@ -33,8 +33,6 @@
 #include "common/axis.h"
 
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 #include "drivers/serial.h"
 
 #include "io/serial.h"

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -46,12 +46,7 @@
 #include "common/utils.h"
 
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
 #include "drivers/serial.h"
-#include "drivers/pwm_rx.h"
 
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -35,12 +35,7 @@
 #include "common/color.h"
 
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
 #include "drivers/serial.h"
-#include "drivers/pwm_rx.h"
 
 #include "io/serial.h"
 #include "fc/rc_controls.h"

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -16,16 +16,7 @@
 #include "common/maths.h"
 
 #include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
-#include "drivers/compass.h"
 #include "drivers/serial.h"
-#include "drivers/bus_i2c.h"
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
-#include "drivers/pwm_rx.h"
-#include "drivers/adc.h"
-#include "drivers/light_led.h"
 
 #include "rx/rx.h"
 #include "rx/msp.h"
@@ -33,24 +24,15 @@
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
 
-#include "io/motors.h"
 #include "io/gps.h"
-#include "io/gimbal.h"
 #include "io/serial.h"
 #include "io/ledstrip.h"
 
-#include "sensors/boardalignment.h"
-#include "sensors/sensors.h"
-#include "sensors/battery.h"
 #include "sensors/acceleration.h"
+#include "sensors/battery.h"
 #include "sensors/barometer.h"
-#include "sensors/compass.h"
-#include "sensors/gyro.h"
 
-#include "flight/pid.h"
 #include "flight/imu.h"
-#include "flight/mixer.h"
-#include "flight/failsafe.h"
 #include "flight/navigation_rewrite.h"
 
 #include "telemetry/telemetry.h"

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -25,19 +25,16 @@
 
 #include "common/utils.h"
 
-#include "drivers/gpio.h"
-#include "drivers/timer.h"
 #include "drivers/serial.h"
-#include "drivers/serial_softserial.h"
+
 #include "io/serial.h"
 
-#include "rx/rx.h"
 #include "fc/rc_controls.h"
-
-
 #include "fc/runtime_config.h"
 
 #include "config/config.h"
+
+#include "rx/rx.h"
 
 #include "telemetry/telemetry.h"
 #include "telemetry/frsky.h"

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -51,7 +51,8 @@ typedef struct telemetryConfig_s {
 
 void telemetryInit(void);
 bool telemetryCheckRxPortShared(serialPortConfig_t *portConfig);
-extern serialPort_t *telemetrySharedPort;
+struct serialPort_s;
+extern struct serialPort_s *telemetrySharedPort;
 
 void telemetryCheckState(void);
 struct rxConfig_s;


### PR DESCRIPTION
Makes a start on "issue https://github.com/cleanflight/cleanflight/issues/2461 - Possibility to make the flight controller run as a linux process" by reducing device driver dependency in the main code.

Should give a minor improvement to build times.