### PR TITLE
Report raw BARO via MSP_ALTITUDE message

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -646,11 +646,21 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
 
     case MSP_ALTITUDE:
 #if defined(NAV)
-        sbufWriteU32(dst, (uint32_t)lrintf(getEstimatedActualPosition(Z)));
-        sbufWriteU16(dst, (uint32_t)lrintf(getEstimatedActualVelocity(Z)));
+        sbufWriteU32(dst, lrintf(getEstimatedActualPosition(Z)));
+        sbufWriteU16(dst, lrintf(getEstimatedActualVelocity(Z)));
 #else
         sbufWriteU32(dst, 0);
         sbufWriteU16(dst, 0);
+#endif
+#if defined(BARO)
+        sbufWriteU32(dst, baroGetLatestAltitude());
+#else
+        sbufWriteU32(dst, 0);
+#endif
+#if defined(SONAR)
+        sbufWriteU32(dst, rangefinderGetLatestAltitude());
+#else
+        sbufWriteU32(dst, 0);
 #endif
         break;
 

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -657,11 +657,6 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
 #else
         sbufWriteU32(dst, 0);
 #endif
-#if defined(SONAR)
-        sbufWriteU32(dst, rangefinderGetLatestAltitude());
-#else
-        sbufWriteU32(dst, 0);
-#endif
         break;
 
     case MSP_SONAR_ALTITUDE:

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -269,6 +269,11 @@ int32_t baroCalculateAltitude(void)
     return baro.BaroAlt;
 }
 
+int32_t baroGetLatestAltitude(void)
+{
+    return baro.BaroAlt;
+}
+
 bool baroIsHealthy(void)
 {
     return true;

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -52,4 +52,5 @@ void baroSetCalibrationCycles(uint16_t calibrationCyclesRequired);
 uint32_t baroUpdate(void);
 bool baroIsReady(void);
 int32_t baroCalculateAltitude(void);
+int32_t baroGetLatestAltitude(void);
 bool baroIsHealthy(void);


### PR DESCRIPTION
Modify MSP_ALTITUDE to to report estimated altitude, raw baro and raw sonar values.
Support on Configurator end will be required as well.