### PR TITLE
Displayport and ledstrip fixes

### DIFF
--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -218,6 +218,9 @@ static void updateFailsafeStatus(void)
         case FAILSAFE_RX_LOSS_DETECTED:
             failsafeIndicator = 'R';
             break;
+        case FAILSAFE_RX_LOSS_IDLE:
+            failsafeIndicator = 'I';
+            break;
 #if defined(NAV)
         case FAILSAFE_RETURN_TO_HOME:
             failsafeIndicator = 'H';

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -646,7 +646,7 @@ static void applyLedGpsLayer(bool updateNow, timeUs_t *timer)
     if (updateNow) {
         if (gpsPauseCounter > 0) {
             gpsPauseCounter--;
-        } else if (gpsFlashCounter >= gpsSol.numSat) {
+        } else if (gpsFlashCounter >= (gpsSol.numSat - 1)) {
             gpsFlashCounter = 0;
             gpsPauseCounter = blinkPauseLength;
         } else {


### PR DESCRIPTION
 * Fix failsafe stage indication in displayport code
 * Fix ledstrip GPS layer blinking out `numSat+1` satellites