### PR TITLE
Failsafe kill switch refactoring (implementation)

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -245,7 +245,6 @@ Re-apply any new defaults as desired.
 |  failsafe_recovery_delay  | 5 | Time in deciseconds to wait before aborting failsafe when signal is recovered. See [Failsafe documentation](Failsafe.md#failsafe_recovery_delay). |
 |  failsafe_off_delay  | 200 | Time in deciseconds to wait before turning off motors when failsafe is activated. 0 = No timeout. See [Failsafe documentation](Failsafe.md#failsafe_off_delay). |
 |  failsafe_throttle  | 1000 | Throttle level used for landing when failsafe is enabled. See [Failsafe documentation](Failsafe.md#failsafe_throttle). |
-|  failsafe_kill_switch  | OFF | Set to ON to use an AUX channel as a failsafe kill switch. |
 |  failsafe_throttle_low_delay  | 100 | If failsafe activated when throttle is low for this much time - bypass failsafe and disarm, in 10th of seconds. 0 = No timeout |
 |  failsafe_procedure  | SET-THR | What failsafe procedure to initiate in Stage 2. See [Failsafe documentation](Failsafe.md#failsafe_throttle). |
 |  failsafe_stick_threshold  | 0 | Threshold for stick motion to consider failsafe condition resolved. If non-zero failsafe won't clear even if RC link is restored - you have to move sticks to exit failsafe. |

--- a/docs/Failsafe.md
+++ b/docs/Failsafe.md
@@ -28,12 +28,9 @@ __Stage 2__ is not activated until 5 seconds after the flight controller boots u
 __Stage 2__ will be aborted when it was due to:
 
 * a lost RC signal and the RC signal has recovered.
-* a transmitter failsafe switch was set to ON position and the switch is set to OFF position (and `failsafe_kill_switch` is set to OFF).
 
 Note that:
 * At the end of the stage 2 procedure, the flight controller will be disarmed and re-arming will be locked until the signal from the receiver is restored for 30 seconds AND the arming switch is in the OFF position (when an arm switch is in use).
-
-* When `failsafe_kill_switch` is set to ON and the rc switch configured for failsafe is set to ON, the craft is instantly disarmed. Re-arming is possible when the signal from the receiver has restored for at least 3 seconds AND the arming switch is in the OFF position (when one is in use). Similar effect can be achieved by setting 'failsafe_throttle' to 1000 and 'failsafe_off_delay' to 0. This is not the prefered method, since the reaction is slower and re-arming will be locked.
 
 * Prior to starting a stage 2 intervention it is checked if the throttle position was below `min_throttle` level for the last `failsafe_throttle_low_delay` seconds. If it was, the craft is assumed to be on the ground and is only disarmed. It may be re-armed without a power cycle. This feature can be disabled completely by 
 setting `failsafe_throttle_low_delay` to zero. This is useful for gliders that may fly long with zero throttle.
@@ -91,10 +88,6 @@ Delay after failsafe activates before motors finally turn off.  This is the amou
 ### `failsafe_throttle`
 
 Throttle level used for landing.  Specify a value that causes the aircraft to descend at about 1M/sec. Default is set to 1000 which should correspond to throttle off.
-
-### `failsafe_kill_switch`
-
-Configure the rc switched failsafe action: the same action as when the rc link is lost (set to OFF) or disarms instantly (set to ON). Also see above.
 
 ### `failsafe_throttle_low_delay`
 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -615,7 +615,6 @@ static const clivalue_t valueTable[] = {
     { "failsafe_delay",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  200 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_delay) },
     { "failsafe_recovery_delay",    VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  200 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_recovery_delay) },
     { "failsafe_off_delay",         VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  200 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_off_delay) },
-    { "failsafe_kill_switch",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_kill_switch) },
     { "failsafe_throttle",          VAR_UINT16 | MASTER_VALUE, .config.minmax = { 1000, 2000 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_throttle) },
     { "failsafe_throttle_low_delay",VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0,  300 }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_throttle_low_delay) },
     { "failsafe_procedure",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_FAILSAFE_PROCEDURE }, PG_FAILSAFE_CONFIG, offsetof(failsafeConfig_t, failsafe_procedure) },

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -253,7 +253,7 @@ void mwArm(void)
         if (ARMING_FLAG(ARMED)) {
             return;
         }
-        if (IS_RC_MODE_ACTIVE(BOXFAILSAFE)) {
+        if (IS_RC_MODE_ACTIVE(BOXFAILSAFE) || IS_RC_MODE_ACTIVE(BOXKILLSWITCH)) {
             return;
         }
         if (!ARMING_FLAG(PREVENT_ARMING)) {

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -140,6 +140,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXTURNASSIST, "TURN ASSIST;", 35 },
     { BOXNAVLAUNCH, "NAV LAUNCH;", 36 },
     { BOXAUTOTRIM, "SERVO AUTOTRIM;", 37 },
+    { BOXKILLSWITCH, "KILLSWITCH;", 38 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -322,6 +323,7 @@ static void initActiveBoxIds(void)
     }
 #endif
 
+    activeBoxIds[activeBoxIdCount++] = BOXKILLSWITCH;
     activeBoxIds[activeBoxIdCount++] = BOXFAILSAFE;
 }
 
@@ -362,6 +364,7 @@ static uint32_t packFlightModeFlags(void)
 #endif
         IS_ENABLED(FLIGHT_MODE(NAV_LAUNCH_MODE)) << BOXNAVLAUNCH |
         IS_ENABLED(IS_RC_MODE_ACTIVE(BOXAUTOTRIM)) << BOXAUTOTRIM |
+        IS_ENABLED(IS_RC_MODE_ACTIVE(BOXKILLSWITCH)) << BOXKILLSWITCH |
         IS_ENABLED(IS_RC_MODE_ACTIVE(BOXHOMERESET)) << BOXHOMERESET;
 
     uint32_t ret = 0;
@@ -895,7 +898,7 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
         sbufWriteU8(dst, failsafeConfig()->failsafe_delay);
         sbufWriteU8(dst, failsafeConfig()->failsafe_off_delay);
         sbufWriteU16(dst, failsafeConfig()->failsafe_throttle);
-        sbufWriteU8(dst, failsafeConfig()->failsafe_kill_switch);
+        sbufWriteU8(dst, 0);    // was failsafe_kill_switch
         sbufWriteU16(dst, failsafeConfig()->failsafe_throttle_low_delay);
         sbufWriteU8(dst, failsafeConfig()->failsafe_procedure);
         sbufWriteU8(dst, failsafeConfig()->failsafe_recovery_delay);
@@ -1871,7 +1874,7 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         failsafeConfigMutable()->failsafe_delay = sbufReadU8(src);
         failsafeConfigMutable()->failsafe_off_delay = sbufReadU8(src);
         failsafeConfigMutable()->failsafe_throttle = sbufReadU16(src);
-        failsafeConfigMutable()->failsafe_kill_switch = sbufReadU8(src);
+        sbufReadU8(src);    // was failsafe_kill_switch
         failsafeConfigMutable()->failsafe_throttle_low_delay = sbufReadU16(src);
         failsafeConfigMutable()->failsafe_procedure = sbufReadU8(src);
         if (dataSize > 8) {

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -183,6 +183,11 @@ void processRcStickPositions(throttleStatus_e throttleStatus, bool disarm_kill_s
         }
     }
 
+    // KILLSWITCH disarms instantly
+    if (IS_RC_MODE_ACTIVE(BOXKILLSWITCH)) {
+        mwDisarm();
+    }
+
     if (rcDelayCommand != 20) {
         return;
     }

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -20,34 +20,34 @@
 #include "config/parameter_group.h"
 
 typedef enum {
-    BOXARM = 0,
-    BOXANGLE,
-    BOXHORIZON,
-    BOXNAVALTHOLD,  // old BOXBARO
-    BOXHEADINGHOLD, // old MAG
-    BOXHEADFREE,
-    BOXHEADADJ,
-    BOXCAMSTAB,
-    BOXNAVRTH,      // old GPSHOME
-    BOXNAVPOSHOLD,  // old GPSHOLD
-    BOXPASSTHRU,
-    BOXBEEPERON,
-    BOXLEDLOW,
-    BOXLLIGHTS,
-    BOXNAVLAUNCH,
-    BOXOSD,
-    BOXTELEMETRY,
-    BOXBLACKBOX,
-    BOXFAILSAFE,
-    BOXNAVWP,
-    BOXAIRMODE,
-    BOXHOMERESET,
-    BOXGCSNAV,
-    BOXUNUSED,      // old HEADING LOCK
-    BOXSURFACE,
-    BOXFLAPERON,
-    BOXTURNASSIST,
-    BOXAUTOTRIM,
+    BOXARM          = 0,
+    BOXANGLE        = 1,
+    BOXHORIZON      = 2,
+    BOXNAVALTHOLD   = 3,    // old BOXBARO
+    BOXHEADINGHOLD  = 4,    // old MAG
+    BOXHEADFREE     = 5,
+    BOXHEADADJ      = 6,
+    BOXCAMSTAB      = 7,
+    BOXNAVRTH       = 8,    // old GPSHOME
+    BOXNAVPOSHOLD   = 9,    // old GPSHOLD
+    BOXPASSTHRU     = 10,
+    BOXBEEPERON     = 11,
+    BOXLEDLOW       = 12,
+    BOXLLIGHTS      = 13,
+    BOXNAVLAUNCH    = 14,
+    BOXOSD          = 15,
+    BOXTELEMETRY    = 16,
+    BOXBLACKBOX     = 17,
+    BOXFAILSAFE     = 18,
+    BOXNAVWP        = 19,
+    BOXAIRMODE      = 20,
+    BOXHOMERESET    = 21,
+    BOXGCSNAV       = 22,
+    BOXKILLSWITCH   = 23,   // old HEADING LOCK
+    BOXSURFACE      = 24,
+    BOXFLAPERON     = 25,
+    BOXTURNASSIST   = 26,
+    BOXAUTOTRIM     = 27,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -35,7 +35,6 @@ typedef struct failsafeConfig_s {
     uint8_t failsafe_delay;                 // Guard time for failsafe activation after signal lost. 1 step = 0.1sec - 1sec in example (10)
     uint8_t failsafe_recovery_delay;        // Time from RC link recovery to failsafe abort. 1 step = 0.1sec - 1sec in example (10)
     uint8_t failsafe_off_delay;             // Time for Landing before motors stop in 0.1sec. 1 step = 0.1sec - 20sec in example (200)
-    uint8_t failsafe_kill_switch;           // failsafe switch action is 0: identical to rc link loss, 1: disarms instantly
     uint8_t failsafe_procedure;             // selected full failsafe procedure is 0: auto-landing, 1: Drop it, 2: Return To Home (RTH)
 
     int16_t failsafe_fw_roll_angle;         // Settings to be applies during "LAND" procedure on a fixed-wing


### PR DESCRIPTION
Remove failsafe_kill_switch setting. Kill switch is no longer related to failsafe procedure.
Replace with new KILLSWITCH box mode.

#1355