### PR TITLE
Barometer calibration improvement

### DIFF
--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -230,11 +230,11 @@ static void performBaroCalibrationCycle(void)
     baroGroundPressure += baroPressure;
     baroGroundAltitude = (1.0f - powf((baroGroundPressure / 8) / 101325.0f, 0.190295f)) * 4433000.0f;
 
-    if (baroGroundPressure==savedGroundPressure)
-      calibratingB=0;
+    if (baroGroundPressure == savedGroundPressure)
+        calibratingB = 0;
     else {
-      calibratingB--;
-      savedGroundPressure=baroGroundPressure;
+        calibratingB--;
+        savedGroundPressure = baroGroundPressure;
     }
 }
 

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -224,7 +224,7 @@ uint32_t baroUpdate(void)
 
 static void performBaroCalibrationCycle(void)
 {
-    static int32_t savedGroundPressure=0;
+    static int32_t savedGroundPressure = 0;
 
     baroGroundPressure -= baroGroundPressure / 8;
     baroGroundPressure += baroPressure;

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -48,7 +48,7 @@ baro_t baro;                        // barometer access functions
 static uint16_t calibratingB = 0;      // baro calibration = get new ground pressure value
 static int32_t baroPressure = 0;
 static int32_t baroGroundAltitude = 0;
-static int32_t baroGroundPressure = 0;
+static int32_t baroGroundPressure = 8*101325;
 
 static barometerConfig_t *barometerConfig;
 
@@ -224,11 +224,18 @@ uint32_t baroUpdate(void)
 
 static void performBaroCalibrationCycle(void)
 {
+    static int32_t savedGroundPressure=0;
+
     baroGroundPressure -= baroGroundPressure / 8;
     baroGroundPressure += baroPressure;
     baroGroundAltitude = (1.0f - powf((baroGroundPressure / 8) / 101325.0f, 0.190295f)) * 4433000.0f;
 
-    calibratingB--;
+    if (baroGroundPressure==savedGroundPressure)
+      calibratingB=0;
+    else {
+      calibratingB--;
+      savedGroundPressure=baroGroundPressure;
+    }
 }
 
 int32_t baroCalculateAltitude(void)


### PR DESCRIPTION
Assumes pressure to be 1 std atm (101325 Pa) before first calibration to dampen overshoot.
Stops calibration early when measurements (moving average) are stable.
One should consider changing CALIBRATING_BARO_CYCLES from 200 to, say, 50 when ground pressure is initialized to 1 std atm.