### PR TITLE
Pikoblx port

### DIFF
--- a/src/main/target/PIKOBLX_limited/target.c
+++ b/src/main/target/PIKOBLX_limited/target.c
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+const uint16_t multiPPM[] = {
+    PWM9  | (MAP_TO_PPM_INPUT << 8),     // PPM input
+
+    PWM1  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const uint16_t multiPWM[] = {
+    PWM1  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const uint16_t airPPM[] = {
+    // TODO
+    0xFFFF
+};
+
+const uint16_t airPWM[] = {
+    // TODO
+    0xFFFF
+};
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    { TIM3,  IO_TAG(PA4),  TIM_Channel_2, TIM3_IRQn,               1, IOCFG_AF_PP,    GPIO_AF_2 }, // PWM1  - PA4  - *TIM3_CH2
+    { TIM3,  IO_TAG(PA6),  TIM_Channel_1, TIM3_IRQn,               1, IOCFG_AF_PP,    GPIO_AF_2 }, // PWM2  - PA6  - *TIM3_CH1, TIM8_BKIN, TIM1_BKIN, TIM16_CH1
+    { TIM3,  IO_TAG(PB0),  TIM_Channel_3, TIM3_IRQn,               1, IOCFG_AF_PP,    GPIO_AF_2 }, // PWM3  - PB0  - *TIM3_CH3, TIM1_CH2N, TIM8_CH2N
+    { TIM3,  IO_TAG(PB1),  TIM_Channel_4, TIM3_IRQn,               1, IOCFG_AF_PP,    GPIO_AF_2 }, // PWM4  - PB1  - *TIM3_CH4, TIM1_CH3N, TIM8_CH3N
+    { TIM2,  IO_TAG(PA1),  TIM_Channel_2, TIM2_IRQn,               1, IOCFG_AF_PP,    GPIO_AF_1 }, // PWM5  - PA1  - *TIM2_CH2, TIM15_CH1N
+    { TIM2,  IO_TAG(PA2),  TIM_Channel_3, TIM2_IRQn,               1, IOCFG_AF_PP,    GPIO_AF_1 }, // PWM6  - PA2  - *TIM2_CH3, !TIM15_CH1
+    { TIM15, IO_TAG(PA3),  TIM_Channel_2, TIM1_BRK_TIM15_IRQn,     1, IOCFG_AF_PP,    GPIO_AF_9 }, // PWM7  - PA3  - *TIM15_CH2, TIM2_CH4
+    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM1_CC_IRQn,            1, IOCFG_AF_PP,    GPIO_AF_6 }, // PWM8  - PA8  - *TIM1_CH1, TIM4_ETR
+    { TIM17, IO_TAG(PA7),  TIM_Channel_1, TIM1_TRG_COM_TIM17_IRQn, 0, IOCFG_AF_PP_PD, GPIO_AF_1 }, // PPM   - PA7  - *TIM17_CH1, TIM1_CH1N, TIM8_CH1
+};
+

--- a/src/main/target/PIKOBLX_limited/target.h
+++ b/src/main/target/PIKOBLX_limited/target.h
@@ -1,0 +1,142 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "PIKO" // Furious FPV Piko BLX
+#define USE_CLI
+
+#define CONFIG_FASTLOOP_PREFERRED_ACC ACC_DEFAULT
+
+#define LED0                    PB9
+#define LED1                    PB5
+
+#define BEEPER                  PA0
+#define BEEPER_INVERTED
+
+// MPU6000 interrupts
+#define USE_EXTI
+#define MPU_INT_EXTI            PA15
+#define EXTI15_10_CALLBACK_HANDLER_COUNT 1 // MPU data ready
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define GYRO
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_MPU6000_ALIGN      CW180_DEG
+
+#define ACC
+#define USE_ACC_SPI_MPU6000
+#define ACC_MPU6000_ALIGN       CW180_DEG
+
+#define MPU6000_CS_GPIO         GPIOB
+#define MPU6000_CS_PIN          PB12
+#define MPU6000_SPI_INSTANCE    SPI2
+
+#define USE_VCP
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define SERIAL_PORT_COUNT       4
+
+#define UART1_TX_PIN            PB6
+#define UART1_RX_PIN            PB7
+
+#define UART2_TX_PIN            PB3
+#define UART2_RX_PIN            PB4
+
+#define UART3_TX_PIN            PB10 // PB10 (AF7)
+#define UART3_RX_PIN            PB11 // PB11 (AF7)
+
+#define USE_SPI
+#define USE_SPI_DEVICE_2
+
+#define SENSORS_SET             (SENSOR_ACC)
+
+#define TELEMETRY
+#define BLACKBOX
+#define SERIAL_RX
+#define USE_SERVOS
+
+#define BOARD_HAS_VOLTAGE_DIVIDER
+#define USE_ADC
+#define ADC_INSTANCE            ADC2
+#define CURRENT_METER_ADC_PIN   PA2
+#define VBAT_ADC_PIN            PA5
+#define RSSI_ADC_PIN            PB2
+
+#define LED_STRIP
+#if 1
+
+#define USE_LED_STRIP_ON_DMA1_CHANNEL3
+#define WS2811_PIN                      PB8 // TIM16_CH1
+#define WS2811_TIMER                    TIM16
+#define WS2811_DMA_CHANNEL              DMA1_Channel3
+#define WS2811_IRQ                      DMA1_Channel3_IRQn
+#define WS2811_DMA_TC_FLAG              DMA1_FLAG_TC3
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_CH3_HANDLER
+#endif
+
+#if 0
+// Alternate LED strip pin
+// FIXME DMA IRQ Transfer Complete is never called because the  TIM17_DMA_RMP needs to be set in SYSCFG_CFGR1
+#define LED_STRIP_TIMER TIM17
+#define USE_LED_STRIP_ON_DMA1_CHANNEL7
+#define WS2811_GPIO                     GPIOA
+#define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
+#define WS2811_GPIO_AF                  GPIO_AF_1
+#define WS2811_PIN                      GPIO_Pin_7 // TIM17_CH1
+#define WS2811_PIN_SOURCE               GPIO_PinSource7
+#define WS2811_TIMER                    TIM17
+#define WS2811_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM17
+#define WS2811_DMA_CHANNEL              DMA1_Channel7
+#define WS2811_IRQ                      DMA1_Channel7_IRQn
+#endif
+
+#define TRANSPONDER
+#define TRANSPONDER_GPIO                     GPIOA
+#define TRANSPONDER_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
+#define TRANSPONDER_GPIO_AF                  GPIO_AF_6
+#define TRANSPONDER_PIN                      GPIO_Pin_8
+#define TRANSPONDER_PIN_SOURCE               GPIO_PinSource8
+#define TRANSPONDER_TIMER                    TIM1
+#define TRANSPONDER_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM1
+#define TRANSPONDER_DMA_CHANNEL              DMA1_Channel2
+#define TRANSPONDER_IRQ                      DMA1_Channel2_IRQn
+#define TRANSPONDER_DMA_TC_FLAG              DMA1_FLAG_TC2
+#define TRANSPONDER_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
+
+#define SPEKTRUM_BIND
+// USART3, PB11
+#define BIND_PIN                PB11
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+// IO - stm32f303cc in 48pin package
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         (BIT(13)|BIT(14)|BIT(15))
+// #define TARGET_IO_PORTF        (BIT(0)|BIT(1))
+// !!TODO - check the following line is correct
+#define TARGET_IO_PORTF         (BIT(0)|BIT(1)|BIT(3)|BIT(4))
+
+#define USABLE_TIMER_CHANNEL_COUNT 9
+#define USED_TIMERS             (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(15) | TIM_N(17))
+
+// sn dec06.16 added MAX_PWM_OUTPUT_PORTS: number of available PWM outputs
+// porting inav to PIKO BLX by using betaflight target files from before inav changes to timer.h/timer_def.h
+// review of target.c shows definitions for PWB1-PWM9. PWM9 is for PPM input
+#define MAX_PWM_OUTPUT_PORTS    9

--- a/src/main/target/PIKOBLX_limited/target.mk
+++ b/src/main/target/PIKOBLX_limited/target.mk
@@ -1,0 +1,15 @@
+F3_TARGETS  += $(TARGET)
+FEATURES    = VCP
+
+TARGET_SRC = \
+            drivers/accgyro_mpu.c \
+            drivers/accgyro_spi_mpu6000.c \
+            drivers/light_ws2811strip.c \
+            drivers/light_ws2811strip_stm32f30x.c \
+            drivers/serial_softserial.c
+			
+# seth neiman dec06.16 porting inav to PIKO BLX using betaflight target related files from before timer.h/timer_def.h changes
+# current inav does not have transponder related files - removing from build
+#            drivers/transponder_ir.c \
+#            drivers/transponder_ir_stm32f30x.c \
+#            io/transponder_ir.c


### PR DESCRIPTION
Experimental port of inav to PIKO BLX flight controller. Following creative suggestion from @martinbudden  took betaflight build files from several months ago, prior to timer.h/timer_def.h changes. With two changes, builds fine, successfully loads, and basically works on one quad - a 66g, 74mm experimental machine being developed as part of a vision based swarm project.

Created new target PIKOBLX_limited.
Changed target.mk to eliminate build of transponder files, as these are not available in inav.
Changed target.h to add MAX_PWM_OUTPUT_PORTS definition.