### PR TITLE
Init OSD after GYRO

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -474,12 +474,6 @@ void init(void)
     }
 #endif
 
-#ifdef OSD
-    if (feature(FEATURE_OSD)) {
-        osdInit();
-    }
-#endif
-
 #ifdef GPS
     if (feature(FEATURE_GPS)) {
         gpsPreInit();
@@ -516,6 +510,12 @@ void init(void)
     failsafeInit();
 
     rxInit();
+
+#ifdef OSD
+    if (feature(FEATURE_OSD)) {
+        osdInit();
+    }
+#endif
 
 #ifdef GPS
     if (feature(FEATURE_GPS)) {


### PR DESCRIPTION
Move OSD initialisation after GYRO initialisation. It solves the problem of falling into FAILURE_MISSING_ACC mode on F4 boards with MPU6000 GYRO and MAX7456 OSD on the same SPI bus.