### PR TITLE
Enable MSP on UART1 for targets with VCP

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -116,9 +116,13 @@ void pgResetFn_serialConfig(serialConfig_t *serialConfig)
 
     serialConfig->portConfigs[0].functionMask = FUNCTION_MSP;
 
-#ifdef CC3D
-    // This allows MSP connection via USART & VCP so the board can be reconfigured.
-    serialConfig->portConfigs[1].functionMask = FUNCTION_MSP;
+#ifdef USE_VCP
+    if (serialConfig->portConfigs[0].identifier == SERIAL_PORT_USB_VCP) {
+        serialPortConfig_t * uart1Config = serialFindPortConfiguration(SERIAL_PORT_USART1);
+        if (uart1Config) {
+            uart1Config->functionMask = FUNCTION_MSP;
+        }
+    }
 #endif
 
     serialConfig->reboot_character = 'R';


### PR DESCRIPTION
Per #1260 

In case VCP is damaged but the board has UART1 exposed one will still be able to flash the board and use it via UART1 (built-in bootloader of STM32F3+ operates on both USB and  UART1).

Implementation won't enable additional MSP port on targets with VCP but _without_ UART1.