### PR TITLE
Fix missing call to `useRcControlsConfig()`

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -429,6 +429,8 @@ static void activateConfig(void)
     activateControlRateConfig();
 
     resetAdjustmentStates();
+    
+    useRcControlsConfig();
 
     failsafeReset();
 


### PR DESCRIPTION
Fixes https://github.com/iNavFlight/inav/issues/1182