### PR TITLE
Added timeUs_t and timeMs_t types

### DIFF
--- a/src/main/blackbox/blackbox_fielddefs.h
+++ b/src/main/blackbox/blackbox_fielddefs.h
@@ -19,6 +19,8 @@
 
 #include <stdint.h>
 
+#include "common/time.h"
+
 typedef enum FlightLogFieldCondition {
     FLIGHT_LOG_FIELD_CONDITION_ALWAYS = 0,
     FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_MOTORS_1,
@@ -122,7 +124,7 @@ typedef struct flightLogEvent_inflightAdjustment_s {
 
 typedef struct flightLogEvent_loggingResume_s {
     uint32_t logIteration;
-    uint32_t currentTime;
+    timeUs_t currentTimeUs;
 } flightLogEvent_loggingResume_t;
 
 #define FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT_FUNCTION_FLOAT_VALUE_FLAG 128

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -346,7 +346,7 @@ static int cmsDrawMenuEntry(displayPort_t *pDisplay, OSD_Entry *p, uint8_t row)
     return cnt;
 }
 
-static void cmsDrawMenu(displayPort_t *pDisplay, uint32_t currentTimeUs)
+static void cmsDrawMenu(displayPort_t *pDisplay, timeUs_t currentTimeUs)
 {
     if (!pageTop)
         return;
@@ -358,7 +358,7 @@ static void cmsDrawMenu(displayPort_t *pDisplay, uint32_t currentTimeUs)
     // Polled (dynamic) value display denominator.
 
     bool drawPolled = false;
-    static uint32_t lastPolledUs = 0;
+    static timeUs_t lastPolledUs = 0;
 
     if (currentTimeUs > lastPolledUs + CMS_POLL_INTERVAL_US) {
         drawPolled = true;

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -795,17 +795,17 @@ uint16_t cmsHandleKeyWithRepeat(displayPort_t *pDisplay, uint8_t key, int repeat
     return ret;
 }
 
-static void cmsUpdate(uint32_t currentTimeUs)
+static void cmsUpdate(timeUs_t currentTimeUs)
 {
     static int16_t rcDelayMs = BUTTON_TIME;
     static int holdCount = 1;
     static int repeatCount = 1;
     static int repeatBase = 0;
 
-    static uint32_t lastCalledMs = 0;
-    static uint32_t lastCmsHeartBeatMs = 0;
+    static timeMs_t lastCalledMs = 0;
+    static timeMs_t lastCmsHeartBeatMs = 0;
 
-    const uint32_t currentTimeMs = currentTimeUs / 1000;
+    const timeMs_t currentTimeMs = currentTimeUs / 1000;
 
     if (!cmsInMenu) {
         // Detect menu invocation
@@ -901,16 +901,16 @@ static void cmsUpdate(uint32_t currentTimeUs)
     lastCalledMs = currentTimeMs;
 }
 
-void cmsHandler(uint32_t currentTime)
+void cmsHandler(timeUs_t currentTimeUs)
 {
     if (cmsDeviceCount < 0)
         return;
 
-    static uint32_t lastCalled = 0;
+    static timeUs_t lastCalled = 0;
 
-    if (currentTime >= lastCalled + CMS_UPDATE_INTERVAL_US) {
-        lastCalled = currentTime;
-        cmsUpdate(currentTime);
+    if (currentTimeUs >= lastCalled + CMS_UPDATE_INTERVAL_US) {
+        lastCalled = currentTimeUs;
+        cmsUpdate(currentTimeUs);
     }
 }
 

--- a/src/main/cms/cms.h
+++ b/src/main/cms/cms.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common/time.h"
+
 #include "drivers/display.h"
 
 // Device management
@@ -7,7 +9,7 @@ bool cmsDisplayPortRegister(displayPort_t *pDisplay);
 
 // For main.c and scheduler
 void cmsInit(void);
-void cmsHandler(uint32_t currentTime);
+void cmsHandler(timeUs_t currentTimeUs);
 
 long cmsMenuChange(displayPort_t *pPort, const void *ptr);
 long cmsMenuExit(displayPort_t *pPort, const void *ptr);

--- a/src/main/common/time.h
+++ b/src/main/common/time.h
@@ -17,18 +17,17 @@
 
 #pragma once
 
-#include "blackbox/blackbox_fielddefs.h"
+#include <stdint.h>
 
-typedef struct blackboxConfig_s {
-    uint8_t rate_num;
-    uint8_t rate_denom;
-    uint8_t device;
-} blackboxConfig_t;
+#include "platform.h"
 
-void blackboxLogEvent(FlightLogEvent event, flightLogEventData_t *data);
-
-void initBlackbox(void);
-void handleBlackbox(timeUs_t currentTimeUs);
-void startBlackbox(void);
-void finishBlackbox(void);
-bool blackboxMayEditConfig(void);
+// millisecond time
+typedef uint32_t timeMs_t ;
+// microsecond time
+#ifdef USE_64BIT_TIME
+typedef uint64_t timeUs_t;
+#define TIMEUS_MAX UINT64_MAX
+#else
+typedef uint32_t timeUs_t;
+#define TIMEUS_MAX UINT32_MAX
+#endif

--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -20,6 +20,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "common/time.h"
+
 #define ARRAYLEN(x) (sizeof(x) / sizeof((x)[0]))
 #define ARRAYEND(x) (&(x)[ARRAYLEN(x)])
 
@@ -71,6 +73,7 @@ http://resnet.uoregon.edu/~gurney_j/jmpc/bitwise.html
 
 static inline int16_t cmp16(uint16_t a, uint16_t b) { return a-b; }
 static inline int32_t cmp32(uint32_t a, uint32_t b) { return a-b; }
+static inline int32_t cmpTimeUs(timeUs_t a, timeUs_t b) { return a-b; }
 
 // using memcpy_fn will force memcpy function call, instead of inlining it. In most cases function call takes fewer instructions
 //  than inlined version (inlining is cheaper for very small moves < 8 bytes / 2 store instructions)

--- a/src/main/drivers/io.c
+++ b/src/main/drivers/io.c
@@ -1,10 +1,11 @@
+#include "platform.h"
+
 #include "common/utils.h"
 
 #include "io.h"
 #include "io_impl.h"
 #include "rcc.h"
 
-#include "target.h"
 #include "build/assert.h"
 
 // io ports defs are stored in array by index now

--- a/src/main/drivers/rx_nrf24l01.c
+++ b/src/main/drivers/rx_nrf24l01.c
@@ -128,8 +128,8 @@ void NRF24L01_Initialize(uint8_t baseConfig)
     standbyConfig = BV(NRF24L01_00_CONFIG_PWR_UP) | baseConfig;
     NRF24_CE_LO();
     // nRF24L01+ needs 100 milliseconds settling time from PowerOnReset to PowerDown mode
-    static const uint32_t settlingTimeUs = 100000;
-    const uint32_t currentTimeUs = micros();
+    static const timeUs_t settlingTimeUs = 100000;
+    const timeUs_t currentTimeUs = micros();
     if (currentTimeUs < settlingTimeUs) {
         delayMicroseconds(settlingTimeUs - currentTimeUs);
     }

--- a/src/main/drivers/stack_check.c
+++ b/src/main/drivers/stack_check.c
@@ -45,9 +45,9 @@ extern char _Min_Stack_Size; // declared in .LD file
 
 static uint32_t usedStackSize;
 
-void taskStackCheck(uint32_t currentTime)
+void taskStackCheck(timeUs_t currentTimeUs)
 {
-    UNUSED(currentTime);
+    UNUSED(currentTimeUs);
 
     char * const stackHighMem = &_estack;
     const uint32_t stackSize = (uint32_t)&_Min_Stack_Size;

--- a/src/main/drivers/stack_check.h
+++ b/src/main/drivers/stack_check.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-void taskStackCheck(uint32_t currentTime);
+void taskStackCheck(timeUs_t currentTimeUs);
 uint32_t stackUsedSize(void);
 uint32_t stackTotalSize(void);
 uint32_t stackHighMem(void);

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -48,9 +48,9 @@ void registerExtiCallbackHandler(IRQn_Type irqn, extiCallbackHandlerFunc *fn)
 }
 
 // cycles per microsecond
-static uint32_t usTicks = 0;
+static timeUs_t usTicks = 0;
 // current uptime for 1kHz systick timer. will rollover after 49 days. hopefully we won't care.
-static volatile uint32_t sysTickUptime = 0;
+static volatile timeMs_t sysTickUptime = 0;
 // cached value of RCC->CSR
 uint32_t cachedRccCsrValue;
 
@@ -76,7 +76,7 @@ void SysTick_Handler(void)
 
 // Return system uptime in microseconds (rollover in 70minutes)
 
-uint32_t microsISR(void)
+timeUs_t microsISR(void)
 {
     register uint32_t ms, pending, cycle_cnt;
 
@@ -103,7 +103,7 @@ uint32_t microsISR(void)
     return ((ms + pending) * 1000) + (usTicks * 1000 - cycle_cnt) / usTicks;
 }
 
-uint32_t micros(void)
+timeUs_t micros(void)
 {
     register uint32_t ms, cycle_cnt;
 
@@ -126,26 +126,26 @@ uint32_t micros(void)
 }
 
 // Return system uptime in milliseconds (rollover in 49 days)
-uint32_t millis(void)
+timeMs_t millis(void)
 {
     return sysTickUptime;
 }
 
 #if 1
-void delayMicroseconds(uint32_t us)
+void delayMicroseconds(timeUs_t us)
 {
-    uint32_t now = micros();
+    timeUs_t now = micros();
     while (micros() - now < us);
 }
 #else
-void delayMicroseconds(uint32_t us)
+void delayMicroseconds(timeUs_t us)
 {
     uint32_t elapsed = 0;
     uint32_t lastCount = SysTick->VAL;
 
     for (;;) {
         register uint32_t current_count = SysTick->VAL;
-        uint32_t elapsed_us;
+        timeUs_t elapsed_us;
 
         // measure the time elapsed since the last time we checked
         elapsed += current_count - lastCount;
@@ -165,7 +165,7 @@ void delayMicroseconds(uint32_t us)
 }
 #endif
 
-void delay(uint32_t ms)
+void delay(timeMs_t ms)
 {
     while (ms--)
         delayMicroseconds(1000);

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -17,13 +17,15 @@
 
 #pragma once
 
-void systemInit(void);
-void delayMicroseconds(uint32_t us);
-void delay(uint32_t ms);
+#include "common/time.h"
 
-uint32_t micros(void);
-uint32_t microsISR(void);
-uint32_t millis(void);
+void systemInit(void);
+void delayMicroseconds(timeUs_t us);
+void delay(timeMs_t ms);
+
+timeUs_t micros(void);
+timeUs_t microsISR(void);
+timeMs_t millis(void);
 
 typedef enum {
     FAILURE_DEVELOPER = 0,

--- a/src/main/fc/fc_tasks.h
+++ b/src/main/fc/fc_tasks.h
@@ -19,12 +19,14 @@
 
 #include <stdint.h>
 
-void taskMainPidLoopChecker(uint32_t currentTime);
-bool taskUpdateRxCheck(uint32_t currentTime, uint32_t currentDeltaTime);
-void taskUpdateRxMain(uint32_t currentTime);
-void taskSystem(uint32_t currentTime);
+#include "common/time.h"
 
-void taskMainPidLoop(uint32_t currentTime);
-void taskGyro(uint32_t currentTime);
+void taskMainPidLoopChecker(timeUs_t currentTimeUs);
+bool taskUpdateRxCheck(timeUs_t currentTimeUs, uint32_t currentDeltaTime);
+void taskUpdateRxMain(timeUs_t currentTimeUs);
+void taskSystem(timeUs_t currentTimeUs);
+
+void taskMainPidLoop(timeUs_t currentTimeUs);
+void taskGyro(timeUs_t currentTimeUs);
 
 void fcTasksInit(void);

--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -518,7 +518,7 @@ void filterRc(bool isRXDataNew)
 void taskGyro(timeUs_t currentTimeUs) {
     // getTaskDeltaTime() returns delta time freezed at the moment of entering the scheduler. currentTime is freezed at the very same point.
     // To make busy-waiting timeout work we need to account for time spent within busy-waiting loop
-    const uint32_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
+    const timeUs_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
 
     if (masterConfig.gyroConfig.gyroSync) {
         while (true) {

--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -257,11 +257,11 @@ void mwArm(void)
     }
 }
 
-void processRx(uint32_t currentTime)
+void processRx(timeUs_t currentTimeUs)
 {
     static bool armedBeeperOn = false;
 
-    calculateRxChannelsAndUpdateFailsafe(currentTime);
+    calculateRxChannelsAndUpdateFailsafe(currentTimeUs);
 
     // in 3D mode, we need to be able to disarm by switch at any time
     if (feature(FEATURE_3D)) {
@@ -269,11 +269,11 @@ void processRx(uint32_t currentTime)
             mwDisarm();
     }
 
-    updateRSSI(currentTime);
+    updateRSSI(currentTimeUs);
 
     if (feature(FEATURE_FAILSAFE)) {
 
-        if (currentTime > FAILSAFE_POWER_ON_DELAY_US && !failsafeIsMonitoring()) {
+        if (currentTimeUs > FAILSAFE_POWER_ON_DELAY_US && !failsafeIsMonitoring()) {
             failsafeStartMonitoring();
         }
 
@@ -515,7 +515,7 @@ void filterRc(bool isRXDataNew)
 }
 
 // Function for loop trigger
-void taskGyro(uint32_t currentTime) {
+void taskGyro(timeUs_t currentTimeUs) {
     // getTaskDeltaTime() returns delta time freezed at the moment of entering the scheduler. currentTime is freezed at the very same point.
     // To make busy-waiting timeout work we need to account for time spent within busy-waiting loop
     const uint32_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
@@ -523,9 +523,9 @@ void taskGyro(uint32_t currentTime) {
     if (masterConfig.gyroConfig.gyroSync) {
         while (true) {
         #ifdef ASYNC_GYRO_PROCESSING
-            if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (getGyroUpdateRate() + GYRO_WATCHDOG_DELAY))) {
+            if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTimeUs)) >= (getGyroUpdateRate() + GYRO_WATCHDOG_DELAY))) {
         #else
-            if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTime)) >= (gyro.targetLooptime + GYRO_WATCHDOG_DELAY))) {
+            if (gyroSyncCheckUpdate() || ((currentDeltaTime + (micros() - currentTimeUs)) >= (gyro.targetLooptime + GYRO_WATCHDOG_DELAY))) {
         #endif
                 break;
             }
@@ -537,29 +537,29 @@ void taskGyro(uint32_t currentTime) {
 
 #ifdef ASYNC_GYRO_PROCESSING
     /* Update IMU for better accuracy */
-    imuUpdateGyroscope(currentDeltaTime + (micros() - currentTime));
+    imuUpdateGyroscope(currentDeltaTime + (micros() - currentTimeUs));
 #endif
 }
 
-void taskMainPidLoop(uint32_t currentTime)
+void taskMainPidLoop(timeUs_t currentTimeUs)
 {
     cycleTime = getTaskDeltaTime(TASK_SELF);
     dT = (float)cycleTime * 0.000001f;
 
 #ifdef ASYNC_GYRO_PROCESSING
     if (getAsyncMode() == ASYNC_MODE_NONE) {
-        taskGyro(currentTime);
+        taskGyro(currentTimeUs);
     }
 
     if (getAsyncMode() != ASYNC_MODE_ALL && sensors(SENSOR_ACC)) {
         imuUpdateAccelerometer();
-        imuUpdateAttitude(currentTime);
+        imuUpdateAttitude(currentTimeUs);
     }
 #else
     /* Update gyroscope */
-    taskGyro(currentTime);
+    taskGyro(currentTimeUs);
     imuUpdateAccelerometer();
-    imuUpdateAttitude(currentTime);
+    imuUpdateAttitude(currentTimeUs);
 #endif
 
 
@@ -669,15 +669,15 @@ void taskMainPidLoop(uint32_t currentTime)
 
 }
 
-bool taskUpdateRxCheck(uint32_t currentTime, uint32_t currentDeltaTime)
+bool taskUpdateRxCheck(timeUs_t currentTimeUs, uint32_t currentDeltaTime)
 {
     UNUSED(currentDeltaTime);
 
-    return updateRx(currentTime);
+    return updateRx(currentTimeUs);
 }
 
-void taskUpdateRxMain(uint32_t currentTime)
+void taskUpdateRxMain(timeUs_t currentTimeUs)
 {
-    processRx(currentTime);
+    processRx(currentTimeUs);
     isRXDataNew = true;
 }

--- a/src/main/fc/rc_curves.c
+++ b/src/main/fc/rc_curves.c
@@ -18,6 +18,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "platform.h"
+
 #include "rx/rx.h"
 #include "fc/rc_controls.h"
 #include "fc/rc_curves.h"

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -18,6 +18,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "platform.h"
+
 #include "fc/runtime_config.h"
 #include "io/beeper.h"
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -579,12 +579,12 @@ void imuUpdateAccelerometer(void)
 #endif
 }
 
-void imuUpdateAttitude(uint32_t currentTime)
+void imuUpdateAttitude(timeUs_t currentTimeUs)
 {
     /* Calculate dT */
-    static uint32_t previousIMUUpdateTime;
-    const float dT = (currentTime - previousIMUUpdateTime) * 1e-6;
-    previousIMUUpdateTime = currentTime;
+    static timeUs_t previousIMUUpdateTimeUs;
+    const float dT = (currentTimeUs - previousIMUUpdateTimeUs) * 1e-6;
+    previousIMUUpdateTimeUs = currentTimeUs;
 
     if (sensors(SENSOR_ACC) && isAccelUpdatedAtLeastOnce) {
 #ifdef HIL

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "common/time.h"
+
 #define GRAVITY_CMSS    980.665f
 
 extern int16_t throttleAngleCorrection;
@@ -57,7 +59,7 @@ typedef struct imuRuntimeConfig_s {
 struct pidProfile_s;
 void imuConfigure(imuConfig_t *imuConfig, struct pidProfile_s *initialPidProfile);
 
-void imuUpdateAttitude(uint32_t currentTime);
+void imuUpdateAttitude(timeUs_t currentTimeUs);
 void imuUpdateAccelerometer(void);
 void imuUpdateGyroscope(uint32_t gyroUpdateDeltaUs);
 float calculateThrottleTiltCompensationFactor(uint8_t throttleTiltCompensationStrength);

--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -1295,21 +1295,21 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_EMERGENCY_LANDING_FINIS
 
 static navigationFSMEvent_t navOnEnteringState_NAV_STATE_LAUNCH_INITIALIZE(navigationFSMState_t previousState)
 {
-    const uint32_t currentTime = micros();
+    const timeUs_t currentTimeUs = micros();
     UNUSED(previousState);
 
-    resetFixedWingLaunchController(currentTime);
+    resetFixedWingLaunchController(currentTimeUs);
 
     return NAV_FSM_EVENT_SUCCESS;   // NAV_STATE_LAUNCH_WAIT
 }
 
 static navigationFSMEvent_t navOnEnteringState_NAV_STATE_LAUNCH_WAIT(navigationFSMState_t previousState)
 {
-    const uint32_t currentTime = micros();
+    const timeUs_t currentTimeUs = micros();
     UNUSED(previousState);
 
     if (isFixedWingLaunchDetected()) {
-        enableFixedWingLaunchController(currentTime);
+        enableFixedWingLaunchController(currentTimeUs);
         return NAV_FSM_EVENT_SUCCESS;   // NAV_STATE_LAUNCH_MOTOR_DELAY
     }
 
@@ -2198,7 +2198,7 @@ static void processNavigationRCAdjustments(void)
  *-----------------------------------------------------------*/
 void applyWaypointNavigationAndAltitudeHold(void)
 {
-    const uint32_t currentTime = micros();
+    const timeUs_t currentTimeUs = micros();
 
 #if defined(NAV_BLACKBOX)
     navFlags = 0;
@@ -2229,10 +2229,10 @@ void applyWaypointNavigationAndAltitudeHold(void)
     /* Process controllers */
     navigationFSMStateFlags_t navStateFlags = navGetStateFlags(posControl.navState);
     if (STATE(FIXED_WING)) {
-        applyFixedWingNavigationController(navStateFlags, currentTime);
+        applyFixedWingNavigationController(navStateFlags, currentTimeUs);
     }
     else {
-        applyMulticopterNavigationController(navStateFlags, currentTime);
+        applyMulticopterNavigationController(navStateFlags, currentTimeUs);
     }
 
     /* Consume position data */

--- a/src/main/flight/navigation_rewrite.h
+++ b/src/main/flight/navigation_rewrite.h
@@ -244,8 +244,8 @@ void navigationInit(navConfig_t *initialnavConfig,
 
 /* Navigation system updates */
 void updateWaypointsAndNavigationMode(void);
-void updatePositionEstimator_BaroTopic(uint32_t currentTime);
-void updatePositionEstimator_SonarTopic(uint32_t currentTime);
+void updatePositionEstimator_BaroTopic(timeUs_t currentTimeUs);
+void updatePositionEstimator_SonarTopic(timeUs_t currentTimeUs);
 void updatePositionEstimator(void);
 void applyWaypointNavigationAndAltitudeHold(void);
 

--- a/src/main/flight/navigation_rewrite_fixedwing.c
+++ b/src/main/flight/navigation_rewrite_fixedwing.c
@@ -387,7 +387,7 @@ int16_t applyFixedWingMinSpeedController(timeUs_t currentTimeUs)
     return throttleSpeedAdjustment;
 }
 
-void applyFixedWingPitchRollThrottleController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTimeUs)
+void applyFixedWingPitchRollThrottleController(navigationFSMStateFlags_t navStateFlags, timeUs_t currentTimeUs)
 {
     int16_t pitchCorrection = 0;        // >0 climb, <0 dive
     int16_t rollCorrection = 0;         // >0 right, <0 left
@@ -488,7 +488,7 @@ void resetFixedWingHeadingController(void)
     updateMagHoldHeading(CENTIDEGREES_TO_DEGREES(posControl.actualState.yaw));
 }
 
-void applyFixedWingNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTimeUs)
+void applyFixedWingNavigationController(navigationFSMStateFlags_t navStateFlags, timeUs_t currentTimeUs)
 {
     if (navStateFlags & NAV_CTL_LAUNCH) {
         applyFixedWingLaunchController(currentTimeUs);

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -542,7 +542,7 @@ bool isMulticopterLandingDetected(void)
 static void applyMulticopterEmergencyLandingController(timeUs_t currentTimeUs)
 {
     static timeUs_t previousTimeUpdate;
-    static uint32_t previousTimePositionUpdate;
+    static timeUs_t previousTimePositionUpdate;
     const timeUs_t deltaMicros = currentTimeUs - previousTimeUpdate;
     previousTimeUpdate = currentTimeUs;
 

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -619,7 +619,7 @@ static void applyMulticopterHeadingController(void)
     updateMagHoldHeading(CENTIDEGREES_TO_DEGREES(posControl.desiredState.yaw));
 }
 
-void applyMulticopterNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTimeUs)
+void applyMulticopterNavigationController(navigationFSMStateFlags_t navStateFlags, timeUs_t currentTimeUs)
 {
     if (navStateFlags & NAV_CTL_EMERG) {
         applyMulticopterEmergencyLandingController(currentTimeUs);

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -438,7 +438,7 @@ static void applyMulticopterPositionController(timeUs_t currentTimeUs)
     if (posControl.flags.hasValidPositionSensor) {
         // If we have new position - update velocity and acceleration controllers
         if (posControl.flags.horizontalPositionDataNew) {
-            uint32_t deltaMicrosPositionUpdate = currentTimeUs - previousTimePositionUpdate;
+            timeUs_t deltaMicrosPositionUpdate = currentTimeUs - previousTimePositionUpdate;
             previousTimePositionUpdate = currentTimeUs;
 
             if (!bypassPositionController) {

--- a/src/main/flight/navigation_rewrite_private.h
+++ b/src/main/flight/navigation_rewrite_private.h
@@ -339,7 +339,7 @@ bool adjustMulticopterAltitudeFromRCInput(void);
 bool adjustMulticopterHeadingFromRCInput(void);
 bool adjustMulticopterPositionFromRCInput(void);
 
-void applyMulticopterNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTime);
+void applyMulticopterNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTimeUs);
 
 void resetFixedWingLandingDetector(void);
 void resetMulticopterLandingDetector(void);
@@ -360,15 +360,15 @@ bool adjustFixedWingAltitudeFromRCInput(void);
 bool adjustFixedWingHeadingFromRCInput(void);
 bool adjustFixedWingPositionFromRCInput(void);
 
-void applyFixedWingNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTime);
+void applyFixedWingNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTimeUs);
 
 void calculateFixedWingInitialHoldPosition(t_fp_vector * pos);
 
 /* Fixed-wing launch controller */
-void resetFixedWingLaunchController(const uint32_t currentTime);
+void resetFixedWingLaunchController(timeUs_t currentTimeUs);
 bool isFixedWingLaunchDetected(void);
-void enableFixedWingLaunchController(const uint32_t currentTime);
+void enableFixedWingLaunchController(timeUs_t currentTimeUs);
 bool isFixedWingLaunchFinishedOrAborted(void);
-void applyFixedWingLaunchController(const uint32_t currentTime);
+void applyFixedWingLaunchController(timeUs_t currentTimeUs);
 
 #endif

--- a/src/main/flight/navigation_rewrite_private.h
+++ b/src/main/flight/navigation_rewrite_private.h
@@ -339,7 +339,7 @@ bool adjustMulticopterAltitudeFromRCInput(void);
 bool adjustMulticopterHeadingFromRCInput(void);
 bool adjustMulticopterPositionFromRCInput(void);
 
-void applyMulticopterNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTimeUs);
+void applyMulticopterNavigationController(navigationFSMStateFlags_t navStateFlags, timeUs_t currentTimeUs);
 
 void resetFixedWingLandingDetector(void);
 void resetMulticopterLandingDetector(void);
@@ -360,7 +360,7 @@ bool adjustFixedWingAltitudeFromRCInput(void);
 bool adjustFixedWingHeadingFromRCInput(void);
 bool adjustFixedWingPositionFromRCInput(void);
 
-void applyFixedWingNavigationController(navigationFSMStateFlags_t navStateFlags, uint32_t currentTimeUs);
+void applyFixedWingNavigationController(navigationFSMStateFlags_t navStateFlags, timeUs_t currentTimeUs);
 
 void calculateFixedWingInitialHoldPosition(t_fp_vector * pos);
 

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -287,7 +287,7 @@ void beeperGpsStatus(void)
  * Beeper handler function to be called periodically in loop. Updates beeper
  * state via time schedule.
  */
-void beeperUpdate(uint32_t currentTime)
+void beeperUpdate(timeUs_t currentTimeUs)
 {
     // If beeper option from AUX switch has been selected
     if (IS_RC_MODE_ACTIVE(BOXBEEPERON)) {
@@ -307,7 +307,7 @@ void beeperUpdate(uint32_t currentTime)
         return;
     }
 
-    const uint32_t now = currentTime / 1000;
+    const timeMs_t now = currentTimeUs / 1000;
     if (beeperNextToggleTime > now) {
         return;
     }
@@ -325,7 +325,7 @@ void beeperUpdate(uint32_t currentTime)
                 beeperPos == 0
                 && (currentBeeperEntry->mode == BEEPER_ARMING || currentBeeperEntry->mode == BEEPER_ARMING_GPS_FIX)
             ) {
-                armingBeepTimeMicros = currentTime;
+                armingBeepTimeMicros = currentTimeUs;
             }
         }
     } else {

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "common/time.h"
+
 typedef enum {
     // IMPORTANT: these are in priority order, 0 = Highest
     BEEPER_SILENCE = 0,             // Silence, see beeperSilence()
@@ -48,7 +50,7 @@ typedef enum {
 
 void beeper(beeperMode_e mode);
 void beeperSilence(void);
-void beeperUpdate(uint32_t currentTime);
+void beeperUpdate(timeUs_t currentTimeUs);
 void beeperConfirmationBeeps(uint8_t beepCount);
 uint32_t getArmingBeepTimeMicros(void);
 beeperMode_e beeperModeForTableIndex(int idx);

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -72,7 +72,7 @@ controlRateConfig_t *getControlRateConfig(uint8_t profileIndex);
 #define DASHBOARD_UPDATE_FREQUENCY (MICROSECONDS_IN_A_SECOND / 5)
 #define PAGE_CYCLE_FREQUENCY (MICROSECONDS_IN_A_SECOND * 5)
 
-static uint32_t nextDisplayUpdateAt = 0;
+static timeUs_t nextDisplayUpdateAt = 0;
 static bool displayPresent = false;
 
 static const rxConfig_t *rxConfig;
@@ -374,7 +374,7 @@ static void showStatusPage(void)
 
 }
 
-void dashboardUpdate(uint32_t currentTime)
+void dashboardUpdate(timeUs_t currentTimeUs)
 {
     static uint8_t previousArmedState = 0;
     static bool wasGrabbed = false;
@@ -394,13 +394,13 @@ void dashboardUpdate(uint32_t currentTime)
     pageChanging = false;
 #endif
 
-    bool updateNow = (int32_t)(currentTime - nextDisplayUpdateAt) >= 0L;
+    bool updateNow = (int32_t)(currentTimeUs - nextDisplayUpdateAt) >= 0L;
 
     if (!updateNow) {
         return;
     }
 
-    nextDisplayUpdateAt = currentTime + DASHBOARD_UPDATE_FREQUENCY;
+    nextDisplayUpdateAt = currentTimeUs + DASHBOARD_UPDATE_FREQUENCY;
 
     bool armedState = ARMING_FLAG(ARMED) ? true : false;
     bool armedStateChanged = armedState != previousArmedState;
@@ -418,7 +418,7 @@ void dashboardUpdate(uint32_t currentTime)
             pageChanging = true;
         }
 
-        if ((currentPageId == PAGE_WELCOME) && ((int32_t)(currentTime - nextPageAt) >= 0L)) {
+        if ((currentPageId == PAGE_WELCOME) && ((int32_t)(currentTimeUs - nextPageAt) >= 0L)) {
             currentPageId = PAGE_STATUS;
             pageChanging = true;
         }

--- a/src/main/io/dashboard.h
+++ b/src/main/io/dashboard.h
@@ -23,7 +23,7 @@ typedef enum {
 
 struct rxConfig_s;
 void dashboardInit(const struct rxConfig_s *intialRxConfig);
-void dashboardUpdate(uint32_t currentTime);
+void dashboardUpdate(timeUs_t currentTimeUs);
 
 void dashboardSetPage(pageId_e newPageId);
 void dashboardSetNextPageChangeAt(uint32_t futureMicros);

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -423,11 +423,11 @@ void gpsEnablePassthrough(serialPort_t *gpsPassthroughPort)
     }
 }
 
-void updateGpsIndicator(uint32_t currentTime)
+void updateGpsIndicator(timeUs_t currentTimeUs)
 {
-    static uint32_t GPSLEDTime;
-    if ((int32_t)(currentTime - GPSLEDTime) >= 0 && (gpsSol.numSat>= 5)) {
-        GPSLEDTime = currentTime + 150000;
+    static timeUs_t GPSLEDTime;
+    if ((int32_t)(currentTimeUs - GPSLEDTime) >= 0 && (gpsSol.numSat>= 5)) {
+        GPSLEDTime = currentTimeUs + 150000;
         LED1_TOGGLE;
     }
 }

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -138,4 +138,4 @@ void gpsPreInit(gpsConfig_t *initialGpsConfig);
 struct serialConfig_s;
 void gpsInit(struct serialConfig_s *serialConfig, gpsConfig_t *initialGpsConfig);
 void gpsThread(void);
-void updateGpsIndicator(uint32_t currentTime);
+void updateGpsIndicator(timeUs_t currentTimeUs);

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -896,7 +896,7 @@ typedef enum {
     timTimerCount
 } timId_e;
 
-static uint32_t timerVal[timTimerCount];
+static timeUs_t timerVal[timTimerCount];
 
 // function to apply layer.
 // function must replan self using timer pointer
@@ -921,7 +921,7 @@ static applyLayerFn_timed* layerTable[] = {
     [timRing] = &applyLedThrustRingLayer
 };
 
-void ledStripUpdate(uint32_t currentTime)
+void ledStripUpdate(timeUs_t currentTimeUs)
 {
     if (!(ledStripInitialised && isWS2811LedStripReady())) {
         return;
@@ -941,12 +941,12 @@ void ledStripUpdate(uint32_t currentTime)
     for (timId_e timId = 0; timId < timTimerCount; timId++) {
         // sanitize timer value, so that it can be safely incremented. Handles inital timerVal value.
         // max delay is limited to 5s
-        int32_t delta = cmp32(currentTime, timerVal[timId]);
+        int32_t delta = cmpTimeUs(currentTimeUs, timerVal[timId]);
         if (delta < 0 && delta > -LED_STRIP_MS(5000))
             continue;  // not ready yet
         timActive |= 1 << timId;
         if (delta >= LED_STRIP_MS(100) || delta < 0) {
-            timerVal[timId] = currentTime;
+            timerVal[timId] = currentTimeUs;
         }
     }
 
@@ -960,7 +960,7 @@ void ledStripUpdate(uint32_t currentTime)
     applyLedFixedLayers();
 
     for (timId_e timId = 0; timId < ARRAYLEN(layerTable); timId++) {
-        uint32_t *timer = &timerVal[timId];
+        timeUs_t *timer = &timerVal[timId];
         bool updateNow = timActive & (1 << timId);
         (*layerTable[timId])(updateNow, timer);
     }

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -513,7 +513,7 @@ typedef enum {
     WARNING_FAILSAFE,
 } warningFlags_e;
 
-static void applyLedWarningLayer(bool updateNow, uint32_t *timer)
+static void applyLedWarningLayer(bool updateNow, timeUs_t *timer)
 {
     static uint8_t warningFlashCounter = 0;
     static uint8_t warningFlags = 0;          // non-zero during blinks
@@ -559,7 +559,7 @@ static void applyLedWarningLayer(bool updateNow, uint32_t *timer)
     }
 }
 
-static void applyLedBatteryLayer(bool updateNow, uint32_t *timer)
+static void applyLedBatteryLayer(bool updateNow, timeUs_t *timer)
 {
     static bool flash = false;
 
@@ -592,7 +592,7 @@ static void applyLedBatteryLayer(bool updateNow, uint32_t *timer)
     }
 }
 
-static void applyLedRssiLayer(bool updateNow, uint32_t *timer)
+static void applyLedRssiLayer(bool updateNow, timeUs_t *timer)
 {
     static bool flash = false;
 
@@ -623,7 +623,7 @@ static void applyLedRssiLayer(bool updateNow, uint32_t *timer)
 }
 
 #ifdef GPS
-static void applyLedGpsLayer(bool updateNow, uint32_t *timer)
+static void applyLedGpsLayer(bool updateNow, timeUs_t *timer)
 {
     static uint8_t gpsFlashCounter = 0;
     static uint8_t gpsPauseCounter = 0;
@@ -662,7 +662,7 @@ static void applyLedGpsLayer(bool updateNow, uint32_t *timer)
 
 #define INDICATOR_DEADBAND 25
 
-static void applyLedIndicatorLayer(bool updateNow, uint32_t *timer)
+static void applyLedIndicatorLayer(bool updateNow, timeUs_t *timer)
 {
     static bool flash = 0;
 
@@ -725,7 +725,7 @@ static void updateLedRingCounts(void)
     ledCounts.ringSeqLen = seqLen;
 }
 
-static void applyLedThrustRingLayer(bool updateNow, uint32_t *timer)
+static void applyLedThrustRingLayer(bool updateNow, timeUs_t *timer)
 {
     static uint8_t rotationPhase;
     int ledRingIndex = 0;
@@ -796,7 +796,7 @@ static void larsonScannerNextStep(larsonParameters_t *larsonParameters, int delt
     }
 }
 
-static void applyLarsonScannerLayer(bool updateNow, uint32_t *timer)
+static void applyLarsonScannerLayer(bool updateNow, timeUs_t *timer)
 {
     static larsonParameters_t larsonParameters = { 0, 0, 1 };
 
@@ -821,7 +821,7 @@ static void applyLarsonScannerLayer(bool updateNow, uint32_t *timer)
 }
 
 // blink twice, then wait ; either always or just when landing
-static void applyLedBlinkLayer(bool updateNow, uint32_t *timer)
+static void applyLedBlinkLayer(bool updateNow, timeUs_t *timer)
 {
     const uint16_t blinkPattern = 0x8005; // 0b1000000000000101;
     static uint16_t blinkMask;
@@ -848,7 +848,7 @@ static void applyLedBlinkLayer(bool updateNow, uint32_t *timer)
 }
 
 #ifdef USE_LED_ANIMATION
-static void applyLedAnimationLayer(bool updateNow, uint32_t *timer)
+static void applyLedAnimationLayer(bool updateNow, timeUs_t *timer)
 {
     static uint8_t frameCounter = 0;
     const int animationFrames = ledGridHeight;
@@ -903,7 +903,7 @@ static timeUs_t timerVal[timTimerCount];
 // when updateNow is true (timer triggered), state must be updated first,
 //  before calculating led state. Otherwise update started by different trigger
 //  may modify LED state.
-typedef void applyLayerFn_timed(bool updateNow, uint32_t *timer);
+typedef void applyLayerFn_timed(bool updateNow, timeUs_t *timer);
 
 static applyLayerFn_timed* layerTable[] = {
     [timBlink] = &applyLedBlinkLayer,

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -166,7 +166,7 @@ void reevaluateLedConfig(void);
 
 void ledStripInit(ledConfig_t *ledConfigsToUse, struct hsvColor_s *colorsToUse, modeColorIndexes_t *modeColorsToUse, specialColorIndexes_t *specialColorsToUse);
 void ledStripEnable(void);
-void ledStripUpdate(uint32_t currentTime);
+void ledStripUpdate(timeUs_t currentTimeUs);
 
 bool setModeColor(ledModeIndex_e modeIndex, int modeColorIndex, int colorIndex);
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -602,7 +602,7 @@ static void osdArmMotors(void)
     osdResetStats();
 }
 
-static void osdRefresh(uint32_t currentTime)
+static void osdRefresh(timeUs_t currentTimeUs)
 {
     static uint8_t lastSec = 0;
     uint8_t sec;
@@ -643,7 +643,7 @@ static void osdRefresh(uint32_t currentTime)
         osdDrawElements();
 #ifdef OSD_CALLS_CMS
     } else {
-        cmsUpdate(currentTime);
+        cmsUpdate(currentTimeUs);
 #endif
     }
 #endif
@@ -652,7 +652,7 @@ static void osdRefresh(uint32_t currentTime)
 /*
  * Called periodically by the scheduler
  */
-void osdUpdate(uint32_t currentTime)
+void osdUpdate(timeUs_t currentTimeUs)
 {
     static uint32_t counter = 0;
 #ifdef MAX7456_DMA_CHANNEL_TX
@@ -663,7 +663,7 @@ void osdUpdate(uint32_t currentTime)
 
     // redraw values in buffer
     if (counter++ % 5 == 0)
-        osdRefresh(currentTime);
+        osdRefresh(currentTimeUs);
     else // rest of time redraw screen 10 chars per idle to don't lock the main idle
         max7456DrawScreen();
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -66,4 +66,4 @@ typedef struct osd_profile_s {
 void osdInit(void);
 void osdResetConfig(osd_profile_t *osdProfile);
 void osdResetAlarms(void);
-void osdUpdate(uint32_t currentTime);
+void osdUpdate(timeUs_t currentTimeUs);

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "common/time.h"
+
 #define STICK_CHANNEL_COUNT 4
 
 #define PWM_RANGE_ZERO 0 // FIXME should all usages of this be changed to use PWM_RANGE_MIN?
@@ -151,14 +153,14 @@ extern rxRuntimeConfig_t rxRuntimeConfig; //!!TODO remove this extern, only need
 struct modeActivationCondition_s;
 void rxInit(const rxConfig_t *rxConfig, const struct modeActivationCondition_s *modeActivationConditions);
 void useRxConfig(const rxConfig_t *rxConfigToUse);
-bool updateRx(uint32_t currentTime);
+bool updateRx(timeUs_t currentTimeUs);
 bool rxIsReceivingSignal(void);
 bool rxAreFlightChannelsValid(void);
-void calculateRxChannelsAndUpdateFailsafe(uint32_t currentTime);
+void calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs);
 
 void parseRcChannels(const char *input, rxConfig_t *rxConfig);
 
-void updateRSSI(uint32_t currentTime);
+void updateRSSI(timeUs_t currentTimeUs);
 void resetAllRxChannelRangeConfigurations(rxChannelRangeConfiguration_t *rxChannelRangeConfiguration);
 
 void suspendRxSignal(void);

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "common/time.h"
+
 //#define SCHEDULER_DEBUG
 
 typedef enum {
@@ -102,23 +104,23 @@ typedef enum {
 typedef struct {
     /* Configuration */
     const char * taskName;
-    bool (*checkFunc)(uint32_t currentTime, uint32_t currentDeltaTime);
-    void (*taskFunc)(uint32_t currentTime);
+    bool (*checkFunc)(timeUs_t currentTimeUs, uint32_t currentDeltaTime);
+    void (*taskFunc)(timeUs_t currentTimeUs);
     uint32_t desiredPeriod;         // target period of execution
     const uint8_t staticPriority;   // dynamicPriority grows in steps of this size, shouldn't be zero
 
     /* Scheduling */
     uint16_t dynamicPriority;       // measurement of how old task was last executed, used to avoid task starvation
     uint16_t taskAgeCycles;
-    uint32_t lastExecutedAt;        // last time of invocation
-    uint32_t lastSignaledAt;        // time of invocation event for event-driven tasks
+    timeUs_t lastExecutedAt;        // last time of invocation
+    timeUs_t lastSignaledAt;        // time of invocation event for event-driven tasks
 
     /* Statistics */
-    uint32_t averageExecutionTime;  // Moving average over 6 samples, used to calculate guard interval
-    uint32_t taskLatestDeltaTime;   //
+    timeUs_t averageExecutionTime;  // Moving average over 6 samples, used to calculate guard interval
+    timeUs_t taskLatestDeltaTime;   //
 #ifndef SKIP_TASK_STATISTICS
-    uint32_t maxExecutionTime;
-    uint32_t totalExecutionTime;    // total time consumed by task since boot
+    timeUs_t maxExecutionTime;
+    timeUs_t totalExecutionTime;    // total time consumed by task since boot
 #endif
 } cfTask_t;
 

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -72,9 +72,9 @@ bool isCompassReady(void)
 
 static sensorCalibrationState_t calState;
 
-void compassUpdate(uint32_t currentTime, flightDynamicsTrims_t *magZero)
+void compassUpdate(timeUs_t currentTimeUs, flightDynamicsTrims_t *magZero)
 {
-    static uint32_t calStartedAt = 0;
+    static timeUs_t calStartedAt = 0;
     static int16_t magPrev[XYZ_AXIS_COUNT];
 
     if (!mag.read(magADCRaw)) {
@@ -89,7 +89,7 @@ void compassUpdate(uint32_t currentTime, flightDynamicsTrims_t *magZero)
     }
 
     if (STATE(CALIBRATE_MAG)) {
-        calStartedAt = currentTime;
+        calStartedAt = currentTimeUs;
 
         for (int axis = 0; axis < 3; axis++) {
             magZero->raw[axis] = 0;
@@ -107,7 +107,7 @@ void compassUpdate(uint32_t currentTime, flightDynamicsTrims_t *magZero)
     }
 
     if (calStartedAt != 0) {
-        if ((currentTime - calStartedAt) < 30000000) {    // 30s: you have 30s to turn the multi in all directions
+        if ((currentTimeUs - calStartedAt) < 30000000) {    // 30s: you have 30s to turn the multi in all directions
             LED0_TOGGLE;
 
             float diffMag = 0;

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "common/time.h"
+
 #include "sensors/sensors.h"
 
 // Type of magnetometer used/detected
@@ -35,7 +37,7 @@ typedef enum {
 
 bool compassInit(int16_t magDeclinationFromConfig);
 union flightDynamicsTrims_u;
-void compassUpdate(uint32_t currentTime, union flightDynamicsTrims_u *magZero);
+void compassUpdate(timeUs_t currentTimeUs, union flightDynamicsTrims_u *magZero);
 bool isCompassReady(void);
 
 extern int32_t magADC[XYZ_AXIS_COUNT];

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -492,33 +492,33 @@ void checkHoTTTelemetryState(void)
         freeHoTTTelemetryPort();
 }
 
-void handleHoTTTelemetry(uint32_t currentTime)
+void handleHoTTTelemetry(timeUs_t currentTimeUs)
 {
-    static uint32_t serialTimer;
+    static timeUs_t serialTimer;
 
     if (!hottTelemetryEnabled) {
         return;
     }
 
-    if (shouldPrepareHoTTMessages(currentTime)) {
+    if (shouldPrepareHoTTMessages(currentTimeUs)) {
         hottPrepareMessages();
-        lastMessagesPreparedAt = currentTime;
+        lastMessagesPreparedAt = currentTimeUs;
     }
 
     if (shouldCheckForHoTTRequest()) {
-        hottCheckSerialData(currentTime);
+        hottCheckSerialData(currentTimeUs);
     }
 
     if (!hottMsg)
         return;
 
     if (hottIsSending) {
-        if(currentTime - serialTimer < HOTT_TX_DELAY_US) {
+        if(currentTimeUs - serialTimer < HOTT_TX_DELAY_US) {
             return;
         }
     }
     hottSendTelemetryData();
-    serialTimer = currentTime;
+    serialTimer = currentTimeUs;
 }
 
 #endif

--- a/src/main/telemetry/hott.h
+++ b/src/main/telemetry/hott.h
@@ -487,7 +487,7 @@ typedef struct HOTT_AIRESC_MSG_s {
     uint8_t stop_byte;      //#44 constant value 0x7d
 } HOTT_AIRESC_MSG_t;
 
-void handleHoTTTelemetry(uint32_t currentTime);
+void handleHoTTTelemetry(timeUs_t currentTimeUs);
 void checkHoTTTelemetryState(void);
 
 void initHoTTTelemetry(telemetryConfig_t *telemetryConfig);

--- a/src/main/telemetry/mavlink.h
+++ b/src/main/telemetry/mavlink.h
@@ -19,7 +19,7 @@
 #define TELEMETRY_MAVLINK_H_
 
 void initMAVLinkTelemetry(void);
-void handleMAVLinkTelemetry(uint32_t currentTime);
+void handleMAVLinkTelemetry(timeUs_t currentTimeUs);
 void checkMAVLinkTelemetryState(void);
 
 void freeMAVLinkTelemetryPort(void);

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -138,7 +138,7 @@ void telemetryCheckState(void)
 
 }
 
-void telemetryProcess(uint32_t currentTime, rxConfig_t *rxConfig, uint16_t deadband3d_throttle)
+void telemetryProcess(timeUs_t currentTimeUs, rxConfig_t *rxConfig, uint16_t deadband3d_throttle)
 {
 #if defined(TELEMETRY_FRSKY)
     handleFrSkyTelemetry(rxConfig, deadband3d_throttle);
@@ -148,9 +148,9 @@ void telemetryProcess(uint32_t currentTime, rxConfig_t *rxConfig, uint16_t deadb
 #endif
 
 #if defined(TELEMETRY_HOTT)
-    handleHoTTTelemetry(currentTime);
+    handleHoTTTelemetry(currentTimeUs);
 #else
-    UNUSED(currentTime);
+    UNUSED(currentTimeUs);
 #endif
 
 #if defined(TELEMETRY_SMARTPORT)
@@ -162,9 +162,9 @@ void telemetryProcess(uint32_t currentTime, rxConfig_t *rxConfig, uint16_t deadb
 #endif
 
 #if defined(TELEMETRY_MAVLINK)
-    handleMAVLinkTelemetry(currentTime);
+    handleMAVLinkTelemetry(currentTimeUs);
 #else
-    UNUSED(currentTime);
+    UNUSED(currentTimeUs);
 #endif
 
 #if defined(TELEMETRY_JETIEXBUS)

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -55,7 +55,7 @@ extern serialPort_t *telemetrySharedPort;
 
 void telemetryCheckState(void);
 struct rxConfig_s;
-void telemetryProcess(uint32_t currentTime, struct rxConfig_s *rxConfig, uint16_t deadband3d_throttle);
+void telemetryProcess(timeUs_t currentTimeUs, struct rxConfig_s *rxConfig, uint16_t deadband3d_throttle);
 
 bool telemetryDetermineEnabledState(portSharing_e portSharing);
 


### PR DESCRIPTION
This PR creates two new types `timeMs_t` (millisecond time) and `timeUs_t` (microsecond time) and applies them across the codebase.

The PR is prompted because currently system time is in microseconds and is stored in 32bit variables, which means it will wrap around after 1.19 hours. While this is not a problem for quadcopters, it is potentially a problem for airplanes and flying wings which can have extended flight times.

There is a `USE_64BIT_TIME` build flag, so this code can be ported back to betaflight, which probably doesn't want the overhead of a 64bit system time.

Currently the `USE-64BIT_TIME` build flag is not set, so this code can be safely merged in, and tested at leisure.