### PR TITLE
Made gyro driver code re-entrant

### DIFF
--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -20,6 +20,7 @@
 #include "common/axis.h"
 #include "drivers/exti.h"
 #include "drivers/sensor.h"
+#include "drivers/accgyro_mpu.h"
 
 #ifndef MPU_I2C_INSTANCE
 #define MPU_I2C_INSTANCE I2C_DEVICE
@@ -37,7 +38,7 @@
 typedef struct gyroDev_s {
     sensorGyroInitFuncPtr init;                             // initialize function
     sensorGyroReadFuncPtr read;                             // read 3 axis data function
-    sensorReadFuncPtr temperature;                          // read temperature if available
+    sensorGyroReadDataFuncPtr temperature;                  // read temperature if available
     sensorGyroInterruptStatusFuncPtr intStatus;
     float scale;                                            // scalefactor
     volatile bool dataReady;
@@ -45,6 +46,8 @@ typedef struct gyroDev_s {
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
     sensor_align_e gyroAlign;
     const extiConfig_t *mpuIntExtiConfig;
+    mpuDetectionResult_t mpuDetectionResult;
+    mpuConfiguration_t mpuConfiguration;
 } gyroDev_t;
 
 typedef struct accDev_s {
@@ -54,4 +57,6 @@ typedef struct accDev_s {
     int16_t ADCRaw[XYZ_AXIS_COUNT];
     char revisionCode;                                      // a revision code for the sensor, if known
     sensor_align_e accAlign;
+    mpuDetectionResult_t mpuDetectionResult;
+    mpuConfiguration_t mpuConfiguration;
 } accDev_t;

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -40,6 +40,7 @@ typedef struct gyroDev_s {
     sensorGyroReadFuncPtr read;                             // read 3 axis data function
     sensorGyroReadDataFuncPtr temperature;                  // read temperature if available
     sensorGyroInterruptStatusFuncPtr intStatus;
+    extiCallbackRec_t exti;
     float scale;                                            // scalefactor
     volatile bool dataReady;
     uint16_t lpf;

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -36,7 +36,7 @@
 
 typedef struct gyroDev_s {
     sensorGyroInitFuncPtr init;                             // initialize function
-    sensorGyroReadFuncPtr read;                                 // read 3 axis data function
+    sensorGyroReadFuncPtr read;                             // read 3 axis data function
     sensorReadFuncPtr temperature;                          // read temperature if available
     sensorGyroInterruptStatusFuncPtr intStatus;
     float scale;                                            // scalefactor
@@ -48,9 +48,10 @@ typedef struct gyroDev_s {
 } gyroDev_t;
 
 typedef struct accDev_s {
-    sensorAccInitFuncPtr init;                                 // initialize function
-    sensorReadFuncPtr read;                                 // read 3 axis data function
+    sensorAccInitFuncPtr init;                              // initialize function
+    sensorAccReadFuncPtr read;                              // read 3 axis data function
     uint16_t acc_1G;
+    int16_t ADCRaw[XYZ_AXIS_COUNT];
     char revisionCode;                                      // a revision code for the sensor, if known
     sensor_align_e accAlign;
 } accDev_t;

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "common/axis.h"
+#include "drivers/exti.h"
 #include "drivers/sensor.h"
 
 #ifndef MPU_I2C_INSTANCE
@@ -43,6 +44,7 @@ typedef struct gyroDev_s {
     uint16_t lpf;
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
     sensor_align_e gyroAlign;
+    const extiConfig_t *mpuIntExtiConfig;
 } gyroDev_t;
 
 typedef struct accDev_s {

--- a/src/main/drivers/accgyro_adxl345.c
+++ b/src/main/drivers/accgyro_adxl345.c
@@ -76,7 +76,7 @@ static void adxl345Init(accDev_t *acc)
 
 uint8_t acc_samples = 0;
 
-static bool adxl345Read(int16_t *accelData)
+static bool adxl345Read(accDev_t *acc)
 {
     uint8_t buf[8];
 
@@ -99,9 +99,9 @@ static bool adxl345Read(int16_t *accelData)
             z += (int16_t)(buf[4] + (buf[5] << 8));
             samples_remaining = buf[7] & 0x7F;
         } while ((i < 32) && (samples_remaining > 0));
-        accelData[0] = x / i;
-        accelData[1] = y / i;
-        accelData[2] = z / i;
+        acc->ADCRaw[0] = x / i;
+        acc->ADCRaw[1] = y / i;
+        acc->ADCRaw[2] = z / i;
         acc_samples = i;
     } else {
 
@@ -109,9 +109,9 @@ static bool adxl345Read(int16_t *accelData)
             return false;
         }
 
-        accelData[0] = buf[0] + (buf[1] << 8);
-        accelData[1] = buf[2] + (buf[3] << 8);
-        accelData[2] = buf[4] + (buf[5] << 8);
+        acc->ADCRaw[0] = buf[0] + (buf[1] << 8);
+        acc->ADCRaw[1] = buf[2] + (buf[3] << 8);
+        acc->ADCRaw[2] = buf[4] + (buf[5] << 8);
     }
 
     return true;

--- a/src/main/drivers/accgyro_bma280.c
+++ b/src/main/drivers/accgyro_bma280.c
@@ -40,7 +40,7 @@ static void bma280Init(accDev_t *acc)
     acc->acc_1G = 512 * 8;
 }
 
-static bool bma280Read(int16_t *accelData)
+static bool bma280Read(accDev_t *acc)
 {
     uint8_t buf[6];
 
@@ -49,9 +49,9 @@ static bool bma280Read(int16_t *accelData)
     }
 
     // Data format is lsb<5:0><crap><new_data_bit> | msb<13:6>
-    accelData[0] = (int16_t)((buf[0] >> 2) + (buf[1] << 8));
-    accelData[1] = (int16_t)((buf[2] >> 2) + (buf[3] << 8));
-    accelData[2] = (int16_t)((buf[4] >> 2) + (buf[5] << 8));
+    acc->ADCRaw[0] = (int16_t)((buf[0] >> 2) + (buf[1] << 8));
+    acc->ADCRaw[1] = (int16_t)((buf[2] >> 2) + (buf[3] << 8));
+    acc->ADCRaw[2] = (int16_t)((buf[4] >> 2) + (buf[5] << 8));
 
     return true;
 }

--- a/src/main/drivers/accgyro_fake.c
+++ b/src/main/drivers/accgyro_fake.c
@@ -51,9 +51,9 @@ static bool fakeGyroRead(gyroDev_t *gyro)
     return true;
 }
 
-static bool fakeGyroReadTemp(int16_t *tempData)
+static bool fakeGyroReadTemperature(gyroDev_t *gyro, int16_t *temperatureData)
 {
-    UNUSED(tempData);
+    UNUSED(temperatureData);
     return true;
 }
 
@@ -68,7 +68,7 @@ bool fakeGyroDetect(gyroDev_t *gyro)
     gyro->init = fakeGyroInit;
     gyro->intStatus = fakeGyroInitStatus;
     gyro->read = fakeGyroRead;
-    gyro->temperature = fakeGyroReadTemp;
+    gyro->temperature = fakeGyroReadTemperature;
     gyro->scale = 1.0f / 16.4f;
     return true;
 }

--- a/src/main/drivers/accgyro_fake.c
+++ b/src/main/drivers/accgyro_fake.c
@@ -91,11 +91,11 @@ void fakeAccSet(int16_t x, int16_t y, int16_t z)
     fakeAccData[Z] = z;
 }
 
-static bool fakeAccRead(int16_t *accData)
+static bool fakeAccRead(accDev_t *acc)
 {
-    accData[X] = fakeAccData[X];
-    accData[Y] = fakeAccData[Y];
-    accData[Z] = fakeAccData[Z];
+    acc->ADCRaw[X] = fakeAccData[X];
+    acc->ADCRaw[Y] = fakeAccData[Y];
+    acc->ADCRaw[Z] = fakeAccData[Z];
     return true;
 }
 

--- a/src/main/drivers/accgyro_fake.c
+++ b/src/main/drivers/accgyro_fake.c
@@ -53,6 +53,7 @@ static bool fakeGyroRead(gyroDev_t *gyro)
 
 static bool fakeGyroReadTemperature(gyroDev_t *gyro, int16_t *temperatureData)
 {
+    UNUSED(gyro);
     UNUSED(temperatureData);
     return true;
 }

--- a/src/main/drivers/accgyro_mma845x.c
+++ b/src/main/drivers/accgyro_mma845x.c
@@ -111,7 +111,7 @@ static void mma8452Init(accDev_t *acc)
     acc->acc_1G = 256;
 }
 
-static bool mma8452Read(int16_t *accelData)
+static bool mma8452Read(accDev_t *acc)
 {
     uint8_t buf[6];
 
@@ -119,9 +119,9 @@ static bool mma8452Read(int16_t *accelData)
         return false;
     }
 
-    accelData[0] = ((int16_t)((buf[0] << 8) | buf[1]) >> 2) / 4;
-    accelData[1] = ((int16_t)((buf[2] << 8) | buf[3]) >> 2) / 4;
-    accelData[2] = ((int16_t)((buf[4] << 8) | buf[5]) >> 2) / 4;
+    acc->ADCRaw[0] = ((int16_t)((buf[0] << 8) | buf[1]) >> 2) / 4;
+    acc->ADCRaw[1] = ((int16_t)((buf[2] << 8) | buf[3]) >> 2) / 4;
+    acc->ADCRaw[2] = ((int16_t)((buf[4] << 8) | buf[5]) >> 2) / 4;
 
     return true;
 }

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -49,19 +49,15 @@
 static bool mpuReadRegisterI2C(uint8_t reg, uint8_t length, uint8_t* data);
 static bool mpuWriteRegisterI2C(uint8_t reg, uint8_t data);
 
-static void mpu6050FindRevision(void);
+static void mpu6050FindRevision(gyroDev_t *gyro);
 
 #ifdef USE_SPI
-static bool detectSPISensorsAndUpdateDetectionResult(void);
+static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro);
 #endif
 
 #ifndef MPU_I2C_INSTANCE
 #define MPU_I2C_INSTANCE I2C_DEVICE
 #endif
-
-mpuDetectionResult_t mpuDetectionResult;
-
-mpuConfiguration_t mpuConfiguration;
 
 #define MPU_ADDRESS             0x68
 
@@ -71,11 +67,8 @@ mpuConfiguration_t mpuConfiguration;
 
 #define MPU_INQUIRY_MASK   0x7E
 
-mpuDetectionResult_t *mpuDetect(void)
+mpuDetectionResult_t *mpuDetect(gyroDev_t *gyro)
 {
-    memset(&mpuDetectionResult, 0, sizeof(mpuDetectionResult));
-    memset(&mpuConfiguration, 0, sizeof(mpuConfiguration));
-
     bool ack;
     uint8_t sig;
     uint8_t inquiryResult;
@@ -90,84 +83,84 @@ mpuDetectionResult_t *mpuDetect(void)
     ack = mpuReadRegisterI2C(MPU_RA_WHO_AM_I, 1, &sig);
 #endif
     if (ack) {
-        mpuConfiguration.read = mpuReadRegisterI2C;
-        mpuConfiguration.write = mpuWriteRegisterI2C;
+        gyro->mpuConfiguration.read = mpuReadRegisterI2C;
+        gyro->mpuConfiguration.write = mpuWriteRegisterI2C;
     } else {
 #ifdef USE_SPI
-        bool detectedSpiSensor = detectSPISensorsAndUpdateDetectionResult();
+        bool detectedSpiSensor = detectSPISensorsAndUpdateDetectionResult(gyro);
         UNUSED(detectedSpiSensor);
 #endif
 
-        return &mpuDetectionResult;
+        return &gyro->mpuDetectionResult;
     }
 
-    mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
+    gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
 
     // If an MPU3050 is connected sig will contain 0.
     ack = mpuReadRegisterI2C(MPU_RA_WHO_AM_I_LEGACY, 1, &inquiryResult);
     inquiryResult &= MPU_INQUIRY_MASK;
     if (ack && inquiryResult == MPUx0x0_WHO_AM_I_CONST) {
-        mpuDetectionResult.sensor = MPU_3050;
-        mpuConfiguration.gyroReadXRegister = MPU3050_GYRO_OUT;
-        return &mpuDetectionResult;
+        gyro->mpuDetectionResult.sensor = MPU_3050;
+        gyro->mpuConfiguration.gyroReadXRegister = MPU3050_GYRO_OUT;
+        return &gyro->mpuDetectionResult;
     }
 
     sig &= MPU_INQUIRY_MASK;
 
     if (sig == MPUx0x0_WHO_AM_I_CONST) {
 
-        mpuDetectionResult.sensor = MPU_60x0;
+        gyro->mpuDetectionResult.sensor = MPU_60x0;
 
-        mpu6050FindRevision();
+        mpu6050FindRevision(gyro);
     } else if (sig == MPU6500_WHO_AM_I_CONST) {
-        mpuDetectionResult.sensor = MPU_65xx_I2C;
+        gyro->mpuDetectionResult.sensor = MPU_65xx_I2C;
     }
 
-    return &mpuDetectionResult;
+    return &gyro->mpuDetectionResult;
 }
 
 #ifdef USE_SPI
-static bool detectSPISensorsAndUpdateDetectionResult(void)
+static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
 {
 #ifdef USE_GYRO_SPI_MPU6500
     if (mpu6500SpiDetect()) {
-        mpuDetectionResult.sensor = MPU_65xx_SPI;
-        mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        mpuConfiguration.read = mpu6500ReadRegister;
-        mpuConfiguration.write = mpu6500WriteRegister;
+        gyro->mpuDetectionResult.sensor = MPU_65xx_SPI;
+        gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
+        gyro->mpuConfiguration.read = mpu6500ReadRegister;
+        gyro->mpuConfiguration.write = mpu6500WriteRegister;
         return true;
     }
 #endif
 
 #ifdef USE_GYRO_SPI_ICM20689
     if (icm20689SpiDetect()) {
-        mpuDetectionResult.sensor = ICM_20689_SPI;
-        mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        mpuConfiguration.read = icm20689ReadRegister;
-        mpuConfiguration.write = icm20689WriteRegister;
+        gyro->mpuDetectionResult.sensor = ICM_20689_SPI;
+        gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
+        gyro->mpuConfiguration.read = icm20689ReadRegister;
+        gyro->mpuConfiguration.write = icm20689WriteRegister;
         return true;
     }
 #endif
 
 #ifdef USE_GYRO_SPI_MPU6000
     if (mpu6000SpiDetect()) {
-        mpuDetectionResult.sensor = MPU_60x0_SPI;
-        mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        mpuConfiguration.read = mpu6000ReadRegister;
-        mpuConfiguration.write = mpu6000WriteRegister;
+        gyro->mpuDetectionResult.sensor = MPU_60x0_SPI;
+        gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
+        gyro->mpuConfiguration.read = mpu6000ReadRegister;
+        gyro->mpuConfiguration.write = mpu6000WriteRegister;
         return true;
     }
 #endif
 
 #ifdef  USE_GYRO_SPI_MPU9250
     if (mpu9250SpiDetect()) {
-        mpuDetectionResult.sensor = MPU_9250_SPI;
-        mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        mpuConfiguration.read = mpu9250ReadRegister;
-        mpuConfiguration.slowread = mpu9250SlowReadRegister;
-        mpuConfiguration.verifywrite = verifympu9250WriteRegister;
-        mpuConfiguration.write = mpu9250WriteRegister;
-        mpuConfiguration.reset = mpu9250ResetGyro;
+        gyro->mpuDetectionResult.sensor = MPU_9250_SPI;
+        gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
+        gyro->mpuConfiguration.read = mpu9250ReadRegister;
+        gyro->mpuConfiguration.slowread = mpu9250SlowReadRegister;
+        gyro->mpuConfiguration.verifywrite = verifympu9250WriteRegister;
+        gyro->mpuConfiguration.write = mpu9250WriteRegister;
+        gyro->mpuConfiguration.reset = mpu9250ResetGyro;
         return true;
     }
 #endif
@@ -176,7 +169,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(void)
 }
 #endif
 
-static void mpu6050FindRevision(void)
+static void mpu6050FindRevision(gyroDev_t *gyro)
 {
     bool ack;
     UNUSED(ack);
@@ -189,28 +182,28 @@ static void mpu6050FindRevision(void)
     // See https://android.googlesource.com/kernel/msm.git/+/eaf36994a3992b8f918c18e4f7411e8b2320a35f/drivers/misc/mpu6050/mldl_cfg.c
 
     // determine product ID and accel revision
-    ack = mpuConfiguration.read(MPU_RA_XA_OFFS_H, 6, readBuffer);
+    ack = gyro->mpuConfiguration.read(MPU_RA_XA_OFFS_H, 6, readBuffer);
     revision = ((readBuffer[5] & 0x01) << 2) | ((readBuffer[3] & 0x01) << 1) | (readBuffer[1] & 0x01);
     if (revision) {
         /* Congrats, these parts are better. */
         if (revision == 1) {
-            mpuDetectionResult.resolution = MPU_HALF_RESOLUTION;
+            gyro->mpuDetectionResult.resolution = MPU_HALF_RESOLUTION;
         } else if (revision == 2) {
-            mpuDetectionResult.resolution = MPU_FULL_RESOLUTION;
+            gyro->mpuDetectionResult.resolution = MPU_FULL_RESOLUTION;
         } else if ((revision == 3) || (revision == 7)) {
-            mpuDetectionResult.resolution = MPU_FULL_RESOLUTION;
+            gyro->mpuDetectionResult.resolution = MPU_FULL_RESOLUTION;
         } else {
             failureMode(FAILURE_ACC_INCOMPATIBLE);
         }
     } else {
-        ack = mpuConfiguration.read(MPU_RA_PRODUCT_ID, 1, &productId);
+        ack = gyro->mpuConfiguration.read(MPU_RA_PRODUCT_ID, 1, &productId);
         revision = productId & 0x0F;
         if (!revision) {
             failureMode(FAILURE_ACC_INCOMPATIBLE);
         } else if (revision == 4) {
-            mpuDetectionResult.resolution = MPU_HALF_RESOLUTION;
+            gyro->mpuDetectionResult.resolution = MPU_HALF_RESOLUTION;
         } else {
-            mpuDetectionResult.resolution = MPU_FULL_RESOLUTION;
+            gyro->mpuDetectionResult.resolution = MPU_FULL_RESOLUTION;
         }
     }
 }
@@ -296,7 +289,7 @@ bool mpuAccRead(accDev_t *acc)
 {
     uint8_t data[6];
 
-    bool ack = mpuConfiguration.read(MPU_RA_ACCEL_XOUT_H, 6, data);
+    bool ack = acc->mpuConfiguration.read(MPU_RA_ACCEL_XOUT_H, 6, data);
     if (!ack) {
         return false;
     }
@@ -312,7 +305,7 @@ bool mpuGyroRead(gyroDev_t *gyro)
 {
     uint8_t data[6];
 
-    const bool ack = mpuConfiguration.read(mpuConfiguration.gyroReadXRegister, 6, data);
+    const bool ack = gyro->mpuConfiguration.read(gyro->mpuConfiguration.gyroReadXRegister, 6, data);
     if (!ack) {
         return false;
     }

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -165,6 +165,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
     }
 #endif
 
+    UNUSED(gyro);
     return false;
 }
 #endif

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -292,7 +292,7 @@ static bool mpuWriteRegisterI2C(uint8_t reg, uint8_t data)
     return ack;
 }
 
-bool mpuAccRead(int16_t *accData)
+bool mpuAccRead(accDev_t *acc)
 {
     uint8_t data[6];
 
@@ -301,9 +301,9 @@ bool mpuAccRead(int16_t *accData)
         return false;
     }
 
-    accData[0] = (int16_t)((data[0] << 8) | data[1]);
-    accData[1] = (int16_t)((data[2] << 8) | data[3]);
-    accData[2] = (int16_t)((data[4] << 8) | data[5]);
+    acc->ADCRaw[X] = (int16_t)((data[0] << 8) | data[1]);
+    acc->ADCRaw[Y] = (int16_t)((data[2] << 8) | data[3]);
+    acc->ADCRaw[Z] = (int16_t)((data[4] << 8) | data[5]);
 
     return true;
 }

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -62,7 +62,6 @@ static bool detectSPISensorsAndUpdateDetectionResult(void);
 mpuDetectionResult_t mpuDetectionResult;
 
 mpuConfiguration_t mpuConfiguration;
-static const extiConfig_t *mpuIntExtiConfig = NULL;
 
 #define MPU_ADDRESS             0x68
 
@@ -72,12 +71,10 @@ static const extiConfig_t *mpuIntExtiConfig = NULL;
 
 #define MPU_INQUIRY_MASK   0x7E
 
-mpuDetectionResult_t *mpuDetect(const extiConfig_t *configToUse)
+mpuDetectionResult_t *mpuDetect(void)
 {
     memset(&mpuDetectionResult, 0, sizeof(mpuDetectionResult));
     memset(&mpuConfiguration, 0, sizeof(mpuConfiguration));
-
-    mpuIntExtiConfig = configToUse;
 
     bool ack;
     uint8_t sig;
@@ -249,14 +246,14 @@ static void mpuIntExtiInit(gyroDev_t *gyro)
 {
     static bool mpuExtiInitDone = false;
 
-    if (mpuExtiInitDone || !mpuIntExtiConfig) {
+    if (mpuExtiInitDone || !gyro->mpuIntExtiConfig) {
         return;
     }
 
     mpuIntRec.gyro = gyro;
 #if defined(USE_MPU_DATA_READY_SIGNAL) && defined(USE_EXTI)
 
-    IO_t mpuIntIO = IOGetByTag(mpuIntExtiConfig->tag);
+    IO_t mpuIntIO = IOGetByTag(gyro->mpuIntExtiConfig->tag);
 
 #ifdef ENSURE_MPU_DATA_READY_IS_LOW
     uint8_t status = IORead(mpuIntIO);

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -121,6 +121,8 @@ typedef bool (*mpuReadRegisterFunc)(uint8_t reg, uint8_t length, uint8_t* data);
 typedef bool (*mpuWriteRegisterFunc)(uint8_t reg, uint8_t data);
 typedef void(*mpuResetFuncPtr)(void);
 
+mpuResetFuncPtr mpuReset;
+
 typedef struct mpuConfiguration_s {
     uint8_t gyroReadXRegister; // Y and Z must registers follow this, 2 words each
     mpuReadRegisterFunc read;
@@ -129,8 +131,6 @@ typedef struct mpuConfiguration_s {
     mpuWriteRegisterFunc verifywrite;
     mpuResetFuncPtr reset;
 } mpuConfiguration_t;
-
-extern mpuConfiguration_t mpuConfiguration;
 
 enum gyro_fsr_e {
     INV_FSR_250DPS = 0,
@@ -181,12 +181,10 @@ typedef struct mpuDetectionResult_s {
     mpu6050Resolution_e resolution;
 } mpuDetectionResult_t;
 
-extern mpuDetectionResult_t mpuDetectionResult;
-
 struct gyroDev_s;
 void mpuGyroInit(struct gyroDev_s *gyro);
 struct accDev_s;
 bool mpuAccRead(struct accDev_s *acc);
 bool mpuGyroRead(struct gyroDev_s *gyro);
-mpuDetectionResult_t *mpuDetect(void);
+mpuDetectionResult_t *mpuDetect(struct gyroDev_s *gyro);
 bool mpuCheckDataReady(struct gyroDev_s *gyro);

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -187,5 +187,5 @@ struct gyroDev_s;
 void mpuGyroInit(struct gyroDev_s *gyro);
 bool mpuAccRead(int16_t *accData);
 bool mpuGyroRead(struct gyroDev_s *gyro);
-mpuDetectionResult_t *mpuDetect(const extiConfig_t *configToUse);
+mpuDetectionResult_t *mpuDetect(void);
 bool mpuCheckDataReady(struct gyroDev_s *gyro);

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -185,7 +185,8 @@ extern mpuDetectionResult_t mpuDetectionResult;
 
 struct gyroDev_s;
 void mpuGyroInit(struct gyroDev_s *gyro);
-bool mpuAccRead(int16_t *accData);
+struct accDev_s;
+bool mpuAccRead(struct accDev_s *acc);
 bool mpuGyroRead(struct gyroDev_s *gyro);
 mpuDetectionResult_t *mpuDetect(void);
 bool mpuCheckDataReady(struct gyroDev_s *gyro);

--- a/src/main/drivers/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro_mpu3050.c
@@ -52,20 +52,20 @@ static void mpu3050Init(gyroDev_t *gyro)
 
     delay(25); // datasheet page 13 says 20ms. other stuff could have been running meanwhile. but we'll be safe
 
-    ack = mpuConfiguration.write(MPU3050_SMPLRT_DIV, 0);
+    ack = gyro->mpuConfiguration.write(MPU3050_SMPLRT_DIV, 0);
     if (!ack)
         failureMode(FAILURE_ACC_INIT);
 
-    mpuConfiguration.write(MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
-    mpuConfiguration.write(MPU3050_INT_CFG, 0);
-    mpuConfiguration.write(MPU3050_USER_CTRL, MPU3050_USER_RESET);
-    mpuConfiguration.write(MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
+    gyro->mpuConfiguration.write(MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
+    gyro->mpuConfiguration.write(MPU3050_INT_CFG, 0);
+    gyro->mpuConfiguration.write(MPU3050_USER_CTRL, MPU3050_USER_RESET);
+    gyro->mpuConfiguration.write(MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
 }
 
-static bool mpu3050ReadTemperature(int16_t *tempData)
+static bool mpu3050ReadTemperature(gyroDev_t *gyro, int16_t *tempData)
 {
     uint8_t buf[2];
-    if (!mpuConfiguration.read(MPU3050_TEMP_OUT, 2, buf)) {
+    if (!gyro->mpuConfiguration.read(MPU3050_TEMP_OUT, 2, buf)) {
         return false;
     }
 
@@ -76,7 +76,7 @@ static bool mpu3050ReadTemperature(int16_t *tempData)
 
 bool mpu3050Detect(gyroDev_t *gyro)
 {
-    if (mpuDetectionResult.sensor != MPU_3050) {
+    if (gyro->mpuDetectionResult.sensor != MPU_3050) {
         return false;
     }
     gyro->init = mpu3050Init;

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -52,7 +52,7 @@
 
 static void mpu6050AccInit(accDev_t *acc)
 {
-    switch (mpuDetectionResult.resolution) {
+    switch (acc->mpuDetectionResult.resolution) {
         case MPU_HALF_RESOLUTION:
             acc->acc_1G = 256 * 4;
             break;
@@ -64,13 +64,13 @@ static void mpu6050AccInit(accDev_t *acc)
 
 bool mpu6050AccDetect(accDev_t *acc)
 {
-    if (mpuDetectionResult.sensor != MPU_60x0) {
+    if (acc->mpuDetectionResult.sensor != MPU_60x0) {
         return false;
     }
 
     acc->init = mpu6050AccInit;
     acc->read = mpuAccRead;
-    acc->revisionCode = (mpuDetectionResult.resolution == MPU_HALF_RESOLUTION ? 'o' : 'n'); // es/non-es variance between MPU6050 sensors, half of the naze boards are mpu6000ES.
+    acc->revisionCode = (acc->mpuDetectionResult.resolution == MPU_HALF_RESOLUTION ? 'o' : 'n'); // es/non-es variance between MPU6050 sensors, half of the naze boards are mpu6000ES.
 
     return true;
 }
@@ -79,30 +79,30 @@ static void mpu6050GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    bool ack = mpuConfiguration.write(MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
+    bool ack = gyro->mpuConfiguration.write(MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
     delay(100);
-    ack = mpuConfiguration.write(MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
-    ack = mpuConfiguration.write(MPU_RA_SMPLRT_DIV, gyroMPU6xxxCalculateDivider()); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
+    ack = gyro->mpuConfiguration.write(MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
+    ack = gyro->mpuConfiguration.write(MPU_RA_SMPLRT_DIV, gyroMPU6xxxCalculateDivider()); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
     delay(15); //PLL Settling time when changing CLKSEL is max 10ms.  Use 15ms to be sure
-    ack = mpuConfiguration.write(MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
-    ack = mpuConfiguration.write(MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
+    ack = gyro->mpuConfiguration.write(MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
+    ack = gyro->mpuConfiguration.write(MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
 
     // ACC Init stuff.
     // Accel scale 8g (4096 LSB/g)
-    ack = mpuConfiguration.write(MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    ack = gyro->mpuConfiguration.write(MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
 
-    ack = mpuConfiguration.write(MPU_RA_INT_PIN_CFG,
+    ack = gyro->mpuConfiguration.write(MPU_RA_INT_PIN_CFG,
             0 << 7 | 0 << 6 | 0 << 5 | 0 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0); // INT_PIN_CFG   -- INT_LEVEL_HIGH, INT_OPEN_DIS, LATCH_INT_DIS, INT_RD_CLEAR_DIS, FSYNC_INT_LEVEL_HIGH, FSYNC_INT_DIS, I2C_BYPASS_EN, CLOCK_DIS
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    ack = mpuConfiguration.write(MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    ack = gyro->mpuConfiguration.write(MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
 #endif
     UNUSED(ack);
 }
 
 bool mpu6050GyroDetect(gyroDev_t *gyro)
 {
-    if (mpuDetectionResult.sensor != MPU_60x0) {
+    if (gyro->mpuDetectionResult.sensor != MPU_60x0) {
         return false;
     }
     gyro->init = mpu6050GyroInit;

--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -41,7 +41,7 @@ void mpu6500AccInit(accDev_t *acc)
 
 bool mpu6500AccDetect(accDev_t *acc)
 {
-    if (mpuDetectionResult.sensor != MPU_65xx_I2C) {
+    if (acc->mpuDetectionResult.sensor != MPU_65xx_I2C) {
         return false;
     }
 
@@ -68,40 +68,40 @@ void mpu6500GyroInit(gyroDev_t *gyro)
     }
 #endif
 
-    mpuConfiguration.write(MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
+    gyro->mpuConfiguration.write(MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
     delay(100);
-    mpuConfiguration.write(MPU_RA_SIGNAL_PATH_RESET, 0x07);
+    gyro->mpuConfiguration.write(MPU_RA_SIGNAL_PATH_RESET, 0x07);
     delay(100);
-    mpuConfiguration.write(MPU_RA_PWR_MGMT_1, 0);
+    gyro->mpuConfiguration.write(MPU_RA_PWR_MGMT_1, 0);
     delay(100);
-    mpuConfiguration.write(MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    gyro->mpuConfiguration.write(MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
-    mpuConfiguration.write(MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
+    gyro->mpuConfiguration.write(MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delay(15);
-    mpuConfiguration.write(MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    gyro->mpuConfiguration.write(MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
     delay(15);
-    mpuConfiguration.write(MPU_RA_CONFIG, gyro->lpf);
+    gyro->mpuConfiguration.write(MPU_RA_CONFIG, gyro->lpf);
     delay(15);
-    mpuConfiguration.write(MPU_RA_SMPLRT_DIV, gyroMPU6xxxCalculateDivider()); // Get Divider
+    gyro->mpuConfiguration.write(MPU_RA_SMPLRT_DIV, gyroMPU6xxxCalculateDivider()); // Get Divider
     delay(100);
 
     // Data ready interrupt configuration
 #ifdef USE_MPU9250_MAG
-    mpuConfiguration.write(MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    gyro->mpuConfiguration.write(MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #else
-    mpuConfiguration.write(MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    gyro->mpuConfiguration.write(MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #endif
     delay(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    mpuConfiguration.write(MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
+    gyro->mpuConfiguration.write(MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif
     delay(15);
 }
 
 bool mpu6500GyroDetect(gyroDev_t *gyro)
 {
-    if (mpuDetectionResult.sensor != MPU_65xx_I2C) {
+    if (gyro->mpuDetectionResult.sensor != MPU_65xx_I2C) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -256,7 +256,7 @@ static void mpu6000AccAndGyroInit(void)
 
 bool mpu6000SpiAccDetect(accDev_t *acc)
 {
-    if (mpuDetectionResult.sensor != MPU_60x0_SPI) {
+    if (acc->mpuDetectionResult.sensor != MPU_60x0_SPI) {
         return false;
     }
 
@@ -268,7 +268,7 @@ bool mpu6000SpiAccDetect(accDev_t *acc)
 
 bool mpu6000SpiGyroDetect(gyroDev_t *gyro)
 {
-    if (mpuDetectionResult.sensor != MPU_60x0_SPI) {
+    if (gyro->mpuDetectionResult.sensor != MPU_60x0_SPI) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -101,7 +101,7 @@ void mpu6500SpiAccInit(accDev_t *acc)
 
 bool mpu6500SpiAccDetect(accDev_t *acc)
 {
-    if (mpuDetectionResult.sensor != MPU_65xx_SPI) {
+    if (acc->mpuDetectionResult.sensor != MPU_65xx_SPI) {
         return false;
     }
 
@@ -128,7 +128,7 @@ void mpu6500SpiGyroInit(gyroDev_t *gyro)
 
 bool mpu6500SpiGyroDetect(gyroDev_t *gyro)
 {
-    if (mpuDetectionResult.sensor != MPU_65xx_SPI) {
+    if (gyro->mpuDetectionResult.sensor != MPU_65xx_SPI) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro_spi_mpu9250.c
@@ -211,7 +211,7 @@ bool mpu9250SpiDetect(void)
 
 bool mpu9250SpiAccDetect(accDev_t *acc)
 {
-    if (mpuDetectionResult.sensor != MPU_9250_SPI) {
+    if (acc->mpuDetectionResult.sensor != MPU_9250_SPI) {
         return false;
     }
 
@@ -223,7 +223,7 @@ bool mpu9250SpiAccDetect(accDev_t *acc)
 
 bool mpu9250SpiGyroDetect(gyroDev_t *gyro)
 {
-    if (mpuDetectionResult.sensor != MPU_9250_SPI) {
+    if (gyro->mpuDetectionResult.sensor != MPU_9250_SPI) {
         return false;
     }
 

--- a/src/main/drivers/sensor.h
+++ b/src/main/drivers/sensor.h
@@ -38,4 +38,5 @@ typedef bool (*sensorAccReadFuncPtr)(struct accDev_s *acc);
 struct gyroDev_s;
 typedef void (*sensorGyroInitFuncPtr)(struct gyroDev_s *gyro);
 typedef bool (*sensorGyroReadFuncPtr)(struct gyroDev_s *gyro);
+typedef bool (*sensorGyroReadDataFuncPtr)(struct gyroDev_s *gyro, int16_t *data);
 typedef bool (*sensorGyroInterruptStatusFuncPtr)(struct gyroDev_s *gyro);

--- a/src/main/drivers/sensor.h
+++ b/src/main/drivers/sensor.h
@@ -29,12 +29,13 @@ typedef enum {
     CW270_DEG_FLIP = 8
 } sensor_align_e;
 
-struct accDev_s;
 typedef bool (*sensorInitFuncPtr)(void);                    // sensor init prototype
 typedef bool (*sensorReadFuncPtr)(int16_t *data);           // sensor read and align prototype
-typedef void (*sensorAccInitFuncPtr)(struct accDev_s *acc);    // sensor init prototype
+typedef bool (*sensorInterruptFuncPtr)(void);
+struct accDev_s;
+typedef void (*sensorAccInitFuncPtr)(struct accDev_s *acc);
+typedef bool (*sensorAccReadFuncPtr)(struct accDev_s *acc);
 struct gyroDev_s;
 typedef void (*sensorGyroInitFuncPtr)(struct gyroDev_s *gyro);
 typedef bool (*sensorGyroReadFuncPtr)(struct gyroDev_s *gyro);
 typedef bool (*sensorGyroInterruptStatusFuncPtr)(struct gyroDev_s *gyro);
-typedef bool (*sensorInterruptFuncPtr)(void);

--- a/src/main/drivers/system_stm32f4xx.c
+++ b/src/main/drivers/system_stm32f4xx.c
@@ -34,8 +34,9 @@ void SetSysClock(void);
 
 void systemReset(void)
 {
-    if (mpuConfiguration.reset)
-        mpuConfiguration.reset();
+    if (mpuReset) {
+        mpuReset();
+    }
 
     __disable_irq();
     NVIC_SystemReset();
@@ -43,8 +44,9 @@ void systemReset(void)
 
 void systemResetToBootloader(void)
 {
-    if (mpuConfiguration.reset)
-        mpuConfiguration.reset();
+    if (mpuReset) {
+        mpuReset();
+    }
 
     *((uint32_t *)0x2001FFFC) = 0xDEADBEEF; // 128KB SRAM STM32F4XX
 

--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -183,8 +183,9 @@ void annexCode(void)
     }
 
     // Read out gyro temperature. can use it for something somewhere. maybe get MCU temperature instead? lots of fun possibilities.
-    if (gyro.dev.temperature)
-        gyro.dev.temperature(&telemTemperature1);
+    if (gyro.dev.temperature) {
+        gyro.dev.temperature(&gyro.dev, &telemTemperature1);
+    }
 }
 
 void mwDisarm(void)

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -62,7 +62,6 @@
 acc_t acc;                       // acc access functions
 
 static uint16_t calibratingA = 0;      // the calibration is done is the main loop. Calibrating decreases at each cycle down to 0, then we enter in a normal mode.
-static int16_t accADCRaw[XYZ_AXIS_COUNT];
 
 static flightDynamicsTrims_t * accZero;
 static flightDynamicsTrims_t * accGain;
@@ -359,12 +358,12 @@ static void applyAccelerationZero(const flightDynamicsTrims_t * accZero, const f
 
 void updateAccelerationReadings(void)
 {
-    if (!acc.dev.read(accADCRaw)) {
+    if (!acc.dev.read(&acc.dev)) {
         return;
     }
 
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        acc.accADC[axis] = accADCRaw[axis];
+        acc.accADC[axis] = acc.dev.ADCRaw[axis];
     }
 
     if (accLpfCutHz) {

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -49,6 +49,7 @@
 #include "sensors/acceleration.h"
 #include "sensors/battery.h"
 #include "sensors/boardalignment.h"
+#include "sensors/gyro.h"
 #include "sensors/sensors.h"
 
 #include "fc/runtime_config.h"
@@ -222,6 +223,9 @@ retry:
 bool accInit(const accelerometerConfig_t *accConfig, uint32_t targetLooptime)
 {
     memset(&acc, 0, sizeof(acc));
+    // copy over the common gyro mpu settings
+    acc.dev.mpuConfiguration = gyro.dev.mpuConfiguration;
+    acc.dev.mpuDetectionResult = gyro.dev.mpuDetectionResult;
     if (!accDetect(&acc.dev, accConfig->acc_hardware)) {
         return false;
     }

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -81,8 +81,10 @@ static const extiConfig_t *selectMPUIntExtiConfig(void)
 #endif
 }
 
-static bool gyroDetect(gyroDev_t *dev)
+static bool gyroDetect(gyroDev_t *dev, const extiConfig_t *extiConfig)
 {
+    dev->mpuIntExtiConfig =  extiConfig;
+
     gyroSensor_e gyroHardware = GYRO_AUTODETECT;
 
     dev->gyroAlign = ALIGN_DEFAULT;
@@ -208,11 +210,11 @@ bool gyroInit(const gyroConfig_t *gyroConfigToUse)
     gyroConfig = gyroConfigToUse;
 #if defined(USE_GYRO_MPU6050) || defined(USE_GYRO_MPU3050) || defined(USE_GYRO_MPU6500) || defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU6000) || defined(USE_ACC_MPU6050) || defined(USE_GYRO_SPI_MPU9250)
     const extiConfig_t *extiConfig = selectMPUIntExtiConfig();
-    mpuDetect(extiConfig);
+    mpuDetect();
 #endif
 
     memset(&gyro, 0, sizeof(gyro));
-    if (!gyroDetect(&gyro.dev)) {
+    if (!gyroDetect(&gyro.dev, extiConfig)) {
         return false;
     }
     // After refactoring this function is always called after gyro sampling rate is known, so

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -208,12 +208,13 @@ static bool gyroDetect(gyroDev_t *dev, const extiConfig_t *extiConfig)
 bool gyroInit(const gyroConfig_t *gyroConfigToUse)
 {
     gyroConfig = gyroConfigToUse;
+    memset(&gyro, 0, sizeof(gyro));
 #if defined(USE_GYRO_MPU6050) || defined(USE_GYRO_MPU3050) || defined(USE_GYRO_MPU6500) || defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU6000) || defined(USE_ACC_MPU6050) || defined(USE_GYRO_SPI_MPU9250)
     const extiConfig_t *extiConfig = selectMPUIntExtiConfig();
-    mpuDetect();
+    mpuDetect(&gyro.dev);
+    mpuReset = gyro.dev.mpuConfiguration.reset;
 #endif
 
-    memset(&gyro, 0, sizeof(gyro));
     if (!gyroDetect(&gyro.dev, extiConfig)) {
         return false;
     }

--- a/src/main/sensors/rangefinder.c
+++ b/src/main/sensors/rangefinder.c
@@ -27,6 +27,7 @@
 #include "build/build_config.h"
 
 #include "common/maths.h"
+#include "common/utils.h"
 
 #include "config/config.h"
 #include "config/feature.h"


### PR DESCRIPTION
This completes the work of making the gyro device driver code re-entrant. This should make it possible for a gyro sensor to own two or more gyro devices.

@digitalentity , I'm pretty confident that this code is OK, but it would probably be a good idea if you gave it a review and tried it out on a couple of your boards before merging in.