### PR TITLE
Only report GPS unavailable if there are some GPS timeouts

### DIFF
--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -175,7 +175,7 @@ hardwareSensorStatus_e getHwGPSStatus(void)
         }
     }
     else {
-        if (feature(FEATURE_GPS)) {
+        if (feature(FEATURE_GPS) && gpsStats.timeouts > 3) {
             // Selected but not detected
             return HW_SENSOR_UNAVAILABLE;
         }


### PR DESCRIPTION
Prevent hardware failure reporting failed GPS until initial detection of GPS is finished.