### PR TITLE
Initial cut on RTH sanity checking

### DIFF
--- a/src/main/fc/serial_cli.c
+++ b/src/main/fc/serial_cli.c
@@ -796,6 +796,7 @@ static const clivalue_t valueTable[] = {
     { "nav_rth_climb_first",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_climb_first) },
     { "nav_rth_tail_first",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_tail_first) },
     { "nav_rth_alt_mode",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_NAV_RTH_ALT_MODE }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_alt_control_mode) },
+    { "nav_rth_abort_threshold",    VAR_UINT16 | MASTER_VALUE | MODE_MAX, .config.max = { 65000 }, PG_NAV_CONFIG, offsetof(navConfig_t, general.rth_abort_threshold) },
     { "nav_rth_altitude",           VAR_UINT16 | MASTER_VALUE | MODE_MAX, .config.max = { 65000 }, PG_NAV_CONFIG, offsetof(navConfig_t, general.rth_altitude) },
 
     { "nav_mc_bank_angle",          VAR_UINT8  | MASTER_VALUE, .config.minmax = { 15,  45 }, PG_NAV_CONFIG, offsetof(navConfig_t, mc.max_bank_angle) },

--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -86,7 +86,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .emerg_descent_rate = 500,    // 5 m/s
         .min_rth_distance = 500,      // If closer than 5m - land immediately
         .rth_altitude = 1000,         // 10m
-        .rth_abort_threshold = 15000, // 150m
+        .rth_abort_threshold = 50000, // 500m - should be safe for all aircraft
     },
 
     // MC-specific

--- a/src/main/flight/navigation_rewrite.h
+++ b/src/main/flight/navigation_rewrite.h
@@ -113,6 +113,7 @@ typedef struct navConfig_s {
         uint16_t emerg_descent_rate;            // emergency landing descent rate
         uint16_t rth_altitude;                  // altitude to maintain when RTH is active (depends on rth_alt_control_mode) (cm)
         uint16_t min_rth_distance;              // 0 Disables. Minimal distance for RTL in cm, otherwise it will just autoland
+        uint16_t rth_abort_threshold;           // Initiate emergency landing if during RTH we get this much [cm] away from home
     } general;
 
     struct {

--- a/src/main/flight/navigation_rewrite_private.h
+++ b/src/main/flight/navigation_rewrite_private.h
@@ -186,35 +186,33 @@ typedef enum {
 
     NAV_STATE_RTH_2D_INITIALIZE,                // 9
     NAV_STATE_RTH_2D_HEAD_HOME,                 // 10
-    NAV_STATE_RTH_2D_GPS_FAILING,               // 11
-    NAV_STATE_RTH_2D_FINISHING,                 // 12
-    NAV_STATE_RTH_2D_FINISHED,                  // 13
+    NAV_STATE_RTH_2D_FINISHING,                 // 11
+    NAV_STATE_RTH_2D_FINISHED,                  // 12
 
-    NAV_STATE_RTH_3D_INITIALIZE,                // 14
-    NAV_STATE_RTH_3D_CLIMB_TO_SAFE_ALT,         // 15
-    NAV_STATE_RTH_3D_HEAD_HOME,                 // 16
-    NAV_STATE_RTH_3D_GPS_FAILING,               // 17
-    NAV_STATE_RTH_3D_HOVER_PRIOR_TO_LANDING,    // 18
-    NAV_STATE_RTH_3D_LANDING,                   // 19
-    NAV_STATE_RTH_3D_FINISHING,                 // 20
-    NAV_STATE_RTH_3D_FINISHED,                  // 21
+    NAV_STATE_RTH_3D_INITIALIZE,                // 13
+    NAV_STATE_RTH_3D_CLIMB_TO_SAFE_ALT,         // 14
+    NAV_STATE_RTH_3D_HEAD_HOME,                 // 15
+    NAV_STATE_RTH_3D_HOVER_PRIOR_TO_LANDING,    // 16
+    NAV_STATE_RTH_3D_LANDING,                   // 17
+    NAV_STATE_RTH_3D_FINISHING,                 // 18
+    NAV_STATE_RTH_3D_FINISHED,                  // 19
 
-    NAV_STATE_WAYPOINT_INITIALIZE,              // 22
-    NAV_STATE_WAYPOINT_PRE_ACTION,              // 23
-    NAV_STATE_WAYPOINT_IN_PROGRESS,             // 24
-    NAV_STATE_WAYPOINT_REACHED,                 // 25
-    NAV_STATE_WAYPOINT_NEXT,                    // 26
-    NAV_STATE_WAYPOINT_FINISHED,                // 27
-    NAV_STATE_WAYPOINT_RTH_LAND,                // 28
+    NAV_STATE_WAYPOINT_INITIALIZE,              // 20
+    NAV_STATE_WAYPOINT_PRE_ACTION,              // 21
+    NAV_STATE_WAYPOINT_IN_PROGRESS,             // 22
+    NAV_STATE_WAYPOINT_REACHED,                 // 23
+    NAV_STATE_WAYPOINT_NEXT,                    // 24
+    NAV_STATE_WAYPOINT_FINISHED,                // 25
+    NAV_STATE_WAYPOINT_RTH_LAND,                // 26
 
-    NAV_STATE_EMERGENCY_LANDING_INITIALIZE,     // 29
-    NAV_STATE_EMERGENCY_LANDING_IN_PROGRESS,    // 30
-    NAV_STATE_EMERGENCY_LANDING_FINISHED,       // 31
+    NAV_STATE_EMERGENCY_LANDING_INITIALIZE,     // 27
+    NAV_STATE_EMERGENCY_LANDING_IN_PROGRESS,    // 28
+    NAV_STATE_EMERGENCY_LANDING_FINISHED,       // 29
 
-    NAV_STATE_LAUNCH_INITIALIZE,                // 32
-    NAV_STATE_LAUNCH_WAIT,                      // 33
-    NAV_STATE_LAUNCH_MOTOR_DELAY,               // 34
-    NAV_STATE_LAUNCH_IN_PROGRESS,               // 35
+    NAV_STATE_LAUNCH_INITIALIZE,                // 30
+    NAV_STATE_LAUNCH_WAIT,                      // 31
+    NAV_STATE_LAUNCH_MOTOR_DELAY,               // 32
+    NAV_STATE_LAUNCH_IN_PROGRESS,               // 33
 
     NAV_STATE_COUNT,
 } navigationFSMState_t;
@@ -254,6 +252,12 @@ typedef struct {
 } navigationFSMStateDescriptor_t;
 
 typedef struct {
+    timeMs_t        lastCheckTime;
+    t_fp_vector     initialPosition;
+    float           minimalDistanceToHome;
+} rthSanityChecker_t;
+
+typedef struct {
     /* Flags and navigation system state */
     navigationFSMState_t        navState;
 
@@ -275,6 +279,7 @@ typedef struct {
     gpsOrigin_s                 gpsOrigin;
 
     /* Home parameters (NEU coordinated), geodetic position of home (LLH) is stores in GPS_home variable */
+    rthSanityChecker_t          rthSanityChecker;
     navWaypointPosition_t       homePosition;       // Special waypoint, stores original yaw (heading when launched)
     navWaypointPosition_t       homeWaypointAbove;  // NEU-coordinates and initial bearing + desired RTH altitude
 


### PR DESCRIPTION
Introducing a new parameter - `nav_rth_abort_threshold` measured in [cm]. If during an RTH (manual, failsafe or WP) we get further away from home by this much - abort RTH and do an emergency landing.

Done per https://github.com/iNavFlight/inav/issues/62#issuecomment-270325236