### PR TITLE
Target version SPRACINGF3EVO_1SS

### DIFF
--- a/docs/Board - SPRacingF3EVO.md
+++ b/docs/Board - SPRacingF3EVO.md
@@ -1,0 +1,160 @@
+# Board - Seriously Pro SP Racing F3 EVO
+
+The Seriously Pro Racing F3 Evo board (SPRacingF3EVO) is the evolution of the first board designed specifically for Cleanflight.
+
+Purchasing boards directly from SeriouslyPro / SP Racing and official retailers helps fund Cleanflight development, it's the reason the Seriously Pro boards exist!  Official retailers are always listed on the SeriouslyPro.com website.
+
+Full details available on the website, here:
+
+http://seriouslypro.com/spracingf3evo
+
+## Hardware Features
+
+* Next-generation STM32 F3 processor with hardware floating point unit for efficient flight calculations and faster ARM-Cortex M4 core.
+* MicroSD-Card socket for black box flight log recorder - optimize your tuning and see the results of your setup without guesswork.
+* Race transponder built in - just turn up at a race and have your lap times recorded.
+* Features the latest Accelerometer, Gyro and Mag/Compass and Baro/Altitude sensor technology.
+* Wire up using using pin headers for all major connections for excellent crash-durability.  Use either right-angled or straight pin-headers.
+* No compromise I/O. Use all the features all the time; e.g. Connect your USB + OSD + SmartPort + SBus + GPS + LED Strip + Battery Monitoring + 8 motors - all at the same time! (Sonar will be supported in CF 1.14)
+* 8 PWM output lines for ESCs and Servos. Arranged for easy wiring on standard pin headers.
+* Supports direct connection of SBus, SumH, SumD, Spektrum1024/2048, XBus receivers. No external inverters required (built-in).
+* Supports direct connection of 3.3v Spektrum Satellite receivers via 3 pin through-hole JST-ZH connector.
+* Dedicated PPM receiver input.
+* 3 Serial Ports - NOT shared with the USB socket.
+* Telemetry port
+* Micro USB socket. 
+* Dedicated output for programmable LEDs - great for orientation, racing and night flying. (Currently mutually exclusive with the Transponder).
+* Dedicated I2C port for connection of OLED display without needing flight battery.
+* Battery monitoring for voltage and current.
+* RSSI monitoring (analogue or PWM).
+* Buzzer port for audible warnings and notifications.
+* Developer friendly debugging port (SWD) and boot mode selection, unbrickable bootloader.
+* Symmetrical design for a super tidy wiring.
+* JST-SH sockets only for I2C, UART2 and SWD.  UART2 also on through-hole pins.
+* Flashing via USB or serial port.
+* Stackable design - perfect for integrating with OSDs and power distribution boards.
+* Standard mounting - 36x36mm with standard 30.5mm mounting holes.
+* LEDs for 3v, 5v and Status for easy diagnostics.
+* Copper-etched Cleanflight logo.
+
+## Serial Ports
+
+| Value | Identifier   | RX           | TX           | 5v Tolerant | Notes                                                                                       |
+| ----- | ------------ | ------------ | ------------ | ----------- | ------------------------------------------------------------------------------------------- |
+| 1     | USART1       | PA10         | PA9          | YES         | 2 through-hole pins. Use for connecting to OSD/GPS/BlueTooth. |
+| 2     | USART2       | PA15         | PA14 / SWCLK | YES         | JST socket and PPM header. Use to connect to RX. |
+| 3     | USART3       | PB11 / AF7   | PB10 / AF7   | NO          | Available on 4 through-hole pins. 3.3V signals only ! Use for GPS, Spektrum Satellite RX, SmartPort Telemetry, HoTT telemetry, etc. |
+
+* You cannot use SWD and USART2 at the same time.
+* When using a Serial RX receiver the TXD (T2) pin cannot be used for telemetry. Use UART3 TXD instead.
+* Two SoftSerial is supported. Enabling SoftSerial disables Servo output 3,4,5,6
+* Windows DFU Flashing requires Zadig (see configurator)
+
+### SoftSerial
+
+| Pin | Function       | Notes                            |
+| --- | -------------- | -------------------------------- |
+| 5   | SOFTSERIAL1 RX | SoftSerial replaces Servo 3,4,5,6|
+| 6   | SOFTSERIAL1 TX |                                  |
+| 7   | SOFTSERIAL2 RX |                                  |
+| 8   | SOFTSERIAL2 TX |                                  |
+
+
+## Pinouts
+
+Full pinout details are available in the manual, here:
+
+http://seriouslypro.com/files/SPRacingF3EVO-Manual-latest.pdf
+
+### IO_1
+
+The 6 pin IO_1 connector has the following pinouts when used in RX_SERIAL mode.
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | Ground         |                                              |
+| 2   | VCC_IN         | Voltage as-supplied by BEC.                  |
+| 3   | RX_SERIAL      | Enable `feature RX_SERIAL` |
+| 4   | | |
+| 5   | +V BATTERY     | Voltage as-supplied by Battery.              |
+| 6   | -V BATTERY     | Voltage as-supplied by Battery.              |
+
+When RX_PPM is used the IO_1 pinout is as follows.
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | Ground         |                                              |
+| 2   | VCC_IN         | Voltage as-supplied by BEC.                  |
+| 3   | RX_PPM         | Enable `feature RX_PPM`                      |
+| 4   | TELEMETRY      | Enable `feature TELEMETRY`                   |
+| 5   | +V BATTERY     | Voltage as-supplied by Battery.              |
+| 6   | -V BATTERY     | Voltage as-supplied by Battery.              |
+
+### IO_2
+
+When TRANSPONDER is used and the IR solder pads are shorted, the 6 pin IO_2 pinout is as follows.
+
+| Pin | Function                  | Notes                                        |
+| --- | ------------------------- | -------------------------------------------- |
+| 1   | IR-                       | Short leg of the IR LED                      |
+| 2   | IR+                       | Long leg of the IR LED                       |
+| 3   | CURRENT                   | Current Sensor                               |
+| 4   | RSSI                      | RSSI (PWM or Analog - select by solder pads) |
+| 5   | BUZZER+                   | 5V Source                                    |
+| 6   | BUZZER-                   | Buzzer signal                                |
+
+When LEDSTRIP is used and the LED solder pads are shorted, the 6 pin IO_2 pinout is as follows.
+
+| Pin | Function                  | Notes                                        |
+| --- | ------------------------- | -------------------------------------------- |
+| 1   | | |
+| 2   | LEDSTRIP                  | WS2812 Ledstrip data                         |
+| 3   | CURRENT                   | Current Sensor                               |
+| 4   | RSSI                      | RSSI (PWM or Analog - select by solder pads) |
+| 5   | BUZZER+                   | 5V Source                                    |
+| 6   | BUZZER-                   | Buzzer signal                                |
+
+### UART1
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 3   | TXD            |                                              |
+| 4   | RXD            |                                              |
+
+### UART2/3
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | Ground         |                                              |
+| 2   | VCC_IN         | Voltage as-supplied by BEC.                  |
+| 3   | TXD            |                                              |
+| 4   | RXD            |                                              |
+
+### Spektrum Satellite
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 3   | 3.3V           |                                              |
+| 2   | Ground         |                                              |
+| 1   | RXD            |                                              |
+
+### I2C
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | Ground         |                                              |
+| 2   | 5.0v           | Voltage as-supplied by BEC OR USB, always on |
+| 3   | SCL            | 3.3V signals only                            |
+| 4   | SDA            | 3.3V signals only                            |
+
+### SWD
+
+The port cannot be used at the same time as UART2.
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | Ground         |                                              |
+| 2   | NRST           |                                              |
+| 3   | SWDIO          |                                              |
+| 4   | SWDCLK         |                                              |
+

--- a/docs/Board - SPRacingF3EVO_1SS.md
+++ b/docs/Board - SPRacingF3EVO_1SS.md
@@ -1,0 +1,159 @@
+# Board - Seriously Pro SP Racing F3 EVO
+
+The Seriously Pro Racing F3 Evo board (SPRacingF3EVO) is the evolution of the first board designed specifically for Cleanflight.
+
+Purchasing boards directly from SeriouslyPro / SP Racing and official retailers helps fund Cleanflight development, it's the reason the Seriously Pro boards exist!  Official retailers are always listed on the SeriouslyPro.com website.
+
+Full details available on the website, here:
+
+http://seriouslypro.com/spracingf3evo
+
+## Hardware Features
+
+* Next-generation STM32 F3 processor with hardware floating point unit for efficient flight calculations and faster ARM-Cortex M4 core.
+* MicroSD-Card socket for black box flight log recorder - optimize your tuning and see the results of your setup without guesswork.
+* Race transponder built in - just turn up at a race and have your lap times recorded.
+* Features the latest Accelerometer, Gyro and Mag/Compass and Baro/Altitude sensor technology.
+* Wire up using using pin headers for all major connections for excellent crash-durability.  Use either right-angled or straight pin-headers.
+* No compromise I/O. Use all the features all the time; e.g. Connect your USB + OSD + SmartPort + SBus + GPS + LED Strip + Battery Monitoring + 8 motors - all at the same time! (Sonar will be supported in CF 1.14)
+* 8 PWM output lines for ESCs and Servos. Arranged for easy wiring on standard pin headers.
+* Supports direct connection of SBus, SumH, SumD, Spektrum1024/2048, XBus receivers. No external inverters required (built-in).
+* Supports direct connection of 3.3v Spektrum Satellite receivers via 3 pin through-hole JST-ZH connector.
+* Dedicated PPM receiver input.
+* 3 Serial Ports - NOT shared with the USB socket.
+* Telemetry port
+* Micro USB socket. 
+* Dedicated output for programmable LEDs - great for orientation, racing and night flying. (Currently mutually exclusive with the Transponder).
+* Dedicated I2C port for connection of OLED display without needing flight battery.
+* Battery monitoring for voltage and current.
+* RSSI monitoring (analogue or PWM).
+* Buzzer port for audible warnings and notifications.
+* Developer friendly debugging port (SWD) and boot mode selection, unbrickable bootloader.
+* Symmetrical design for a super tidy wiring.
+* JST-SH sockets only for I2C, UART2 and SWD.  UART2 also on through-hole pins.
+* Flashing via USB or serial port.
+* Stackable design - perfect for integrating with OSDs and power distribution boards.
+* Standard mounting - 36x36mm with standard 30.5mm mounting holes.
+* LEDs for 3v, 5v and Status for easy diagnostics.
+* Copper-etched Cleanflight logo.
+
+## Serial Ports
+
+| Value | Identifier   | RX           | TX           | 5v Tolerant | Notes                                                                                       |
+| ----- | ------------ | ------------ | ------------ | ----------- | ------------------------------------------------------------------------------------------- |
+| 1     | USART1       | PA10         | PA9          | YES         | 2 through-hole pins. Use for connecting to OSD/GPS/BlueTooth. |
+| 2     | USART2       | PA15         | PA14 / SWCLK | YES         | JST socket and PPM header. Use to connect to RX. |
+| 3     | USART3       | PB11 / AF7   | PB10 / AF7   | NO          | Available on 4 through-hole pins. 3.3V signals only ! Use for GPS, Spektrum Satellite RX, SmartPort Telemetry, HoTT telemetry, etc. |
+
+* You cannot use SWD and USART2 at the same time.
+* When using a Serial RX receiver the TXD (T2) pin cannot be used for telemetry. Use UART3 TXD instead.
+* One Software serial is supported in th SPRacingF3EVO_1SS version, see table below
+* Windows DFU Flashing requires Zadig (see configurator)
+
+### SoftSerial
+
+| Pin | Function       | Notes                            |
+| --- | -------------- | -------------------------------- |
+| 7   | SOFTSERIAL1 RX | SoftSerial disables Servo 5,6    |
+| 8   | SOFTSERIAL1 TX |                                  |
+
+## Pinouts
+
+Full pinout details are available in the manual, here:
+
+http://seriouslypro.com/files/SPRacingF3EVO-Manual-latest.pdf
+
+### IO_1
+
+The 6 pin IO_1 connector has the following pinouts when used in RX_SERIAL mode.
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | Ground         |                                              |
+| 2   | VCC_IN         | Voltage as-supplied by BEC.                  |
+| 3   | RX_SERIAL      | Enable `feature RX_SERIAL` |
+| 4   | | |
+| 5   | +V BATTERY     | Voltage as-supplied by Battery.              |
+| 6   | -V BATTERY     | Voltage as-supplied by Battery.              |
+
+When RX_PPM is used the IO_1 pinout is as follows.
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | Ground         |                                              |
+| 2   | VCC_IN         | Voltage as-supplied by BEC.                  |
+| 3   | RX_PPM         | Enable `feature RX_PPM`                      |
+| 4   | TELEMETRY      | Enable `feature TELEMETRY`                   |
+| 5   | +V BATTERY     | Voltage as-supplied by Battery.              |
+| 6   | -V BATTERY     | Voltage as-supplied by Battery.              |
+
+### IO_2
+
+When TRANSPONDER is used and the IR solder pads are shorted, the 6 pin IO_2 pinout is as follows.
+
+| Pin | Function                  | Notes                                        |
+| --- | ------------------------- | -------------------------------------------- |
+| 1   | IR-                       | Short leg of the IR LED                      |
+| 2   | IR+                       | Long leg of the IR LED                       |
+| 3   | CURRENT                   | Current Sensor                               |
+| 4   | RSSI                      | RSSI (PWM or Analog - select by solder pads) |
+| 5   | BUZZER+                   | 5V Source                                    |
+| 6   | BUZZER-                   | Buzzer signal                                |
+
+When LEDSTRIP is used and the LED solder pads are shorted, the 6 pin IO_2 pinout is as follows.
+
+| Pin | Function                  | Notes                                        |
+| --- | ------------------------- | -------------------------------------------- |
+| 1   | | |
+| 2   | LEDSTRIP                  | WS2812 Ledstrip data                         |
+| 3   | CURRENT                   | Current Sensor                               |
+| 4   | RSSI                      | RSSI (PWM or Analog - select by solder pads) |
+| 5   | BUZZER+                   | 5V Source                                    |
+| 6   | BUZZER-                   | Buzzer signal                                |
+
+### UART1
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 3   | TXD            |                                              |
+| 4   | RXD            |                                              |
+
+### UART2/3
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | Ground         |                                              |
+| 2   | VCC_IN         | Voltage as-supplied by BEC.                  |
+| 3   | TXD            |                                              |
+| 4   | RXD            |                                              |
+
+### Spektrum Satellite
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 3   | 3.3V           |                                              |
+| 2   | Ground         |                                              |
+| 1   | RXD            |                                              |
+
+### I2C
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | Ground         |                                              |
+| 2   | 5.0v           | Voltage as-supplied by BEC OR USB, always on |
+| 3   | SCL            | 3.3V signals only                            |
+| 4   | SDA            | 3.3V signals only                            |
+
+### SWD
+
+The port cannot be used at the same time as UART2.
+
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | Ground         |                                              |
+| 2   | NRST           |                                              |
+| 3   | SWDIO          |                                              |
+| 4   | SWDCLK         |                                              |
+
+
+

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -271,7 +271,7 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
             }
 #endif
 
-#if defined(SPRACINGF3EVO)
+#if defined(SPRACINGF3EVO) || defined(SPRACINGF3EVO_1SS)
             if ((timerIndex == PWM8 || timerIndex == PWM9) && timerHardwarePtr->tim == TIM3) {
                 type = MAP_TO_SERVO_OUTPUT;
             }
@@ -323,7 +323,7 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
                     type = MAP_TO_SERVO_OUTPUT;
 #endif
 
-#if defined(SPRACINGF3EVO)
+#if defined(SPRACINGF3EVO) || defined(SPRACINGF3EVO_1SS)
             if ((timerIndex == PWM6 || timerIndex == PWM7 || timerIndex == PWM8 || timerIndex == PWM9) && timerHardwarePtr->tim == TIM3) {
                 type = MAP_TO_SERVO_OUTPUT;
             }

--- a/src/main/target/SPRACINGF3EVO_1SS/target.c
+++ b/src/main/target/SPRACINGF3EVO_1SS/target.c
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+const uint16_t multiPPM[] = {
+    PWM1  | (MAP_TO_PPM_INPUT    << 8),  // PPM input
+
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM11 | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const uint16_t multiPWM[] = {
+    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM6  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM11 | (MAP_TO_MOTOR_OUTPUT << 8),
+    0xFFFF
+};
+
+const uint16_t airPPM[] = {
+    PWM1  | (MAP_TO_PPM_INPUT << 8),     // PPM input
+    PWM2  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #1 Out1
+    PWM3  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #2 Out 2
+    PWM4  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #1 Out 3
+    PWM5  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #2 Out 4
+    PWM6  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #3 Out 5
+    PWM7  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #4 Out 6
+    PWM8  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #5 Out 7
+    PWM9  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #6 Out 8
+    PWM10 | (MAP_TO_SERVO_OUTPUT  << 8), // servo #7
+    PWM11 | (MAP_TO_SERVO_OUTPUT  << 8), // servo #8
+    0xFFFF
+};
+
+const uint16_t airPWM[] = {
+    PWM2  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #1
+    PWM3  | (MAP_TO_MOTOR_OUTPUT  << 8), // motor #2
+    PWM4  | (MAP_TO_SERVO_OUTPUT  << 8), // servo #1
+    PWM5  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM6  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM7  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM8  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM9  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM10 | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM11 | (MAP_TO_SERVO_OUTPUT  << 8),
+    0xFFFF
+};
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    // PPM / UART2 RX
+    { TIM8,  IO_TAG(PA15), TIM_Channel_1, TIM8_CC_IRQn,            0, IOCFG_AF_PP, GPIO_AF_2},  // PPM
+
+    { TIM2,  IO_TAG(PA0),  TIM_Channel_1, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1},  // PWM1
+    { TIM2,  IO_TAG(PA1),  TIM_Channel_2, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1},  // PWM2
+    { TIM15, IO_TAG(PA2),  TIM_Channel_1, TIM1_BRK_TIM15_IRQn,     1, IOCFG_AF_PP, GPIO_AF_9},  // PWM3
+    { TIM15, IO_TAG(PA3),  TIM_Channel_2, TIM1_BRK_TIM15_IRQn,     1, IOCFG_AF_PP, GPIO_AF_9},  // PWM4
+    { TIM16, IO_TAG(PA6),  TIM_Channel_1, TIM1_UP_TIM16_IRQn,      1, IOCFG_AF_PP, GPIO_AF_1 }, // PWM5 - PA6  - TIM3_CH1, TIM8_BKIN, TIM1_BKIN, *TIM16_CH1
+    { TIM17, IO_TAG(PA7),  TIM_Channel_1, TIM1_TRG_COM_TIM17_IRQn, 1, IOCFG_AF_PP, GPIO_AF_1 }, // PWM6 - PA7  - TIM3_CH2, *TIM17_CH1, TIM1_CH1N, TIM8_CH1  
+    { TIM3,  IO_TAG(PB0),  TIM_Channel_3, TIM3_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2},  // PWM7
+    { TIM3,  IO_TAG(PB1),  TIM_Channel_4, TIM3_IRQn,               1, IOCFG_AF_PP, GPIO_AF_2},  // PWM8
+
+    // UART3 RX/TX
+    { TIM2,  IO_TAG(PB10), TIM_Channel_3, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1}, // RC_CH4 - PB10 - *TIM2_CH3, USART3_TX (AF7)
+    { TIM2,  IO_TAG(PB11), TIM_Channel_4, TIM2_IRQn,               1, IOCFG_AF_PP, GPIO_AF_1}, // RC_CH3 - PB11 - *TIM2_CH4, USART3_RX (AF7)
+
+    // IR / LED Strip Pad
+    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM1_CC_IRQn,            1, IOCFG_AF_PP, GPIO_AF_6},  // GPIO_TIMER / LED_STRIP
+};

--- a/src/main/target/SPRACINGF3EVO_1SS/target.h
+++ b/src/main/target/SPRACINGF3EVO_1SS/target.h
@@ -1,0 +1,157 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+//Speical version of SPRACINGF3EVO with one SoftSerial instead of two which enables two motors and four servos for airplanes with Rudder, Elevator and two Ailerons
+
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "SPEV"
+
+#define LED0                    PB8
+
+#define BEEPER                  PC15
+#define BEEPER_INVERTED
+
+#define USE_EXTI
+#define MPU_INT_EXTI            PC13
+#define EXTI_CALLBACK_HANDLER_COUNT 2 // MPU data ready and MAG data ready
+#define EXTI15_10_CALLBACK_HANDLER_COUNT 2 // MPU_INT, SDCardDetect
+#define USE_MPU_DATA_READY_SIGNAL
+#define ENSURE_MPU_DATA_READY_IS_LOW
+#define MPU6500_CS_PIN          PB9
+#define MPU6500_SPI_INSTANCE    SPI1
+
+//#define USE_MAG_DATA_READY_SIGNAL
+//#define ENSURE_MAG_DATA_READY_IS_HIGH
+
+#define GYRO
+#define USE_GYRO_SPI_MPU6500
+#define GYRO_MPU6500_ALIGN      CW180_DEG
+
+#define ACC
+#define USE_ACC_SPI_MPU6500
+#define ACC_MPU6500_ALIGN       CW180_DEG
+
+#define BARO
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+
+#define MAG
+#define USE_MPU9250_MAG // Enables bypass configuration
+#define USE_MAG_AK8963
+//#define USE_MAG_MAG3110 // External
+#define USE_MAG_HMC5883 // External
+#define MAG_AK8963_ALIGN        CW270_DEG_FLIP
+
+#define USB_IO
+
+#define USE_VCP
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_SOFTSERIAL1
+//#define USE_SOFTSERIAL2
+#define SERIAL_PORT_COUNT       5
+
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define UART2_TX_PIN            PA14 // PA14 / SWCLK
+#define UART2_RX_PIN            PA15
+
+#define UART3_TX_PIN            PB10 // PB10 (AF7)
+#define UART3_RX_PIN            PB11 // PB11 (AF7)
+
+#define SOFTSERIAL_1_TIMER      TIM3
+#define SOFTSERIAL_1_TIMER_RX_HARDWARE 7
+#define SOFTSERIAL_1_TIMER_TX_HARDWARE 8
+
+
+#define USE_I2C
+#define I2C_DEVICE              (I2CDEV_1) // PB6/SCL, PB7/SDA
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1 // PB9,3,4,5 on AF5 SPI1 (MPU)
+#define USE_SPI_DEVICE_2 // PB12,13,14,15 on AF5 SPI2 (SDCard)
+
+#define SPI1_NSS_PIN            PB9
+#define SPI1_SCK_PIN            PB3
+#define SPI1_MISO_PIN           PB4
+#define SPI1_MOSI_PIN           PB5
+
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_SDCARD
+#define USE_SDCARD_SPI2
+
+#define SDCARD_DETECT_INVERTED
+#define SDCARD_DETECT_PIN       PC14
+#define SDCARD_SPI_INSTANCE     SPI2
+#define SDCARD_SPI_CS_PIN       SPI2_NSS_PIN
+// SPI2 is on the APB1 bus whose clock runs at 36MHz. Divide to under 400kHz for init:
+#define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 128
+// Divide to under 25MHz for normal operation:
+#define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER     2
+// Note, this is the same DMA channel as UART1_RX. Luckily we don't use DMA for USART Rx.
+#define SDCARD_DMA_CHANNEL_TX               DMA1_Channel5
+#define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG DMA1_FLAG_TC5
+
+#define USE_ADC
+#define ADC_INSTANCE            ADC2
+#define VBAT_ADC_PIN            PA4
+#define CURRENT_METER_ADC_PIN   PA5
+#define RSSI_ADC_PIN            PB2
+
+#define LED_STRIP
+#define USE_LED_STRIP_ON_DMA1_CHANNEL2
+#define WS2811_PIN                      PA8
+#define WS2811_TIMER                    TIM1
+#define WS2811_DMA_CHANNEL              DMA1_Channel2
+#define WS2811_IRQ                      DMA1_Channel2_IRQn
+#define WS2811_DMA_TC_FLAG              DMA1_FLAG_TC2
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_CH2_HANDLER
+
+#define SONAR
+#define SONAR_TRIGGER_PIN       PB0
+#define SONAR_ECHO_PIN          PB1
+#define USE_SONAR_SRF10
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_PPM
+#define DEFAULT_FEATURES        (FEATURE_TRANSPONDER | FEATURE_BLACKBOX | FEATURE_RSSI_ADC | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY)
+
+#define SPEKTRUM_BIND
+#define BIND_PIN                PB11 // UART3
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+// Number of available PWM outputs
+#define MAX_PWM_OUTPUT_PORTS    10
+
+// IO - stm32f303cc in 48pin package
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         (BIT(13)|BIT(14)|BIT(15))
+#define TARGET_IO_PORTF         (BIT(0)|BIT(1)|BIT(4))
+
+#define USABLE_TIMER_CHANNEL_COUNT 12 // PPM, 8 PWM, UART3 RX/TX, LED Strip
+#define USED_TIMERS             (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(8) | TIM_N(15)| TIM_N(16) | TIM_N(17))

--- a/src/main/target/SPRACINGF3EVO_1SS/target.mk
+++ b/src/main/target/SPRACINGF3EVO_1SS/target.mk
@@ -1,0 +1,16 @@
+F3_TARGETS  += $(TARGET)
+FEATURES    = VCP SDCARD
+
+TARGET_SRC = \
+            drivers/accgyro_mpu.c \
+            drivers/accgyro_mpu6500.c \
+            drivers/accgyro_spi_mpu6500.c \
+            drivers/barometer_bmp280.c \
+            drivers/barometer_ms5611.c \
+            drivers/compass_ak8963.c \
+            drivers/compass_hmc5883l.c \
+            drivers/compass_mag3110.c \
+            drivers/light_ws2811strip.c \
+            drivers/light_ws2811strip_stm32f30x.c \
+            drivers/serial_usb_vcp.c \
+            drivers/serial_softserial.c


### PR DESCRIPTION
Hello,

Made a new pull, and will close the old pull request #1206 
This is the solution DigitalEntity proposed in the comments of #1206 

New version of target for SPRACINGF3EVO with just one soft serial for enabling 4 servo outputs and beeing able to still use one soft serial.

Enables two motors and four servos for airplanes with Rudder, Elevator and two Ailerons. This is great if you want an FRSKY receiver together with telemetry, GPS and MWOSD in a SPRACING F3 EVO board. 

Have also added the board documentation file for SPRACINGF3EVO from Cleanflight and added a SPRACINGF3EVO_1SS describing this special version. 

Tested on bench. Works perfect.