### PR TITLE
SPRACINGF3EVO one softserial

### DIFF
--- a/src/main/target/SPRACINGF3EVO/target.c
+++ b/src/main/target/SPRACINGF3EVO/target.c
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
+ 
+//Speical version of SPRACINGF3EVO with one SoftSerial instead of two which enables two motors and four servos for airplanes with Rudder, Elevator and two Ailerons
 
 #include <stdint.h>
 
@@ -54,16 +56,16 @@ const uint16_t multiPWM[] = {
 
 const uint16_t airPPM[] = {
     PWM1  | (MAP_TO_PPM_INPUT << 8),     // PPM input
-    PWM2  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #1
-    PWM3  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #2
-    PWM4  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #1
-    PWM5  | (MAP_TO_SERVO_OUTPUT  << 8),
-    PWM6  | (MAP_TO_SERVO_OUTPUT  << 8),
-    PWM7  | (MAP_TO_SERVO_OUTPUT  << 8),
-    PWM8  | (MAP_TO_SERVO_OUTPUT  << 8),
-    PWM9  | (MAP_TO_SERVO_OUTPUT  << 8),
-    PWM10 | (MAP_TO_SERVO_OUTPUT  << 8),
-    PWM11 | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM2  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #1 Out1
+    PWM3  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #2 Out 2
+    PWM4  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #1 Out 3
+    PWM5  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #2 Out 4
+    PWM6  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #3 Out 5
+    PWM7  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #4 Out 6
+    PWM8  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #5 Out 7
+    PWM9  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #6 Out 8
+    PWM10 | (MAP_TO_SERVO_OUTPUT  << 8), // servo #7
+    PWM11 | (MAP_TO_SERVO_OUTPUT  << 8), // servo #8
     0xFFFF
 };
 
@@ -89,8 +91,8 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     { TIM2,  IO_TAG(PA1),  TIM_Channel_2, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1},  // PWM2
     { TIM15, IO_TAG(PA2),  TIM_Channel_1, TIM1_BRK_TIM15_IRQn,     1, IOCFG_AF_PP, GPIO_AF_9},  // PWM3
     { TIM15, IO_TAG(PA3),  TIM_Channel_2, TIM1_BRK_TIM15_IRQn,     1, IOCFG_AF_PP, GPIO_AF_9},  // PWM4
-    { TIM3,  IO_TAG(PA6),  TIM_Channel_1, TIM3_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2},  // PWM5
-    { TIM3,  IO_TAG(PA7),  TIM_Channel_2, TIM3_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2},  // PWM6
+    { TIM16, IO_TAG(PA6),  TIM_Channel_1, TIM1_UP_TIM16_IRQn,      1, IOCFG_AF_PP, GPIO_AF_1 }, // PWM5 - PA6  - TIM3_CH1, TIM8_BKIN, TIM1_BKIN, *TIM16_CH1
+    { TIM17, IO_TAG(PA7),  TIM_Channel_1, TIM1_TRG_COM_TIM17_IRQn, 1, IOCFG_AF_PP, GPIO_AF_1 }, // PWM6 - PA7  - TIM3_CH2, *TIM17_CH1, TIM1_CH1N, TIM8_CH1  
     { TIM3,  IO_TAG(PB0),  TIM_Channel_3, TIM3_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2},  // PWM7
     { TIM3,  IO_TAG(PB1),  TIM_Channel_4, TIM3_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2},  // PWM8
 

--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -14,6 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
+ 
+//Speical version of SPRACINGF3EVO with one SoftSerial instead of two which enables two motors and four servos for airplanes with Rudder, Elevator and two Ailerons
+
 
 #pragma once
 
@@ -62,8 +65,8 @@
 #define USE_UART2
 #define USE_UART3
 #define USE_SOFTSERIAL1
-#define USE_SOFTSERIAL2
-#define SERIAL_PORT_COUNT       6
+//#define USE_SOFTSERIAL2
+#define SERIAL_PORT_COUNT       5
 
 #define UART1_TX_PIN            PA9
 #define UART1_RX_PIN            PA10
@@ -75,12 +78,9 @@
 #define UART3_RX_PIN            PB11 // PB11 (AF7)
 
 #define SOFTSERIAL_1_TIMER      TIM3
-#define SOFTSERIAL_1_TIMER_RX_HARDWARE 5
-#define SOFTSERIAL_1_TIMER_TX_HARDWARE 6
+#define SOFTSERIAL_1_TIMER_RX_HARDWARE 7
+#define SOFTSERIAL_1_TIMER_TX_HARDWARE 8
 
-#define SOFTSERIAL_2_TIMER      TIM3
-#define SOFTSERIAL_2_TIMER_RX_HARDWARE 7
-#define SOFTSERIAL_2_TIMER_TX_HARDWARE 8
 
 #define USE_I2C
 #define I2C_DEVICE              (I2CDEV_1) // PB6/SCL, PB7/SDA
@@ -154,4 +154,4 @@
 #define TARGET_IO_PORTF         (BIT(0)|BIT(1)|BIT(4))
 
 #define USABLE_TIMER_CHANNEL_COUNT 12 // PPM, 8 PWM, UART3 RX/TX, LED Strip
-#define USED_TIMERS             (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(8) | TIM_N(15))
+#define USED_TIMERS             (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(8) | TIM_N(15)| TIM_N(16) | TIM_N(17))


### PR DESCRIPTION
This is a special version of SPRACINGF3EVO with one SoftSerial instead of two, which enables two motors and four servos for airplanes with Rudder, Elevator and two Ailerons. This is great if you want an FRSKY receiver together with telemetry, GPS and MWOSD in a SPRACING F3 EVO board. Maybe suits better for many INAV users than the current one? I guess that INAV is and will often be used in 4-servo airplane setups. Also the EVO board is great for those planes because of the logging to the microSD card.

Works perfect on bench - not flight tested yet.

Background:
Different IO pins have different timers connected, and timers are also shared for several IO pins. The matrix is a bit complex for IO vs timers. Servo and softserial can not share one timer, so timers has to be remapped together with interrupt to make it working.

Possible improvement:
Making the configuration and remapping of timers depending of the INAV configurator, If you eneable one softserial then get this mapping. If you enable two you get the previous one. However this change will add hardware related code in other parts of the code than the target files for SPRACINGF3EVO which not is good development from my understanding. To my understanding of the code it can not be done in only the target files.

