### PR TITLE
Automatic gyro bias correction

### DIFF
--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -28,6 +28,7 @@ extern int16_t smallAngle;
 extern t_fp_vector imuAccelInBodyFrame;         // cm/s/s
 extern t_fp_vector imuMeasuredGravityBF;        // cm/s/s
 extern t_fp_vector imuMeasuredRotationBF;       // rad/s
+extern t_fp_vector imuEstimatedGyroBiasDPS;     // deg/s
 
 typedef union {
     int16_t raw[XYZ_AXIS_COUNT];

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -615,8 +615,8 @@ void pidController(const pidProfile_t *pidProfile, const controlRateConfig_t *co
     }
 
     for (int axis = 0; axis < 3; axis++) {
-        // Step 1: Calculate gyro rates
-        pidState[axis].gyroRate = gyro.gyroADC[axis] * gyro.dev.scale;
+        // Step 1: Calculate gyro rates and use bias calculated by IMU to improve accuracy
+        pidState[axis].gyroRate = gyro.gyroADC[axis] * gyro.dev.scale + imuEstimatedGyroBiasDPS.A[axis];
 
         // Step 2: Read target
         float rateTarget;


### PR DESCRIPTION
IMU calculates gyro bias correction to estimate attitude better. This PR exposes this calculated bias and uses it in PID controller for better accuracy or rate controller.