### PR TITLE
Axis acceleration limit MSP scaling

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1016,11 +1016,11 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
         sbufWriteU8(dst, 0); //BF: currentProfile->pidProfile.itermThrottleGain
 
         /*
-         * To keep compatibility on MSP level with Betaflight, axis axisAccelerationLimitYaw
-         * limit will be sent and received in [dps / 1000]
+         * To keep compatibility on MSP frame length level with Betaflight, axis axisAccelerationLimitYaw
+         * limit will be sent and received in [dps / 10]
          */
-        sbufWriteU16(dst, constrain(currentProfile->pidProfile.axisAccelerationLimitRollPitch / 1000, 0, 65535));
-        sbufWriteU16(dst, constrain(currentProfile->pidProfile.axisAccelerationLimitYaw / 1000, 0, 65535));
+        sbufWriteU16(dst, constrain(currentProfile->pidProfile.axisAccelerationLimitRollPitch / 10, 0, 65535));
+        sbufWriteU16(dst, constrain(currentProfile->pidProfile.axisAccelerationLimitYaw / 10, 0, 65535));
         break;
 
     case MSP_INAV_PID:

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1393,11 +1393,11 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         sbufReadU8(src); //BF: currentProfile->pidProfile.itermThrottleGain
 
         /*
-         * To keep compatibility on MSP level with Betaflight, axis axisAccelerationLimitYaw
-         * limit will be sent and received in [dps / 1000]
+         * To keep compatibility on MSP frame length level with Betaflight, axis axisAccelerationLimitYaw
+         * limit will be sent and received in [dps / 10]
          */
-        currentProfile->pidProfile.axisAccelerationLimitRollPitch = sbufReadU16(src) * 1000;
-        currentProfile->pidProfile.axisAccelerationLimitYaw = sbufReadU16(src) * 1000;
+        currentProfile->pidProfile.axisAccelerationLimitRollPitch = sbufReadU16(src) * 10;
+        currentProfile->pidProfile.axisAccelerationLimitYaw = sbufReadU16(src) * 10;
         break;
 
     case MSP_SET_INAV_PID:


### PR DESCRIPTION
I just realized that is we want to keep axis acceleration limiting useful over MSP, scaling has to be changed from `/ 1000` to ` / 10`
Large UAVs requires it below 500dps^2 while existing scaling would allow to set min 1000