### PR TITLE
AltHold performance improvements

### DIFF
--- a/src/main/flight/navigation_rewrite.c
+++ b/src/main/flight/navigation_rewrite.c
@@ -2557,8 +2557,8 @@ void navigationUsePIDs(void)
     // Initialize altitude hold PID-controllers (pos_z, vel_z, acc_z
     navPInit(&posControl.pids.pos[Z], (float)pidProfile()->P8[PIDALT] / 100.0f);
 
-    navPidInit(&posControl.pids.vel[Z], (float)pidProfile()->P8[PIDVEL] / 100.0f,
-                                        (float)pidProfile()->I8[PIDVEL] / 100.0f,
+    navPidInit(&posControl.pids.vel[Z], (float)pidProfile()->P8[PIDVEL] / 66.7f,
+                                        (float)pidProfile()->I8[PIDVEL] / 20.0f,
                                         (float)pidProfile()->D8[PIDVEL] / 100.0f);
 
     // Initialize surface tracking PID

--- a/src/main/flight/navigation_rewrite_multicopter.c
+++ b/src/main/flight/navigation_rewrite_multicopter.c
@@ -116,19 +116,19 @@ static void updateAltitudeThrottleController_MC(uint32_t deltaMicros)
 
 bool adjustMulticopterAltitudeFromRCInput(void)
 {
-    int16_t rcThrottleAdjustment = rcCommand[THROTTLE] - altHoldThrottleRCZero;
-    if (ABS(rcThrottleAdjustment) > rcControlsConfig()->alt_hold_deadband) {
+    const int16_t rcThrottleAdjustment = applyDeadband(rcCommand[THROTTLE] - altHoldThrottleRCZero, rcControlsConfig()->alt_hold_deadband);
+    if (rcThrottleAdjustment) {
         // set velocity proportional to stick movement
         float rcClimbRate;
 
         // Make sure we can satisfy max_manual_climb_rate in both up and down directions
         if (rcThrottleAdjustment > 0) {
             // Scaling from altHoldThrottleRCZero to maxthrottle
-            rcClimbRate = rcThrottleAdjustment * navConfig()->general.max_manual_climb_rate / (motorConfig()->maxthrottle - altHoldThrottleRCZero);
+            rcClimbRate = rcThrottleAdjustment * navConfig()->general.max_manual_climb_rate / (motorConfig()->maxthrottle - altHoldThrottleRCZero - rcControlsConfig()->alt_hold_deadband);
         }
         else {
             // Scaling from minthrottle to altHoldThrottleRCZero
-            rcClimbRate = rcThrottleAdjustment * navConfig()->general.max_manual_climb_rate / (altHoldThrottleRCZero - motorConfig()->minthrottle);
+            rcClimbRate = rcThrottleAdjustment * navConfig()->general.max_manual_climb_rate / (altHoldThrottleRCZero - motorConfig()->minthrottle - rcControlsConfig()->alt_hold_deadband);
         }
 
         updateAltitudeTargetFromClimbRate(rcClimbRate, CLIMB_RATE_UPDATE_SURFACE_TARGET);


### PR DESCRIPTION
1. Give more authority to current defaults for VEL PID
1. Smoother climb/descent control in AltHold mode regardless of deadband size