### PR TITLE
Add EPE sanity check on GPS data for pos/vel/accBias corrections

### DIFF
--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -600,7 +600,7 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
     bool isGPSValid = sensors(SENSOR_GPS) &&
                       posControl.gpsOrigin.valid &&
                       ((currentTimeUs - posEstimator.gps.lastUpdateTime) <= MS2US(INAV_GPS_TIMEOUT_MS)) &&
-                      (posEstimator.gps.eph > positionEstimationConfig()->max_eph_epv);   // EPV is checked later
+                      (posEstimator.gps.eph < positionEstimationConfig()->max_eph_epv);   // EPV is checked later
     bool isBaroValid = sensors(SENSOR_BARO) && ((currentTimeUs - posEstimator.baro.lastUpdateTime) <= MS2US(INAV_BARO_TIMEOUT_MS));
     bool isSonarValid = sensors(SENSOR_SONAR) && ((currentTimeUs - posEstimator.sonar.lastUpdateTime) <= MS2US(INAV_SONAR_TIMEOUT_MS));
 
@@ -636,7 +636,7 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
 #endif
 
     /* Validate EPV for GPS and calculate altitude/climb rate correction flags */
-    const bool isGPSZValid = (posEstimator.gps.epv > positionEstimationConfig()->max_eph_epv);
+    const bool isGPSZValid = (posEstimator.gps.epv < positionEstimationConfig()->max_eph_epv);
     const bool useGpsZPos = STATE(FIXED_WING) && isGPSValid && !sensors(SENSOR_BARO) && isGPSZValid;
     const bool useGpsZVel = isGPSValid && isGPSZValid;
 


### PR DESCRIPTION
Bug reported on RCG:
>Today j update my quad 250, SPRACINGF3,with INAV 1.6 RC1, after 3 minutes and 28 secondes the quad fall on ground , motor on minimum 1070. j dont understand what append. Before j have the INAV 1.5.1 and j flight many time with no problem. J have BB but it s difficult for know what problem.

According to logs it a GPS glitch that messed up accelerometer bias correction and caused position estimator to go crazy.