### PR TITLE
Notch filters are disabled by default

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -141,8 +141,8 @@ PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
         .D8[PIDVEL] = 10,    // NAV_VEL_Z_D * 100
 
         .acc_soft_lpf_hz = 15,
-        .dterm_soft_notch_cutoff = 43,
-        .dterm_soft_notch_hz = 86,
+        .dterm_soft_notch_cutoff = 0,
+        .dterm_soft_notch_hz = 0,
         .dterm_lpf_hz = 40,
         .yaw_lpf_hz = 30,
         .dterm_setpoint_weight = 0.0f,

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -91,10 +91,10 @@ PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
     .looptime = 2000,
     .gyroSync = 0,
     .gyroSyncDenominator = 2,
-    .gyro_soft_notch_cutoff_1 = 129,
-    .gyro_soft_notch_hz_1 = 172,
-    .gyro_soft_notch_cutoff_2 = 43,
-    .gyro_soft_notch_hz_2 = 86
+    .gyro_soft_notch_cutoff_1 = 0,
+    .gyro_soft_notch_hz_1 = 0,
+    .gyro_soft_notch_cutoff_2 = 0,
+    .gyro_soft_notch_hz_2 = 0
 );
 
 static const extiConfig_t *selectMPUIntExtiConfig(void)


### PR DESCRIPTION
INAV is run on too wide scope of UAV to have default notch filters setup, so this PR disables them.

They would be reenabled by Configurator presets to match real UAVs better