### PR TITLE
Add ADC input for analog air speed sensor support

### DIFF
--- a/src/main/drivers/adc.c
+++ b/src/main/drivers/adc.c
@@ -60,6 +60,9 @@ uint16_t adcGetChannel(uint8_t channel)
     if (adcConfig[3].enabled) {
         debug[3] = adcValues[adcConfig[3].dmaIndex];
     }
+    if (adcConfig[4].enabled) {
+        debug[4] = adcValues[adcConfig[4].dmaIndex];
+    }
 #endif
     return adcValues[adcConfig[channel].dmaIndex];
 }

--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -24,7 +24,8 @@ typedef enum {
     ADC_RSSI = 1,
     ADC_EXTERNAL1 = 2,
     ADC_CURRENT = 3,
-    ADC_CHANNEL_MAX = ADC_CURRENT
+	ADC_AIRSPEED = 4,
+    ADC_CHANNEL_MAX = ADC_AIRSPEED
 } AdcChannel;
 
 #define ADC_CHANNEL_COUNT (ADC_CHANNEL_MAX + 1)
@@ -42,6 +43,7 @@ typedef struct drv_adc_config_s {
     bool enableRSSI;
     bool enableCurrentMeter;
     bool enableExternal1;
+    bool enableAirSpeed;
 } drv_adc_config_t;
 
 void adcInit(drv_adc_config_t *init);

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -111,6 +111,12 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
+#ifdef AIRSPEED_ADC_PIN
+    if (init->enableAirSpeed) {
+        adcConfig[ADC_AIRSPEED].tag = IO_TAG(AIRSPEED_ADC_PIN);
+    }
+#endif
+
     ADCDevice device = adcDeviceByInstance(ADC_INSTANCE);
     if (device == ADCINVALID)
         return;

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -129,6 +129,12 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
+#ifdef AIRSPEED_ADC_PIN
+    if (init->enableAirSpeed) {
+        adcConfig[ADC_AIRSPEED].tag = IO_TAG(AIRSPEED_ADC_PIN);
+    }
+#endif
+
     ADCDevice device = adcDeviceByInstance(ADC_INSTANCE);
     if (device == ADCINVALID)
         return;

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -120,6 +120,12 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
+#ifdef AIRSPEED_ADC_PIN
+    if (init->enableAirSpeed) {
+        adcConfig[ADC_AIRSPEED].tag = IO_TAG(AIRSPEED_ADC_PIN);
+    }
+#endif
+
     //RCC_ADCCLKConfig(RCC_ADC12PLLCLK_Div256);  // 72 MHz divided by 256 = 281.25 kHz
 
     ADCDevice device = adcDeviceByInstance(ADC_INSTANCE);

--- a/src/main/drivers/adc_stm32f7xx.c
+++ b/src/main/drivers/adc_stm32f7xx.c
@@ -118,6 +118,12 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
+#ifdef AIRSPEED_ADC_PIN
+    if (init->enableAirSpeed) {
+        adcConfig[ADC_AIRSPEED].tag = IO_TAG(AIRSPEED_ADC_PIN);
+    }
+#endif
+
     ADCDevice device = adcDeviceByInstance(ADC_INSTANCE);
     if (device == ADCINVALID)
         return;


### PR DESCRIPTION
Add analog airspeed adc support.See https://github.com/iNavFlight/inav/issues/1423
