### PR TITLE
Failsafe/passthrough bug

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -448,7 +448,7 @@ void processRx(timeUs_t currentTimeUs)
 #endif
 
     // Navigation may override PASSTHRU_MODE
-    if (IS_RC_MODE_ACTIVE(BOXPASSTHRU) && !naivationRequiresAngleMode()) {
+    if (IS_RC_MODE_ACTIVE(BOXPASSTHRU) && !naivationRequiresAngleMode() && !failsafeRequiresAngleMode()) {
         ENABLE_FLIGHT_MODE(PASSTHRU_MODE);
     } else {
         DISABLE_FLIGHT_MODE(PASSTHRU_MODE);

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -183,7 +183,7 @@ bool failsafeShouldApplyControlInput(void)
 
 bool failsafeRequiresAngleMode(void)
 {
-    return failsafeState.active && failsafeProcedureLogic[failsafeConfig()->failsafe_procedure].forceAngleMode;
+    return failsafeState.active && failsafeState.controlling && failsafeProcedureLogic[failsafeConfig()->failsafe_procedure].forceAngleMode;
 }
 
 bool failsafeRequiresMotorStop(void)


### PR DESCRIPTION
Allow FAILSAFE to override PASSTHROUGH mode. 
Release control to pilot once FAILSAFE disarms (only block arming)