### PR TITLE
Made Tricopter mixer functional on OMNIBUS when UART3 is used

### DIFF
--- a/docs/Board - OMNIBUS.md
+++ b/docs/Board - OMNIBUS.md
@@ -33,6 +33,8 @@ The OMNIBUS target in iNav has different configuration from the BetaFlight suppo
 Six PWM outputs (PWM1~PWM6) are supported, but PWM5 and PWM6 is not available when UART3 is in use.
 PWM7 and PWM8 are dedicated for I2C; in this document, they are used to indicate the pin location, not the function.
 
+If servos are used on a multirotor mixer (i.e. Tricopter) PWM1 is remapped to servo and motor 1 is moved to PWM2 etc.
+
 Note: Tested only for QUAD-X configuration.
 
 ### Hardware UART Ports

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -247,9 +247,15 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
                 type = MAP_TO_SERVO_OUTPUT;
 #endif
 
-#if defined(SPRACINGF3MINI) || defined(OMNIBUS)
+#if defined(SPRACINGF3MINI)
             // remap PWM6+7 as servos
             if ((timerIndex == PWM6 || timerIndex == PWM7) && timerHardwarePtr->tim == TIM15)
+                type = MAP_TO_SERVO_OUTPUT;
+#endif
+
+#if defined(OMNIBUS)
+            // remap PWM2 (OUT1) as servo
+            if (timerIndex == PWM2 && timerHardwarePtr->tim == TIM8)
                 type = MAP_TO_SERVO_OUTPUT;
 #endif
 

--- a/src/main/target/OMNIBUS/target.c
+++ b/src/main/target/OMNIBUS/target.c
@@ -71,7 +71,7 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     // PB5 / TIM3 CH2 is connected to USBPresent
 
     // PWM2-PWM5
-    { TIM4,  IO_TAG(PB8),  TIM_Channel_3, TIM4_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2 }, // Pin PWM1 - PB8
+    { TIM8,  IO_TAG(PB8),  TIM_Channel_2, TIM8_CC_IRQn,            1, IOCFG_AF_PP, GPIO_AF_10 },// Pin PWM1 - PB8
     { TIM4,  IO_TAG(PB9),  TIM_Channel_4, TIM4_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2 }, // Pin PWM2 - PB9
     { TIM15, IO_TAG(PA3),  TIM_Channel_2, TIM1_BRK_TIM15_IRQn,     1, IOCFG_AF_PP, GPIO_AF_9 }, // Pin PWM3 - PA3
     { TIM15, IO_TAG(PA2),  TIM_Channel_1, TIM1_BRK_TIM15_IRQn,     1, IOCFG_AF_PP, GPIO_AF_9 }, // Pin PWM4 - PA2

--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -208,12 +208,13 @@
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 // Number of available PWM outputs
-#define MAX_PWM_OUTPUT_PORTS    12
+#define MAX_PWM_OUTPUT_PORTS    6
 
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff
 #define TARGET_IO_PORTC         (BIT(13)|BIT(14)|BIT(15))
 #define TARGET_IO_PORTF         (BIT(0)|BIT(1)|BIT(4))
 
-#define USABLE_TIMER_CHANNEL_COUNT 7 // 6 Outputs; PPM;
+#define USABLE_TIMER_CHANNEL_COUNT  7
+
 #define USED_TIMERS             (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(15))


### PR DESCRIPTION
Fixes https://github.com/iNavFlight/inav/issues/947