### PR TITLE
Fixes for servo mixer

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2285,7 +2285,7 @@ static void cliServo(char *cmdline)
 #ifdef USE_SERVOS
 static void printServoMix(uint8_t dumpMask, const servoMixer_t *customServoMixers, const servoMixer_t *defaultCustomServoMixers)
 {
-    const char *format = "smix %d %d %d %d %d %d %d %d\r\n";
+    const char *format = "smix %d %d %d %d %d %d %d\r\n";
     for (uint32_t i = 0; i < MAX_SERVO_RULES; i++) {
         servoMixer_t customServoMixer = customServoMixers[i];
         if (customServoMixer.rate == 0) {

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -266,6 +266,7 @@ void loadCustomServoMixer(void)
             maxServoIndex = customServoMixers(i)->targetChannel;
         }
 
+        memcpy(&currentServoMixer[i], customServoMixers(i), sizeof(servoMixer_t));
         servoRuleCount++;
     }
 }


### PR DESCRIPTION
 * Removed last parameter from `smix` command output - it was garbage.
 * Fixed non-loading custom servo mixer