### PR TITLE
Mpu6500 performance fix

### DIFF
--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -109,7 +109,10 @@ void mpu6500GyroInit(uint8_t lpf)
 #else
     mpuConfiguration.write(MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #endif
+    delay(15);
+
 #ifdef USE_MPU_DATA_READY_SIGNAL
     mpuConfiguration.write(MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif
+    delay(15);
 }

--- a/src/main/drivers/accgyro_mpu6500.h
+++ b/src/main/drivers/accgyro_mpu6500.h
@@ -15,13 +15,17 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #define MPU6500_WHO_AM_I_CONST              (0x70)
 #define MPU9250_WHO_AM_I_CONST              (0x71)
 #define ICM20608G_WHO_AM_I_CONST            (0xAF)
 
 #define MPU6500_BIT_RESET                   (0x80)
-
-#pragma once
+#define MPU6500_BIT_INT_ANYRD_2CLEAR        (1 << 4)
+#define MPU6500_BIT_BYPASS_EN               (1 << 0)
+#define MPU6500_BIT_I2C_IF_DIS              (1 << 4)
+#define MPU6500_BIT_RAW_RDY_EN              (0x01)
 
 bool mpu6500AccDetect(acc_t *acc);
 bool mpu6500GyroDetect(gyro_t *gyro);

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -91,16 +91,36 @@ bool mpu6500SpiDetect(void)
     return false;
 }
 
+void mpu6500SpiAccInit(acc_t *acc)
+{
+    mpu6500AccInit(acc);
+}
+
 bool mpu6500SpiAccDetect(acc_t *acc)
 {
     if (mpuDetectionResult.sensor != MPU_65xx_SPI) {
         return false;
     }
 
-    acc->init = mpu6500AccInit;
+    acc->init = mpu6500SpiAccInit;
     acc->read = mpuAccRead;
 
     return true;
+}
+
+void mpu6500SpiGyroInit(uint8_t lpf)
+{
+    spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_SLOW);
+    delayMicroseconds(1);
+
+    mpu6500GyroInit(lpf);
+
+    // Disable Primary I2C Interface
+    mpu6500WriteRegister(MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
+    delay(100);
+
+    spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_FAST);
+    delayMicroseconds(1);
 }
 
 bool mpu6500SpiGyroDetect(gyro_t *gyro)
@@ -109,7 +129,7 @@ bool mpu6500SpiGyroDetect(gyro_t *gyro)
         return false;
     }
 
-    gyro->init = mpu6500GyroInit;
+    gyro->init = mpu6500SpiGyroInit;
     gyro->read = mpuGyroRead;
     gyro->intStatus = checkMPUDataReady;
 

--- a/src/main/drivers/accgyro_spi_mpu6500.h
+++ b/src/main/drivers/accgyro_spi_mpu6500.h
@@ -24,3 +24,6 @@ bool mpu6500SpiGyroDetect(gyro_t *gyro);
 
 bool mpu6500WriteRegister(uint8_t reg, uint8_t data);
 bool mpu6500ReadRegister(uint8_t reg, uint8_t length, uint8_t *data);
+
+void mpu6500SpiGyroInit(uint8_t lpf);
+void mpu6500SpiAccInit(acc_t *acc);


### PR DESCRIPTION
This PR completes 2 goals:

1. Catches up MPU6500 SPI driver to Betaflight
1. Solves a problem of low performance of SPI MPU6500 causing F4 overload with gyro frequency of 8kHz

Bench tested on Airbot F4 MPU6500