### PR TITLE
quick and dirty removal of imu async updates

### DIFF
--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -542,10 +542,10 @@ void taskGyro(void) {
     /* Update actual hardware readings */
     gyroUpdate();
 
-#ifdef ASYNC_GYRO_PROCESSING
+// #ifdef ASYNC_GYRO_PROCESSING
     /* Update IMU for better accuracy */
-    imuUpdateGyroscope(currentDeltaTime + (micros() - currentTime));
-#endif
+    // imuUpdateGyroscope(currentDeltaTime + (micros() - currentTime));
+// #endif
 }
 
 void taskMainPidLoop(void)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -95,8 +95,8 @@ static bool gpsHeadingInitialized = false;
 /* Asynchronous update accumulators */
 static float imuAccumulatedRate[XYZ_AXIS_COUNT];
 static float imuAccumulatedRateTime;
-static float imuAccumulatedAcc[XYZ_AXIS_COUNT];
-static int   imuAccumulatedAccCount;
+// static float imuAccumulatedAcc[XYZ_AXIS_COUNT];
+// static int   imuAccumulatedAccCount;
 #endif
 
 #ifdef ASYNC_GYRO_PROCESSING
@@ -487,18 +487,18 @@ static void imuUpdateMeasuredRotationRate(void)
 {
     int axis;
 
-#ifdef ASYNC_GYRO_PROCESSING
-    for (axis = 0; axis < 3; axis++) {
-        imuMeasuredRotationBF.A[axis] = imuAccumulatedRate[axis] / imuAccumulatedRateTime;
-        imuAccumulatedRate[axis] = 0.0f;
-    }
-
-    imuAccumulatedRateTime = 0.0f;
-#else
+// #ifdef ASYNC_GYRO_PROCESSING
+//     for (axis = 0; axis < 3; axis++) {
+//         imuMeasuredRotationBF.A[axis] = imuAccumulatedRate[axis] / imuAccumulatedRateTime;
+//         imuAccumulatedRate[axis] = 0.0f;
+//     }
+//
+//     imuAccumulatedRateTime = 0.0f;
+// #else
     for (axis = 0; axis < 3; axis++) {
         imuMeasuredRotationBF.A[axis] = gyroADC[axis] * gyroScale;
     }
-#endif
+// #endif
 }
 
 /* Calculate measured acceleration in body frame cm/s/s */
@@ -506,19 +506,19 @@ static void imuUpdateMeasuredAcceleration(void)
 {
     int axis;
 
-#ifdef ASYNC_GYRO_PROCESSING
-    for (axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        imuAccelInBodyFrame.A[axis] = imuAccumulatedAcc[axis] / imuAccumulatedAccCount;
-        imuAccumulatedAcc[axis] = 0;
-    }
-    imuAccumulatedAccCount = 0;;
-#else
+// #ifdef ASYNC_GYRO_PROCESSING
+//     for (axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
+//         imuAccelInBodyFrame.A[axis] = imuAccumulatedAcc[axis] / imuAccumulatedAccCount;
+//         imuAccumulatedAcc[axis] = 0;
+//     }
+//     imuAccumulatedAccCount = 0;;
+// #else
     /* Convert acceleration to cm/s/s */
     for (axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         imuAccelInBodyFrame.A[axis] = accADC[axis] * (GRAVITY_CMSS / acc.acc_1G);
         imuMeasuredGravityBF.A[axis] = imuAccelInBodyFrame.A[axis];
     }
-#endif
+// #endif
 
 #ifdef GPS
     /** Centrifugal force compensation on a fixed-wing aircraft
@@ -565,12 +565,12 @@ void imuUpdateAccelerometer(void)
     }
 #endif
 
-#ifdef ASYNC_GYRO_PROCESSING
-    for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        imuAccumulatedAcc[axis] += accADC[axis] * (GRAVITY_CMSS / acc.acc_1G);
-    }
-    imuAccumulatedAccCount++;
-#endif
+// #ifdef ASYNC_GYRO_PROCESSING
+//     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
+//         imuAccumulatedAcc[axis] += accADC[axis] * (GRAVITY_CMSS / acc.acc_1G);
+//     }
+//     imuAccumulatedAccCount++;
+// #endif
 }
 
 void imuUpdateAttitude(void)


### PR DESCRIPTION
@stronnag could you test this branch against 1.3 ? Only on default values from 1.3, leave `async_mode` to none.
Move to `async_mode = GYRO` only if NONE will give good results. 

It removes some code and relies only on downsampled by LPF gyro and acc data during attitude computations. Code that was doing some precomputations (which I removed now) was the only difference I know between 1.3 and 1.4 that could affect acc and attitude processing.
