### PR TITLE
Acc notch filter

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -536,6 +536,11 @@ static const clivalue_t valueTable[] = {
     { "current_adc_channel",        VAR_UINT8 | MASTER_VALUE, .config.minmax = {ADC_CHN_NONE, ADC_CHN_MAX}, PG_ADC_CHANNEL_CONFIG, offsetof(adcChannelConfig_t, adcFunctionChannel[ADC_CURRENT]) },
     { "airspeed_adc_channel",       VAR_UINT8 | MASTER_VALUE, .config.minmax = {ADC_CHN_NONE, ADC_CHN_MAX}, PG_ADC_CHANNEL_CONFIG, offsetof(adcChannelConfig_t, adcFunctionChannel[ADC_AIRSPEED]) },
 
+#ifdef USE_ACC_NOTCH
+    { "acc_notch_hz",               VAR_UINT8  | MASTER_VALUE, .config.minmax = {0, 255 }, PG_ACCELEROMETER_CONFIG, offsetof(accelerometerConfig_t,acc_notch_hz)  },
+    { "acc_notch_cutoff",           VAR_UINT8  | MASTER_VALUE, .config.minmax = {1, 255 }, PG_ACCELEROMETER_CONFIG, offsetof(accelerometerConfig_t, acc_notch_cutoff)  },
+#endif
+
 // PG_ACCELEROMETER_CONFIG
     { "align_acc",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ALIGNMENT }, PG_ACCELEROMETER_CONFIG, offsetof(accelerometerConfig_t, acc_align) },
     { "acc_hardware",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ACC_HARDWARE }, PG_ACCELEROMETER_CONFIG, offsetof(accelerometerConfig_t, acc_hardware) },

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -214,6 +214,13 @@ void validateAndFixConfig(void)
         pidProfileMutable()->dterm_soft_notch_hz = 0;
     }
 #endif
+
+#ifdef USE_ACC_NOTCH
+    if (accelerometerConfig()->acc_notch_cutoff >= accelerometerConfig()->acc_notch_hz) {
+        accelerometerConfigMutable()->acc_notch_hz = 0;
+    }
+#endif
+
     // Disable unused features
     featureClear(FEATURE_UNUSED_1 | FEATURE_UNUSED_2);
 

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -83,7 +83,7 @@ void pgResetFn_accelerometerConfig(accelerometerConfig_t *instance)
         .acc_hardware = ACC_AUTODETECT,
         .acc_lpf_hz = 15,
         .acc_notch_hz = 0,
-        .acc_notch_cutoff = 0
+        .acc_notch_cutoff = 1
     );
     RESET_CONFIG_2(flightDynamicsTrims_t, &instance->accZero,
         .raw[X] = 0,

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -75,7 +75,7 @@ static filterApplyFnPtr accNotchFilterApplyFn;
 static void *accNotchFilter[XYZ_AXIS_COUNT];
 #endif
 
-PG_REGISTER_WITH_RESET_FN(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
+PG_REGISTER_WITH_RESET_FN(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 1);
 
 void pgResetFn_accelerometerConfig(accelerometerConfig_t *instance)
 {

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -70,6 +70,8 @@ static uint16_t calibratingA = 0;      // the calibration is done is the main lo
 
 static biquadFilter_t accFilter[XYZ_AXIS_COUNT];
 
+static void *accNotchFilter[XYZ_AXIS_COUNT];
+
 PG_REGISTER_WITH_RESET_FN(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
 
 void pgResetFn_accelerometerConfig(accelerometerConfig_t *instance)
@@ -442,6 +444,7 @@ static void applyAccelerationZero(const flightDynamicsTrims_t * accZero, const f
 
 void accUpdate(void)
 {
+    float temp;
     if (!acc.dev.read(&acc.dev)) {
         return;
     }
@@ -452,7 +455,8 @@ void accUpdate(void)
 
     if (accelerometerConfig()->acc_lpf_hz) {
         for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            acc.accADC[axis] = lrintf(biquadFilterApply(&accFilter[axis], (float)acc.accADC[axis]));
+            temp = biquadFilterApply(&accFilter[axis], (float)acc.accADC[axis]);
+            acc.accADC[axis] = lrintf(biquadFilterApply(accNotchFilter[axis], temp));
         }
     }
 
@@ -478,10 +482,15 @@ void accSetCalibrationValues(void)
 
 void accInitFilters(void)
 {
+    static biquadFilter_t accFilterNotch[XYZ_AXIS_COUNT];
+
     if (acc.accTargetLooptime && accelerometerConfig()->acc_lpf_hz) {
         for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
             biquadFilterInitLPF(&accFilter[axis], accelerometerConfig()->acc_lpf_hz, acc.accTargetLooptime);
-        }
+
+            accNotchFilter[axis] = &accFilterNotch[axis];
+            biquadFilterInitNotch(accNotchFilter[axis], acc.accTargetLooptime, 75, 30);
+        }    
     }
 }
 

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -52,6 +52,8 @@ typedef struct accelerometerConfig_s {
     uint16_t acc_lpf_hz;                    // cutoff frequency for the low pass filter used on the acc z-axis for althold in Hz
     flightDynamicsTrims_t accZero;          // Accelerometer offset
     flightDynamicsTrims_t accGain;          // Accelerometer gain to read exactly 1G
+    uint8_t acc_notch_hz;                   // Accelerometer notch filter frequency
+    uint8_t acc_notch_cutoff;               // Accelerometer notch filter cutoff frequency
 } accelerometerConfig_t;
 
 PG_DECLARE(accelerometerConfig_t, accelerometerConfig);

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -59,6 +59,7 @@
 #define USE_GYRO_NOTCH_1
 #define USE_GYRO_NOTCH_2
 #define USE_DTERM_NOTCH
+#define USE_ACC_NOTCH
 #define CMS
 #define USE_DASHBOARD
 #define USE_MSP_DISPLAYPORT


### PR DESCRIPTION
This might be the next thing for multirotors in INAV: Acc notch filter.

Why: I had acc problems due to big props and poor balancing: Althold poor performance and other problems. 
Acc trace before (even after I replaced bearings)
![acc no notch](https://cloud.githubusercontent.com/assets/966811/23814637/92f28e64-05e4-11e7-90aa-f948866eae1c.PNG)

After applying notch:

![acc notch](https://cloud.githubusercontent.com/assets/966811/23814642/99850fea-05e4-11e7-9fbe-4ef58eb48a7f.PNG)

Noise at 75Hz is gone! Did not enabled Angle or any GPS mode yet since it is 23:00 ATM, but gyro traces looks very very promising. I will try to continue this topic tomorrow.

But there is a problem with CPU. F3 was unable to process next notch, OLED and SoftwareSerial at the same time. Board was not booting. I'm not sure if it was memory or CPU issue. I suspect the first one.

BB log:
[blackbox_log_2017-03-10_205726 acc notch.TXT](https://github.com/iNavFlight/inav/files/835194/blackbox_log_2017-03-10_205726.acc.notch.TXT)

Work will continue to make it configurable, since it is hardcoded ATM.