### PR TITLE
sub 9600  baud rate updates

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1747,7 +1747,7 @@ static void cliSerial(char *cmdline)
 
         switch(i) {
             case 0:
-                if (baudRateIndex < BAUD_9600 || baudRateIndex > BAUD_115200) {
+                if (baudRateIndex < BAUD_1200 || baudRateIndex > BAUD_115200) {
                     continue;
                 }
                 portConfig.msp_baudrateIndex = baudRateIndex;

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -437,6 +437,12 @@ void configureLtmTelemetryPort(void)
     else
         ltm_schedule = ltm_normal_schedule;
 
+    /* Sanity check that we can support the scheduler */
+    if(baudRateIndex == BAUD_2400 && telemetryConfig()->ltmUpdateRate == LTM_RATE_NORMAL)
+         ltm_schedule = ltm_medium_schedule;
+    if(baudRateIndex == BAUD_1200)
+         ltm_schedule = ltm_slow_schedule;
+
     ltmPort = openSerialPort(portConfig->identifier, FUNCTION_TELEMETRY_LTM, NULL, baudRates[baudRateIndex], TELEMETRY_LTM_INITIAL_PORT_MODE, SERIAL_NOT_INVERTED);
     if (!ltmPort)
         return;


### PR DESCRIPTION
* fix cli for sub-9600 baud rates (as https://github.com/iNavFlight/inav/pull/1464)
* update ltm to force slower scheduler on unrealisticly low rates

Bench tested in mwp (after that was fixed for sub-9600:). 

LTM at 1200 baud (c.100 byte schedule forced (from normal CLI setting). 
Alas I'm old enough to remember blazing fast 1200 baud modems in the 1980s.