### PR TITLE
Remove failsafe channel fallback

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -326,10 +326,6 @@ static const char * const lookupTableDebug[DEBUG_COUNT] = {
     "NOTCH"
 };
 
-static const char * const lookupTableNoSignalThrottle[] = {
-    "HOLD", "DROP"
-};
-
 #ifdef TELEMETRY_LTM
 static const char * const lookupTableLTMRates[] = {
     "NORMAL", "MEDIUM", "SLOW"
@@ -392,7 +388,6 @@ typedef enum {
     TABLE_OSD,
 #endif
     TABLE_DEBUG,
-    TABLE_RX_NOSIGNAL_THROTTLE,
 #ifdef TELEMETRY_LTM
     TABLE_LTM_UPDATE_RATE,
 #endif
@@ -450,7 +445,6 @@ static const lookupTableEntry_t lookupTables[] = {
     { lookupTableOsdType, sizeof(lookupTableOsdType) / sizeof(char *) },
 #endif
     { lookupTableDebug, sizeof(lookupTableDebug) / sizeof(char *) },
-    { lookupTableNoSignalThrottle, sizeof(lookupTableNoSignalThrottle) / sizeof(char *) },
 #ifdef TELEMETRY_LTM
     {lookupTableLTMRates, sizeof(lookupTableLTMRates) / sizeof(char *) },
 #endif
@@ -595,7 +589,6 @@ static const clivalue_t valueTable[] = {
 #endif
     { "rx_min_usec",                VAR_UINT16 | MASTER_VALUE, .config.minmax = { PWM_PULSE_MIN,  PWM_PULSE_MAX }, PG_RX_CONFIG, offsetof(rxConfig_t, rx_min_usec) },
     { "rx_max_usec",                VAR_UINT16 | MASTER_VALUE, .config.minmax = { PWM_PULSE_MIN,  PWM_PULSE_MAX }, PG_RX_CONFIG, offsetof(rxConfig_t, rx_max_usec) },
-    { "rx_nosignal_throttle",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_RX_NOSIGNAL_THROTTLE }, PG_RX_CONFIG, offsetof(rxConfig_t, rxNoSignalThrottleBehavior) },
 
 // PG_BLACKBOX_CONFIG
 #ifdef BLACKBOX

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -91,9 +91,6 @@ typedef struct rxChannelRangeConfig_s {
 } rxChannelRangeConfig_t;
 PG_DECLARE_ARRAY(rxChannelRangeConfig_t, NON_AUX_CHANNEL_COUNT, rxChannelRangeConfigs);
 
-#define RX_NOSIGNAL_THROTTLE_HOLD   0
-#define RX_NOSIGNAL_THROTTLE_DROP   1
-
 typedef struct rxConfig_s {
     uint8_t rcmap[MAX_MAPPABLE_RX_INPUTS];  // mapping of radio channels to internal RPYTA+ order
     uint8_t serialrx_provider;              // type of UART-based receiver (0 = spek 10, 1 = spek 11, 2 = sbus). Must be enabled by FEATURE_RX_SERIAL first.
@@ -112,7 +109,6 @@ typedef struct rxConfig_s {
     uint16_t rx_min_usec;
     uint16_t rx_max_usec;
     uint8_t rcSmoothing;                    // Enable/Disable RC filtering
-    uint8_t rxNoSignalThrottleBehavior;
 } rxConfig_t;
 
 PG_DECLARE(rxConfig_t, rxConfig);

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -210,6 +210,7 @@
 
 // #undef TELEMETRY_FRSKY
 // #define TELEMETRY_MAVLINK
+#define USE_SERIALRX_SUMD
 
 // IO - from schematics
 #define TARGET_IO_PORTA         0xffff


### PR DESCRIPTION
>Software failsafe in INAV will override what RX is telling it anyhow (in all modes except NO ACTION).
>This means I can safely take out signal loss behavior logic from RC RX code. This means that values from RC will always make it to the firmware (and show in RC receiver tab), but in some cases they will be ignored by software-based failsafe.

https://github.com/iNavFlight/inav/issues/1473