### PR TITLE
FW navigation fixes

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -218,8 +218,8 @@ void resetNavConfig(navConfig_t * navConfig)
     navConfig->fw.cruise_throttle = 1400;
     navConfig->fw.max_throttle = 1700;
     navConfig->fw.min_throttle = 1200;
-    navConfig->fw.pitch_to_throttle = 10;
-    navConfig->fw.roll_to_pitch = 75;
+    navConfig->fw.pitch_to_throttle = 10;   // pwm units per degree of pitch (10pwm units ~ 1% throttle)
+    navConfig->fw.roll_to_pitch = 75;       // percent of coupling
     navConfig->fw.loiter_radius = 5000;     // 50m
 
     // Fixed wing launch

--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -966,12 +966,12 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_INITIALIZE(navig
             else {
                 t_fp_vector targetHoldPos;
 
-                if (!STATE(FIXED_WING)) {
-                    // Multicopter, hover and climb
-                    calculateInitialHoldPosition(&targetHoldPos);
-                } else {
+                if (STATE(FIXED_WING)) {
                     // Airplane - climbout before turning around
                     calculateFarAwayTarget(&targetHoldPos, posControl.actualState.yaw, 100000.0f);  // 1km away
+                } else {
+                    // Multicopter, hover and climb
+                    calculateInitialHoldPosition(&targetHoldPos);
                 }
 
                 setDesiredPosition(&targetHoldPos, posControl.actualState.yaw, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_HEADING);
@@ -1025,14 +1025,9 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_HEAD_HOME(naviga
     }
 
     if (isWaypointReached(&posControl.homeWaypointAbove)) {
-        if (!STATE(FIXED_WING)) {
-            // Successfully reached position target - update XYZ-position
-            setDesiredPosition(&posControl.homeWaypointAbove.pos, posControl.homeWaypointAbove.yaw, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_Z | NAV_POS_UPDATE_HEADING);
-            return NAV_FSM_EVENT_SUCCESS;       // NAV_STATE_RTH_3D_HOVER_PRIOR_TO_LANDING
-        } else {
-            // Don't switch to landing for airplanes
-            return NAV_FSM_EVENT_NONE;
-        }
+        // Successfully reached position target - update XYZ-position
+        setDesiredPosition(&posControl.homeWaypointAbove.pos, posControl.homeWaypointAbove.yaw, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_Z | NAV_POS_UPDATE_HEADING);
+        return NAV_FSM_EVENT_SUCCESS;       // NAV_STATE_RTH_3D_HOVER_PRIOR_TO_LANDING
     }
     else {
         // Update XYZ-position target
@@ -1062,13 +1057,19 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_HOVER_PRIOR_TO_L
     }
 
     // Wait until target heading is reached (with 15 deg margin for error)
-    if (ABS(wrap_18000(posControl.homeWaypointAbove.yaw - posControl.actualState.yaw)) < DEGREES_TO_CENTIDEGREES(15)) {
+    if (STATE(FIXED_WING)) {
         resetLandingDetector();
         return NAV_FSM_EVENT_SUCCESS;
     }
     else {
-        setDesiredPosition(&posControl.homeWaypointAbove.pos, posControl.homeWaypointAbove.yaw, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_Z | NAV_POS_UPDATE_HEADING);
-        return NAV_FSM_EVENT_NONE;
+        if (ABS(wrap_18000(posControl.homeWaypointAbove.yaw - posControl.actualState.yaw)) < DEGREES_TO_CENTIDEGREES(15)) {
+            resetLandingDetector();
+            return NAV_FSM_EVENT_SUCCESS;
+        }
+        else {
+            setDesiredPosition(&posControl.homeWaypointAbove.pos, posControl.homeWaypointAbove.yaw, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_Z | NAV_POS_UPDATE_HEADING);
+            return NAV_FSM_EVENT_NONE;
+        }
     }
 }
 
@@ -1083,26 +1084,32 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_LANDING(navigati
         return NAV_FSM_EVENT_SUCCESS;
     }
     else {
-        // A safeguard - if sonar is available and it is reading < 50cm altitude - drop to low descend speed
-        if (posControl.flags.hasValidSurfaceSensor && posControl.actualState.surface >= 0 && posControl.actualState.surface < 50.0f) {
-            // land_descent_rate == 200 : descend speed = 30 cm/s, gentle touchdown
-            // Do not allow descent velocity slower than -30cm/s so the landing detector works.
-            float descentVelLimited = MIN(-0.15f * posControl.navConfig->general.land_descent_rate, -30.0f);
-            updateAltitudeTargetFromClimbRate(descentVelLimited, CLIMB_RATE_RESET_SURFACE_TARGET);
+        if (STATE(FIXED_WING)) {
+            // FIXME: Continue loitering at home altitude
+            return NAV_FSM_EVENT_NONE;
         }
         else {
-            // Ramp down descent velocity from 100% at maxAlt altitude to 25% from minAlt to 0cm.
-            float descentVelScaling = (posControl.actualState.pos.V.Z - posControl.homePosition.pos.V.Z - posControl.navConfig->general.land_slowdown_minalt)
-                                        / (posControl.navConfig->general.land_slowdown_maxalt - posControl.navConfig->general.land_slowdown_minalt) * 0.75f + 0.25f;  // Yield 1.0 at 2000 alt and 0.25 at 500 alt
+            // A safeguard - if sonar is available and it is reading < 50cm altitude - drop to low descend speed
+            if (posControl.flags.hasValidSurfaceSensor && posControl.actualState.surface >= 0 && posControl.actualState.surface < 50.0f) {
+                // land_descent_rate == 200 : descend speed = 30 cm/s, gentle touchdown
+                // Do not allow descent velocity slower than -30cm/s so the landing detector works.
+                float descentVelLimited = MIN(-0.15f * posControl.navConfig->general.land_descent_rate, -30.0f);
+                updateAltitudeTargetFromClimbRate(descentVelLimited, CLIMB_RATE_RESET_SURFACE_TARGET);
+            }
+            else {
+                // Ramp down descent velocity from 100% at maxAlt altitude to 25% from minAlt to 0cm.
+                float descentVelScaling = (posControl.actualState.pos.V.Z - posControl.homePosition.pos.V.Z - posControl.navConfig->general.land_slowdown_minalt)
+                                            / (posControl.navConfig->general.land_slowdown_maxalt - posControl.navConfig->general.land_slowdown_minalt) * 0.75f + 0.25f;  // Yield 1.0 at 2000 alt and 0.25 at 500 alt
 
-            descentVelScaling = constrainf(descentVelScaling, 0.25f, 1.0f);
+                descentVelScaling = constrainf(descentVelScaling, 0.25f, 1.0f);
 
-            // Do not allow descent velocity slower than -50cm/s so the landing detector works.
-            float descentVelLimited = MIN(-descentVelScaling * posControl.navConfig->general.land_descent_rate, -50.0f);
-            updateAltitudeTargetFromClimbRate(descentVelLimited, CLIMB_RATE_RESET_SURFACE_TARGET);
+                // Do not allow descent velocity slower than -50cm/s so the landing detector works.
+                float descentVelLimited = MIN(-descentVelScaling * posControl.navConfig->general.land_descent_rate, -50.0f);
+                updateAltitudeTargetFromClimbRate(descentVelLimited, CLIMB_RATE_RESET_SURFACE_TARGET);
+            }
+
+            return NAV_FSM_EVENT_NONE;
         }
-
-        return NAV_FSM_EVENT_NONE;
     }
 }
 

--- a/src/main/flight/navigation_rewrite_fixedwing.c
+++ b/src/main/flight/navigation_rewrite_fixedwing.c
@@ -417,12 +417,12 @@ void applyFixedWingPitchRollThrottleController(navigationFSMStateFlags_t navStat
     // Limit and apply
     if (isPitchAdjustmentValid && (navStateFlags & NAV_CTL_ALT)) {
         // PITCH angle is measured in opposite direction ( >0 - dive, <0 - climb)
-        pitchCorrection = constrain(pitchCorrection, -DEGREES_TO_CENTIDEGREES(posControl.navConfig->fw.max_dive_angle), DEGREES_TO_CENTIDEGREES(posControl.navConfig->fw.max_climb_angle));
+        pitchCorrection = constrain(pitchCorrection, -DEGREES_TO_DECIDEGREES(posControl.navConfig->fw.max_dive_angle), DEGREES_TO_DECIDEGREES(posControl.navConfig->fw.max_climb_angle));
         rcCommand[PITCH] = -pidAngleToRcCommand(pitchCorrection, posControl.pidProfile->max_angle_inclination[FD_PITCH]);
     }
 
     if (isRollAdjustmentValid && (navStateFlags & NAV_CTL_POS)) {
-        rollCorrection = constrain(rollCorrection, -DEGREES_TO_CENTIDEGREES(posControl.navConfig->fw.max_bank_angle), DEGREES_TO_CENTIDEGREES(posControl.navConfig->fw.max_bank_angle));
+        rollCorrection = constrain(rollCorrection, -DEGREES_TO_DECIDEGREES(posControl.navConfig->fw.max_bank_angle), DEGREES_TO_DECIDEGREES(posControl.navConfig->fw.max_bank_angle));
         rcCommand[ROLL] = pidAngleToRcCommand(rollCorrection, posControl.pidProfile->max_angle_inclination[FD_ROLL]);
 
         // Calculate coordinated turn rate based on velocity and banking angle
@@ -462,9 +462,16 @@ bool isFixedWingLandingDetected(void)
 /*-----------------------------------------------------------
  * FixedWing emergency landing
  *-----------------------------------------------------------*/
+#define FW_EMERGENCY_DIVE_DECIDEG   100
+#define FW_EMERGENCY_ROLL_DECIDEG   200
+#define FW_EMERGENCY_YAW_RATE_DPS   20
 void applyFixedWingEmergencyLandingController(void)
 {
-    // TODO
+    // FIXME: Make this configurable, use altitude controller if available (similar to MC code)
+    rcCommand[PITCH] = pidAngleToRcCommand(-FW_EMERGENCY_DIVE_DECIDEG, posControl.pidProfile->max_angle_inclination[FD_PITCH]);
+    rcCommand[ROLL] = pidAngleToRcCommand(-FW_EMERGENCY_ROLL_DECIDEG, posControl.pidProfile->max_angle_inclination[FD_ROLL]);
+    rcCommand[YAW] = pidRateToRcCommand(-FW_EMERGENCY_YAW_RATE_DPS, currentControlRateProfile->rates[FD_YAW]);
+    rcCommand[THROTTLE] = posControl.navConfig->fw.min_throttle;
 }
 
 /*-----------------------------------------------------------

--- a/src/main/flight/navigation_rewrite_fixedwing.c
+++ b/src/main/flight/navigation_rewrite_fixedwing.c
@@ -397,15 +397,15 @@ void applyFixedWingPitchRollThrottleController(navigationFSMStateFlags_t navStat
     int16_t maxThrottleCorrection = posControl.navConfig->fw.max_throttle - posControl.navConfig->fw.cruise_throttle;
 
     // Mix Pitch/Roll/Throttle
-    if (isPitchAdjustmentValid && (navStateFlags & NAV_CTL_ALT)) {
-        pitchCorrection += posControl.rcAdjustment[PITCH];
-        throttleCorrection += DECIDEGREES_TO_DEGREES(posControl.rcAdjustment[PITCH]) * posControl.navConfig->fw.pitch_to_throttle;
-        throttleCorrection = constrain(throttleCorrection, minThrottleCorrection, maxThrottleCorrection);
-    }
-
     if (isRollAdjustmentValid && (navStateFlags & NAV_CTL_POS)) {
         pitchCorrection += ABS(posControl.rcAdjustment[ROLL]) * (posControl.navConfig->fw.roll_to_pitch / 100.0f);
         rollCorrection += posControl.rcAdjustment[ROLL];
+    }
+
+    if (isPitchAdjustmentValid && (navStateFlags & NAV_CTL_ALT)) {
+        pitchCorrection += posControl.rcAdjustment[PITCH];
+        throttleCorrection += DECIDEGREES_TO_DEGREES(pitchCorrection) * posControl.navConfig->fw.pitch_to_throttle;
+        throttleCorrection = constrain(throttleCorrection, minThrottleCorrection, maxThrottleCorrection);
     }
 
     // Speed controller - only apply in POS mode


### PR DESCRIPTION
Fix for #378 - no more landing initiated for airplanes in both RTH and WP-RTH
Initial cut on #91 - hardcoded 20deg roll, 20deg/s yaw and 10 deg dive

Better pitch/throttle coupling that accounts for overall requested pitch. 
Previously it was only accounting for pitch correction requested by altitude controller which might have caused roll/pitch coupling to create a climb without increasing throttle and stall as a result.

Fixed a bug in incorrect deg->decideg conversion which caused roll/pitch limitations for FW navigation to be effectively ignored.