### PR TITLE
Ltm rate options

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -210,7 +210,8 @@ Re-apply any new defaults as desired.
 |  frsky_vfas_cell_voltage  | OFF |  |
 |  hott_alarm_sound_interval  | 5 | Battery alarm delay in seconds for Hott telemetry |
 |  smartport_uart_unidir  | OFF | Turn UART into UNIDIR for smartport telemetry for usage on F1 and F4 target. See Telemertry.md for details |
-|  ibus_telemetry_type  | 0 | Type compatibility ibus telemetry for transmitters. See Telemertry.md label IBUS for details. |
+|  ibus_telemetry_type  | 0 | Type compatibility ibus telemetry for transmitters. See Telemetry.md label IBUS for details. |
+|  ltm_update_rate  | NORMAL | Defines the LTM update rate (use of bandwidth [NORMAL/MEDIUM/SLOW]). See Telemetry.md, LTM section for details. |
 |  battery_capacity  | 0 | Battery capacity in mAH. This value is used in conjunction with the current meter to determine remaining battery capacity. |
 |  vbat_scale  | 110 | Result is Vbatt in 0.1V steps. 3.3V = ADC Vref, 4095 = 12bit adc, 110 = 11:1 voltage divider (10k:1k) x 10 for 0.1V. Adjust this slightly if reported pack voltage is different from multimeter reading. You can get current voltage by typing "status" in cli. |
 |  vbat_max_cell_voltage  | 43 | Maximum voltage per cell, used for auto-detecting battery voltage in 0.1V units, default is 43 (4.3V) |

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -108,7 +108,7 @@ LTM is transmit only, and can work at any supported baud rate. It is
 designed to operate over 2400 baud (9600 in INAV) and does not
 benefit from higher rates. It is thus usable on soft serial.
 
-A CLI variable `ltm-update-rate` may be used to configure the update
+A CLI variable `ltm_update_rate` may be used to configure the update
 rate and hence band-width used by LTM, with the following enumerations:
 
 * NORMAL: Legacy rate, currently 303 bytes/second (requires 4800 bps)

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -98,17 +98,30 @@ The INAV implementation of LTM implements the following frames:
   suffixed '+' not implemented in INAV.
 * O-FRAME: Origin (home position, lat, long, altitude, fix)
 
-In addition, in the inav (navigation-rewrite) fork:
+In addition, in  iNav:
+
 * N-FRAME: Navigation information (GPS mode, Nav mode, Nav action,
   Waypoint number, Nav Error, Nav Flags).
+* X-FRAME: Extra information. Currently HDOP is reported.
 
 LTM is transmit only, and can work at any supported baud rate. It is
 designed to operate over 2400 baud (9600 in INAV) and does not
 benefit from higher rates. It is thus usable on soft serial.
 
+A CLI variable `ltm-update-rate` may be used to configure the update
+rate and hence band-width used by LTM, with the following enumerations:
+
+* NORMAL: Legacy rate, currently 303 bytes/second (requires 4800 bps)
+* MEDIUM: 164 bytes/second (requires 2400 bps)
+* SLOW: 105 bytes/second (requires 1200 bps)
+
+For many telemetry devices, there is direction correlation between the
+air-speed of the radio link and range; thus a lower value may
+facilitate longer range links.
+
 More information about the fields, encoding and enumerations may be
-found at
-https://github.com/stronnag/mwptools/blob/master/docs/ltm-definition.txt
+found at https://github.com/iNavFlight/inav/wiki/Lightweight-Telemetry-(LTM).
+
 
 ## MAVLink telemetry
 
@@ -237,7 +250,7 @@ HDOP: 0 is 0-9m, 8 is 80-90m, 9 is >90m
 
 Mode: 1-Armed(rate), 2-Horizon, 3-Angle, 4-HeadFree or Mag, 5-AltHold, 6-PosHold, 7-Rth, 8-Fail and Rth, 9-Fail
 
-Example: 12803 is 12 satelites, Fix3D, FixHome, 0-9m HDOP, Angle Mode 
+Example: 12803 is 12 satelites, Fix3D, FixHome, 0-9m HDOP, Angle Mode
 
 ### CLI command
 
@@ -257,6 +270,3 @@ These receivers are reported to work with i-bus telemetry:
 - FlySky/Turnigy FS-iA10B 10-Channel Receiver (http://www.flysky-cn.com/products_detail/productId=52.html)
 
 Note that the FlySky/Turnigy FS-iA4B 4-Channel Receiver (http://www.flysky-cn.com/products_detail/productId=46.html) seems to work but has a bug that might lose the binding, DO NOT FLY the FS-iA4B!
-
-
-

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -330,6 +330,12 @@ static const char * const lookupTableNoSignalThrottle[] = {
     "HOLD", "DROP"
 };
 
+#ifdef TELEMETRY_LTM
+static const char * const lookupTableLTMRates[] = {
+    "NORMAL", "MEDIUM", "SLOW"
+};
+#endif
+
 typedef struct lookupTableEntry_s {
     const char * const *values;
     const uint8_t valueCount;
@@ -387,6 +393,9 @@ typedef enum {
 #endif
     TABLE_DEBUG,
     TABLE_RX_NOSIGNAL_THROTTLE,
+#ifdef TELEMETRY_LTM
+    TABLE_LTM_UPDATE_RATE,
+#endif
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 
@@ -442,6 +451,9 @@ static const lookupTableEntry_t lookupTables[] = {
 #endif
     { lookupTableDebug, sizeof(lookupTableDebug) / sizeof(char *) },
     { lookupTableNoSignalThrottle, sizeof(lookupTableNoSignalThrottle) / sizeof(char *) },
+#ifdef TELEMETRY_LTM
+    {lookupTableLTMRates, sizeof(lookupTableLTMRates) / sizeof(char *) },
+#endif
 };
 
 #define VALUE_TYPE_OFFSET 0
@@ -869,6 +881,9 @@ static const clivalue_t valueTable[] = {
     { "smartport_uart_unidir",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, smartportUartUnidirectional) },
 #endif
     { "ibus_telemetry_type",       VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  255 }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, ibusTelemetryType ) },
+#ifdef TELEMETRY_LTM
+    {"ltm_update_rate",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_LTM_UPDATE_RATE }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, ltmUpdateRate) },
+#endif
 #endif
 #ifdef LED_STRIP
     { "ledstrip_visual_beeper",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_LED_STRIP_CONFIG, offsetof(ledStripConfig_t, ledstrip_visual_beeper) },

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -279,7 +279,7 @@ void ltm_nframe(sbuf_t *dst)
 #define LTM_BIT_NFRAME  (1 << 4)
 #define LTM_BIT_XFRAME  (1 << 5)
 
-static uint8_t ltm_schedule[10] = {
+static uint8_t ltm_normal_schedule[10] = {
     LTM_BIT_AFRAME | LTM_BIT_GFRAME,
     LTM_BIT_AFRAME | LTM_BIT_SFRAME | LTM_BIT_OFRAME,
     LTM_BIT_AFRAME | LTM_BIT_GFRAME,
@@ -291,6 +291,35 @@ static uint8_t ltm_schedule[10] = {
     LTM_BIT_AFRAME | LTM_BIT_GFRAME,
     LTM_BIT_AFRAME | LTM_BIT_SFRAME | LTM_BIT_NFRAME
 };
+
+static uint8_t ltm_medium_schedule[] = {
+    LTM_BIT_AFRAME,
+    LTM_BIT_GFRAME,
+    LTM_BIT_AFRAME | LTM_BIT_SFRAME,
+    LTM_BIT_OFRAME,
+    LTM_BIT_AFRAME | LTM_BIT_XFRAME,
+    LTM_BIT_OFRAME,
+    LTM_BIT_AFRAME | LTM_BIT_SFRAME,
+    LTM_BIT_GFRAME,
+    LTM_BIT_AFRAME,
+    LTM_BIT_NFRAME
+};
+
+static uint8_t ltm_slow_schedule[] = {
+    LTM_BIT_GFRAME,
+    LTM_BIT_SFRAME,
+    LTM_BIT_OFRAME,
+    0,
+    LTM_BIT_AFRAME,
+    LTM_BIT_XFRAME,
+    LTM_BIT_GFRAME,
+    0,
+    LTM_BIT_AFRAME,
+    LTM_BIT_NFRAME,
+};
+
+/* This is the default scheduler, needs c. 4800 baud or faster */
+static uint8_t *ltm_schedule = ltm_normal_schedule;
 
 static void process_ltm(void)
 {
@@ -380,6 +409,14 @@ void configureLtmTelemetryPort(void)
     if (baudRateIndex == BAUD_AUTO) {
         baudRateIndex = BAUD_19200;
     }
+
+    if(telemetryConfig()->ltmUpdateRate == LTM_RATE_MEDIUM)
+        ltm_schedule = ltm_medium_schedule;
+    else if (telemetryConfig()->ltmUpdateRate == LTM_RATE_SLOW)
+        ltm_schedule = ltm_slow_schedule;
+    else
+        ltm_schedule = ltm_normal_schedule;
+
     ltmPort = openSerialPort(portConfig->identifier, FUNCTION_TELEMETRY_LTM, NULL, baudRates[baudRateIndex], TELEMETRY_LTM_INITIAL_PORT_MODE, SERIAL_NOT_INVERTED);
     if (!ltmPort)
         return;

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -80,6 +80,7 @@
 
 #define TELEMETRY_LTM_INITIAL_PORT_MODE MODE_TX
 #define LTM_CYCLETIME   100
+#define LTM_SCHEDULE_SIZE (1000/LTM_CYCLETIME)
 
 extern uint16_t rssi;           // FIXME dependency on mw.c
 static serialPort_t *ltmPort;
@@ -88,6 +89,7 @@ static bool ltmEnabled;
 static portSharing_e ltmPortSharing;
 static uint8_t ltm_crc;
 static uint8_t ltmPayload[LTM_MAX_MESSAGE_SIZE];
+static uint8_t ltm_x_counter;
 
 static void ltm_initialise_packet(sbuf_t *dst)
 {
@@ -251,9 +253,10 @@ void ltm_xframe(sbuf_t *dst)
     sbufWriteU8(dst, 'X');
     ltm_serialise_16(dst, gpsSol.hdop);
     ltm_serialise_8(dst, sensorStatus);
+    ltm_serialise_8(dst, ltm_x_counter);
     ltm_serialise_8(dst, 0);
     ltm_serialise_8(dst, 0);
-    ltm_serialise_8(dst, 0);
+    ltm_x_counter++; // overflow is OK
 }
 #endif
 
@@ -279,7 +282,11 @@ void ltm_nframe(sbuf_t *dst)
 #define LTM_BIT_NFRAME  (1 << 4)
 #define LTM_BIT_XFRAME  (1 << 5)
 
-static uint8_t ltm_normal_schedule[10] = {
+/*
+ * This is the normal (default) scheduler, needs c. 4800 baud or faster
+ * Equates to c. 303 bytes / second
+ */
+static uint8_t ltm_normal_schedule[LTM_SCHEDULE_SIZE] = {
     LTM_BIT_AFRAME | LTM_BIT_GFRAME,
     LTM_BIT_AFRAME | LTM_BIT_SFRAME | LTM_BIT_OFRAME,
     LTM_BIT_AFRAME | LTM_BIT_GFRAME,
@@ -292,7 +299,11 @@ static uint8_t ltm_normal_schedule[10] = {
     LTM_BIT_AFRAME | LTM_BIT_SFRAME | LTM_BIT_NFRAME
 };
 
-static uint8_t ltm_medium_schedule[] = {
+/*
+ * This is the medium scheduler, needs c. 2400 baud or faster
+ * Equates to c. 164 bytes / second
+ */
+static uint8_t ltm_medium_schedule[LTM_SCHEDULE_SIZE] = {
     LTM_BIT_AFRAME,
     LTM_BIT_GFRAME,
     LTM_BIT_AFRAME | LTM_BIT_SFRAME,
@@ -305,21 +316,25 @@ static uint8_t ltm_medium_schedule[] = {
     LTM_BIT_NFRAME
 };
 
-static uint8_t ltm_slow_schedule[] = {
+/*
+ * This is the slow scheduler, needs c. 1200 baud or faster
+ * Equates to c. 105 bytes / second (91 b/s if the second GFRAME is zeroed)
+ */
+static uint8_t ltm_slow_schedule[LTM_SCHEDULE_SIZE] = {
     LTM_BIT_GFRAME,
     LTM_BIT_SFRAME,
     LTM_BIT_AFRAME,
     0,
     LTM_BIT_OFRAME,
     LTM_BIT_XFRAME,
-    LTM_BIT_GFRAME,
+    LTM_BIT_GFRAME, // consider zeroing this for even lower bytes/sec
     0,
     LTM_BIT_AFRAME,
     LTM_BIT_NFRAME,
 };
 
-/* This is the default scheduler, needs c. 4800 baud or faster */
-static uint8_t *ltm_schedule = ltm_normal_schedule;
+/* Set by initialisation */
+static uint8_t *ltm_schedule;
 
 static void process_ltm(void)
 {
@@ -410,6 +425,7 @@ void configureLtmTelemetryPort(void)
         baudRateIndex = BAUD_19200;
     }
 
+    /* setup scheduler, default to 'normal' */
     if(telemetryConfig()->ltmUpdateRate == LTM_RATE_MEDIUM)
         ltm_schedule = ltm_medium_schedule;
     else if (telemetryConfig()->ltmUpdateRate == LTM_RATE_SLOW)
@@ -420,6 +436,7 @@ void configureLtmTelemetryPort(void)
     ltmPort = openSerialPort(portConfig->identifier, FUNCTION_TELEMETRY_LTM, NULL, baudRates[baudRateIndex], TELEMETRY_LTM_INITIAL_PORT_MODE, SERIAL_NOT_INVERTED);
     if (!ltmPort)
         return;
+    ltm_x_counter = 0;
     ltmEnabled = true;
 }
 

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -240,6 +240,7 @@ void ltm_oframe(sbuf_t *dst)
     ltm_serialise_8(dst, 1);                 // OSD always ON
     ltm_serialise_8(dst, STATE(GPS_FIX_HOME) ? 1 : 0);
 }
+#endif
 
 /*
  * Extended information data frame, 1 Hz rate
@@ -251,14 +252,17 @@ void ltm_xframe(sbuf_t *dst)
         (isHardwareHealthy() ? 0 : 1) << 0;     // bit 0 - hardware failure indication (1 - something is wrong with the hardware sensors)
 
     sbufWriteU8(dst, 'X');
+#if defined(GPS)
     ltm_serialise_16(dst, gpsSol.hdop);
+#else
+    ltm_serialise_16(dst, 9999);
+#endif
     ltm_serialise_8(dst, sensorStatus);
     ltm_serialise_8(dst, ltm_x_counter);
     ltm_serialise_8(dst, 0);
     ltm_serialise_8(dst, 0);
     ltm_x_counter++; // overflow is OK
 }
-#endif
 
 #if defined(NAV)
 /** OSD additional data frame, ~4 Hz rate, navigation system status
@@ -473,10 +477,10 @@ int getLtmFrame(uint8_t *frame, ltm_frame_e ltmFrameType)
     case LTM_OFRAME:
         ltm_oframe(sbuf);
         break;
+#endif
     case LTM_XFRAME:
         ltm_xframe(sbuf);
         break;
-#endif
 #if defined(NAV)
     case LTM_NFRAME:
         ltm_nframe(sbuf);

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -308,9 +308,9 @@ static uint8_t ltm_medium_schedule[] = {
 static uint8_t ltm_slow_schedule[] = {
     LTM_BIT_GFRAME,
     LTM_BIT_SFRAME,
-    LTM_BIT_OFRAME,
-    0,
     LTM_BIT_AFRAME,
+    0,
+    LTM_BIT_OFRAME,
     LTM_BIT_XFRAME,
     LTM_BIT_GFRAME,
     0,

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -67,7 +67,8 @@ PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
     .frsky_vfas_cell_voltage = 0,
     .hottAlarmSoundInterval = 5,
     .smartportUartUnidirectional = 0,
-    .ibusTelemetryType = 0
+    .ibusTelemetryType = 0,
+    .ltmUpdateRate = LTM_RATE_NORMAL
 );
 
 void telemetryInit(void)

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -36,6 +36,12 @@ typedef enum {
     FRSKY_UNIT_IMPERIALS
 } frskyUnit_e;
 
+typedef enum {
+    LTM_RATE_NORMAL,
+    LTM_RATE_MEDIUM,
+    LTM_RATE_SLOW
+} ltmUpdateRate_e;
+
 typedef struct telemetryConfig_s {
     float gpsNoFixLatitude;
     float gpsNoFixLongitude;
@@ -48,6 +54,7 @@ typedef struct telemetryConfig_s {
     uint8_t hottAlarmSoundInterval;
     uint8_t smartportUartUnidirectional;
     uint8_t ibusTelemetryType;
+    uint8_t ltmUpdateRate;
 } telemetryConfig_t;
 
 PG_DECLARE(telemetryConfig_t, telemetryConfig);


### PR DESCRIPTION
This PR addresses comments in https://github.com/iNavFlight/inav/issues/712 concerning LTM

* Adds a CLI option `ltm_update_rate` to configure the LTM update rate:
  * NORMAL: Legacy LTM updates, 303 bytes / sec, 4800 bps or better (default)
  * MEDIUM: 164 bytes/sec, 2400 bps 
  * SLOW: 105 bytes /sec, hopefully 1200bps
* Adds an xframe counter in spare[0]
* Updates documentation

Review note: It would be possible to reduce SLOW to 91 bytes / sec by only issuing GFRAME once per second; currently the difference between MEDIUM and SLOW is in other frame updates.

The PR has been flight tested, examples of update density are shown. Images below show normal, medium and slow rates for a default (5m/s) mission.

![ltm-normal](https://cloud.githubusercontent.com/assets/158229/24334081/df08ba2a-125b-11e7-8959-3fefab8f879d.png)
![ltm-medium](https://cloud.githubusercontent.com/assets/158229/24334085/e837546c-125b-11e7-976f-08252d5b1d93.png)
![ltm-slow](https://cloud.githubusercontent.com/assets/158229/24334086/ef1c499a-125b-11e7-93d1-128c0f42d3d3.png)



