### PR TITLE
Fix HoTT telemetry enable bug

### DIFF
--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -416,6 +416,9 @@ void handleHoTTTelemetry(timeUs_t currentTimeUs)
     static uint8_t hottRequestBuffer[2];
     static int hottRequestBufferPtr = 0;
 
+    if (!hottTelemetryEnabled)
+        return;
+
     bool reprocessState;
     do {
         reprocessState = false;


### PR DESCRIPTION
It appears that I've forgotten to add "enable" check in refactored HoTT code. Never noticed because HoTT was enabled anyway on my test board.