### PR TITLE
Correctly handle timer overflow in PWM RX 

### DIFF
--- a/src/main/drivers/pwm_rx.c
+++ b/src/main/drivers/pwm_rx.c
@@ -327,8 +327,13 @@ static void pwmEdgeCallback(timerCCHandlerRec_t *cbRec, captureCompare_t capture
     } else {
         pwmInputPort->fall = capture;
 
-        // compute and store capture
-        pwmInputPort->capture = pwmInputPort->fall - pwmInputPort->rise;
+        // compute and store capture and handle overflow correctly - timer may be configured for PWM output in such case overflow value is not 0xFFFF
+        if (pwmInputPort->fall >= pwmInputPort->rise) {
+            pwmInputPort->capture = pwmInputPort->fall - pwmInputPort->rise;
+        }
+        else {
+            pwmInputPort->capture = (pwmInputPort->fall + timerGetPeriod(timerHardwarePtr)) - pwmInputPort->rise;
+        }
         captures[pwmInputPort->channel] = pwmInputPort->capture;
 
         // switch state

--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -509,7 +509,10 @@ volatile timCCR_t* timerChCCRLo(const timerHardware_t *timHw)
     return (volatile timCCR_t*)((volatile char*)&timHw->tim->CCR1 + (timHw->channel & ~TIM_Channel_2));
 }
 
-
+uint16_t timerGetPeriod(const timerHardware_t *timHw)
+{
+    return timHw->tim->ARR;
+}
 
 volatile timCCR_t* timerChCCR(const timerHardware_t *timHw)
 {

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -154,6 +154,8 @@ void timerForceOverflow(TIM_TypeDef *tim);
 
 void configTimeBase(TIM_TypeDef *tim, uint16_t period, uint8_t mhz);  // TODO - just for migration
 
+uint16_t timerGetPeriod(const timerHardware_t *timHw);
+
 rccPeriphTag_t timerRCC(TIM_TypeDef *tim);
 
 #if defined(STM32F3) || defined(STM32F4)


### PR DESCRIPTION
If timer period is not 0xFFFF (i.e. when timer is shared with PWM output) pulse length code didn't handle overflow correctly - timer is overflowing around `period`, while the code expected it to overflow around `0xFFFF` which caused prolonged bugs if PWM input period and actual timer `period` were multiples of each other.

In case of a FlySky RX PWM signal is precisely 50Hz and motor output is 400Hz which caused very slowly moving overflow point. In case of FrSky RX PWM input is at 44.44Hz which only caused small and not noticable hickups,