### PR TITLE
Add detection retry to compass/baro drivers

### DIFF
--- a/src/main/drivers/barometer_bmp085.c
+++ b/src/main/drivers/barometer_bmp085.c
@@ -154,6 +154,7 @@ void bmp085Disable(const bmp085Config_t *config)
     BMP085_OFF;
 }
 
+#define DETECTION_MAX_RETRY_COUNT   5
 bool bmp085Detect(const bmp085Config_t *config, baro_t *baro)
 {
     uint8_t data;
@@ -184,28 +185,30 @@ bool bmp085Detect(const bmp085Config_t *config, baro_t *baro)
 
     delay(20); // datasheet says 10ms, we'll be careful and do 20.
 
-    ack = i2cRead(BARO_I2C_INSTANCE, BMP085_I2C_ADDR, BMP085_CHIP_ID__REG, 1, &data); /* read Chip Id */
-    if (ack) {
-        bmp085.chip_id = BMP085_GET_BITSLICE(data, BMP085_CHIP_ID);
-        bmp085.oversampling_setting = 3;
+    for (int retryCount = 0; retryCount < DETECTION_MAX_RETRY_COUNT; retryCount++) {
+        ack = i2cRead(BARO_I2C_INSTANCE, BMP085_I2C_ADDR, BMP085_CHIP_ID__REG, 1, &data); /* read Chip Id */
+        if (ack) {
+            bmp085.chip_id = BMP085_GET_BITSLICE(data, BMP085_CHIP_ID);
+            bmp085.oversampling_setting = 3;
 
-        if (bmp085.chip_id == BMP085_CHIP_ID) { /* get bitslice */
-            i2cRead(BARO_I2C_INSTANCE, BMP085_I2C_ADDR, BMP085_VERSION_REG, 1, &data); /* read Version reg */
-            bmp085.ml_version = BMP085_GET_BITSLICE(data, BMP085_ML_VERSION); /* get ML Version */
-            bmp085.al_version = BMP085_GET_BITSLICE(data, BMP085_AL_VERSION); /* get AL Version */
-            bmp085_get_cal_param(); /* readout bmp085 calibparam structure */
-            baro->ut_delay = UT_DELAY;
-            baro->up_delay = UP_DELAY;
-            baro->start_ut = bmp085_start_ut;
-            baro->get_ut = bmp085_get_ut;
-            baro->start_up = bmp085_start_up;
-            baro->get_up = bmp085_get_up;
-            baro->calculate = bmp085_calculate;
+            if (bmp085.chip_id == BMP085_CHIP_ID) { /* get bitslice */
+                i2cRead(BARO_I2C_INSTANCE, BMP085_I2C_ADDR, BMP085_VERSION_REG, 1, &data); /* read Version reg */
+                bmp085.ml_version = BMP085_GET_BITSLICE(data, BMP085_ML_VERSION); /* get ML Version */
+                bmp085.al_version = BMP085_GET_BITSLICE(data, BMP085_AL_VERSION); /* get AL Version */
+                bmp085_get_cal_param(); /* readout bmp085 calibparam structure */
+                baro->ut_delay = UT_DELAY;
+                baro->up_delay = UP_DELAY;
+                baro->start_ut = bmp085_start_ut;
+                baro->get_ut = bmp085_get_ut;
+                baro->start_up = bmp085_start_up;
+                baro->get_up = bmp085_get_up;
+                baro->calculate = bmp085_calculate;
 #if defined(BARO_EOC_GPIO)
-            isEOCConnected = bmp085TestEOCConnected(config);
+                isEOCConnected = bmp085TestEOCConnected(config);
 #endif
-            bmp085InitDone = true;
-            return true;
+                bmp085InitDone = true;
+                return true;
+            }
         }
     }
 

--- a/src/main/drivers/barometer_ms5611.c
+++ b/src/main/drivers/barometer_ms5611.c
@@ -58,36 +58,36 @@ STATIC_UNIT_TESTED uint32_t ms5611_up;  // static result of pressure measurement
 STATIC_UNIT_TESTED uint16_t ms5611_c[PROM_NB];  // on-chip ROM
 static uint8_t ms5611_osr = CMD_ADC_4096;
 
+#define DETECTION_MAX_RETRY_COUNT   5
 bool ms5611Detect(baro_t *baro)
 {
-    bool ack = false;
-    uint8_t sig;
-    int i;
-
     delay(10); // No idea how long the chip takes to power-up, but let's make it 10ms
+    for (int retryCount = 0; retryCount < DETECTION_MAX_RETRY_COUNT; retryCount++) {
+        uint8_t sig;
+        bool ack = i2cRead(BARO_I2C_INSTANCE, MS5611_ADDR, CMD_PROM_RD, 1, &sig);
+        if (ack) {
+            ms5611_reset();
+            // read all coefficients
+            for (int i = 0; i < PROM_NB; i++)
+                ms5611_c[i] = ms5611_prom(i);
+            // check crc, bail out if wrong - we are probably talking to BMP085 w/o XCLR line!
+            if (ms5611_crc(ms5611_c) != 0)
+                return false;
 
-    ack = i2cRead(BARO_I2C_INSTANCE, MS5611_ADDR, CMD_PROM_RD, 1, &sig);
-    if (!ack)
-        return false;
+            // TODO prom + CRC
+            baro->ut_delay = 10000;
+            baro->up_delay = 10000;
+            baro->start_ut = ms5611_start_ut;
+            baro->get_ut = ms5611_get_ut;
+            baro->start_up = ms5611_start_up;
+            baro->get_up = ms5611_get_up;
+            baro->calculate = ms5611_calculate;
 
-    ms5611_reset();
-    // read all coefficients
-    for (i = 0; i < PROM_NB; i++)
-        ms5611_c[i] = ms5611_prom(i);
-    // check crc, bail out if wrong - we are probably talking to BMP085 w/o XCLR line!
-    if (ms5611_crc(ms5611_c) != 0)
-        return false;
+            return true;
+        }
+    }
 
-    // TODO prom + CRC
-    baro->ut_delay = 10000;
-    baro->up_delay = 10000;
-    baro->start_ut = ms5611_start_ut;
-    baro->get_ut = ms5611_get_ut;
-    baro->start_up = ms5611_start_up;
-    baro->get_up = ms5611_get_up;
-    baro->calculate = ms5611_calculate;
-
-    return true;
+    return false;
 }
 
 static void ms5611_reset(void)

--- a/src/main/drivers/compass_ak8975.c
+++ b/src/main/drivers/compass_ak8975.c
@@ -58,19 +58,20 @@
 #define AK8975_MAG_REG_CNTL         0x0a
 #define AK8975_MAG_REG_ASCT         0x0c // self test
 
+#define DETECTION_MAX_RETRY_COUNT   5
 bool ak8975Detect(mag_t *mag)
 {
-    bool ack = false;
-    uint8_t sig = 0;
+    for (int retryCount = 0; retryCount < DETECTION_MAX_RETRY_COUNT; retryCount++) {
+        uint8_t sig = 0;
+        bool ack = i2cRead(MAG_I2C_INSTANCE, AK8975_MAG_I2C_ADDRESS, AK8975_MAG_REG_WHO_AM_I, 1, &sig);
+        if (ack && sig == 'H') { // 0x48 / 01001000 / 'H'
+            mag->init = ak8975Init;
+            mag->read = ak8975Read;
+            return true;
+        }
+    }
 
-    ack = i2cRead(MAG_I2C_INSTANCE, AK8975_MAG_I2C_ADDRESS, AK8975_MAG_REG_WHO_AM_I, 1, &sig);
-    if (!ack || sig != 'H') // 0x48 / 01001000 / 'H'
-        return false;
-
-    mag->init = ak8975Init;
-    mag->read = ak8975Read;
-
-    return true;
+    return false;
 }
 
 #define AK8975A_ASAX 0x10 // Fuse ROM x-axis sensitivity adjustment value

--- a/src/main/drivers/compass_hmc5883l.c
+++ b/src/main/drivers/compass_hmc5883l.c
@@ -169,20 +169,23 @@ static void hmc5883lConfigureDataReadyInterruptHandling(void)
 #endif
 }
 
+#define DETECTION_MAX_RETRY_COUNT   5
 bool hmc5883lDetect(mag_t* mag, const hmc5883Config_t *hmc5883ConfigToUse)
 {
     hmc5883Config = hmc5883ConfigToUse;
 
-    uint8_t sig = 0;
-    bool ack = i2cRead(MAG_I2C_INSTANCE, MAG_ADDRESS, 0x0A, 1, &sig);
-    if (!ack || sig != 'H') {
-        return false;
+    for (int retryCount = 0; retryCount < DETECTION_MAX_RETRY_COUNT; retryCount++) {
+        uint8_t sig = 0;
+        bool ack = i2cRead(MAG_I2C_INSTANCE, MAG_ADDRESS, 0x0A, 1, &sig);
+        if (ack && sig == 'H') {
+            mag->init = hmc5883lInit;
+            mag->read = hmc5883lRead;
+
+            return true;
+        }
     }
 
-    mag->init = hmc5883lInit;
-    mag->read = hmc5883lRead;
-
-    return true;
+    return false;
 }
 
 #define INITIALISATION_MAX_READ_FAILURES 5

--- a/src/main/drivers/compass_mag3110.c
+++ b/src/main/drivers/compass_mag3110.c
@@ -59,18 +59,20 @@
 #define MAG3110_MAG_REG_CTRL_REG1    0x10
 #define MAG3110_MAG_REG_CTRL_REG2    0x11
 
+#define DETECTION_MAX_RETRY_COUNT   5
 bool mag3110detect(mag_t *mag)
 {
-    uint8_t sig = 0;
+    for (int retryCount = 0; retryCount < DETECTION_MAX_RETRY_COUNT; retryCount++) {
+        uint8_t sig = 0;
+        bool ack = i2cRead(MAG_I2C_INSTANCE, MAG3110_MAG_I2C_ADDRESS, MAG3110_MAG_REG_WHO_AM_I, 1, &sig);
+        if (ack && sig == 0xC4) {
+            mag->init = mag3110Init;
+            mag->read = mag3110Read;
+            return true;
+        }
+    }
 
-    bool ack = i2cRead(MAG_I2C_INSTANCE, MAG3110_MAG_I2C_ADDRESS, MAG3110_MAG_REG_WHO_AM_I, 1, &sig);
-    if (!ack || sig != 0xC4)
-        return false;
-
-    mag->init = mag3110Init;
-    mag->read = mag3110Read;
-
-    return true;
+    return false;
 }
 
 bool mag3110Init()


### PR DESCRIPTION
Now all compass & baro drivers attempt detection 5 times before failing.
This might fix the following:
#774, #766, #727, #578