### PR TITLE
Fix actication of RTH modes when no GPS at the moment of activation

### DIFF
--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -2297,7 +2297,7 @@ static navigationFSMEvent_t selectNavEventFromBoxModeInput(void)
         }
 
         // RTH/Failsafe_RTH can override PASSTHRU
-        if (posControl.flags.forcedRTHActivated || IS_RC_MODE_ACTIVE(BOXNAVRTH)) {
+        if (posControl.flags.forcedRTHActivated || (IS_RC_MODE_ACTIVE(BOXNAVRTH) && canActivatePosHold && STATE(GPS_FIX_HOME))) {
             // If we request forced RTH - attempt to activate it no matter what
             // This might switch to emergency landing controller if GPS is unavailable
             canActivateWaypoint = false;    // Block WP mode if we switched to RTH for whatever reason


### PR DESCRIPTION
In a GPS-denied environment activating RTH (either manually or by failsafe) result in instant emergency landing.

Now it behaved differently:

- Manual RTH - don't allow pilot to activate RTH
- Failsafe RTH - allow the UAV to drift with the wind and maintain only altitude for a certain timeout to allow GPS to recover, then switch to emergency landing.

Fixes #733