### PR TITLE
Initial cut on OMNIBUSF4_SD target

### DIFF
--- a/src/main/target/OMNIBUSF4/OMNIBUSF4SD.mk
+++ b/src/main/target/OMNIBUSF4/OMNIBUSF4SD.mk
@@ -1,0 +1,2 @@
+# the OMNIBUSF4SD has an SDCARD instead of flash, a BMP280 baro and therefore a slightly different ppm/pwm and SPI mapping
+FEATURES       = VCP SDCARD

--- a/src/main/target/OMNIBUSF4/target.c
+++ b/src/main/target/OMNIBUSF4/target.c
@@ -74,8 +74,13 @@ const uint16_t airPWM[] = {
 
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+#ifdef OMNIBUSF4SD
+    { TIM4,  IO_TAG(PB8),  TIM_Channel_3, TIM4_IRQn,           0, IOCFG_AF_PP_PD, GPIO_AF_TIM4}, // PPM
+    { TIM4,  IO_TAG(PB9),  TIM_Channel_4, TIM4_IRQn,           0, IOCFG_AF_PP_PD, GPIO_AF_TIM4}, // S2_IN
+#else
     { TIM12, IO_TAG(PB14), TIM_Channel_1, TIM8_BRK_TIM12_IRQn, 0, IOCFG_AF_PP_PD, GPIO_AF_TIM12 }, // PPM / S.BUS input, above MOTOR1
     { TIM12, IO_TAG(PB15), TIM_Channel_2, TIM8_BRK_TIM12_IRQn, 0, IOCFG_AF_PP_PD, GPIO_AF_TIM12 }, // Connected: small CH2 pad, not used as PWM, definition inherited from REVO target - GPIO_PartialRemap_TIM3
+#endif
     { TIM8,  IO_TAG(PC6),  TIM_Channel_1, TIM8_CC_IRQn,        0, IOCFG_AF_PP_PD, GPIO_AF_TIM8  }, // Connected: UART6 TX, not used as PWM, definition inherited from REVO target
     { TIM8,  IO_TAG(PC7),  TIM_Channel_2, TIM8_CC_IRQn,        0, IOCFG_AF_PP_PD, GPIO_AF_TIM8  }, // Connected: UART6 RX, not used as PWM, definition inherited from REVO target
     { TIM8,  IO_TAG(PC8),  TIM_Channel_3, TIM8_CC_IRQn,        0, IOCFG_AF_PP_PD, GPIO_AF_TIM8  }, // Connected: small CH5 pad, not used as PWM, definition inherited from REVO target

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -198,4 +198,9 @@
 #define TARGET_IO_PORTD         0xffff
 
 #define USABLE_TIMER_CHANNEL_COUNT 12
+
+#ifdef OMNIBUSF4SD
+#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(4) | TIM_N(8) | TIM_N(9) )
+#else 
 #define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(12) | TIM_N(8) | TIM_N(9) )
+#endif

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -17,7 +17,12 @@
 
 #pragma once
 
+#ifdef OMNIBUSF4SD
+#define TARGET_BOARD_IDENTIFIER "OBSD"
+#else
 #define TARGET_BOARD_IDENTIFIER "OBF4"
+#endif
+
 #define USBD_PRODUCT_STRING     "Omnibus F4"
 
 #define LED0                    PB5
@@ -35,13 +40,19 @@
 
 #define GYRO
 #define USE_GYRO_SPI_MPU6000
-#define GYRO_MPU6000_ALIGN      CW270_DEG
 #define MPU6000_CS_PIN          PA4
 #define MPU6000_SPI_INSTANCE    SPI1
 
 #define ACC
 #define USE_ACC_SPI_MPU6000
-#define ACC_MPU6000_ALIGN       CW270_DEG
+
+#ifdef OMNIBUSF4SD
+  #define GYRO_MPU6000_ALIGN      CW270_DEG
+  #define ACC_MPU6000_ALIGN       CW270_DEG
+#else
+  #define GYRO_MPU6000_ALIGN      CW180_DEG
+  #define ACC_MPU6000_ALIGN       CW180_DEG
+#endif
 
 #define MAG
 #define USE_MAG_AK8963
@@ -52,18 +63,18 @@
 
 #define BARO
 #define USE_BARO_BMP085
-#define USE_BARO_BMP280
 #define USE_BARO_MS5611
+
+#ifdef OMNIBUSF4SD
+  #define USE_BARO_BMP280
+  #define USE_BARO_SPI_BMP280
+  #define BMP280_SPI_INSTANCE     SPI3
+  #define BMP280_CS_PIN           PB3 // v1
+#endif
 
 //#define PITOT
 //#define USE_PITOT_MS4525
 #define PITOT_I2C_INSTANCE      I2C_DEVICE
-
-#define M25P16_CS_PIN           PB3
-#define M25P16_SPI_INSTANCE     SPI3
-
-#define USE_FLASHFS
-#define USE_FLASH_M25P16
 
 #define USE_VCP
 #define VBUS_SENSING_PIN        PC5
@@ -90,10 +101,20 @@
 
 #define USE_SPI
 
-#define USE_SPI_DEVICE_1
+#ifdef OMNIBUSF4SD
+  #define USE_SPI_DEVICE_2
+  #define SPI2_NSS_PIN          PB12
+  #define SPI2_SCK_PIN          PB13
+  #define SPI2_MISO_PIN         PB14
+  #define SPI2_MOSI_PIN         PB15
+#endif
 
 #define USE_SPI_DEVICE_3
-#define SPI3_NSS_PIN            PB3
+#ifdef OMNIBUSF4SD
+  #define SPI3_NSS_PIN          PA15
+#else
+  #define SPI3_NSS_PIN          PB3
+#endif
 #define SPI3_SCK_PIN            PC10
 #define SPI3_MISO_PIN           PC11
 #define SPI3_MOSI_PIN           PC12
@@ -104,6 +125,33 @@
 #define MAX7456_SPI_CS_PIN      PA15
 #define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD*2)
 #define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
+
+#ifdef OMNIBUSF4SD
+  #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+  #define USE_SDCARD
+  #define USE_SDCARD_SPI2
+
+  #define SDCARD_DETECT_INVERTED
+  #define SDCARD_DETECT_PIN               PB7
+  #define SDCARD_SPI_INSTANCE             SPI2
+  #define SDCARD_SPI_CS_PIN               SPI2_NSS_PIN
+
+  // SPI2 is on the APB1 bus whose clock runs at 84MHz. Divide to under 400kHz for init:
+  #define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 256 // 328kHz
+  // Divide to under 25MHz for normal operation:
+  #define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER 4 // 21MHz
+
+  #define SDCARD_DMA_CHANNEL_TX               DMA1_Stream4
+  #define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG DMA_FLAG_TCIF4
+  #define SDCARD_DMA_CLK                      RCC_AHB1Periph_DMA1
+  #define SDCARD_DMA_CHANNEL                  DMA_Channel_0
+#else
+  #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+  #define M25P16_CS_PIN           SPI3_NSS_PIN
+  #define M25P16_SPI_INSTANCE     SPI3
+  #define USE_FLASHFS
+  #define USE_FLASH_M25P16
+#endif
 
 #define USE_I2C
 #define I2C_DEVICE              (I2CDEV_2)
@@ -129,16 +177,14 @@
 #define WS2811_DMA_FLAG                 DMA_FLAG_TCIF4
 #define WS2811_DMA_IT                   DMA_IT_TCIF4
 
-#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
-
-#define MAG_GPS_ALIGN           CW180_DEG_FLIP
-
 #define DEFAULT_RX_FEATURE      FEATURE_RX_PPM
 #define DISABLE_RX_PWM_FEATURE
 #define DEFAULT_FEATURES        (FEATURE_BLACKBOX | FEATURE_VBAT)
 
 #define SPEKTRUM_BIND
 #define BIND_PIN                PB11 // USART3 RX
+
+#define AVOID_UART1_FOR_PWM_PPM
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -101,6 +101,8 @@
 
 #define USE_SPI
 
+#define USE_SPI_DEVICE_1
+
 #ifdef OMNIBUSF4SD
   #define USE_SPI_DEVICE_2
   #define SPI2_NSS_PIN          PB12
@@ -183,8 +185,6 @@
 
 #define SPEKTRUM_BIND
 #define BIND_PIN                PB11 // USART3 RX
-
-#define AVOID_UART1_FOR_PWM_PPM
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -63,10 +63,10 @@
 
 #define BARO
 #define USE_BARO_BMP085
+#define USE_BARO_BMP280
 #define USE_BARO_MS5611
 
 #ifdef OMNIBUSF4SD
-  #define USE_BARO_BMP280
   #define USE_BARO_SPI_BMP280
   #define BMP280_SPI_INSTANCE     SPI3
   #define BMP280_CS_PIN           PB3 // v1

--- a/src/main/target/OMNIBUSF4/target.mk
+++ b/src/main/target/OMNIBUSF4/target.mk
@@ -5,6 +5,7 @@ TARGET_SRC = \
 			drivers/accgyro_spi_mpu6000.c \
             drivers/barometer_bmp085.c \
             drivers/barometer_bmp280.c \
+            drivers/barometer_spi_bmp280.c \
             drivers/barometer_ms5611.c \
             drivers/compass_ak8963.c \
             drivers/compass_ak8975.c \


### PR DESCRIPTION
- [x] MPU6000
- [x] I2C
- [x] Baro -> Built in BMP280
- [x] Baro -> External -> tested BMP085 over I2c
- [x] Vbat
- [x] Motors
- [x] Servos
- [x] PPM
- [x] S.Bus
- [x] RSSI -> No RSSI 
- [x] Current
- [x] Buzzer
- [x] UART1
- [x] UART3
- [x] UART6
- [x] OSD
- [x] SD Card
- [x] GPS
- [x] Mag