### PR TITLE
Add additional 1us delay for MPU6xxx CS pin assertion

### DIFF
--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -107,9 +107,11 @@ static IO_t mpuSpi6000CsPin = IO_NONE;
 bool mpu6000WriteRegister(uint8_t reg, uint8_t data)
 {
     ENABLE_MPU6000;
+    delayMicroseconds(1);
     spiTransferByte(MPU6000_SPI_INSTANCE, reg);
     spiTransferByte(MPU6000_SPI_INSTANCE, data);
     DISABLE_MPU6000;
+    delayMicroseconds(1);
 
     return true;
 }

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -43,9 +43,11 @@ static IO_t mpuSpi6500CsPin = IO_NONE;
 bool mpu6500WriteRegister(uint8_t reg, uint8_t data)
 {
     ENABLE_MPU6500;
+    delayMicroseconds(1);
     spiTransferByte(MPU6500_SPI_INSTANCE, reg);
     spiTransferByte(MPU6500_SPI_INSTANCE, data);
     DISABLE_MPU6500;
+    delayMicroseconds(1);
 
     return true;
 }


### PR DESCRIPTION
Looks like MPU9250 needs the extra delay after #CS pin asserion when doing a write to configuration registers.

Appears to fix the issue mentioned here: https://github.com/iNavFlight/inav/issues/1172#issuecomment-275939779