### PR TITLE
Time overflow issues

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -130,7 +130,7 @@ timeUs_t microsISR(void)
         pending = sysTickPending;
     }
 
-    return ((ms + pending) * 1000) + (usTicks * 1000 - cycle_cnt) / usTicks;
+    return ((timeUs_t)(ms + pending) * 1000LL) + (usTicks * 1000LL - (timeUs_t)cycle_cnt) / usTicks;
 }
 
 timeUs_t micros(void)
@@ -154,7 +154,7 @@ timeUs_t micros(void)
          */
         asm volatile("\tnop\n");
     } while (ms != sysTickUptime);
-    return (ms * 1000) + (usTicks * 1000 - cycle_cnt) / usTicks;
+    return ((timeUs_t)ms * 1000LL) + (usTicks * 1000LL - (timeUs_t)cycle_cnt) / usTicks;
 }
 
 // Return system uptime in milliseconds (rollover in 49 days)

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -64,7 +64,7 @@ void imuConfigure(void);
 
 void imuUpdateAttitude(timeUs_t currentTimeUs);
 void imuUpdateAccelerometer(void);
-void imuUpdateGyroscope(uint32_t gyroUpdateDeltaUs);
+void imuUpdateGyroscope(timeUs_t gyroUpdateDeltaUs);
 float calculateCosTiltAngle(void);
 bool isImuReady(void);
 bool isImuHeadingValid(void);


### PR DESCRIPTION
- Fix micros() returning gibberish after crossing the 32-bit boundary
- Optimisation to async gyro