### PR TITLE
Reordered code to avoid forward declarations

### DIFF
--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -49,29 +49,6 @@
 static bool ibusFrameDone = false;
 static uint32_t ibusChannelData[IBUS_MAX_CHANNEL];
 
-static void ibusDataReceive(uint16_t c);
-static uint16_t ibusReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan);
-
-bool ibusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
-{
-    UNUSED(rxConfig);
-
-    rxRuntimeConfig->channelCount = IBUS_MAX_CHANNEL;
-    rxRuntimeConfig->rxRefreshRate = 20000; // TODO - Verify speed
-
-    rxRuntimeConfig->rcReadRawFn = ibusReadRawRC;
-    rxRuntimeConfig->rcFrameStatusFn = ibusFrameStatus;
-
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
-    if (!portConfig) {
-        return false;
-    }
-
-    serialPort_t *ibusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, ibusDataReceive, IBUS_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
-
-    return ibusPort != NULL;
-}
-
 static uint8_t ibus[IBUS_BUFFSIZE] = { 0, };
 
 // Receive ISR callback
@@ -140,5 +117,25 @@ static uint16_t ibusReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t 
 {
     UNUSED(rxRuntimeConfig);
     return ibusChannelData[chan];
+}
+
+bool ibusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    UNUSED(rxConfig);
+
+    rxRuntimeConfig->channelCount = IBUS_MAX_CHANNEL;
+    rxRuntimeConfig->rxRefreshRate = 20000; // TODO - Verify speed
+
+    rxRuntimeConfig->rcReadRawFn = ibusReadRawRC;
+    rxRuntimeConfig->rcFrameStatusFn = ibusFrameStatus;
+
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
+    if (!portConfig) {
+        return false;
+    }
+
+    serialPort_t *ibusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, ibusDataReceive, IBUS_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+
+    return ibusPort != NULL;
 }
 #endif // USE_SERIALRX_IBUS

--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -207,10 +207,6 @@ static uint8_t jetiExBusChannelFrame[EXBUS_MAX_CHANNEL_FRAME_SIZE];
 static uint8_t jetiExBusRequestFrame[EXBUS_MAX_REQUEST_FRAME_SIZE];
 
 static uint16_t jetiExBusChannelData[JETIEXBUS_CHANNEL_COUNT];
-static void jetiExBusDataReceive(uint16_t c);
-static uint16_t jetiExBusReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan);
-
-static void jetiExBusFrameReset();
 
 #ifdef TELEMETRY
 
@@ -221,32 +217,6 @@ static void sendJetiExBusTelemetry(uint8_t packetID);
 uint8_t calcCRC8(uint8_t *pt, uint8_t msgLen);
 
 #endif //TELEMETRY
-
-uint16_t calcCRC16(uint8_t *pt, uint8_t msgLen);
-
-
-bool jetiExBusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
-{
-    UNUSED(rxConfig);
-
-    rxRuntimeConfig->channelCount = JETIEXBUS_CHANNEL_COUNT;
-    rxRuntimeConfig->rxRefreshRate = 5500;
-
-    rxRuntimeConfig->rcReadRawFn = jetiExBusReadRawRC;
-    rxRuntimeConfig->rcFrameStatusFn = jetiExBusFrameStatus;
-
-    jetiExBusFrameReset();
-
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
-
-    if (!portConfig) {
-        return false;
-    }
-
-    jetiExBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, jetiExBusDataReceive, JETIEXBUS_BAUDRATE, MODE_RXTX, JETIEXBUS_OPTIONS );
-    serialSetMode(jetiExBusPort, MODE_RX);
-    return jetiExBusPort != NULL;
-}
 
 
 // Jeti Ex Bus CRC calculations for a frame
@@ -610,4 +580,27 @@ void sendJetiExBusTelemetry(uint8_t packetID)
     requestLoop++;
 }
 #endif // TELEMETRY
+
+bool jetiExBusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    UNUSED(rxConfig);
+
+    rxRuntimeConfig->channelCount = JETIEXBUS_CHANNEL_COUNT;
+    rxRuntimeConfig->rxRefreshRate = 5500;
+
+    rxRuntimeConfig->rcReadRawFn = jetiExBusReadRawRC;
+    rxRuntimeConfig->rcFrameStatusFn = jetiExBusFrameStatus;
+
+    jetiExBusFrameReset();
+
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
+
+    if (!portConfig) {
+        return false;
+    }
+
+    jetiExBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, jetiExBusDataReceive, JETIEXBUS_BAUDRATE, MODE_RXTX, JETIEXBUS_OPTIONS );
+    serialSetMode(jetiExBusPort, MODE_RX);
+    return jetiExBusPort != NULL;
+}
 #endif // USE_SERIALRX_JETIEXBUS

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -71,32 +71,8 @@ static uint16_t sbusStateFlags = 0;
 #define SBUS_DIGITAL_CHANNEL_MAX 1812
 
 static bool sbusFrameDone = false;
-static void sbusDataReceive(uint16_t c);
-static uint16_t sbusReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan);
 
 static uint32_t sbusChannelData[SBUS_MAX_CHANNEL];
-
-bool sbusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
-{
-    for (int b = 0; b < SBUS_MAX_CHANNEL; b++) {
-        sbusChannelData[b] = (16 * rxConfig->midrc) / 10 - 1408;
-    }
-
-    rxRuntimeConfig->channelCount = SBUS_MAX_CHANNEL;
-    rxRuntimeConfig->rxRefreshRate = 11000;
-
-    rxRuntimeConfig->rcReadRawFn = sbusReadRawRC;
-    rxRuntimeConfig->rcFrameStatusFn = sbusFrameStatus;
-
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
-    if (!portConfig) {
-        return false;
-    }
-
-    serialPort_t *sBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sbusDataReceive, SBUS_BAUDRATE, MODE_RX, SBUS_PORT_OPTIONS);
-
-    return sBusPort != NULL;
-}
 
 #define SBUS_FLAG_CHANNEL_17        (1 << 0)
 #define SBUS_FLAG_CHANNEL_18        (1 << 1)
@@ -243,5 +219,27 @@ static uint16_t sbusReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t 
     // Linear fitting values read from OpenTX-ppmus and comparing with values received by X4R
     // http://www.wolframalpha.com/input/?i=linear+fit+%7B173%2C+988%7D%2C+%7B1812%2C+2012%7D%2C+%7B993%2C+1500%7D
     return (0.625f * sbusChannelData[chan]) + 880;
+}
+
+bool sbusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    for (int b = 0; b < SBUS_MAX_CHANNEL; b++) {
+        sbusChannelData[b] = (16 * rxConfig->midrc) / 10 - 1408;
+    }
+
+    rxRuntimeConfig->channelCount = SBUS_MAX_CHANNEL;
+    rxRuntimeConfig->rxRefreshRate = 11000;
+
+    rxRuntimeConfig->rcReadRawFn = sbusReadRawRC;
+    rxRuntimeConfig->rcFrameStatusFn = sbusFrameStatus;
+
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
+    if (!portConfig) {
+        return false;
+    }
+
+    serialPort_t *sBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sbusDataReceive, SBUS_BAUDRATE, MODE_RX, SBUS_PORT_OPTIONS);
+
+    return sBusPort != NULL;
 }
 #endif // USE_SERIALRX_SBUS

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -60,9 +60,6 @@ static bool spekHiRes = false;
 
 static volatile uint8_t spekFrame[SPEK_FRAME_SIZE];
 
-static void spektrumDataReceive(uint16_t c);
-static uint16_t spektrumReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan);
-
 static rxRuntimeConfig_t *rxRuntimeConfigPtr;
 
 #ifdef SPEKTRUM_BIND
@@ -72,53 +69,6 @@ static IO_t BindPin = DEFIO_IO(NONE);
 static IO_t BindPlug = DEFIO_IO(NONE);
 #endif
 
-bool spektrumInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
-{
-    rxRuntimeConfigPtr = rxRuntimeConfig;
-
-    switch (rxConfig->serialrx_provider) {
-    case SERIALRX_SPEKTRUM2048:
-        // 11 bit frames
-        spek_chan_shift = 3;
-        spek_chan_mask = 0x07;
-        spekHiRes = true;
-        rxRuntimeConfig->channelCount = SPEKTRUM_2048_CHANNEL_COUNT;
-        rxRuntimeConfig->rxRefreshRate = 11000;
-        break;
-    case SERIALRX_SPEKTRUM1024:
-        // 10 bit frames
-        spek_chan_shift = 2;
-        spek_chan_mask = 0x03;
-        spekHiRes = false;
-        rxRuntimeConfig->channelCount = SPEKTRUM_1024_CHANNEL_COUNT;
-        rxRuntimeConfig->rxRefreshRate = 22000;
-        break;
-    }
-
-    rxRuntimeConfig->rcReadRawFn = spektrumReadRawRC;
-    rxRuntimeConfig->rcFrameStatusFn = spektrumFrameStatus;
-
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
-    if (!portConfig) {
-        return false;
-    }
-
-#ifdef TELEMETRY
-    bool portShared = telemetryCheckRxPortShared(portConfig);
-#else
-    bool portShared = false;
-#endif
-
-    serialPort_t *spektrumPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, spektrumDataReceive, SPEKTRUM_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
-
-#ifdef TELEMETRY
-    if (portShared) {
-        telemetrySharedPort = spektrumPort;
-    }
-#endif
-
-    return spektrumPort != NULL;
-}
 
 // Receive ISR callback
 static void spektrumDataReceive(uint16_t c)
@@ -259,4 +209,52 @@ void spektrumBind(rxConfig_t *rxConfig)
 
 }
 #endif // SPEKTRUM_BIND
+
+bool spektrumInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    rxRuntimeConfigPtr = rxRuntimeConfig;
+
+    switch (rxConfig->serialrx_provider) {
+    case SERIALRX_SPEKTRUM2048:
+        // 11 bit frames
+        spek_chan_shift = 3;
+        spek_chan_mask = 0x07;
+        spekHiRes = true;
+        rxRuntimeConfig->channelCount = SPEKTRUM_2048_CHANNEL_COUNT;
+        rxRuntimeConfig->rxRefreshRate = 11000;
+        break;
+    case SERIALRX_SPEKTRUM1024:
+        // 10 bit frames
+        spek_chan_shift = 2;
+        spek_chan_mask = 0x03;
+        spekHiRes = false;
+        rxRuntimeConfig->channelCount = SPEKTRUM_1024_CHANNEL_COUNT;
+        rxRuntimeConfig->rxRefreshRate = 22000;
+        break;
+    }
+
+    rxRuntimeConfig->rcReadRawFn = spektrumReadRawRC;
+    rxRuntimeConfig->rcFrameStatusFn = spektrumFrameStatus;
+
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
+    if (!portConfig) {
+        return false;
+    }
+
+#ifdef TELEMETRY
+    bool portShared = telemetryCheckRxPortShared(portConfig);
+#else
+    bool portShared = false;
+#endif
+
+    serialPort_t *spektrumPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, spektrumDataReceive, SPEKTRUM_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
+
+#ifdef TELEMETRY
+    if (portShared) {
+        telemetrySharedPort = spektrumPort;
+    }
+#endif
+
+    return spektrumPort != NULL;
+}
 #endif // USE_SERIALRX_SPEKTRUM

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -48,29 +48,6 @@ static bool sumdFrameDone = false;
 static uint16_t sumdChannels[SUMD_MAX_CHANNEL];
 static uint16_t crc;
 
-static void sumdDataReceive(uint16_t c);
-static uint16_t sumdReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan);
-
-bool sumdInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
-{
-    UNUSED(rxConfig);
-
-    rxRuntimeConfig->channelCount = SUMD_MAX_CHANNEL;
-    rxRuntimeConfig->rxRefreshRate = 11000;
-
-    rxRuntimeConfig->rcReadRawFn = sumdReadRawRC;
-    rxRuntimeConfig->rcFrameStatusFn = sumdFrameStatus;
-
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
-    if (!portConfig) {
-        return false;
-    }
-
-    serialPort_t *sumdPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumdDataReceive, SUMD_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
-
-    return sumdPort != NULL;
-}
-
 #define CRC_POLYNOME 0x1021
 
 // CRC calculation, adds a 8 bit unsigned to 16 bit crc
@@ -177,5 +154,25 @@ static uint16_t sumdReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t 
 {
     UNUSED(rxRuntimeConfig);
     return sumdChannels[chan] / 8;
+}
+
+bool sumdInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    UNUSED(rxConfig);
+
+    rxRuntimeConfig->channelCount = SUMD_MAX_CHANNEL;
+    rxRuntimeConfig->rxRefreshRate = 11000;
+
+    rxRuntimeConfig->rcReadRawFn = sumdReadRawRC;
+    rxRuntimeConfig->rcFrameStatusFn = sumdFrameStatus;
+
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
+    if (!portConfig) {
+        return false;
+    }
+
+    serialPort_t *sumdPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumdDataReceive, SUMD_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+
+    return sumdPort != NULL;
 }
 #endif // USE_SERIALRX_SUMD

--- a/src/main/rx/sumh.c
+++ b/src/main/rx/sumh.c
@@ -53,29 +53,6 @@ static uint32_t sumhChannels[SUMH_MAX_CHANNEL_COUNT];
 
 static serialPort_t *sumhPort;
 
-static void sumhDataReceive(uint16_t c);
-static uint16_t sumhReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan);
-
-
-bool sumhInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
-{
-    UNUSED(rxConfig);
-
-    rxRuntimeConfig->channelCount = SUMH_MAX_CHANNEL_COUNT;
-    rxRuntimeConfig->rxRefreshRate = 11000;
-
-    rxRuntimeConfig->rcReadRawFn = sumhReadRawRC;
-    rxRuntimeConfig->rcFrameStatusFn = sumhFrameStatus;
-
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
-    if (!portConfig) {
-        return false;
-    }
-
-    sumhPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumhDataReceive, SUMH_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
-
-    return sumhPort != NULL;
-}
 
 // Receive ISR callback
 static void sumhDataReceive(uint16_t c)
@@ -130,5 +107,25 @@ static uint16_t sumhReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t 
     }
 
     return sumhChannels[chan];
+}
+
+bool sumhInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+{
+    UNUSED(rxConfig);
+
+    rxRuntimeConfig->channelCount = SUMH_MAX_CHANNEL_COUNT;
+    rxRuntimeConfig->rxRefreshRate = 11000;
+
+    rxRuntimeConfig->rcReadRawFn = sumhReadRawRC;
+    rxRuntimeConfig->rcFrameStatusFn = sumhFrameStatus;
+
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
+    if (!portConfig) {
+        return false;
+    }
+
+    sumhPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumhDataReceive, SUMH_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+
+    return sumhPort != NULL;
 }
 #endif // USE_SERIALRX_SUMH


### PR DESCRIPTION
Reordered code to avoid forward declarations.

Some whitespace tidy.
