### PR TITLE
MPU6500 enabled on AirbotF4 / Flip32F4 target

### DIFF
--- a/src/main/target/FLIP32F4/target.h
+++ b/src/main/target/FLIP32F4/target.h
@@ -34,16 +34,25 @@
 #define MPU_INT_EXTI            PC4
 #define USE_MPU_DATA_READY_SIGNAL
 
+#define GYRO
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_MPU6000_ALIGN      CW270_DEG
 #define MPU6000_CS_PIN          PA4
 #define MPU6000_SPI_INSTANCE    SPI1
 
-#define GYRO
-#define USE_GYRO_SPI_MPU6000
-#define ACC_MPU6000_ALIGN       CW270_DEG
+#define USE_GYRO_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define GYRO_MPU6500_ALIGN      CW270_DEG
+#define MPU6500_CS_PIN          PA4
+#define MPU6500_SPI_INSTANCE    SPI1
 
 #define ACC
 #define USE_ACC_SPI_MPU6000
-#define GYRO_MPU6000_ALIGN      CW270_DEG
+#define ACC_MPU6000_ALIGN       CW270_DEG
+
+#define USE_ACC_MPU6500
+#define USE_ACC_SPI_MPU6500
+#define ACC_MPU6500_ALIGN       CW270_DEG
 
 #define MAG
 #define USE_MAG_AK8963

--- a/src/main/target/FLIP32F4/target.mk
+++ b/src/main/target/FLIP32F4/target.mk
@@ -2,7 +2,9 @@ F405_TARGETS   += $(TARGET)
 FEATURES       += VCP ONBOARDFLASH
 
 TARGET_SRC = \
-            drivers/accgyro_spi_mpu6000.c \
+			drivers/accgyro_spi_mpu6500.c \
+			drivers/accgyro_spi_mpu6000.c \
+			drivers/accgyro_mpu6500.c \
             drivers/barometer_bmp085.c \
             drivers/barometer_bmp280.c \
             drivers/barometer_ms5611.c \
@@ -12,4 +14,3 @@ TARGET_SRC = \
             drivers/compass_mag3110.c \
             drivers/light_ws2811strip.c \
             drivers/light_ws2811strip_stm32f4xx.c
-


### PR DESCRIPTION
This allows MPU6500 on popular F4 board like Flip32 F4, Airbot F4 and others