### PR TITLE
LED enabled on Omnibus F4 (and Pro) targets

### DIFF
--- a/docs/Board - Airbot F4 and Flip32 F4.md
+++ b/docs/Board - Airbot F4 and Flip32 F4.md
@@ -74,7 +74,7 @@ it can do without overeating (150mA on 4S gives 1.5W of waste heat!). OSD, LED S
 
 ## LED Strip
 
-Right now, LED strip is not functioning correctly on this target. It is a known bug. When bug will be fixed, LED Strip should be connected to **MOTOR 5** output, not dedicated "LED" connector.
+LED strip is enabled on Motor 5 pin (PA1)
 
 ## SoftwareSerial
 

--- a/docs/Board - Omnibus F4.md
+++ b/docs/Board - Omnibus F4.md
@@ -2,6 +2,8 @@
 
 ![Omnibus F4](https://quadmeup.com/wp-content/uploads/2016/11/Omnibus-F4-Pinout-Top-Full-768x447.jpg)
 
+For Omnibus F4 Pro (v2 with BMP280 baro, current sensor and SD Card use Omnibus F4 Pro target)
+
 ## Features
 
 * STM32F405 CPU
@@ -73,7 +75,7 @@ it can do without overeating (150mA on 4S gives 1.5W of waste heat!). OSD, LED S
 
 ## LED Strip
 
-Right now, LED strip is not functioning correctly on this target. It is a known bug. When bug will be fixed, LED Strip should be connected to **MOTOR 5** output, not dedicated "LED" connector.
+LED strip is enabled on Motor 5 pin (PA1)
 
 ## SoftwareSerial
 

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -166,7 +166,7 @@
 
 #define SENSORS_SET (SENSOR_ACC|SENSOR_MAG|SENSOR_BARO)
 
-// #define LED_STRIP
+#define LED_STRIP
 // LED Strip can run off Pin 5 (PA1) of the MOTOR outputs.
 #define WS2811_GPIO_AF                  GPIO_AF_TIM5
 #define WS2811_PIN                      PA1


### PR DESCRIPTION
as @flounderscore tested in #957 , LED now works on Omnibus F4
So, enabled in target