### PR TITLE
adding accelerometer trim display

### DIFF
--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -378,7 +378,10 @@ static void showStatusPage(void)
 #endif
 
     rowIndex++;
-    tfp_sprintf(lineBuffer, "Acc: %dR, %dP", boardAlignment()->rollDeciDegrees, boardAlignment()->pitchDeciDegrees );
+    char rollTrim[7], pitchTrim[7];
+    formatTrimDegrees(rollTrim, boardAlignment()->rollDeciDegrees);
+    formatTrimDegrees(pitchTrim, boardAlignment()->pitchDeciDegrees);
+    tfp_sprintf(lineBuffer, "Acc: %sR, %sP", rollTrim, pitchTrim );
     i2c_OLED_set_line(rowIndex++);
     i2c_OLED_send_string(lineBuffer);
 }
@@ -506,3 +509,15 @@ void dashboardSetNextPageChangeAt(timeUs_t futureMicros)
     nextPageAt = futureMicros;
 }
 #endif
+
+void formatTrimDegrees ( char *formattedTrim, int16_t trimValue ) {
+	char trim[6];
+	sprintf(trim, "%d", trimValue);
+	int x = strlen(trim)-1;
+	strncpy(formattedTrim,trim,x);
+	formattedTrim[x] = '\0';
+	if (trimValue !=0) {
+		strcat(formattedTrim,".");
+	}
+	strcat(formattedTrim,trim+x);
+}

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -61,6 +61,7 @@
 #include "sensors/sensors.h"
 #include "sensors/compass.h"
 #include "sensors/acceleration.h"
+#include "sensors/boardalignment.h"
 #include "sensors/gyro.h"
 #include "sensors/barometer.h"
 
@@ -378,6 +379,10 @@ static void showStatusPage(void)
     }
 #endif
 
+    rowIndex++;
+    tfp_sprintf(lineBuffer, "Acc: %dR, %dP", boardAlignment()->rollDeciDegrees, boardAlignment()->pitchDeciDegrees );
+    i2c_OLED_set_line(rowIndex++);
+    i2c_OLED_send_string(lineBuffer);
 }
 
 void dashboardUpdate(timeUs_t currentTimeUs)

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -333,8 +333,6 @@ static void showStatusPage(void)
         drawHorizonalPercentageBar(10, capacityPercentage);
     }
 
-    rowIndex++;
-
 #ifdef GPS
     if (feature(FEATURE_GPS)) {
         tfp_sprintf(lineBuffer, "Sats: %d", gpsSol.numSat);

--- a/src/main/io/dashboard.h
+++ b/src/main/io/dashboard.h
@@ -26,3 +26,5 @@ void dashboardUpdate(timeUs_t currentTimeUs);
 
 void dashboardSetPage(pageId_e newPageId);
 void dashboardSetNextPageChangeAt(timeUs_t futureMicros);
+
+void formatTrimDegrees ( char formattedTrim[7], int16_t trimValue );


### PR DESCRIPTION
This change is for:
[New Feature Request] display status - add board/accelerometer trim  #1425 

It needs to be tested on a fully loaded display to make sure it fits, otherwise would need to remove heading/altitude line

Degrees are currently shown in *10 value, I had an issue printing signed floats with tfp_sprintf, will need to add a custom handler for that

Did not include yaw trim since it cannot be changed via sticks, and even when modified in configurator values are not coming back consistent

Using sticks to change Roll and Pitch trims does get updated realtime on display