### PR TITLE
Fix incorrect default calculation for map command

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2780,7 +2780,7 @@ static void cliBeeper(char *cmdline)
 
 static void printMap(uint8_t dumpMask, const rxConfig_t *rxConfig, const rxConfig_t *defaultRxConfig)
 {
-    bool equalsDefault = false;
+    bool equalsDefault = true;
     char buf[16];
     char bufDefault[16];
     uint32_t i;


### PR DESCRIPTION
Per @sambas report on Slack