### PR TITLE
fix for missing SPI1 on OmnibusF4SD

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -101,6 +101,8 @@
 
 #define USE_SPI
 
+#define USE_SPI_DEVICE_1
+
 #ifdef OMNIBUSF4SD
   #define USE_SPI_DEVICE_2
   #define SPI2_NSS_PIN          PB12
@@ -183,8 +185,6 @@
 
 #define SPEKTRUM_BIND
 #define BIND_PIN                PB11 // USART3 RX
-
-#define AVOID_UART1_FOR_PWM_PPM
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 


### PR DESCRIPTION
@digitalentity This fixes Omnibus F4 SD target from #957 
It took me only whole evening and the reason was the most obvious one... Anyhow, board now boots correctly