### PR TITLE
Added direct support for MPU9250 gyro

### DIFF
--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -42,6 +42,7 @@
 #include "accgyro_mpu6500.h"
 #include "accgyro_spi_mpu6000.h"
 #include "accgyro_spi_mpu6500.h"
+#include "accgyro_spi_mpu9250.h"
 #include "accgyro_mpu.h"
 
 //#define DEBUG_MPU_DATA_READY_INTERRUPT
@@ -238,6 +239,19 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro)
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.read = mpu6500ReadRegister;
         gyro->mpuConfiguration.write = mpu6500WriteRegister;
+        return true;
+    }
+#endif
+
+#ifdef  USE_GYRO_SPI_MPU9250
+    if (mpu9250SpiDetect()) {
+        gyro->mpuDetectionResult.sensor = MPU_9250_SPI;
+        gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
+        gyro->mpuConfiguration.read = mpu9250ReadRegister;
+        gyro->mpuConfiguration.slowread = mpu9250SlowReadRegister;
+        gyro->mpuConfiguration.verifywrite = verifympu9250WriteRegister;
+        gyro->mpuConfiguration.write = mpu9250WriteRegister;
+        gyro->mpuConfiguration.reset = mpu9250ResetGyro;
         return true;
     }
 #endif

--- a/src/main/drivers/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro_spi_mpu9250.c
@@ -1,0 +1,235 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+/*
+ * Authors:
+ * Dominic Clifton - Cleanflight implementation
+ * John Ihlein - Initial FF32 code
+ * Kalyn Doerr (RS2K) - Robust rewrite
+*/
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "build/debug.h"
+
+#include "common/axis.h"
+#include "common/maths.h"
+
+#include "io.h"
+
+#include "system.h"
+#include "exti.h"
+#include "bus_spi.h"
+#include "gyro_sync.h"
+#include "light_led.h"
+
+#include "sensor.h"
+#include "accgyro.h"
+#include "accgyro_mpu.h"
+#include "accgyro_spi_mpu9250.h"
+
+static bool mpuSpi9250InitDone = false;
+
+static IO_t mpuSpi9250CsPin = IO_NONE;
+
+#define DISABLE_MPU9250       IOHi(mpuSpi9250CsPin)
+#define ENABLE_MPU9250        IOLo(mpuSpi9250CsPin)
+
+bool mpu9250ReadRegister(uint8_t reg, uint8_t length, uint8_t *data)
+{
+    ENABLE_MPU9250;
+    spiTransferByte(MPU9250_SPI_INSTANCE, reg | 0x80); // read transaction
+    spiTransfer(MPU9250_SPI_INSTANCE, data, NULL, length);
+    DISABLE_MPU9250;
+
+    return true;
+}
+
+bool mpu9250SlowReadRegister(uint8_t reg, uint8_t length, uint8_t *data)
+{
+    ENABLE_MPU9250;
+    delayMicroseconds(1);
+    spiTransferByte(MPU9250_SPI_INSTANCE, reg | 0x80); // read transaction
+    spiTransfer(MPU9250_SPI_INSTANCE, data, NULL, length);
+    DISABLE_MPU9250;
+    delayMicroseconds(1);
+
+    return true;
+}
+
+bool mpu9250WriteRegister(uint8_t reg, uint8_t data)
+{
+    ENABLE_MPU9250;
+    delayMicroseconds(1);
+    spiTransferByte(MPU9250_SPI_INSTANCE, reg);
+    spiTransferByte(MPU9250_SPI_INSTANCE, data);
+    DISABLE_MPU9250;
+    delayMicroseconds(1);
+
+    return true;
+}
+
+bool verifympu9250WriteRegister(uint8_t reg, uint8_t data)
+{
+    mpu9250WriteRegister(reg, data);
+    delayMicroseconds(100);
+
+    uint8_t attemptsRemaining = 20;
+    do {
+        uint8_t in;
+        mpu9250SlowReadRegister(reg, 1, &in);
+        if (in == data) {
+            return true;
+        } else {
+            debug[3]++;
+            mpu9250WriteRegister(reg, data);
+            delayMicroseconds(100);
+        }
+    } while (attemptsRemaining--);
+    return false;
+}
+
+void mpu9250ResetGyro(void)
+{
+    // Device Reset
+    mpu9250WriteRegister(MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    delay(150);
+}
+
+static void mpu9250AccAndGyroInit(gyroDev_t *gyro)
+{
+    if (mpuSpi9250InitDone) {
+        return;
+    }
+
+    spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed for writing to slow registers
+
+    mpu9250WriteRegister(MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    delay(50);
+
+    verifympu9250WriteRegister(MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+
+    //Fchoice_b defaults to 00 which makes fchoice 11
+    const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
+    verifympu9250WriteRegister(MPU_RA_GYRO_CONFIG, raGyroConfigData);
+
+    if (gyro->lpf == 4) {
+        verifympu9250WriteRegister(MPU_RA_CONFIG, 1); //1KHz, 184DLPF
+    } else if (gyro->lpf < 4) {
+        verifympu9250WriteRegister(MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
+    } else if (gyro->lpf > 4) {
+        verifympu9250WriteRegister(MPU_RA_CONFIG, 0); //8KHz, 250DLPF
+    }
+
+    verifympu9250WriteRegister(MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+
+    verifympu9250WriteRegister(MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    verifympu9250WriteRegister(MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+
+#if defined(USE_MPU_DATA_READY_SIGNAL)
+    verifympu9250WriteRegister(MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
+#endif
+
+    spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_FAST);
+
+    mpuSpi9250InitDone = true; //init done
+}
+
+bool mpu9250SpiDetect(void)
+{
+    /* not the best place for this - should really have an init method */
+#ifdef MPU9250_CS_PIN
+    mpuSpi9250CsPin = IOGetByTag(IO_TAG(MPU9250_CS_PIN));
+#endif
+    IOInit(mpuSpi9250CsPin, OWNER_MPU, RESOURCE_SPI_CS, 0);
+    IOConfigGPIO(mpuSpi9250CsPin, SPI_IO_CS_CFG);
+
+    spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed
+    mpu9250WriteRegister(MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+
+    uint8_t attemptsRemaining = 20;
+    do {
+        delay(150);
+        uint8_t in;
+        mpu9250ReadRegister(MPU_RA_WHO_AM_I, 1, &in);
+        if (in == MPU9250_WHO_AM_I_CONST) {
+            break;
+        }
+        if (!attemptsRemaining) {
+            return false;
+        }
+    } while (attemptsRemaining--);
+
+    spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_FAST);
+
+    return true;
+}
+
+static void mpu9250SpiAccInit(accDev_t *acc)
+{
+    acc->acc_1G = 512 * 8;
+}
+
+bool mpu9250SpiAccDetect(accDev_t *acc)
+{
+    if (acc->mpuDetectionResult.sensor != MPU_9250_SPI) {
+        return false;
+    }
+
+    acc->init = mpu9250SpiAccInit;
+    acc->read = mpuAccRead;
+
+    return true;
+}
+
+static void mpu9250SpiGyroInit(gyroDev_t *gyro)
+{
+    mpuGyroInit(gyro);
+
+    mpu9250AccAndGyroInit(gyro);
+
+    spiResetErrorCounter(MPU9250_SPI_INSTANCE);
+
+    spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_FAST); //high speed now that we don't need to write to the slow registers
+
+    mpuGyroRead(gyro);
+
+    if ((((int8_t)gyro->gyroADCRaw[1]) == -1 && ((int8_t)gyro->gyroADCRaw[0]) == -1) || spiGetErrorCounter(MPU9250_SPI_INSTANCE) != 0) {
+        spiResetErrorCounter(MPU9250_SPI_INSTANCE);
+        failureMode(FAILURE_GYRO_INIT_FAILED);
+    }
+}
+
+bool mpu9250SpiGyroDetect(gyroDev_t *gyro)
+{
+    if (gyro->mpuDetectionResult.sensor != MPU_9250_SPI) {
+        return false;
+    }
+
+    gyro->init = mpu9250SpiGyroInit;
+    gyro->read = mpuGyroRead;
+    gyro->intStatus = mpuCheckDataReady;
+
+    // 16.4 dps/lsb scalefactor
+    gyro->scale = 1.0f / 16.4f;
+
+    return true;
+}

--- a/src/main/drivers/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro_spi_mpu9250.h
@@ -1,0 +1,36 @@
+
+#pragma once
+
+#define mpu9250_CONFIG                      0x1A
+
+/* We should probably use these. :)
+#define BITS_DLPF_CFG_256HZ         0x00
+#define BITS_DLPF_CFG_188HZ         0x01
+#define BITS_DLPF_CFG_98HZ          0x02
+#define BITS_DLPF_CFG_42HZ          0x03
+#define BITS_DLPF_CFG_20HZ          0x04
+#define BITS_DLPF_CFG_10HZ          0x05
+#define BITS_DLPF_CFG_5HZ           0x06
+#define BITS_DLPF_CFG_2100HZ_NOLPF  0x07
+*/
+
+#define GYRO_SCALE_FACTOR  0.00053292f  // (4/131) * pi/180   (32.75 LSB = 1 DPS)
+
+#define MPU9250_WHO_AM_I_CONST              (0x71)
+
+#define MPU9250_BIT_RESET                   (0x80)
+
+// RF = Register Flag
+#define MPU_RF_DATA_RDY_EN (1 << 0)
+
+void mpu9250ResetGyro(void);
+
+bool mpu9250SpiDetect(void);
+
+bool mpu9250SpiAccDetect(accDev_t *acc);
+bool mpu9250SpiGyroDetect(gyroDev_t *gyro);
+
+bool mpu9250WriteRegister(uint8_t reg, uint8_t data);
+bool verifympu9250WriteRegister(uint8_t reg, uint8_t data);
+bool mpu9250ReadRegister(uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SlowReadRegister(uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -163,9 +163,9 @@ static const rxFailsafeChannelMode_e rxFailsafeModesTable[RX_FAILSAFE_TYPE_COUNT
 
 /* Sensor names (used in lookup tables for *_hardware settings and in status command output) */
 // sync with gyroSensor_e
-static const char * const gyroNames[] = { "NONE", "AUTO", "MPU6050", "L3G4200D", "MPU3050", "L3GD20", "MPU6000", "MPU6500", "FAKE"};
+static const char * const gyroNames[] = { "NONE", "AUTO", "MPU6050", "L3G4200D", "MPU3050", "L3GD20", "MPU6000", "MPU6500", "MPU9250", "FAKE"};
 // sync with accelerationSensor_e
-static const char * const lookupTableAccHardware[] = { "NONE", "AUTO", "ADXL345", "MPU6050", "MMA845x", "BMA280", "LSM303DLHC", "MPU6000", "MPU6500", "FAKE"};
+static const char * const lookupTableAccHardware[] = { "NONE", "AUTO", "ADXL345", "MPU6050", "MMA845x", "BMA280", "LSM303DLHC", "MPU6000", "MPU6500", "MPU9250", "FAKE"};
 #if (FLASH_SIZE > 64)
 // sync with baroSensor_e
 static const char * const lookupTableBaroHardware[] = { "NONE", "AUTO", "BMP085", "MS5611", "BMP280", "FAKE"};

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -33,7 +33,8 @@ typedef enum {
     ACC_LSM303DLHC = 6,
     ACC_MPU6000 = 7,
     ACC_MPU6500 = 8,
-    ACC_FAKE = 9,
+    ACC_MPU9250 = 9,
+    ACC_FAKE = 10,
     ACC_MAX = ACC_FAKE
 } accelerationSensor_e;
 

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -30,6 +30,7 @@ typedef enum {
     GYRO_L3GD20,
     GYRO_MPU6000,
     GYRO_MPU6500,
+    GYRO_MPU9250,
     GYRO_FAKE
 } gyroSensor_e;
 

--- a/src/main/target/BLUEJAYF4/target.h
+++ b/src/main/target/BLUEJAYF4/target.h
@@ -43,18 +43,16 @@
 #define USE_MPU_DATA_READY_SIGNAL
 //#define EXTI_CALLBACK_HANDLER_COUNT 1 // MPU data ready
 #define MPU_INT_EXTI            PC5
-#define MPU6500_CS_PIN          PC4
-#define MPU6500_SPI_INSTANCE    SPI1
+#define MPU9250_CS_PIN          PC4
+#define MPU9250_SPI_INSTANCE    SPI1
 
 #define ACC
-#define USE_ACC_MPU6500
-#define USE_ACC_SPI_MPU6500
-#define ACC_MPU6500_ALIGN       CW0_DEG
+#define USE_ACC_SPI_MPU9250
+#define ACC_MPU9250_ALIGN       CW0_DEG
 
 #define GYRO
-#define USE_GYRO_MPU6500
-#define USE_GYRO_SPI_MPU6500
-#define GYRO_MPU6500_ALIGN      CW0_DEG
+#define USE_GYRO_SPI_MPU9250
+#define GYRO_MPU9250_ALIGN      CW0_DEG
 
 #define MAG
 #define USE_MAG_AK8963

--- a/src/main/target/BLUEJAYF4/target.mk
+++ b/src/main/target/BLUEJAYF4/target.mk
@@ -2,8 +2,8 @@ F405_TARGETS    += $(TARGET)
 FEATURES        += SDCARD VCP ONBOARDFLASH
 
 TARGET_SRC = \
-            drivers/accgyro_spi_mpu6500.c \
             drivers/accgyro_mpu6500.c \
+            drivers/accgyro_spi_mpu9250.c \
             drivers/barometer_bmp085.c \
             drivers/barometer_bmp280.c \
             drivers/barometer_ms5611.c \

--- a/src/test/unit/sensor_gyro_unittest.cc
+++ b/src/test/unit/sensor_gyro_unittest.cc
@@ -69,6 +69,7 @@ TEST(SensorGyro, Init)
 TEST(SensorGyro, Read)
 {
     gyroInit();
+    EXPECT_EQ(GYRO_FAKE, detectedSensors[SENSOR_INDEX_GYRO]);
     fakeGyroSet(5, 6, 7);
     const bool read = gyro.dev.read(&gyro.dev);
     EXPECT_EQ(true, read);


### PR DESCRIPTION
Having explicit MPU9250 support makes `target.h` files clearer. It also makes it easier to support boards with dual gyros.