### PR TITLE
Revert P-gain TPA scaling to pre-PIFF to allow direct migration of previously tuned PIDs

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -340,7 +340,7 @@ void updatePIDCoefficients(void)
     for (int axis = 0; axis < 3; axis++) {
         if (STATE(FIXED_WING)) {
             // Airplanes - scale all PIDs according to TPA
-            pidState[axis].kP  = pidBank()->pid[axis].P / FP_PID_RATE_P_MULTIPLIER  * tpaFactor * tpaFactor;
+            pidState[axis].kP  = pidBank()->pid[axis].P / FP_PID_RATE_P_MULTIPLIER  * tpaFactor;
             pidState[axis].kI  = pidBank()->pid[axis].I / FP_PID_RATE_I_MULTIPLIER  * tpaFactor;
             pidState[axis].kD  = 0.0f;
             pidState[axis].kFF = pidBank()->pid[axis].D / FP_PID_RATE_FF_MULTIPLIER * tpaFactor;


### PR DESCRIPTION
There are some reports of PIFF controller being harder to tune. I suspect this is because of error-driven loop is scaled by TPA^2. This PR will allow direct usage of TPA, P and I-gains from old setups.