### PR TITLE
F1 & F4 : Disable UART TX DMA by default

### DIFF
--- a/src/main/drivers/serial_uart_stm32f10x.c
+++ b/src/main/drivers/serial_uart_stm32f10x.c
@@ -76,6 +76,7 @@ void uartIrqCallback(uartPort_t *s)
     }
 }
 
+#ifdef USE_UART1_TX_DMA
 // USART1 Tx DMA Handler
 void uart_tx_dma_IRQHandler(dmaChannelDescriptor_t* descriptor)
 {
@@ -88,6 +89,7 @@ void uart_tx_dma_IRQHandler(dmaChannelDescriptor_t* descriptor)
     else
         s->txDMAEmpty = true;
 }
+#endif
 
 #ifdef USE_UART1
 // USART1 - Telemetry (RX/TX by DMA)
@@ -114,8 +116,10 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
     s->rxDMAChannel = DMA1_Channel5;
     s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
 #endif
+#ifdef USE_UART1_TX_DMA
     s->txDMAChannel = DMA1_Channel4;
     s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
+#endif
 
     RCC_ClockCmd(RCC_APB2(USART1), ENABLE);
     RCC_ClockCmd(RCC_AHB(DMA1), ENABLE);
@@ -137,8 +141,10 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
         }
     }
 
+#ifdef USE_UART1_TX_DMA
     // DMA TX Interrupt
     dmaSetHandler(DMA1_CH4_HANDLER, uart_tx_dma_IRQHandler, NVIC_PRIO_SERIALUART1_TXDMA, (uint32_t)&uartPort1);
+#endif
 
 #ifndef USE_UART1_RX_DMA
     // RX/TX Interrupt
@@ -185,8 +191,12 @@ uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t option
 
     s->USARTx = USART2;
 
+#ifdef USE_UART2_TX_DMA
     s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
+#endif
+#ifdef USE_UART2_RX_DMA
     s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
+#endif
 
     RCC_ClockCmd(RCC_APB1(USART2), ENABLE);
     RCC_ClockCmd(RCC_AHB(DMA1), ENABLE);
@@ -250,8 +260,12 @@ uartPort_t *serialUART3(uint32_t baudRate, portMode_t mode, portOptions_t option
 
     s->USARTx = USART3;
 
+#ifdef USE_UART3_TX_DMA
     s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
+#endif
+#ifdef USE_UART3_RX_DMA
     s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
+#endif
 
     RCC_ClockCmd(RCC_APB1(USART3), ENABLE);
 

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -67,9 +67,11 @@ typedef struct uartDevice_s {
 static uartDevice_t uart1 =
 {
     .DMAChannel = DMA_Channel_4,
-    .txDMAStream = DMA2_Stream7,
 #ifdef USE_UART1_RX_DMA
     .rxDMAStream = DMA2_Stream5,
+#endif
+#ifdef USE_UART1_TX_DMA
+    .txDMAStream = DMA2_Stream7,
 #endif
     .dev = USART1,
     .rx = IO_TAG(UART1_RX_PIN),
@@ -93,7 +95,9 @@ static uartDevice_t uart2 =
 #ifdef USE_UART2_RX_DMA
     .rxDMAStream = DMA1_Stream5,
 #endif
+#ifdef USE_UART2_TX_DMA
     .txDMAStream = DMA1_Stream6,
+#endif
     .dev = USART2,
     .rx = IO_TAG(UART2_RX_PIN),
     .tx = IO_TAG(UART2_TX_PIN),
@@ -116,7 +120,9 @@ static uartDevice_t uart3 =
 #ifdef USE_UART3_RX_DMA
     .rxDMAStream = DMA1_Stream1,
 #endif
+#ifdef USE_UART3_TX_DMA
     .txDMAStream = DMA1_Stream3,
+#endif
     .dev = USART3,
     .rx = IO_TAG(UART3_RX_PIN),
     .tx = IO_TAG(UART3_TX_PIN),
@@ -139,7 +145,9 @@ static uartDevice_t uart4 =
 #ifdef USE_UART4_RX_DMA
     .rxDMAStream = DMA1_Stream2,
 #endif
+#ifdef USE_UART4_TX_DMA
     .txDMAStream = DMA1_Stream4,
+#endif
     .dev = UART4,
     .rx = IO_TAG(UART4_RX_PIN),
     .tx = IO_TAG(UART4_TX_PIN),
@@ -162,7 +170,9 @@ static uartDevice_t uart5 =
 #ifdef USE_UART5_RX_DMA
     .rxDMAStream = DMA1_Stream0,
 #endif
+#ifdef USE_UART5_TX_DMA
     .txDMAStream = DMA1_Stream7,
+#endif
     .dev = UART5,
     .rx = IO_TAG(UART5_RX_PIN),
     .tx = IO_TAG(UART5_TX_PIN),
@@ -185,7 +195,9 @@ static uartDevice_t uart6 =
 #ifdef USE_UART6_RX_DMA
     .rxDMAStream = DMA2_Stream1,
 #endif
+#ifdef USE_UART6_RX_DMA
     .txDMAStream = DMA2_Stream6,
+#endif
     .dev = USART6,
     .rx = IO_TAG(UART6_RX_PIN),
     .tx = IO_TAG(UART6_TX_PIN),
@@ -260,6 +272,7 @@ void uartIrqHandler(uartPort_t *s)
     }
 }
 
+#if defined(USE_UART1_TX_DMA) || defined(USE_UART2_TX_DMA) || defined(USE_UART3_TX_DMA) || defined(USE_UART4_TX_DMA) || defined(USE_UART5_TX_DMA) || defined(USE_UART6_TX_DMA)
 static void handleUsartTxDma(uartPort_t *s)
 {
     DMA_Cmd(s->txDMAStream, DISABLE);
@@ -292,6 +305,7 @@ void dmaIRQHandler(dmaChannelDescriptor_t* descriptor)
         DMA_CLEAR_FLAG(descriptor, DMA_IT_DMEIF);
     }
 }
+#endif
 
 uartPort_t *serialUART(UARTDevice device, uint32_t baudRate, portMode_t mode, portOptions_t options)
 {
@@ -350,8 +364,10 @@ uartPort_t *serialUART(UARTDevice device, uint32_t baudRate, portMode_t mode, po
         }
     }
 
+#if defined(USE_UART1_TX_DMA) || defined(USE_UART2_TX_DMA) || defined(USE_UART3_TX_DMA) || defined(USE_UART4_TX_DMA) || defined(USE_UART5_TX_DMA) || defined(USE_UART6_TX_DMA)
     // DMA TX Interrupt
     dmaSetHandler(uart->txIrq, dmaIRQHandler, uart->txPriority, (uint32_t)uart);
+#endif
 
     if (!(s->rxDMAChannel)) {
         NVIC_InitStructure.NVIC_IRQChannel = uart->rxIrq;


### PR DESCRIPTION
Temporary solution for #1008.

- F4: UART1~UART6 are all disabled by NOT setting txDMAStream.
- F1: UART1 is disabled by NOT setting txDMAChannel. UART2 and UART3 did not have valid dma init code, but these were disabled, too.

Need regression test, especially for F1 which depended on UART1 TX DMA.