### PR TITLE
Built in osd improvement: baterry icon level changes depending on voltage

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -177,7 +177,9 @@ static void osdDrawSingleElement(uint8_t item)
 
         case OSD_MAIN_BATT_VOLTAGE:
         {
-            buff[0] = SYM_BATT_5;
+            uint8_t p = calculateBatteryPercentage();
+            p = (100-p)/16.6;
+            buff[0] = SYM_BATT_FULL + p;
             sprintf(buff + 1, "%d.%1dV", vbat / 10, vbat % 10);
             break;
         }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -178,7 +178,7 @@ static void osdDrawSingleElement(uint8_t item)
         case OSD_MAIN_BATT_VOLTAGE:
         {
             uint8_t p = calculateBatteryPercentage();
-            p = (100-p)/16.6;
+            p = (100 - p) / 16.6;
             buff[0] = SYM_BATT_FULL + p;
             sprintf(buff + 1, "%d.%1dV", vbat / 10, vbat % 10);
             break;


### PR DESCRIPTION
This improvement is related with issue [#1444](https://github.com/iNavFlight/inav/issues/1444).

See video: [![demo](https://img.youtube.com/vi/YOUTUBE_VIDEO_ID_HERE/0.jpg)](https://youtu.be/Bm8SyZ9BTPc)