### PR TITLE
Fix mixed UART2/UART3 hardware clash handling code

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -126,7 +126,7 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
 
 #ifdef STM32F10X
         // skip UART2 ports
-        if (init->useUART3 && (timerHardwarePtr->tag == IO_TAG(PA2) || timerHardwarePtr->tag == IO_TAG(PA3))) {
+        if (init->useUART2 && (timerHardwarePtr->tag == IO_TAG(PA2) || timerHardwarePtr->tag == IO_TAG(PA3))) {
             addBootlogEvent6(BOOT_EVENT_TIMER_CH_SKIPPED, BOOT_EVENT_FLAGS_WARNING, i, pwmIOConfiguration.motorCount, pwmIOConfiguration.servoCount, 3);
             continue;
         }


### PR DESCRIPTION
Looks like this bug was introduced by me when creating the code to skip PA2/PA3 timer pins if UART was used on those pins. Should fix https://github.com/iNavFlight/inav/issues/989