### PR TITLE
Make max total PID output configurable; Reduce default limit to 500

### DIFF
--- a/src/main/fc/serial_cli.c
+++ b/src/main/fc/serial_cli.c
@@ -711,6 +711,8 @@ static const clivalue_t valueTable[] = {
     { "dterm_notch_cutoff",         VAR_UINT16 | PROFILE_VALUE, .config.minmax = {1, 500 }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_soft_notch_cutoff) },
 #endif
 
+    { "pidsum_limit",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = { PID_SUM_LIMIT_MIN,  PID_SUM_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, pidSumLimit) },
+
     { "yaw_p_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmax = { YAW_P_LIMIT_MIN,  YAW_P_LIMIT_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, yaw_p_limit) },
 
     { "iterm_ignore_threshold",     VAR_UINT16 | PROFILE_VALUE, .config.minmax = {15, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, rollPitchItermIgnoreRate) },

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -158,6 +158,7 @@ PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
         .max_angle_inclination[FD_ROLL] = 300,    // 30 degrees
         .max_angle_inclination[FD_PITCH] = 300,    // 30 degrees
         .fixedWingItermThrowLimit = FW_ITERM_THROW_LIMIT_DEFAULT,
+        .pidSumLimit = PID_SUM_LIMIT_DEFAULT,
 );
 
 void pidInit(void)
@@ -449,7 +450,7 @@ static void pidApplyRateController(const pidProfile_t *pidProfile, pidState_t *p
 
     // TODO: Get feedback from mixer on available correction range for each axis
     const float newOutput = newPTerm + newDTerm + pidState->errorGyroIf;
-    const float newOutputLimited = constrainf(newOutput, -PID_MAX_OUTPUT, +PID_MAX_OUTPUT);
+    const float newOutputLimited = constrainf(newOutput, -pidProfile->pidSumLimit, +pidProfile->pidSumLimit);
 
     // Prevent strong Iterm accumulation during stick inputs
     const float integratorThreshold = (axis == FD_YAW) ? pidProfile->yawItermIgnoreRate : pidProfile->rollPitchItermIgnoreRate;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -20,7 +20,9 @@
 #include "config/parameter_group.h"
 
 #define GYRO_SATURATION_LIMIT   1800        // 1800dps
-#define PID_MAX_OUTPUT          1000
+#define PID_SUM_LIMIT_MIN       100
+#define PID_SUM_LIMIT_MAX       1000
+#define PID_SUM_LIMIT_DEFAULT   500
 #define YAW_P_LIMIT_MIN 100                 // Maximum value for yaw P limiter
 #define YAW_P_LIMIT_MAX 500                 // Maximum value for yaw P limiter
 #define YAW_P_LIMIT_DEFAULT 300             // Default value for yaw P limiter
@@ -72,6 +74,7 @@ typedef struct pidProfile_s {
     float dterm_setpoint_weight;
 
     uint16_t fixedWingItermThrowLimit;
+    uint16_t pidSumLimit;
 } pidProfile_t;
 
 PG_DECLARE_PROFILE(pidProfile_t, pidProfile);


### PR DESCRIPTION
Currently `axisPID` (PID total output) is limited to [-1000;1000] range which is worst case may cause a mixer to effectively zero out small PID corrections if another two axis is saturating. 

I.e. when Roll+Yaw PID outputs saturating at +1000 and Pitch trying to make correction of -100; mixer will scale the overall 2100 range down to 1000 effectively reducing Pitch correction to -47 (similar to reducing Pitch PIDs by factor of 2.1). This may cause destabilisation of aircraft which is especially noticable on bigger machines where doing hard Yaws causes destabilisation on Roll and Pitch due to mixer saturating. In the worst case PID reduction can be up to 3 times.

New default of 500 will limit effective PID reduction to c. 1.5 times which is more acceptable in most cases. Also ability to adjust this parameter will allow better tuning for bigger machines.