### PR TITLE
Fix shifted beeper command

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -199,7 +199,7 @@ static const beeperTableEntry_t *currentBeeperEntry = NULL;
  */
 void beeper(beeperMode_e mode)
 {
-    if (mode == BEEPER_SILENCE || ((getBeeperOffMask() & (1 << (BEEPER_USB-1))) && (feature(FEATURE_VBAT) && (batteryCellCount < 2)))) {
+    if (mode == BEEPER_SILENCE || ((getBeeperOffMask() & (1 << BEEPER_USB)) && (feature(FEATURE_VBAT) && (batteryCellCount < 2)))) {
         beeperSilence();
         return;
     }
@@ -326,7 +326,7 @@ void beeperUpdate(timeUs_t currentTimeUs)
     if (!beeperIsOn) {
         beeperIsOn = 1;
         if (currentBeeperEntry->sequence[beeperPos] != 0) {
-            if (!(getBeeperOffMask() & (1 << (currentBeeperEntry->mode - 1))))
+            if (!(getBeeperOffMask() & (1 << (currentBeeperEntry->mode))))
                 BEEP_ON;
 
             warningLedEnable();


### PR DESCRIPTION
Hi,

I'm flying with a SP Racing F3 EVO. I wanted to disable the beeper on USB but the command "beeper -ON_USB" did not disable it. It disable the beeper for the launch mode. After some testing I realize that :
- beeper ON_USB correspond to beeper LAUNCH_MODE
- beeper SYSTEM_INIT correspond to beeper beeper ON_USB
All the "beeper" command are shifted

Tested on inav 1.5.1
Merged in the latest developpement branch