### PR TITLE
Airplane servo autotrim feature

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -138,6 +138,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXFLAPERON, "FLAPERON;", 34 },
     { BOXTURNASSIST, "TURN ASSIST;", 35 },
     { BOXNAVLAUNCH, "NAV LAUNCH;", 36 },
+    { BOXAUTOTRIM, "SERVO AUTOTRIM;", 37 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -289,6 +290,7 @@ static void initActiveBoxIds(void)
     if (isFixedWing) {
         activeBoxIds[activeBoxIdCount++] = BOXPASSTHRU;
         activeBoxIds[activeBoxIdCount++] = BOXNAVLAUNCH;
+        activeBoxIds[activeBoxIdCount++] = BOXAUTOTRIM;
     }
 
     /*
@@ -358,6 +360,7 @@ static uint32_t packFlightModeFlags(void)
         IS_ENABLED(FLIGHT_MODE(FLAPERON)) << BOXFLAPERON |
         IS_ENABLED(FLIGHT_MODE(TURN_ASSISTANT)) << BOXTURNASSIST |
         IS_ENABLED(FLIGHT_MODE(NAV_LAUNCH_MODE)) << BOXNAVLAUNCH |
+        IS_ENABLED(IS_RC_MODE_ACTIVE(BOXAUTOTRIM)) << BOXAUTOTRIM |
         IS_ENABLED(IS_RC_MODE_ACTIVE(BOXHOMERESET)) << BOXHOMERESET;
 
     uint32_t ret = 0;

--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -647,6 +647,8 @@ void taskMainPidLoop(timeUs_t currentTimeUs)
         processServoTilt();
     }
 
+    processServoAutotrim();
+
     //Servos should be filtered or written only when mixer is using servos or special feaures are enabled
     if (isServoOutputEnabled()) {
         filterServos();

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -47,6 +47,7 @@ typedef enum {
     BOXSURFACE,
     BOXFLAPERON,
     BOXTURNASSIST,
+    BOXAUTOTRIM,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -124,6 +124,7 @@ void mixTable(void);
 void writeMotors(void);
 void servoMixer(uint16_t flaperon_throw_offset, uint8_t flaperon_throw_inverted);
 void processServoTilt(void);
+void processServoAutotrim(void);
 void stopMotors(void);
 void stopPwmAllMotors(void);
 


### PR DESCRIPTION
Ok, this is some initial work on https://github.com/iNavFlight/inav/issues/821

Logic:

1. Fly
2. Enable `SERVO AUTOTRIM` mode
3. Firmware will collect data for 1 second, compude average servo position for `SERVO_ELEVATOR`, `SERVO_FLAPPERON_1`, `SERVO_FLAPPERON_2` and `SERVO_RUDDER` and set that as a new servo middles. Change takes effect instantly.
4. If you are not happy with results - disable `SERVO AUTOTRIM` mode, original midpoints will be restored.

This feature does not save configuration to EEPROM. If you are happy with the results you'll have to land, disarm without disbaling `SERVO AUTOTRIM` and save manually.