### PR TITLE
RTH improvements

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -170,6 +170,7 @@ Re-apply any new defaults as desired.
 |  nav_rth_climb_first  | ON | If set to ON drone will climb to nav_rth_altitude first and head home afterwards. If set to OFF drone will head home instantly and climb on the way. |
 |  nav_rth_tail_first  | OFF | If set to ON drone will return tail-first. Obviously meaningless for airplanes. |
 |  nav_rth_allow_landing  | ON | If set to ON drone will land as a last phase of RTH. |
+|  nav_rth_climb_ignore_emerg  | ON | If set to ON, aircraft will execute initial climb regardless of position sensor (GPS) status. |
 |  nav_rth_alt_mode  | AT_LEAST | Configure how the aircraft will manage altitude on the way home, se Navigation modes on wiki for more details |
 |  nav_rth_altitude  | 1000 | Used in EXTRA, FIXED and AT_LEAST rth alt modes (Default 1000 means 10 meters) |
 |  nav_mc_bank_angle  | 30 | Maximum banking angle (deg) that multicopter navigation is allowed to set. Machine must be able to satisfy this angle without loosing altitude |

--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -169,6 +169,7 @@ Re-apply any new defaults as desired.
 |  nav_min_rth_distance  | 500 | Minimum distance from homepoint when RTH can be activated [cm] |
 |  nav_rth_climb_first  | ON | If set to ON drone will climb to nav_rth_altitude first and head home afterwards. If set to OFF drone will head home instantly and climb on the way. |
 |  nav_rth_tail_first  | OFF | If set to ON drone will return tail-first. Obviously meaningless for airplanes. |
+|  nav_rth_allow_landing  | ON | If set to ON drone will land as a last phase of RTH. |
 |  nav_rth_alt_mode  | AT_LEAST | Configure how the aircraft will manage altitude on the way home, se Navigation modes on wiki for more details |
 |  nav_rth_altitude  | 1000 | Used in EXTRA, FIXED and AT_LEAST rth alt modes (Default 1000 means 10 meters) |
 |  nav_mc_bank_angle  | 30 | Maximum banking angle (deg) that multicopter navigation is allowed to set. Machine must be able to satisfy this angle without loosing altitude |

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -802,6 +802,7 @@ static const clivalue_t valueTable[] = {
     { "nav_emerg_landing_speed",    VAR_UINT16 | MASTER_VALUE, .config.minmax = { 100,  2000 }, PG_NAV_CONFIG, offsetof(navConfig_t, general.emerg_descent_rate) },
     { "nav_min_rth_distance",       VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0,  5000 }, PG_NAV_CONFIG, offsetof(navConfig_t, general.min_rth_distance) },
     { "nav_rth_climb_first",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_climb_first) },
+    { "nav_rth_climb_ignore_emerg", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_climb_ignore_emerg) },
     { "nav_rth_tail_first",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_tail_first) },
     { "nav_rth_allow_landing",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_allow_landing) },
     { "nav_rth_alt_mode",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_NAV_RTH_ALT_MODE }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_alt_control_mode) },

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -803,6 +803,7 @@ static const clivalue_t valueTable[] = {
     { "nav_min_rth_distance",       VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0,  5000 }, PG_NAV_CONFIG, offsetof(navConfig_t, general.min_rth_distance) },
     { "nav_rth_climb_first",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_climb_first) },
     { "nav_rth_tail_first",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_tail_first) },
+    { "nav_rth_allow_landing",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_allow_landing) },
     { "nav_rth_alt_mode",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_NAV_RTH_ALT_MODE }, PG_NAV_CONFIG, offsetof(navConfig_t, general.flags.rth_alt_control_mode) },
     { "nav_rth_abort_threshold",    VAR_UINT16 | MASTER_VALUE | MODE_MAX, .config.max = { 65000 }, PG_NAV_CONFIG, offsetof(navConfig_t, general.rth_abort_threshold) },
     { "nav_rth_altitude",           VAR_UINT16 | MASTER_VALUE | MODE_MAX, .config.max = { 65000 }, PG_NAV_CONFIG, offsetof(navConfig_t, general.rth_altitude) },

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -70,8 +70,8 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
             .extra_arming_safety = 1,
             .user_control_mode = NAV_GPS_ATTI,
             .rth_alt_control_mode = NAV_RTH_AT_LEAST_ALT,
-            .rth_climb_first = 1,                       // Climb first, turn after reaching safe altitude
-            .rth_ignore_energency_on_climb = 0,         // Ignore GPS loss on initial climb
+            .rth_climb_first = 1,                   // Climb first, turn after reaching safe altitude
+            .rth_climb_ignore_emerg = 0,            // Ignore GPS loss on initial climb
             .rth_tail_first = 0,
             .disarm_on_landing = 0,
             .rth_allow_landing = 1,
@@ -994,7 +994,7 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_INITIALIZE(navig
         return NAV_FSM_EVENT_SWITCH_TO_IDLE;
     }
     else {
-        if (posControl.flags.hasValidPositionSensor || navConfig()->general.flags.rth_ignore_energency_on_climb) {
+        if (posControl.flags.hasValidPositionSensor || navConfig()->general.flags.rth_climb_ignore_emerg) {
             // If close to home - reset home position and land
             if (posControl.homeDistance < navConfig()->general.min_rth_distance) {
                 setHomePosition(&posControl.actualState.pos, posControl.actualState.yaw, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_HEADING);
@@ -1038,7 +1038,7 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_CLIMB_TO_SAFE_AL
     UNUSED(previousState);
 
     // If we have valid pos sensor OR we are configured to ignore GPS loss
-    if (posControl.flags.hasValidPositionSensor || !checkForPositionSensorTimeout() || navConfig()->general.flags.rth_ignore_energency_on_climb) {
+    if (posControl.flags.hasValidPositionSensor || !checkForPositionSensorTimeout() || navConfig()->general.flags.rth_climb_ignore_emerg) {
         if (((posControl.actualState.pos.V.Z - posControl.homeWaypointAbove.pos.V.Z) > -50.0f) || (!navConfig()->general.flags.rth_climb_first)) {
             // Delayed initialization for RTH sanity check on airplanes - allow to finish climb first as it can take some distance
             if (STATE(FIXED_WING)) {

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -73,6 +73,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
             .rth_climb_first = 1,                         // Climb first, turn after reaching safe altitude
             .rth_tail_first = 0,
             .disarm_on_landing = 0,
+            .rth_allow_landing = 1,
         },
 
         // General navigation parameters
@@ -1152,11 +1153,7 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_LANDING(navigati
             return NAV_FSM_EVENT_SWITCH_TO_EMERGENCY_LANDING;
         }
 
-        if (STATE(FIXED_WING)) {
-            // FIXME: Continue loitering at home altitude
-            return NAV_FSM_EVENT_NONE;
-        }
-        else {
+        if (navConfig()->general.flags.rth_allow_landing) {
             // A safeguard - if sonar is available and it is reading < 50cm altitude - drop to low descend speed
             if (posControl.flags.hasValidSurfaceSensor && posControl.actualState.surface >= 0 && posControl.actualState.surface < 50.0f) {
                 // land_descent_rate == 200 : descend speed = 30 cm/s, gentle touchdown
@@ -1175,9 +1172,9 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_3D_LANDING(navigati
                 float descentVelLimited = MIN(-descentVelScaling * navConfig()->general.land_descent_rate, -50.0f);
                 updateAltitudeTargetFromClimbRate(descentVelLimited, CLIMB_RATE_RESET_SURFACE_TARGET);
             }
-
-            return NAV_FSM_EVENT_NONE;
         }
+
+        return NAV_FSM_EVENT_NONE;
     }
 }
 

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -100,7 +100,7 @@ typedef struct navConfig_s {
             uint8_t rth_tail_first;             // Return to home tail first
             uint8_t disarm_on_landing;          //
             uint8_t rth_allow_landing;          // Enable landing as last stage of RTH
-            uint8_t rth_ignore_energency_on_climb;  // Option to ignore GPS loss on initial climb stage of RTH
+            uint8_t rth_climb_ignore_emerg;     // Option to ignore GPS loss on initial climb stage of RTH
         } flags;
 
         uint8_t  pos_failure_timeout;           // Time to wait before switching to emergency landing (0 - disable)

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -100,6 +100,7 @@ typedef struct navConfig_s {
             uint8_t rth_tail_first;             // Return to home tail first
             uint8_t disarm_on_landing;          //
             uint8_t rth_allow_landing;          // Enable landing as last stage of RTH
+            uint8_t rth_ignore_energency_on_climb;  // Option to ignore GPS loss on initial climb stage of RTH
         } flags;
 
         uint8_t  pos_failure_timeout;           // Time to wait before switching to emergency landing (0 - disable)

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -99,6 +99,7 @@ typedef struct navConfig_s {
             uint8_t rth_climb_first;            // Controls the logic for initial RTH climbout
             uint8_t rth_tail_first;             // Return to home tail first
             uint8_t disarm_on_landing;          //
+            uint8_t rth_allow_landing;          // Enable landing as last stage of RTH
         } flags;
 
         uint8_t  pos_failure_timeout;           // Time to wait before switching to emergency landing (0 - disable)


### PR DESCRIPTION
- [x] Option to ignore GPS loss (don't execute emergency landing) during initial stage of RTH. CLI: `nav_rth_climb_ignore_emerg`
- [x] Option to enable/disable landing at last stage of RTH (all aircrafts). CLI: `nav_rth_allow_landing`

Closes #994 and #964