### PR TITLE
Avoid target clash between PPM and motor output on REVO target

### DIFF
--- a/src/main/target/REVO/target.c
+++ b/src/main/target/REVO/target.c
@@ -30,7 +30,7 @@ const uint16_t multiPPM[] = {
     PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM11 | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM12 | (MAP_TO_MOTOR_OUTPUT << 8),
-    PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),  // Swap to servo if needed
+    //PWM2  | (MAP_TO_MOTOR_OUTPUT << 8),  // Swap to servo if needed
     PWM3  | (MAP_TO_MOTOR_OUTPUT << 8),  // Swap to servo if needed
     PWM4  | (MAP_TO_MOTOR_OUTPUT << 8),  // Swap to servo if needed
     PWM5  | (MAP_TO_MOTOR_OUTPUT << 8),  // Swap to servo if needed
@@ -62,7 +62,7 @@ const uint16_t airPPM[] = {
     PWM10 | (MAP_TO_SERVO_OUTPUT  << 8),
     PWM11 | (MAP_TO_SERVO_OUTPUT  << 8),
     PWM12 | (MAP_TO_SERVO_OUTPUT  << 8),
-    PWM2  | (MAP_TO_SERVO_OUTPUT  << 8),
+    //PWM2  | (MAP_TO_SERVO_OUTPUT  << 8),
     PWM3  | (MAP_TO_SERVO_OUTPUT  << 8),
     PWM4  | (MAP_TO_SERVO_OUTPUT  << 8),
     PWM5  | (MAP_TO_SERVO_OUTPUT  << 8),

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -136,7 +136,7 @@
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 // Number of available PWM outputs
-#define MAX_PWM_OUTPUT_PORTS    11
+#define MAX_PWM_OUTPUT_PORTS    10
 
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff


### PR DESCRIPTION
Fix for https://github.com/iNavFlight/inav/issues/1377

@anbello could you test this?