### PR TITLE
Added settable fake acc, baro, compass, and gyro drivers

### DIFF
--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "sensor.h"
+
 #ifndef MPU_I2C_INSTANCE
 #define MPU_I2C_INSTANCE I2C_DEVICE
 #endif

--- a/src/main/drivers/accgyro_fake.c
+++ b/src/main/drivers/accgyro_fake.c
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "build/build_config.h"
+
+#include "common/axis.h"
+
+#include "accgyro.h"
+#include "accgyro_fake.h"
+
+
+#ifdef USE_FAKE_GYRO
+
+static int16_t fakeGyroADC[XYZ_AXIS_COUNT];
+
+static void fakeGyroInit(uint8_t lpf)
+{
+    UNUSED(lpf);
+}
+
+void fakeGyroSet(int16_t x, int16_t y, int16_t z)
+{
+    fakeGyroADC[X] = x;
+    fakeGyroADC[Y] = y;
+    fakeGyroADC[Z] = z;
+}
+
+static bool fakeGyroRead(int16_t *gyroADC)
+{
+    gyroADC[X] = fakeGyroADC[X];
+    gyroADC[Y] = fakeGyroADC[Y];
+    gyroADC[Z] = fakeGyroADC[Z];
+    return true;
+}
+
+static bool fakeGyroReadTemp(int16_t *tempData)
+{
+    UNUSED(tempData);
+    return true;
+}
+
+static bool fakeGyroInitStatus(void)
+{
+    return true;
+}
+
+bool fakeGyroDetect(gyro_t *gyro)
+{
+    gyro->init = fakeGyroInit;
+    gyro->intStatus = fakeGyroInitStatus;
+    gyro->read = fakeGyroRead;
+    gyro->temperature = fakeGyroReadTemp;
+    gyro->scale = 1.0f / 16.4f;
+    return true;
+}
+#endif // USE_FAKE_GYRO
+
+
+#ifdef USE_FAKE_ACC
+
+static int16_t fakeAccData[XYZ_AXIS_COUNT];
+
+static void fakeAccInit(acc_t *acc)
+{
+    UNUSED(acc);
+}
+
+void fakeAccSet(int16_t x, int16_t y, int16_t z)
+{
+    fakeAccData[X] = x;
+    fakeAccData[Y] = y;
+    fakeAccData[Z] = z;
+}
+
+static bool fakeAccRead(int16_t *accData)
+{
+    accData[X] = fakeAccData[X];
+    accData[Y] = fakeAccData[Y];
+    accData[Z] = fakeAccData[Z];
+    return true;
+}
+
+bool fakeAccDetect(acc_t *acc)
+{
+    acc->init = fakeAccInit;
+    acc->read = fakeAccRead;
+    acc->revisionCode = 0;
+    return true;
+}
+#endif // USE_FAKE_ACC
+

--- a/src/main/drivers/accgyro_fake.h
+++ b/src/main/drivers/accgyro_fake.h
@@ -17,13 +17,10 @@
 
 #pragma once
 
-#include "sensor.h"
+struct acc_s;
+bool fakeAccDetect(struct acc_s *acc);
+void fakeAccSet(int16_t x, int16_t y, int16_t z);
 
-typedef struct mag_s {
-    sensorInitFuncPtr init;                                 // initialize function
-    sensorReadFuncPtr read;                                 // read 3 axis data function
-} mag_t;
-
-#ifndef MAG_I2C_INSTANCE
-#define MAG_I2C_INSTANCE I2C_DEVICE
-#endif
+struct gyro_s;
+bool fakeGyroDetect(struct gyro_s *gyro);
+void fakeGyroSet(int16_t x, int16_t y, int16_t z);

--- a/src/main/drivers/barometer_fake.c
+++ b/src/main/drivers/barometer_fake.c
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#ifdef USE_FAKE_BARO
+
+#include "barometer.h"
+#include "barometer_fake.h"
+
+
+static int32_t fakePressure;
+static int32_t fakeTemperature;
+
+
+static void fakeBaroStartGet(void)
+{
+}
+
+static void fakeBaroCalculate(int32_t *pressure, int32_t *temperature)
+{
+    if (pressure)
+        *pressure = fakePressure;
+    if (temperature)
+        *temperature = fakeTemperature;
+}
+
+void fakeBaroSet(int32_t pressure, int32_t temperature)
+{
+    fakePressure = pressure;
+    fakeTemperature = temperature;
+}
+
+bool fakeBaroDetect(baro_t *baro)
+{
+    fakePressure = 101325;    // pressure in Pa (0m MSL)
+    fakeTemperature = 2500;   // temperature in 0.01 C = 25 deg
+
+    // these are dummy as temperature is measured as part of pressure
+    baro->ut_delay = 10000;
+    baro->get_ut = fakeBaroStartGet;
+    baro->start_ut = fakeBaroStartGet;
+
+    // only _up part is executed, and gets both temperature and pressure
+    baro->up_delay = 10000;
+    baro->start_up = fakeBaroStartGet;
+    baro->get_up = fakeBaroStartGet;
+    baro->calculate = fakeBaroCalculate;
+
+    return true;
+}
+#endif // USE_FAKE_BARO
+

--- a/src/main/drivers/barometer_fake.h
+++ b/src/main/drivers/barometer_fake.h
@@ -17,13 +17,7 @@
 
 #pragma once
 
-#include "sensor.h"
+struct baro_s;
+bool fakeBaroDetect(struct baro_s *baro);
+void fakeBaroSet(int32_t pressure, int32_t temperature);
 
-typedef struct mag_s {
-    sensorInitFuncPtr init;                                 // initialize function
-    sensorReadFuncPtr read;                                 // read 3 axis data function
-} mag_t;
-
-#ifndef MAG_I2C_INSTANCE
-#define MAG_I2C_INSTANCE I2C_DEVICE
-#endif

--- a/src/main/drivers/compass_fake.c
+++ b/src/main/drivers/compass_fake.c
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#ifdef USE_FAKE_MAG
+
+#include "build/build_config.h"
+
+#include "common/axis.h"
+
+#include "compass.h"
+#include "compass_fake.h"
+
+
+static int16_t fakeMagData[XYZ_AXIS_COUNT];
+
+static bool fakeMagInit(void)
+{
+    // initially point north
+    fakeMagData[X] = 4096;
+    fakeMagData[Y] = 0;
+    fakeMagData[Z] = 0;
+    return true;
+}
+
+void fakeMagSet(int16_t x, int16_t y, int16_t z)
+{
+    fakeMagData[X] = x;
+    fakeMagData[Y] = y;
+    fakeMagData[Z] = z;
+}
+
+static bool fakeMagRead(int16_t *magData)
+{
+    magData[X] = fakeMagData[X];
+    magData[Y] = fakeMagData[Y];
+    magData[Z] = fakeMagData[Z];
+    return true;
+}
+
+bool fakeMagDetect(mag_t *mag)
+{
+    mag->init = fakeMagInit;
+    mag->read = fakeMagRead;
+    return true;
+}
+#endif // USE_FAKE_MAG
+

--- a/src/main/drivers/compass_fake.h
+++ b/src/main/drivers/compass_fake.h
@@ -17,13 +17,6 @@
 
 #pragma once
 
-#include "sensor.h"
-
-typedef struct mag_s {
-    sensorInitFuncPtr init;                                 // initialize function
-    sensorReadFuncPtr read;                                 // read 3 axis data function
-} mag_t;
-
-#ifndef MAG_I2C_INSTANCE
-#define MAG_I2C_INSTANCE I2C_DEVICE
-#endif
+struct mag_s;
+bool fakeMagDetect(struct mag_s *mag);
+void fakeMagSet(int16_t x, int16_t y, int16_t z);

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -35,6 +35,7 @@
 #include "drivers/accgyro.h"
 #include "drivers/accgyro_adxl345.h"
 #include "drivers/accgyro_bma280.h"
+#include "drivers/accgyro_fake.h"
 #include "drivers/accgyro_l3g4200d.h"
 #include "drivers/accgyro_mma845x.h"
 #include "drivers/accgyro_mpu.h"
@@ -53,12 +54,14 @@
 #include "drivers/barometer.h"
 #include "drivers/barometer_bmp085.h"
 #include "drivers/barometer_bmp280.h"
+#include "drivers/barometer_fake.h"
 #include "drivers/barometer_ms5611.h"
 
 #include "drivers/compass.h"
-#include "drivers/compass_hmc5883l.h"
-#include "drivers/compass_ak8975.h"
 #include "drivers/compass_ak8963.h"
+#include "drivers/compass_ak8975.h"
+#include "drivers/compass_fake.h"
+#include "drivers/compass_hmc5883l.h"
 #include "drivers/compass_mag3110.h"
 
 #include "drivers/sonar_hcsr04.h"
@@ -101,110 +104,6 @@ const extiConfig_t *selectMPUIntExtiConfig(void)
     return NULL;
 #endif
 }
-
-#ifdef USE_FAKE_GYRO
-static void fakeGyroInit(uint8_t lpf)
-{
-    UNUSED(lpf);
-}
-
-static bool fakeGyroRead(int16_t *gyroADC)
-{
-    memset(gyroADC, 0, sizeof(int16_t[XYZ_AXIS_COUNT]));
-    return true;
-}
-
-static bool fakeGyroReadTemp(int16_t *tempData)
-{
-    UNUSED(tempData);
-    return true;
-}
-
-
-static bool fakeGyroInitStatus(void) {
-    return true;
-}
-
-bool fakeGyroDetect(gyro_t *gyro)
-{
-    gyro->init = fakeGyroInit;
-    gyro->intStatus = fakeGyroInitStatus;
-    gyro->read = fakeGyroRead;
-    gyro->temperature = fakeGyroReadTemp;
-    gyro->scale = 1.0f / 16.4f;
-    return true;
-}
-#endif
-
-#ifdef USE_FAKE_ACC
-static void fakeAccInit(acc_t *acc) {UNUSED(acc);}
-static bool fakeAccRead(int16_t *accData) {
-    memset(accData, 0, sizeof(int16_t[XYZ_AXIS_COUNT]));
-    return true;
-}
-
-bool fakeAccDetect(acc_t *acc)
-{
-    acc->init = fakeAccInit;
-    acc->read = fakeAccRead;
-    acc->revisionCode = 0;
-    return true;
-}
-#endif
-
-#ifdef USE_FAKE_BARO
-static void fakeBaroStartGet(void)
-{
-}
-
-static void fakeBaroCalculate(int32_t *pressure, int32_t *temperature)
-{
-    if (pressure)
-        *pressure = 101325;    // pressure in Pa (0m MSL)
-    if (temperature)
-        *temperature = 2500;   // temperature in 0.01 C = 25 deg
-}
-
-bool fakeBaroDetect(baro_t *baro)
-{
-    // these are dummy as temperature is measured as part of pressure
-    baro->ut_delay = 10000;
-    baro->get_ut = fakeBaroStartGet;
-    baro->start_ut = fakeBaroStartGet;
-
-    // only _up part is executed, and gets both temperature and pressure
-    baro->up_delay = 10000;
-    baro->start_up = fakeBaroStartGet;
-    baro->get_up = fakeBaroStartGet;
-    baro->calculate = fakeBaroCalculate;
-
-    return true;
-}
-#endif
-
-#ifdef USE_FAKE_MAG
-static bool fakeMagInit(void)
-{
-    return true;
-}
-
-static bool fakeMagRead(int16_t *magData)
-{
-    // Always pointint North
-    magData[X] = 4096;
-    magData[Y] = 0;
-    magData[Z] = 0;
-    return true;
-}
-
-static bool fakeMagDetect(mag_t *mag)
-{
-    mag->init = fakeMagInit;
-    mag->read = fakeMagRead;
-
-    return true;
-}
-#endif
 
 bool detectGyro(void)
 {

--- a/src/main/target/STM32F3DISCOVERY/target.mk
+++ b/src/main/target/STM32F3DISCOVERY/target.mk
@@ -4,6 +4,7 @@ FEATURES    = VCP SDCARD
 TARGET_SRC = \
             drivers/accgyro_adxl345.c \
             drivers/accgyro_bma280.c \
+            drivers/accgyro_fake.c \
             drivers/accgyro_l3gd20.c \
             drivers/accgyro_l3g4200d.c \
             drivers/accgyro_lsm303dlhc.c \
@@ -17,12 +18,13 @@ TARGET_SRC = \
             drivers/accgyro_spi_mpu9250.c \
             drivers/barometer_bmp085.c \
             drivers/barometer_bmp280.c \
+            drivers/barometer_fake.c \
             drivers/barometer_ms5611.c \
             drivers/compass_ak8963.c \
             drivers/compass_ak8975.c \
             drivers/compass_hmc5883l.c \
+            drivers/compass_fake.c \
             drivers/compass_mag3110.c \
             drivers/flash_m25p16.c \
-            drivers/light_ws2811strip.c \
-            drivers/light_ws2811strip_stm32f30x.c
+            drivers/light_ws2811strip.c
 


### PR DESCRIPTION
Partially addresses "issue https://github.com/cleanflight/cleanflight/issues/2461 - Possibility to make the flight controller run as a linux process" by introducing settable fake drivers.
