### PR TITLE
LED strips enabled on AirbotF4 target

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -294,7 +294,7 @@ void validateAndFixConfig(void)
 #if defined(LED_STRIP) && (defined(USE_SOFTSERIAL1) || defined(USE_SOFTSERIAL2))
     if (featureConfigured(FEATURE_SOFTSERIAL) && (
             0
-#ifdef USE_SOFTSERIAL1
+#if defined(USE_SOFTSERIAL1) && defined(SOFTSERIAL_1_TIMER)
             || (WS2811_TIMER == SOFTSERIAL_1_TIMER)
 #endif
 #ifdef USE_SOFTSERIAL2

--- a/src/main/target/AIRBOTF4/target.h
+++ b/src/main/target/AIRBOTF4/target.h
@@ -119,7 +119,7 @@
 
 #define SENSORS_SET (SENSOR_ACC|SENSOR_MAG|SENSOR_BARO)
 
-// #define LED_STRIP
+#define LED_STRIP
 // LED Strip can run off Pin 5 (PA1) of the MOTOR outputs.
 #define WS2811_GPIO_AF                  GPIO_AF_TIM5
 #define WS2811_PIN                      PA1


### PR DESCRIPTION
Looks like the reason it was not working before was DMA conflict with UART implementation.
Verified, working. Probably works on Omnibus F4 too, but do not have a board on me now