### PR TITLE
Fix array out of bounds issue in I2C driver

### DIFF
--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -40,6 +40,8 @@ typedef enum I2CDevice {
     I2CDEV_MAX = I2CDEV_4,
 } I2CDevice;
 
+#define I2CDEV_COUNT    (I2CDEV_MAX + 1)
+
 typedef struct i2cDevice_s {
     I2C_TypeDef *dev;
     ioTag_t scl;

--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -140,7 +140,7 @@ static i2cDevice_t i2cHardwareMap[] = {
 #endif
 };
 
-static i2cBusState_t busState[I2CDEV_MAX] = { { 0 } };
+static i2cBusState_t busState[I2CDEV_COUNT] = { { 0 } };
 
 static void i2cResetInterface(i2cBusState_t * i2cBusState)
 {

--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -106,7 +106,7 @@ static i2cDevice_t i2cHardwareMap[] = {
     { .dev = I2C2, .scl = IO_TAG(I2C2_SCL), .sda = IO_TAG(I2C2_SDA), .rcc = RCC_APB1(I2C2), .overClock = I2C2_OVERCLOCK }
 };
 
-static i2cBusState_t busState[I2CDEV_MAX] = { { 0 } };
+static i2cBusState_t busState[I2CDEV_COUNT] = { { 0 } };
 
 static void i2cResetInterface(i2cBusState_t * i2cBusState)
 {


### PR DESCRIPTION
Fix for https://github.com/iNavFlight/inav/issues/1018