### PR TITLE
Add support for servos on AirbotF4/FlipF4 targets

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -288,6 +288,12 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
             if (timerIndex == PWM6 || timerIndex == PWM7)
                 type = MAP_TO_SERVO_OUTPUT;
 #endif
+
+#if defined(AIRBOTF4)
+            // remap PWM11+PWM12 as servos on multirotor mixers that use servos (i.e. Tri)
+            if (timerIndex == PWM11 || timerIndex == PWM12)
+                type = MAP_TO_SERVO_OUTPUT;
+#endif
         }
 
         if (init->useChannelForwarding && !init->airplane) {


### PR DESCRIPTION
Tricopter mixer (and other multirotor mixers that use servos) will now have servos on M5/M6 outputs on AirbotF4/FlipF4 targets.

Intended to fix https://github.com/iNavFlight/inav/issues/851