### PR TITLE
CC3D buzzer moved back to PA15

### DIFF
--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -22,7 +22,7 @@
 #define INVERTER                PB2 // PB2 (BOOT1) used as inverter select GPIO
 #define INVERTER_USART          USART1
 
-#define BEEPER                  PB15
+#define BEEPER                  PA15
 #define BEEPER_OPT              PB2
 
 #define USE_EXTI


### PR DESCRIPTION
Reported in #613 

Looks like in 0489eb8b0840719277450a8d15bb6f1d5e6f62be buzzer in CC3D was moved from PA15 to PB15 (pin 38 to 28). @martinbudden do you rebember the reason or was it just a mistake?
I suppose it was the latter, so this PR puts buzzer back on PA15 pin 38