### PR TITLE
Set default servo LPF to some practical value

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -67,8 +67,8 @@ PG_REGISTER_WITH_RESET_TEMPLATE(servoConfig_t, servoConfig, PG_SERVO_CONFIG, 0);
 
 PG_RESET_TEMPLATE(servoConfig_t, servoConfig,
     .servoCenterPulse = 1500,
-    .servoPwmRate = 50,
-    .servo_lowpass_freq = 0,
+    .servoPwmRate = 50,             // Default for analog servos
+    .servo_lowpass_freq = 20,       // Default servo update rate is 50Hz, everything above Nyquist frequency (25Hz) is going to fold and cause distortions
     .flaperon_throw_offset = FLAPERON_THROW_DEFAULT,
     .flaperon_throw_inverted = 0,
     .tri_unarmed_servo = 1


### PR DESCRIPTION
Today when testing my S800 wing I noticed that in acro servos were jittering at constant stick input and airplane on the bench. I figure PID loop was reactng to gyro noise of c. 0.5-1dps occuring at high frequency.

After tinkering with it for a while I realised that I'm in fact looking at aliasing issues. Out servos are updated (sampled) at 50Hz rate meaning that anything above 25Hz being fed into the servos will be folded (aliased) down to low frequencies and cause jitter. Setting `servo_lpf_hz` to something practical like 20Hz eliminated the jitter issue.

This PR updated servo lpf to 20Hz which is almost the highest possible value given the default servo update frequency of 50Hz.