### PR TITLE
Failsafe fixes

### DIFF
--- a/src/main/fc/mw.c
+++ b/src/main/fc/mw.c
@@ -198,7 +198,7 @@ void annexCode(void)
     if (ARMING_FLAG(ARMED)) {
         LED0_ON;
     } else {
-        if (!IS_RC_MODE_ACTIVE(BOXARM)) {
+        if (!IS_RC_MODE_ACTIVE(BOXARM) && failsafeIsReceivingRxData()) {
             ENABLE_ARMING_FLAG(OK_TO_ARM);
         }
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -461,11 +461,6 @@ static uint16_t getRxfailValue(uint8_t channel)
     const rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &rxConfig->failsafe_channel_configurations[channel];
     uint8_t mode = channelFailsafeConfiguration->mode;
 
-    // force auto mode to prevent fly away when failsafe stage 2 is disabled
-    if ( channel < NON_AUX_CHANNEL_COUNT && (!feature(FEATURE_FAILSAFE)) ) {
-        mode = RX_FAILSAFE_MODE_AUTO;
-    }
-
     switch(mode) {
         case RX_FAILSAFE_MODE_AUTO:
             switch (channel) {


### PR DESCRIPTION
This fixes two bugs:

First bug was reported in "RC School Models" community when testing 1.5-RC2. When Failsafe Stage 2 is disabled Stage 1 settings are ignored and forced to `AUTO` - therefore it's impossible to have failsafe completely disabled and force throttle channel to `HOLD`.

Second bug was discovered shortly after. When Failsafe Stage 2 is enabled, and `failsafe_recovery_delay` is large and you turn on your radio and flip the arming switch right away you will end up arming right into Failsafe Stage 2 procedure. This PR fixes this by requiring `failsafeIsReceivingRxData` to return `true` to allow arming.