### PR TITLE
Hardware failure detection and warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,6 +452,7 @@ COMMON_SRC = \
             sensors/compass.c \
             sensors/gyro.c \
             sensors/initialisation.c \
+            sensors/diagnostics.c \
             $(CMSIS_SRC) \
             $(DEVICE_STDPERIPH_SRC)
 

--- a/docs/LedStrip.md
+++ b/docs/LedStrip.md
@@ -163,6 +163,7 @@ This mode simply uses the LEDs to flash when warnings occur.
 |---------|-------------|-------|
 | Arm-lock enabled | flash between green and off | occurs calibration or when unarmed and the aircraft is tilted too much |
 | Low Battery | flash red and off | battery monitoring must be enabled.  May trigger temporarily under high-throttle due to voltage drop |
+| Hardware Error | flash blue and off | indicates that at least one of hardware components is not working correctly |
 | Failsafe | flash between light blue and yellow | Failsafe must be enabled |
 
 Flash patterns appear in order, so that it's clear which warnings are enabled.

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -500,11 +500,13 @@ static void resetConf(void)
     masterConfig.boardAlignment.rollDeciDegrees = 0;
     masterConfig.boardAlignment.pitchDeciDegrees = 0;
     masterConfig.boardAlignment.yawDeciDegrees = 0;
-    masterConfig.accelerometerConfig.acc_hardware = ACC_DEFAULT;     // default/autodetect
+
     masterConfig.gyroConfig.gyroMovementCalibrationThreshold = 32;
 
-    masterConfig.compassConfig.mag_hardware = MAG_DEFAULT;     // default/autodetect
-    masterConfig.barometerConfig.baro_hardware = BARO_DEFAULT;   // default/autodetect
+    masterConfig.accelerometerConfig.acc_hardware = ACC_AUTODETECT;     // default/autodetect
+    masterConfig.compassConfig.mag_hardware = MAG_NONE;
+    masterConfig.barometerConfig.baro_hardware = BARO_NONE;
+    masterConfig.pitotmeterConfig.pitot_hardware = PITOT_NONE;
 
     resetBatteryConfig(&masterConfig.batteryConfig);
 

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -370,6 +370,21 @@ static uint32_t packFlightModeFlags(void)
     return ret;
 }
 
+static uint16_t packSensorStatus(void)
+{
+    uint16_t sensorStatus =
+            IS_ENABLED(sensors(SENSOR_ACC))     << 0 |
+            IS_ENABLED(sensors(SENSOR_BARO))    << 1 |
+            IS_ENABLED(sensors(SENSOR_MAG))     << 2 |
+            IS_ENABLED(sensors(SENSOR_GPS))     << 3 |
+            IS_ENABLED(sensors(SENSOR_SONAR))   << 4 |
+            //IS_ENABLED(sensors(SENSOR_OPFLOW))  << 5 |
+            IS_ENABLED(sensors(SENSOR_PITOT))   << 6 |
+            IS_ENABLED(isHardwareHealthy())     << 15;          // Bit 15 of sensor bit field indicates general hardware health
+
+    return sensorStatus;
+}
+
 static void serializeSDCardSummaryReply(sbuf_t *dst)
 {
 #ifdef USE_SDCARD
@@ -529,7 +544,7 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
 #else
         sbufWriteU16(dst, 0);
 #endif
-        sbufWriteU16(dst, sensors(SENSOR_ACC) | sensors(SENSOR_BARO) << 1 | sensors(SENSOR_MAG) << 2 | sensors(SENSOR_GPS) << 3 | sensors(SENSOR_SONAR) << 4 | sensors(SENSOR_PITOT) << 6);
+        sbufWriteU16(dst, packSensorStatus());
         sbufWriteU32(dst, packFlightModeFlags());
         sbufWriteU8(dst, masterConfig.current_profile_index);
         sbufWriteU16(dst, averageSystemLoadPercent);
@@ -542,7 +557,7 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
 #else
         sbufWriteU16(dst, 0);
 #endif
-        sbufWriteU16(dst, sensors(SENSOR_ACC) | sensors(SENSOR_BARO) << 1 | sensors(SENSOR_MAG) << 2 | sensors(SENSOR_GPS) << 3 | sensors(SENSOR_SONAR) << 4 | sensors(SENSOR_PITOT) << 6);
+        sbufWriteU16(dst, packSensorStatus());
         sbufWriteU32(dst, packFlightModeFlags());
         sbufWriteU8(dst, masterConfig.current_profile_index);
         break;

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -67,6 +67,7 @@
 
 #include "sensors/boardalignment.h"
 #include "sensors/sensors.h"
+#include "sensors/diagnostics.h"
 #include "sensors/battery.h"
 #include "sensors/rangefinder.h"
 #include "sensors/acceleration.h"
@@ -508,6 +509,17 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
         sbufWriteU16(dst, hilToSIM.pidCommand[THROTTLE]);
         break;
 #endif
+
+    case MSP_SENSOR_STATUS:
+        sbufWriteU8(dst, isHardwareHealthy() ? 1 : 0);
+        sbufWriteU8(dst, getHwGyroStatus());
+        sbufWriteU8(dst, getHwAccelerometerStatus());
+        sbufWriteU8(dst, getHwCompassStatus());
+        sbufWriteU8(dst, getHwBarometerStatus());
+        sbufWriteU8(dst, getHwGPSStatus());
+        sbufWriteU8(dst, getHwRangefinderStatus());
+        sbufWriteU8(dst, HW_SENSOR_NONE);                   // Optical flow
+        break;
 
     case MSP_STATUS_EX:
         sbufWriteU16(dst, cycleTime);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -518,6 +518,7 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
         sbufWriteU8(dst, getHwBarometerStatus());
         sbufWriteU8(dst, getHwGPSStatus());
         sbufWriteU8(dst, getHwRangefinderStatus());
+        sbufWriteU8(dst, getHwPitotmeterStatus());
         sbufWriteU8(dst, HW_SENSOR_NONE);                   // Optical flow
         break;
 

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -372,6 +372,7 @@ static uint32_t packFlightModeFlags(void)
 
 static uint16_t packSensorStatus(void)
 {
+    // Sensor bits
     uint16_t sensorStatus =
             IS_ENABLED(sensors(SENSOR_ACC))     << 0 |
             IS_ENABLED(sensors(SENSOR_BARO))    << 1 |
@@ -379,8 +380,12 @@ static uint16_t packSensorStatus(void)
             IS_ENABLED(sensors(SENSOR_GPS))     << 3 |
             IS_ENABLED(sensors(SENSOR_SONAR))   << 4 |
             //IS_ENABLED(sensors(SENSOR_OPFLOW))  << 5 |
-            IS_ENABLED(sensors(SENSOR_PITOT))   << 6 |
-            IS_ENABLED(isHardwareHealthy())     << 15;          // Bit 15 of sensor bit field indicates general hardware health
+            IS_ENABLED(sensors(SENSOR_PITOT))   << 6;
+
+    // Hardware failure indication bit
+    if (!isHardwareHealthy()) {
+        sensorStatus |= 1 << 15;        // Bit 15 of sensor bit field indicates hardware failure
+    }
 
     return sensorStatus;
 }

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1107,10 +1107,10 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
         break;
 
     case MSP_SENSOR_CONFIG:
-        sbufWriteU8(dst, masterConfig.sensorSelectionConfig.acc_hardware);
-        sbufWriteU8(dst, masterConfig.sensorSelectionConfig.baro_hardware);
-        sbufWriteU8(dst, masterConfig.sensorSelectionConfig.mag_hardware);
-        sbufWriteU8(dst, masterConfig.sensorSelectionConfig.pitot_hardware);
+        sbufWriteU8(dst, masterConfig.accelerometerConfig.acc_hardware);
+        sbufWriteU8(dst, masterConfig.barometerConfig.baro_hardware);
+        sbufWriteU8(dst, masterConfig.compassConfig.mag_hardware);
+        sbufWriteU8(dst, masterConfig.pitotmeterConfig.pitot_hardware);
         sbufWriteU8(dst, 0);    // rangefinder hardware
         sbufWriteU8(dst, 0);    // optical flow hardware
         break;
@@ -1500,10 +1500,10 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_SENSOR_CONFIG:
-        masterConfig.sensorSelectionConfig.acc_hardware = sbufReadU8(src);
-        masterConfig.sensorSelectionConfig.baro_hardware = sbufReadU8(src);
-        masterConfig.sensorSelectionConfig.mag_hardware = sbufReadU8(src);
-        masterConfig.sensorSelectionConfig.pitot_hardware = sbufReadU8(src);
+        masterConfig.accelerometerConfig.acc_hardware = sbufReadU8(src);
+        masterConfig.barometerConfig.baro_hardware = sbufReadU8(src);
+        masterConfig.compassConfig.mag_hardware = sbufReadU8(src);
+        masterConfig.pitotmeterConfig.pitot_hardware = sbufReadU8(src);
         sbufReadU8(src);        // rangefinder hardware
         sbufReadU8(src);        // optical flow hardware
         break;

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1101,6 +1101,15 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
         sbufWriteU8(dst, 0); //reserved
         break;
 
+    case MSP_SENSOR_CONFIG:
+        sbufWriteU8(dst, masterConfig.sensorSelectionConfig.acc_hardware);
+        sbufWriteU8(dst, masterConfig.sensorSelectionConfig.baro_hardware);
+        sbufWriteU8(dst, masterConfig.sensorSelectionConfig.mag_hardware);
+        sbufWriteU8(dst, masterConfig.sensorSelectionConfig.pitot_hardware);
+        sbufWriteU8(dst, 0);    // rangefinder hardware
+        sbufWriteU8(dst, 0);    // optical flow hardware
+        break;
+
     case MSP_REBOOT:
         if (mspPostProcessFn) {
             *mspPostProcessFn = mspRebootFn;
@@ -1483,6 +1492,15 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
             sbufReadU8(src); //reserved
             sbufReadU8(src); //reserved
             sbufReadU8(src); //reserved
+        break;
+
+    case MSP_SET_SENSOR_CONFIG:
+        masterConfig.sensorSelectionConfig.acc_hardware = sbufReadU8(src);
+        masterConfig.sensorSelectionConfig.baro_hardware = sbufReadU8(src);
+        masterConfig.sensorSelectionConfig.mag_hardware = sbufReadU8(src);
+        masterConfig.sensorSelectionConfig.pitot_hardware = sbufReadU8(src);
+        sbufReadU8(src);        // rangefinder hardware
+        sbufReadU8(src);        // optical flow hardware
         break;
 
     case MSP_RESET_CONF:

--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -37,6 +37,7 @@
 #include "drivers/system.h"
 
 #include "sensors/sensors.h"
+#include "sensors/diagnostics.h"
 #include "sensors/boardalignment.h"
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
@@ -153,7 +154,7 @@ void annexCode(void)
     if (ARMING_FLAG(ARMED)) {
         LED0_ON;
     } else {
-        if (IS_RC_MODE_ACTIVE(BOXARM) == 0) {
+        if (!IS_RC_MODE_ACTIVE(BOXARM)) {
             ENABLE_ARMING_FLAG(OK_TO_ARM);
         }
 
@@ -161,7 +162,7 @@ void annexCode(void)
             DISABLE_ARMING_FLAG(OK_TO_ARM);
         }
 
-        if (isCalibrating() || isSystemOverloaded()) {
+        if (isCalibrating() || isSystemOverloaded() || !isHardwareHealthy()) {
             warningLedFlash();
             DISABLE_ARMING_FLAG(OK_TO_ARM);
         }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -425,7 +425,12 @@ static int imuCalculateAccelerometerConfidence(void)
 
 static void imuCalculateEstimatedAttitude(float dT)
 {
-    const bool canUseMAG = sensors(SENSOR_MAG) && isMagnetometerHealthy();
+#if defined(MAG)
+    const bool canUseMAG = sensors(SENSOR_MAG) && isCompassHealthy();
+#else
+    const bool canUseMAG = false;
+#endif
+
     const int accWeight = imuCalculateAccelerometerConfidence();
 
     float courseOverGround = 0;

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -423,11 +423,6 @@ static int imuCalculateAccelerometerConfidence(void)
     return (nearness > MAX_ACC_SQ_NEARNESS) ? 0 : MAX_ACC_SQ_NEARNESS - nearness;
 }
 
-static bool isMagnetometerHealthy(void)
-{
-    return (mag.magADC[X] != 0) && (mag.magADC[Y] != 0) && (mag.magADC[Z] != 0);
-}
-
 static void imuCalculateEstimatedAttitude(float dT)
 {
     const bool canUseMAG = sensors(SENSOR_MAG) && isMagnetometerHealthy();

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -28,6 +28,7 @@
 
 #include "sensors/battery.h"
 #include "sensors/sensors.h"
+#include "sensors/diagnostics.h"
 
 #include "rx/rx.h"
 
@@ -123,6 +124,10 @@ static const uint8_t beep_gyroCalibrated[] = {
 static const uint8_t beep_launchModeBeep[] = {
     5, 5, 5, 100, BEEPER_COMMAND_STOP
 };
+// short beeps
+static const uint8_t beep_hardwareFailure[] = {
+    10, 10, BEEPER_COMMAND_STOP
+};
 
 // array used for variable # of beeps (reporting GPS sat count, etc)
 static uint8_t beep_multiBeeps[MAX_MULTI_BEEPS + 2];
@@ -160,27 +165,28 @@ typedef struct beeperTableEntry_s {
 
 /*static*/ const beeperTableEntry_t beeperTable[] = {
     { BEEPER_ENTRY(BEEPER_GYRO_CALIBRATED,       0, beep_gyroCalibrated,   "GYRO_CALIBRATED") },
-    { BEEPER_ENTRY(BEEPER_RX_LOST,               1, beep_txLostBeep,       "RX_LOST") },
-    { BEEPER_ENTRY(BEEPER_RX_LOST_LANDING,       2, beep_sos,              "RX_LOST_LANDING") },
-    { BEEPER_ENTRY(BEEPER_DISARMING,             3, beep_disarmBeep,       "DISARMING") },
-    { BEEPER_ENTRY(BEEPER_ARMING,                4, beep_armingBeep,       "ARMING")  },
-    { BEEPER_ENTRY(BEEPER_ARMING_GPS_FIX,        5, beep_armedGpsFix,      "ARMING_GPS_FIX") },
-    { BEEPER_ENTRY(BEEPER_BAT_CRIT_LOW,          6, beep_critBatteryBeep,  "BAT_CRIT_LOW") },
-    { BEEPER_ENTRY(BEEPER_BAT_LOW,               7, beep_lowBatteryBeep,   "BAT_LOW") },
-    { BEEPER_ENTRY(BEEPER_GPS_STATUS,            8, beep_multiBeeps,       "GPS_STATUS") },
-    { BEEPER_ENTRY(BEEPER_RX_SET,                9, beep_shortBeep,        "RX_SET") },
-    { BEEPER_ENTRY(BEEPER_ACC_CALIBRATION,       10, beep_2shortBeeps,     "ACC_CALIBRATION") },
-    { BEEPER_ENTRY(BEEPER_ACC_CALIBRATION_FAIL,  11, beep_2longerBeeps,    "ACC_CALIBRATION_FAIL") },
-    { BEEPER_ENTRY(BEEPER_READY_BEEP,            12, beep_readyBeep,       "READY_BEEP") },
-    { BEEPER_ENTRY(BEEPER_MULTI_BEEPS,           13, beep_multiBeeps,      "MULTI_BEEPS") }, // FIXME having this listed makes no sense since the beep array will not be initialised.
-    { BEEPER_ENTRY(BEEPER_DISARM_REPEAT,         14, beep_disarmRepeatBeep, "DISARM_REPEAT") },
-    { BEEPER_ENTRY(BEEPER_ARMED,                 15, beep_armedBeep,       "ARMED") },
-    { BEEPER_ENTRY(BEEPER_SYSTEM_INIT,           16, NULL,                 "SYSTEM_INIT") },
-    { BEEPER_ENTRY(BEEPER_USB,                   17, NULL,                 "ON_USB") },
-    { BEEPER_ENTRY(BEEPER_LAUNCH_MODE_ENABLED,   18, beep_launchModeBeep,  "LAUNCH_MODE") },
+    { BEEPER_ENTRY(BEEPER_HARDWARE_FAILURE ,     1, beep_hardwareFailure,  "HW_FAILURE") },
+    { BEEPER_ENTRY(BEEPER_RX_LOST,               2, beep_txLostBeep,       "RX_LOST") },
+    { BEEPER_ENTRY(BEEPER_RX_LOST_LANDING,       3, beep_sos,              "RX_LOST_LANDING") },
+    { BEEPER_ENTRY(BEEPER_DISARMING,             4, beep_disarmBeep,       "DISARMING") },
+    { BEEPER_ENTRY(BEEPER_ARMING,                5, beep_armingBeep,       "ARMING")  },
+    { BEEPER_ENTRY(BEEPER_ARMING_GPS_FIX,        6, beep_armedGpsFix,      "ARMING_GPS_FIX") },
+    { BEEPER_ENTRY(BEEPER_BAT_CRIT_LOW,          7, beep_critBatteryBeep,  "BAT_CRIT_LOW") },
+    { BEEPER_ENTRY(BEEPER_BAT_LOW,               8, beep_lowBatteryBeep,   "BAT_LOW") },
+    { BEEPER_ENTRY(BEEPER_GPS_STATUS,            9, beep_multiBeeps,       "GPS_STATUS") },
+    { BEEPER_ENTRY(BEEPER_RX_SET,                10, beep_shortBeep,       "RX_SET") },
+    { BEEPER_ENTRY(BEEPER_ACC_CALIBRATION,       11, beep_2shortBeeps,     "ACC_CALIBRATION") },
+    { BEEPER_ENTRY(BEEPER_ACC_CALIBRATION_FAIL,  12, beep_2longerBeeps,    "ACC_CALIBRATION_FAIL") },
+    { BEEPER_ENTRY(BEEPER_READY_BEEP,            13, beep_readyBeep,       "READY_BEEP") },
+    { BEEPER_ENTRY(BEEPER_MULTI_BEEPS,           14, beep_multiBeeps,      "MULTI_BEEPS") }, // FIXME having this listed makes no sense since the beep array will not be initialised.
+    { BEEPER_ENTRY(BEEPER_DISARM_REPEAT,         15, beep_disarmRepeatBeep, "DISARM_REPEAT") },
+    { BEEPER_ENTRY(BEEPER_ARMED,                 16, beep_armedBeep,       "ARMED") },
+    { BEEPER_ENTRY(BEEPER_SYSTEM_INIT,           17, NULL,                 "SYSTEM_INIT") },
+    { BEEPER_ENTRY(BEEPER_USB,                   18, NULL,                 "ON_USB") },
+    { BEEPER_ENTRY(BEEPER_LAUNCH_MODE_ENABLED,   19, beep_launchModeBeep,  "LAUNCH_MODE") },
 
-    { BEEPER_ENTRY(BEEPER_ALL,                   19, NULL,                 "ALL") },
-    { BEEPER_ENTRY(BEEPER_PREFERENCE,            20, NULL,                 "PREFERED") },
+    { BEEPER_ENTRY(BEEPER_ALL,                   20, NULL,                 "ALL") },
+    { BEEPER_ENTRY(BEEPER_PREFERENCE,            21, NULL,                 "PREFERED") },
 };
 
 static const beeperTableEntry_t *currentBeeperEntry = NULL;
@@ -300,6 +306,11 @@ void beeperUpdate(timeUs_t currentTimeUs)
 #else
         beeper(BEEPER_RX_SET);
 #endif
+    }
+
+    // Beep out hardware failure
+    if (!isHardwareHealthy()) {
+        beeper(BEEPER_HARDWARE_FAILURE);
     }
 
     // Beeper routine doesn't need to update if there aren't any sounds ongoing

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -42,6 +42,7 @@ typedef enum {
     BEEPER_SYSTEM_INIT,             // Initialisation beeps when board is powered on
     BEEPER_USB,                     // Some boards have beeper powered USB connected
     BEEPER_LAUNCH_MODE_ENABLED,     // Fixed-wing launch mode enabled
+    BEEPER_HARDWARE_FAILURE,        // HW failure
 
     BEEPER_ALL,                     // Turn ON or OFF all beeper conditions
     BEEPER_PREFERENCE,              // Save preferred beeper configuration

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -460,4 +460,8 @@ bool gpsMagDetect(magDev_t *mag)
     return true;
 }
 
+bool isGPSHealthy(void)
+{
+    return true;
+}
 #endif

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -139,3 +139,4 @@ struct serialConfig_s;
 void gpsInit(struct serialConfig_s *serialConfig, gpsConfig_t *initialGpsConfig);
 void gpsThread(void);
 void updateGpsIndicator(timeUs_t currentTimeUs);
+bool isGPSHealthy(void);

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -512,6 +512,7 @@ typedef enum {
     WARNING_ARMING_DISABLED,
     WARNING_LOW_BATTERY,
     WARNING_FAILSAFE,
+    WARNING_HW_ERROR,
 } warningFlags_e;
 
 static void applyLedWarningLayer(bool updateNow, timeUs_t *timer)
@@ -532,6 +533,10 @@ static void applyLedWarningLayer(bool updateNow, timeUs_t *timer)
                 warningFlags |= 1 << WARNING_FAILSAFE;
             if (!ARMING_FLAG(ARMED) && !ARMING_FLAG(OK_TO_ARM))
                 warningFlags |= 1 << WARNING_ARMING_DISABLED;
+#ifdef MAG
+            if (masterConfig.mag_hardware != MAG_NONE && !compassIsWorking())
+                warningFlags |= 1 << WARNING_HW_ERROR;
+#endif
         }
         *timer += LED_STRIP_HZ(10);
     }
@@ -551,6 +556,9 @@ static void applyLedWarningLayer(bool updateNow, timeUs_t *timer)
                     break;
                 case WARNING_FAILSAFE:
                     warningColor = colorOn ? &HSV(YELLOW) : &HSV(BLUE);
+                    break;
+                case WARNING_HW_ERROR:
+                    warningColor = colorOn ? &HSV(BLUE) : &HSV(BLACK);
                     break;
                 default:;
             }

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -44,6 +44,7 @@
 #include "fc/runtime_config.h"
 
 #include "sensors/acceleration.h"
+#include "sensors/diagnostics.h"
 #include "sensors/barometer.h"
 #include "sensors/battery.h"
 #include "sensors/boardalignment.h"

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -533,10 +533,8 @@ static void applyLedWarningLayer(bool updateNow, timeUs_t *timer)
                 warningFlags |= 1 << WARNING_FAILSAFE;
             if (!ARMING_FLAG(ARMED) && !ARMING_FLAG(OK_TO_ARM))
                 warningFlags |= 1 << WARNING_ARMING_DISABLED;
-#ifdef MAG
-            if (masterConfig.mag_hardware != MAG_NONE && !compassIsWorking())
+            if (!isHardwareHealthy())
                 warningFlags |= 1 << WARNING_HW_ERROR;
-#endif
         }
         *timer += LED_STRIP_HZ(10);
     }

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -71,6 +71,7 @@
 #include "rx/spektrum.h"
 
 #include "sensors/battery.h"
+#include "sensors/diagnostics.h"
 #include "sensors/boardalignment.h"
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"
@@ -239,6 +240,11 @@ static const char * const sensorTypeNames[] = {
 };
 
 #define SENSOR_NAMES_MASK (SENSOR_GYRO | SENSOR_ACC | SENSOR_BARO | SENSOR_MAG | SENSOR_SONAR | SENSOR_PITOT)
+
+static const char * const hardwareSensorStatusNames[] = {
+    "NONE", "OK", "UNAVAILABLE", "FAILING"
+};
+
 // sync with gyroSensor_e
 static const char * const gyroNames[] = { "", "None", "MPU6050", "L3G4200D", "MPU3050", "L3GD20", "MPU6000", "MPU6500", "MPU9250", "FAKE"};
 // sync with accelerationSensor_e
@@ -2905,8 +2911,18 @@ static void cliStatus(char *cmdline)
             }
         }
     }
-#endif
     cliPrint("\r\n");
+
+    cliPrintf("Sensor status: GYRO=%s, ACC=%s, MAG=%s, BARO=%s, SONAR=%s, GPS=%s\r\n", 
+        hardwareSensorStatusNames[getHwGyroStatus()],
+        hardwareSensorStatusNames[getHwAccelerometerStatus()],
+        hardwareSensorStatusNames[getHwCompassStatus()],
+        hardwareSensorStatusNames[getHwBarometerStatus()],
+        hardwareSensorStatusNames[getHwRangefinderStatus()],
+        hardwareSensorStatusNames[getHwGPSStatus()]
+    );
+    
+#endif
 
 #ifdef USE_I2C
     const uint16_t i2cErrorCounter = i2cGetErrorCounter();

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -246,17 +246,17 @@ static const char * const hardwareSensorStatusNames[] = {
 };
 
 // sync with gyroSensor_e
-static const char * const gyroNames[] = { "", "None", "MPU6050", "L3G4200D", "MPU3050", "L3GD20", "MPU6000", "MPU6500", "MPU9250", "FAKE"};
+static const char * const gyroNames[] = { "NONE", "AUTO", "MPU6050", "L3G4200D", "MPU3050", "L3GD20", "MPU6000", "MPU6500", "MPU9250", "FAKE"};
 // sync with accelerationSensor_e
-static const char * const accNames[] = { "", "None", "ADXL345", "MPU6050", "MMA845x", "BMA280", "LSM303DLHC", "MPU6000", "MPU6500", "MPU9250", "FAKE"};
+static const char * const accNames[] = { "NONE", "AUTO", "ADXL345", "MPU6050", "MMA845x", "BMA280", "LSM303DLHC", "MPU6000", "MPU6500", "MPU9250", "FAKE"};
 // sync with baroSensor_e
-static const char * const baroNames[] = { "", "None", "BMP085", "MS5611", "BMP280", "FAKE"};
+static const char * const baroNames[] = { "NONE", "BMP085", "MS5611", "BMP280", "FAKE"};
 // sync with magSensor_e
-static const char * const magNames[] = { "", "None", "HMC5883", "AK8975", "MAG_GPS", "MAG_MAG3110", "MAG_AK8963", "FAKE"};
+static const char * const magNames[] = { "NONE", "HMC5883", "AK8975", "MAG_GPS", "MAG_MAG3110", "MAG_AK8963", "FAKE"};
 // sycn with rangefinderType_e
-static const char * const rangefinderNames[] = { "None", "HCSR04", "SRF10"};
+static const char * const rangefinderNames[] = { "NONE", "HCSR04", "SRF10"};
 // sync with pitotSensor_e
-static const char * const pitotmeterNames[] = { "Auto", "None", "MS4525", "FAKE"};
+static const char * const pitotmeterNames[] = { "NONE", "MS4525", "FAKE"};
 
 static const char * const *sensorHardwareNames[] = {gyroNames, accNames, baroNames, magNames, rangefinderNames, pitotmeterNames};
 
@@ -539,6 +539,11 @@ typedef enum {
 #ifdef OSD
     TABLE_OSD,
 #endif
+    TABLE_HW_ACC,
+    TABLE_HW_BARO,
+    TABLE_HW_MAG,
+    TABLE_HW_RANGEFINDER,   // currently not used
+    TABLE_HW_PITOT,
 } lookupTableIndex_e;
 
 static const lookupTableEntry_t lookupTables[] = {
@@ -577,6 +582,11 @@ static const lookupTableEntry_t lookupTables[] = {
 #ifdef OSD
     { lookupTableOsdType, sizeof(lookupTableOsdType) / sizeof(char *) },
 #endif
+    { accNames, sizeof(accNames) / sizeof(char *) },
+    { baroNames, sizeof(baroNames) / sizeof(char *) },
+    { magNames, sizeof(magNames) / sizeof(char *) },
+    { rangefinderNames, sizeof(rangefinderNames) / sizeof(char *) },
+    { pitotmeterNames, sizeof(pitotmeterNames) / sizeof(char *) },
 };
 
 #define VALUE_TYPE_OFFSET 0

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -233,18 +233,7 @@ static const rxFailsafeChannelMode_e rxFailsafeModesTable[RX_FAILSAFE_TYPE_COUNT
     { RX_FAILSAFE_MODE_INVALID, RX_FAILSAFE_MODE_HOLD, RX_FAILSAFE_MODE_SET }
 };
 
-#if (FLASH_SIZE > 64)
-// sync this with sensors_e
-static const char * const sensorTypeNames[] = {
-    "GYRO", "ACC", "BARO", "MAG", "SONAR", "PITOT", "GPS", "GPS+MAG", NULL
-};
-
-#define SENSOR_NAMES_MASK (SENSOR_GYRO | SENSOR_ACC | SENSOR_BARO | SENSOR_MAG | SENSOR_SONAR | SENSOR_PITOT)
-
-static const char * const hardwareSensorStatusNames[] = {
-    "NONE", "OK", "UNAVAILABLE", "FAILING"
-};
-
+/* Sensor names (used in lookup tables for *_hardware settings and in status command output) */
 // sync with gyroSensor_e
 static const char * const gyroNames[] = { "NONE", "AUTO", "MPU6050", "L3G4200D", "MPU3050", "L3GD20", "MPU6000", "MPU6500", "MPU9250", "FAKE"};
 // sync with accelerationSensor_e
@@ -258,8 +247,19 @@ static const char * const rangefinderNames[] = { "NONE", "HCSR04", "SRF10"};
 // sync with pitotSensor_e
 static const char * const pitotmeterNames[] = { "NONE", "MS4525", "FAKE"};
 
-static const char * const *sensorHardwareNames[] = {gyroNames, accNames, baroNames, magNames, rangefinderNames, pitotmeterNames};
+#if (FLASH_SIZE > 64)
+// sync this with sensors_e
+static const char * const sensorTypeNames[] = {
+    "GYRO", "ACC", "BARO", "MAG", "SONAR", "PITOT", "GPS", "GPS+MAG", NULL
+};
 
+#define SENSOR_NAMES_MASK (SENSOR_GYRO | SENSOR_ACC | SENSOR_BARO | SENSOR_MAG | SENSOR_SONAR | SENSOR_PITOT)
+
+static const char * const hardwareSensorStatusNames[] = {
+    "NONE", "OK", "UNAVAILABLE", "FAILING"
+};
+
+static const char * const *sensorHardwareNames[] = {gyroNames, accNames, baroNames, magNames, rangefinderNames, pitotmeterNames};
 #endif
 
 #ifdef OSD

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -293,6 +293,7 @@
 
 // Additional commands that are not compatible with MultiWii
 #define MSP_STATUS_EX            150    //out message         cycletime, errors_count, CPU load, sensor present etc
+#define MSP_SENSOR_STATUS        151    //out message         Hardware sensor status
 #define MSP_UID                  160    //out message         Unique device ID
 #define MSP_GPSSVINFO            164    //out message         get Signal Strength (only U-Blox)
 #define MSP_GPSSTATISTICS        166    //out message         get GPS debugging data

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -224,3 +224,8 @@ void setAccelerationFilter(uint8_t initialAccLpfCutHz)
         }
     }
 }
+
+bool isAccelerometerHealthy(void)
+{
+    return true;
+}

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -23,8 +23,8 @@
 
 // Type of accelerometer used/detected
 typedef enum {
-    ACC_DEFAULT = 0,
-    ACC_NONE = 1,
+    ACC_NONE = 0,
+    ACC_AUTODETECT = 1,
     ACC_ADXL345 = 2,
     ACC_MPU6050 = 3,
     ACC_MMA8452 = 4,

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -58,3 +58,4 @@ union flightDynamicsTrims_u;
 void setAccelerationZero(union flightDynamicsTrims_u * accZeroToUse);
 void setAccelerationGain(union flightDynamicsTrims_u * accGainToUse);
 void setAccelerationFilter(uint8_t initialAccLpfCutHz);
+bool isAccelerometerHealthy(void);

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -148,4 +148,9 @@ int32_t baroCalculateAltitude(void)
     return baro.BaroAlt;
 }
 
+bool isBarometerHealthy(void)
+{
+    return true;
+}
+
 #endif /* BARO */

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -20,12 +20,11 @@
 #include "drivers/barometer.h"
 
 typedef enum {
-    BARO_DEFAULT = 0,
-    BARO_NONE = 1,
-    BARO_BMP085 = 2,
-    BARO_MS5611 = 3,
-    BARO_BMP280 = 4,
-    BARO_FAKE = 5,
+    BARO_NONE = 0,
+    BARO_BMP085 = 1,
+    BARO_MS5611 = 2,
+    BARO_BMP280 = 3,
+    BARO_FAKE = 4,
     BARO_MAX = BARO_FAKE
 } baroSensor_e;
 

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -49,4 +49,5 @@ void baroSetCalibrationCycles(uint16_t calibrationCyclesRequired);
 uint32_t baroUpdate(void);
 bool isBaroReady(void);
 int32_t baroCalculateAltitude(void);
+bool isBarometerHealthy(void);
 #endif

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -65,7 +65,7 @@ bool compassInit(const compassConfig_t *compassConfig)
 
 bool isCompassHealthy(void)
 {
-    return (magADC[X] != 0) && (magADC[Y] != 0) && (magADC[Z] != 0);
+    return (magADC[X] != 0) || (magADC[Y] != 0) || (magADC[Z] != 0);
 }
 
 bool isCompassReady(void)

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -63,9 +63,9 @@ bool compassInit(const compassConfig_t *compassConfig)
     return ret;
 }
 
-bool compassIsWorking(void)
+bool isCompassHealthy(void)
 {
-	return (magADC[X] | magADC[Y] | magADC[Z]) != 0;
+    return (magADC[X] != 0) && (magADC[Y] != 0) && (magADC[Z] != 0);
 }
 
 bool isCompassReady(void)

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -63,6 +63,11 @@ bool compassInit(const compassConfig_t *compassConfig)
     return ret;
 }
 
+bool compassIsWorking(void)
+{
+	return (magADC[X] | magADC[Y] | magADC[Z]) != 0;
+}
+
 bool isCompassReady(void)
 {
     return magUpdatedAtLeastOnce;

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -65,7 +65,7 @@ bool compassInit(const compassConfig_t *compassConfig)
 
 bool isCompassHealthy(void)
 {
-    return (magADC[X] != 0) || (magADC[Y] != 0) || (magADC[Z] != 0);
+    return (mag.magADC[X] != 0) || (mag.magADC[Y] != 0) || (mag.magADC[Z] != 0);
 }
 
 bool isCompassReady(void)

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -55,4 +55,4 @@ bool compassInit(const compassConfig_t *compassConfig);
 union flightDynamicsTrims_u;
 void compassUpdate(timeUs_t currentTimeUs, union flightDynamicsTrims_u *magZero);
 bool isCompassReady(void);
-bool compassIsWorking(void);
+bool isCompassHealthy(void);

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -25,14 +25,13 @@
 
 // Type of magnetometer used/detected
 typedef enum {
-    MAG_DEFAULT = 0,
-    MAG_NONE = 1,
-    MAG_HMC5883 = 2,
-    MAG_AK8975 = 3,
-    MAG_GPS = 4,
-    MAG_MAG3110 = 5,
-    MAG_AK8963 = 6,
-    MAG_FAKE = 7,
+    MAG_NONE = 0,
+    MAG_HMC5883 = 1,
+    MAG_AK8975 = 2,
+    MAG_GPS = 3,
+    MAG_MAG3110 = 4,
+    MAG_AK8963 = 5,
+    MAG_FAKE = 6,
     MAG_MAX = MAG_FAKE
 } magSensor_e;
 

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -55,3 +55,4 @@ bool compassInit(const compassConfig_t *compassConfig);
 union flightDynamicsTrims_u;
 void compassUpdate(timeUs_t currentTimeUs, union flightDynamicsTrims_u *magZero);
 bool isCompassReady(void);
+bool compassIsWorking(void);

--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -1,0 +1,27 @@
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+#include "build/debug.h"
+
+#include "common/axis.h"
+#include "common/maths.h"
+
+#include "flight/navigation_rewrite.h"
+
+#include "config/config.h"
+#include "config/config_master.h"
+
+#include "sensors/sensors.h"
+#include "sensors/compass.h"
+
+
+bool isHardwareHealthy(void)
+{
+#ifdef MAG
+	if (masterConfig.mag_hardware != MAG_NONE && !isCompassHealthy())
+		return false;
+#endif
+
+	return true;
+}

--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -7,12 +7,12 @@
 #include "common/axis.h"
 #include "common/maths.h"
 
-#include "flight/navigation_rewrite.h"
-
 #include "config/config.h"
 #include "config/feature.h"
 
 #include "fc/runtime_config.h"
+
+#include "io/gps.h"
 
 #include "sensors/sensors.h"
 #include "sensors/diagnostics.h"
@@ -33,8 +33,9 @@ hardwareSensorStatus_e getHwGyroStatus(void)
 
 hardwareSensorStatus_e getHwAccelerometerStatus(void)
 {
+#if defined(ACC)
     if (detectedSensors[SENSOR_INDEX_ACC] != ACC_NONE) {
-        if (true) { // isAccelerometerHealthy()
+        if (isAccelerometerHealthy()) {
             return HW_SENSOR_OK;
         }
         else {
@@ -51,6 +52,9 @@ hardwareSensorStatus_e getHwAccelerometerStatus(void)
             return HW_SENSOR_NONE;
         }
     }
+#else
+    return HW_SENSOR_NONE;
+#endif
 }
 
 hardwareSensorStatus_e getHwCompassStatus(void)
@@ -81,8 +85,9 @@ hardwareSensorStatus_e getHwCompassStatus(void)
 
 hardwareSensorStatus_e getHwBarometerStatus(void)
 {
+#if defined(BARO)
     if (detectedSensors[SENSOR_INDEX_BARO] != BARO_NONE) {
-        if (true) { // isBarometerHealthy()
+        if (isBarometerHealthy()) {
             return HW_SENSOR_OK;
         }
         else {
@@ -99,12 +104,16 @@ hardwareSensorStatus_e getHwBarometerStatus(void)
             return HW_SENSOR_NONE;
         }
     }
+#else
+    return HW_SENSOR_NONE;
+#endif
 }
 
 hardwareSensorStatus_e getHwRangefinderStatus(void)
 {
+#if defined(SONAR)
     if (detectedSensors[SENSOR_INDEX_RANGEFINDER] != RANGEFINDER_NONE) {
-        if (true) { // isBarometerHealthy()
+        if (isRangefinderHealthy())
             return HW_SENSOR_OK;
         }
         else {
@@ -121,12 +130,16 @@ hardwareSensorStatus_e getHwRangefinderStatus(void)
             return HW_SENSOR_NONE;
         }
     }
+#else
+    return HW_SENSOR_NONE;
+#endif
 }
 
 hardwareSensorStatus_e getHwGPSStatus(void)
 {
+#if defined(GPS)
     if (sensors(SENSOR_GPS)) {
-        if (true) { // isGPSHealthy()
+        if (isGPSHealthy()) {
             return HW_SENSOR_OK;
         }
         else {
@@ -143,6 +156,9 @@ hardwareSensorStatus_e getHwGPSStatus(void)
             return HW_SENSOR_NONE;
         }
     }
+#else
+    return HW_SENSOR_NONE;
+#endif
 }
 
 bool isHardwareHealthy(void)

--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -21,6 +21,7 @@
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
 #include "sensors/rangefinder.h"
+#include "sensors/pitotmeter.h"
 
 extern uint8_t requestedSensors[SENSOR_INDEX_COUNT];
 extern uint8_t detectedSensors[SENSOR_INDEX_COUNT];
@@ -113,7 +114,7 @@ hardwareSensorStatus_e getHwRangefinderStatus(void)
 {
 #if defined(SONAR)
     if (detectedSensors[SENSOR_INDEX_RANGEFINDER] != RANGEFINDER_NONE) {
-        if (isRangefinderHealthy())
+        if (isRangefinderHealthy()) {
             return HW_SENSOR_OK;
         }
         else {
@@ -122,6 +123,32 @@ hardwareSensorStatus_e getHwRangefinderStatus(void)
     }
     else {
         if (requestedSensors[SENSOR_INDEX_RANGEFINDER] != RANGEFINDER_NONE) {
+            // Selected but not detected
+            return HW_SENSOR_UNAVAILABLE;
+        }
+        else {
+            // Not selected and not detected
+            return HW_SENSOR_NONE;
+        }
+    }
+#else
+    return HW_SENSOR_NONE;
+#endif
+}
+
+hardwareSensorStatus_e getHwPitotmeterStatus(void)
+{
+#if defined(PITOT)
+    if (detectedSensors[SENSOR_INDEX_PITOT] != PITOT_NONE) {
+        if (isPitotmeterHealthy()) {
+            return HW_SENSOR_OK;
+        }
+        else {
+            return HW_SENSOR_UNHEALTHY;
+        }
+    }
+    else {
+        if (requestedSensors[SENSOR_INDEX_PITOT] != PITOT_NONE) {
             // Selected but not detected
             return HW_SENSOR_UNAVAILABLE;
         }
@@ -168,6 +195,7 @@ bool isHardwareHealthy(void)
     const hardwareSensorStatus_e baroStatus = getHwBarometerStatus();
     const hardwareSensorStatus_e magStatus = getHwCompassStatus();
     const hardwareSensorStatus_e rangefinderStatus = getHwRangefinderStatus();
+    const hardwareSensorStatus_e pitotStatus = getHwPitotmeterStatus();
     const hardwareSensorStatus_e gpsStatus = getHwGPSStatus();
 
     // Sensor is considered failing if it's either unavailable (selected but not detected) or unhealthy (returning invalid readings)
@@ -184,6 +212,9 @@ bool isHardwareHealthy(void)
         return false;
 
     if (rangefinderStatus == HW_SENSOR_UNAVAILABLE || rangefinderStatus == HW_SENSOR_UNHEALTHY)
+        return false;
+
+    if (pitotStatus == HW_SENSOR_UNAVAILABLE || pitotStatus == HW_SENSOR_UNHEALTHY)
         return false;
 
     if (gpsStatus == HW_SENSOR_UNAVAILABLE || gpsStatus == HW_SENSOR_UNHEALTHY)

--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -10,18 +10,164 @@
 #include "flight/navigation_rewrite.h"
 
 #include "config/config.h"
-#include "config/config_master.h"
+#include "config/feature.h"
+
+#include "fc/runtime_config.h"
 
 #include "sensors/sensors.h"
+#include "sensors/diagnostics.h"
+#include "sensors/gyro.h"
 #include "sensors/compass.h"
+#include "sensors/acceleration.h"
+#include "sensors/barometer.h"
+#include "sensors/rangefinder.h"
 
+extern uint8_t requestedSensors[SENSOR_INDEX_COUNT];
+extern uint8_t detectedSensors[SENSOR_INDEX_COUNT];
+
+hardwareSensorStatus_e getHwGyroStatus(void)
+{
+    // Gyro is assumed to be always healthy
+    return HW_SENSOR_OK;
+}
+
+hardwareSensorStatus_e getHwAccelerometerStatus(void)
+{
+    if (detectedSensors[SENSOR_INDEX_ACC] != ACC_NONE) {
+        if (true) { // isAccelerometerHealthy()
+            return HW_SENSOR_OK;
+        }
+        else {
+            return HW_SENSOR_UNHEALTHY;
+        }
+    }
+    else {
+        if (requestedSensors[SENSOR_INDEX_ACC] != ACC_NONE) {
+            // Selected but not detected
+            return HW_SENSOR_UNAVAILABLE;
+        }
+        else {
+            // Not selected and not detected
+            return HW_SENSOR_NONE;
+        }
+    }
+}
+
+hardwareSensorStatus_e getHwCompassStatus(void)
+{
+    if (detectedSensors[SENSOR_INDEX_MAG] != MAG_NONE) {
+        if (isCompassHealthy()) {
+            return HW_SENSOR_OK;
+        }
+        else {
+            return HW_SENSOR_UNHEALTHY;
+        }
+    }
+    else {
+        if (requestedSensors[SENSOR_INDEX_MAG] != MAG_NONE) {
+            // Selected but not detected
+            return HW_SENSOR_UNAVAILABLE;
+        }
+        else {
+            // Not selected and not detected
+            return HW_SENSOR_NONE;
+        }
+    }
+}
+
+hardwareSensorStatus_e getHwBarometerStatus(void)
+{
+    if (detectedSensors[SENSOR_INDEX_BARO] != BARO_NONE) {
+        if (true) { // isBarometerHealthy()
+            return HW_SENSOR_OK;
+        }
+        else {
+            return HW_SENSOR_UNHEALTHY;
+        }
+    }
+    else {
+        if (requestedSensors[SENSOR_INDEX_BARO] != BARO_NONE) {
+            // Selected but not detected
+            return HW_SENSOR_UNAVAILABLE;
+        }
+        else {
+            // Not selected and not detected
+            return HW_SENSOR_NONE;
+        }
+    }
+}
+
+hardwareSensorStatus_e getHwRangefinderStatus(void)
+{
+    if (detectedSensors[SENSOR_INDEX_RANGEFINDER] != RANGEFINDER_NONE) {
+        if (true) { // isBarometerHealthy()
+            return HW_SENSOR_OK;
+        }
+        else {
+            return HW_SENSOR_UNHEALTHY;
+        }
+    }
+    else {
+        if (requestedSensors[SENSOR_INDEX_RANGEFINDER] != RANGEFINDER_NONE) {
+            // Selected but not detected
+            return HW_SENSOR_UNAVAILABLE;
+        }
+        else {
+            // Not selected and not detected
+            return HW_SENSOR_NONE;
+        }
+    }
+}
+
+hardwareSensorStatus_e getHwGPSStatus(void)
+{
+    if (sensors(SENSOR_GPS)) {
+        if (true) { // isGPSHealthy()
+            return HW_SENSOR_OK;
+        }
+        else {
+            return HW_SENSOR_UNHEALTHY;
+        }
+    }
+    else {
+        if (feature(FEATURE_GPS)) {
+            // Selected but not detected
+            return HW_SENSOR_UNAVAILABLE;
+        }
+        else {
+            // Not selected and not detected
+            return HW_SENSOR_NONE;
+        }
+    }
+}
 
 bool isHardwareHealthy(void)
 {
-#ifdef MAG
-	if (masterConfig.mag_hardware != MAG_NONE && !isCompassHealthy())
-		return false;
-#endif
+    const hardwareSensorStatus_e gyroStatus = getHwGyroStatus();
+    const hardwareSensorStatus_e accStatus = getHwAccelerometerStatus();
+    const hardwareSensorStatus_e baroStatus = getHwBarometerStatus();
+    const hardwareSensorStatus_e magStatus = getHwCompassStatus();
+    const hardwareSensorStatus_e rangefinderStatus = getHwRangefinderStatus();
+    const hardwareSensorStatus_e gpsStatus = getHwGPSStatus();
+
+    // Sensor is considered failing if it's either unavailable (selected but not detected) or unhealthy (returning invalid readings)
+    if (gyroStatus == HW_SENSOR_UNAVAILABLE || gyroStatus == HW_SENSOR_UNHEALTHY)
+        return false;
+
+    if (accStatus == HW_SENSOR_UNAVAILABLE || accStatus == HW_SENSOR_UNHEALTHY)
+        return false;
+
+    if (baroStatus == HW_SENSOR_UNAVAILABLE || baroStatus == HW_SENSOR_UNHEALTHY)
+        return false;
+
+    if (magStatus == HW_SENSOR_UNAVAILABLE || magStatus == HW_SENSOR_UNHEALTHY)
+        return false;
+
+    if (rangefinderStatus == HW_SENSOR_UNAVAILABLE || rangefinderStatus == HW_SENSOR_UNHEALTHY)
+        return false;
+
+    if (gpsStatus == HW_SENSOR_UNAVAILABLE || gpsStatus == HW_SENSOR_UNHEALTHY)
+        return false;
 
 	return true;
 }

--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -55,6 +55,7 @@ hardwareSensorStatus_e getHwAccelerometerStatus(void)
 
 hardwareSensorStatus_e getHwCompassStatus(void)
 {
+#if defined(MAG)
     if (detectedSensors[SENSOR_INDEX_MAG] != MAG_NONE) {
         if (isCompassHealthy()) {
             return HW_SENSOR_OK;
@@ -73,6 +74,9 @@ hardwareSensorStatus_e getHwCompassStatus(void)
             return HW_SENSOR_NONE;
         }
     }
+#else
+    return HW_SENSOR_NONE;
+#endif
 }
 
 hardwareSensorStatus_e getHwBarometerStatus(void)

--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -6,6 +6,7 @@
 
 #include "common/axis.h"
 #include "common/maths.h"
+#include "common/time.h"
 
 #include "config/config.h"
 #include "config/feature.h"

--- a/src/main/sensors/diagnostics.h
+++ b/src/main/sensors/diagnostics.h
@@ -18,6 +18,7 @@ hardwareSensorStatus_e getHwCompassStatus(void);
 hardwareSensorStatus_e getHwBarometerStatus(void);
 hardwareSensorStatus_e getHwGPSStatus(void);
 hardwareSensorStatus_e getHwRangefinderStatus(void);
+hardwareSensorStatus_e getHwPitotmeterStatus(void);
 
 bool isHardwareHealthy(void);
 

--- a/src/main/sensors/diagnostics.h
+++ b/src/main/sensors/diagnostics.h
@@ -1,0 +1,8 @@
+
+/**
+ * Collects hardware failure information from devices.
+ * No hardware checking should be actually performed,
+ * rather already known hardware status should be returned.
+ */
+bool isHardwareHealthy(void);
+

--- a/src/main/sensors/diagnostics.h
+++ b/src/main/sensors/diagnostics.h
@@ -4,5 +4,20 @@
  * No hardware checking should be actually performed,
  * rather already known hardware status should be returned.
  */
+
+typedef enum {
+    HW_SENSOR_NONE          = 0,    // Not selected
+    HW_SENSOR_OK            = 1,    // Selected, detected and healthy (ready to be used)
+    HW_SENSOR_UNAVAILABLE   = 2,    // Selected in configuration but not detected
+    HW_SENSOR_UNHEALTHY     = 3,    // Selected, detected but is reported as not healthy
+} hardwareSensorStatus_e;
+
+hardwareSensorStatus_e getHwGyroStatus(void);
+hardwareSensorStatus_e getHwAccelerometerStatus(void);
+hardwareSensorStatus_e getHwCompassStatus(void);
+hardwareSensorStatus_e getHwBarometerStatus(void);
+hardwareSensorStatus_e getHwGPSStatus(void);
+hardwareSensorStatus_e getHwRangefinderStatus(void);
+
 bool isHardwareHealthy(void);
 

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -22,7 +22,7 @@
 
 typedef enum {
     GYRO_NONE = 0,
-    GYRO_DEFAULT,
+    GYRO_AUTODETECT,
     GYRO_MPU6050,
     GYRO_L3G4200D,
     GYRO_MPU3050,

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -463,6 +463,7 @@ static bool detectBaro(baroDev_t *dev, baroSensor_e baroHardwareToUse)
 static bool detectPitot(pitotDev_t *dev, uint8_t pitotHardwareToUse)
 {
     pitotSensor_e pitotHardware = pitotHardwareToUse;
+    requestedSensors[SENSOR_INDEX_PITOT] = pitotHardwareToUse;   // FIXME
 
     switch (pitotHardware) {
         case PITOT_DEFAULT:

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -90,6 +90,7 @@
 #include "hardware_revision.h"
 #endif
 
+uint8_t requestedSensors[SENSOR_INDEX_COUNT] = { GYRO_DEFAULT, ACC_NONE, BARO_NONE, MAG_NONE, RANGEFINDER_NONE, PITOT_NONE };
 uint8_t detectedSensors[SENSOR_INDEX_COUNT] = { GYRO_NONE, ACC_NONE, BARO_NONE, MAG_NONE, RANGEFINDER_NONE, PITOT_NONE };
 
 
@@ -238,6 +239,8 @@ static bool detectAcc(accDev_t *dev, accelerationSensor_e accHardwareToUse)
 retry:
     dev->accAlign = ALIGN_DEFAULT;
 
+    requestedSensors[SENSOR_INDEX_ACC] = accHardwareToUse;
+
     switch (accHardwareToUse) {
         case ACC_DEFAULT:
             ; // fallthrough
@@ -381,6 +384,7 @@ static bool detectBaro(baroDev_t *dev, baroSensor_e baroHardwareToUse)
     // Detect what pressure sensors are available. baro->update() is set to sensor-specific update function
 
     baroSensor_e baroHardware = baroHardwareToUse;
+    requestedSensors[SENSOR_INDEX_BARO] = baroHardwareToUse;
 
 #ifdef USE_BARO_BMP085
 
@@ -504,6 +508,7 @@ static bool detectPitot(pitotDev_t *dev, uint8_t pitotHardwareToUse)
 static bool detectMag(magDev_t *dev, magSensor_e magHardwareToUse)
 {
     magSensor_e magHardware = MAG_NONE;
+    requestedSensors[SENSOR_INDEX_MAG] = magHardwareToUse;
 
 #ifdef USE_MAG_HMC5883
     const hmc5883Config_t *hmc5883Config = 0;
@@ -646,6 +651,7 @@ static rangefinderType_e detectRangefinder(void)
 
     addBootlogEvent6(BOOT_EVENT_RANGEFINDER_DETECTION, BOOT_EVENT_FLAGS_NONE, rangefinderType, 0, 0, 0);
 
+    requestedSensors[SENSOR_INDEX_RANGEFINDER] = rangefinderType;   // FIXME: Make rangefinder type selectable from CLI
     detectedSensors[SENSOR_INDEX_RANGEFINDER] = rangefinderType;
 
     if (rangefinderType != RANGEFINDER_NONE) {

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -149,4 +149,9 @@ int32_t pitotCalculateAirSpeed(void)
     return pitot.airSpeed;
 }
 
+bool isPitotmeterHealthy(void)
+{
+    return true;
+}
+
 #endif /* PITOT */

--- a/src/main/sensors/pitotmeter.h
+++ b/src/main/sensors/pitotmeter.h
@@ -20,10 +20,9 @@
 #include "drivers/pitotmeter.h"
 
 typedef enum {
-    PITOT_DEFAULT = 0,
-    PITOT_NONE = 1,
-    PITOT_MS4525 = 2,
-    PITOT_FAKE = 3,
+    PITOT_NONE = 0,
+    PITOT_MS4525 = 1,
+    PITOT_FAKE = 2,
 } pitotSensor_e;
 
 #define PITOT_MAX  PITOT_FAKE

--- a/src/main/sensors/pitotmeter.h
+++ b/src/main/sensors/pitotmeter.h
@@ -50,4 +50,5 @@ void pitotSetCalibrationCycles(uint16_t calibrationCyclesRequired);
 uint32_t pitotUpdate(void);
 bool isPitotReady(void);
 int32_t pitotCalculateAirSpeed(void);
+bool isPitotmeterHealthy(void);
 #endif

--- a/src/main/sensors/rangefinder.c
+++ b/src/main/sensors/rangefinder.c
@@ -210,5 +210,10 @@ int32_t rangefinderGetLatestAltitude(void)
 {
     return calculatedAltitude;
 }
+
+bool isRangefinderHealthy(void)
+{
+    return true;
+}
 #endif
 

--- a/src/main/sensors/rangefinder.h
+++ b/src/main/sensors/rangefinder.h
@@ -43,4 +43,4 @@ rangefinderType_e rangefinderDetect(void);
 void rangefinderInit(rangefinderType_e rangefinderType);
 void rangefinderUpdate(void);
 int32_t rangefinderRead(void);
-
+bool isRangefinderHealthy(void);

--- a/src/main/sensors/rangefinder.h
+++ b/src/main/sensors/rangefinder.h
@@ -20,7 +20,8 @@
 #include <stdint.h>
 
 typedef enum {
-    RANGEFINDER_NONE = 0,
+    RANGEFINDER_DEFAULT = 0,
+    RANGEFINDER_NONE = 1,
     RANGEFINDER_HCSR04,
     RANGEFINDER_SRF10
 } rangefinderType_e;

--- a/src/main/sensors/rangefinder.h
+++ b/src/main/sensors/rangefinder.h
@@ -20,10 +20,9 @@
 #include <stdint.h>
 
 typedef enum {
-    RANGEFINDER_DEFAULT = 0,
-    RANGEFINDER_NONE = 1,
-    RANGEFINDER_HCSR04,
-    RANGEFINDER_SRF10
+    RANGEFINDER_NONE    = 0,
+    RANGEFINDER_HCSR04  = 1,
+    RANGEFINDER_SRF10   = 2,
 } rangefinderType_e;
 
 struct rangefinder_s;

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -53,6 +53,7 @@
 #include "sensors/gyro.h"
 #include "sensors/barometer.h"
 #include "sensors/boardalignment.h"
+#include "sensors/diagnostics.h"
 #include "sensors/battery.h"
 
 #include "io/serial.h"
@@ -245,9 +246,12 @@ void ltm_oframe(sbuf_t *dst)
  */
 void ltm_xframe(sbuf_t *dst)
 {
+    uint8_t sensorStatus =
+        (isHardwareHealthy() ? 1 : 0) << 0;     // bit 0 - hardware health indication
+
     sbufWriteU8(dst, 'X');
     ltm_serialise_16(dst, gpsSol.hdop);
-    ltm_serialise_8(dst, 0);
+    ltm_serialise_8(dst, sensorStatus);
     ltm_serialise_8(dst, 0);
     ltm_serialise_8(dst, 0);
     ltm_serialise_8(dst, 0);

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -247,7 +247,7 @@ void ltm_oframe(sbuf_t *dst)
 void ltm_xframe(sbuf_t *dst)
 {
     uint8_t sensorStatus =
-        (isHardwareHealthy() ? 1 : 0) << 0;     // bit 0 - hardware health indication
+        (isHardwareHealthy() ? 0 : 1) << 0;     // bit 0 - hardware failure indication (1 - something is wrong with the hardware sensors)
 
     sbufWriteU8(dst, 'X');
     ltm_serialise_16(dst, gpsSol.hdop);
@@ -270,20 +270,6 @@ void ltm_nframe(sbuf_t *dst)
     ltm_serialise_8(dst, NAV_Status.activeWpNumber);
     ltm_serialise_8(dst, NAV_Status.error);
     ltm_serialise_8(dst, NAV_Status.flags);
-}
-#endif
-
-#if defined(GPS)
-static bool ltm_shouldSendXFrame(void)
-{
-    static uint16_t lastHDOP = 0;
-
-    if (lastHDOP != gpsSol.hdop) {
-        lastHDOP = gpsSol.hdop;
-        return true;
-    }
-
-    return false;
 }
 #endif
 
@@ -334,7 +320,7 @@ static void process_ltm(void)
         ltm_finalise(dst);
     }
 
-    if (current_schedule & LTM_BIT_XFRAME && ltm_shouldSendXFrame()) {
+    if (current_schedule & LTM_BIT_XFRAME) {
         ltm_initialise_packet(dst);
         ltm_xframe(dst);
         ltm_finalise(dst);


### PR DESCRIPTION
Continuation of #731. Fixes #650.

Added new generic ledstrip warning: HW_ERROR (BLUE-BLACK)
HW_ERROR warning set on compass failure (on init or in runtime)

Things to do:

- [x] ~~Create failure detection for all available sensors (GYRO, ACC, BARO, MAG, SONAR, GPS)~~
- [x] Make a way to indicate sensor failure for machines w/o ledstrip
- [x] Report sensor health via telemetry and MSP
- [x] ~~Configurator support for clearly indicating the failure~~
- [x] Block ARMing if one of configured sensor fails
- [x] Make sensor selection explicit (no autodetection)
- [x] Support sensor hardware selection via MSP