### PR TITLE
CleanFlight -> INAV docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ irc://irc.freenode.net/#inavflight
 
 ## Configuration Tool
 
-To configure INAV you should use the INAV-configurator GUI tool (Windows/OSX/Linux).
-[//]: # (Can be found here: https://chrome.google.com/webstore/detail/inav-configurator/)
-Currently you have to download the sourcecode and load into Chrome manually from the github page 
+To configure INAV you should use the [INAV-configurator GUI tool](https://chrome.google.com/webstore/detail/inav-configurator/fmaidjmgkdkpafmbnmigkpdnpdhopgel) (Windows/OSX/Linux).
+
+The source for it is here:
 
 https://github.com/iNavFlight/inav-configurator
 

--- a/docs/Blackbox.md
+++ b/docs/Blackbox.md
@@ -191,8 +191,8 @@ These chips are also supported:
 On the Configurator's CLI tab, you must enter `set blackbox_device=SPIFLASH` to switch to logging to an onboard dataflash chip,
 then save.
 
-[your serial ports]: https://github.com/cleanflight/cleanflight/blob/master/docs/Serial.md
-[INAV Configurator]: https://chrome.google.com/webstore/detail/cleanflight-configurator/enacoimjcgeinfnnnpajinjgmkahmfgb?hl=en
+[your serial ports]: https://github.com/iNavFlight/inav/blob/master/docs/Serial.md
+[INAV Configurator]: https://chrome.google.com/webstore/detail/inav-configurator/fmaidjmgkdkpafmbnmigkpdnpdhopgel
 
 ## Configuring the Blackbox
 

--- a/docs/Board - CC3D.md
+++ b/docs/Board - CC3D.md
@@ -5,7 +5,7 @@ auto-piloting.  It only has one sensor, the MPU6000 SPI based Accelerometer/Gyro
 It also features a 16Mbit SPI based EEPROM chip.  It has 6 ports labeled as inputs (one pin each)
 and 6 ports labeled as motor/servo outputs (3 pins each).
 
-If issues are found with this board please report via the [github issue tracker](https://github.com/cleanflight/cleanflight/issues).
+If issues are found with this board please report via the [github issue tracker](https://github.com/iNavFlight/inav/issues).
 
 The board has a USB port directly connected to the processor.  Other boards like the Naze and Flip32
 have an on-board USB to uart adapter which connect to the processor's serial port instead.

--- a/docs/Board - Naze32.md
+++ b/docs/Board - Naze32.md
@@ -2,7 +2,7 @@
 
 The Naze32 target supports all Naze hardware revisions.  Revision 4 and 5 are used and
 frequently flown by the primary maintainer.  Previous Naze hardware revisions may have issues,
-if found please report via the [github issue tracker](https://github.com/cleanflight/cleanflight/issues).
+if found please report via the [github issue tracker](https://github.com/iNavFlight/inav/issues).
 
 ## Serial Ports
 

--- a/docs/Board - Sparky.md
+++ b/docs/Board - Sparky.md
@@ -38,13 +38,13 @@ A binary file is required for DFU, not a .hex file.  If one is not included in t
 
 ```
 Unpack DfuSE and the STM VCP Drivers into a folder on your Hardrive
-Download the latest Sparky release (cleanflight_SPARKY.hex) from:
-https://github.com/cleanflight/cleanflight/releases and store it on your Hardrive
+Download the latest Sparky release (inav_SPARKY.hex) from:
+https://github.com/iNavFlight/inav/releases and store it on your Hardrive
 
 In your DfuSE folder go to BIN and start DfuFileMgr.exe
 Select: "I want to GENERATE a DFUfile from S19,HEX or BIN files" press OK
 Press: "S19 or Hex.."
-Go to the folder where you saved the cleanflight_SPARKY.hex file, select it  and press open
+Go to the folder where you saved the inav_SPARKY.hex file, select it  and press open
 (you might need to change the filetype in the DfuSE explorer window to "hex Files (*.hex)" to be able to see the file)
 Press: "Generate" and select the .dfu output file and location
 If all worked well you should see " Success for 'Image for lternate Setting 00 (ST..)'!"
@@ -110,7 +110,7 @@ Found DFU: [0483:df11] devnum=0, cfg=1, intf=0, alt=1, name="@Option Bytes  /0x1
 Then flash the binary as below.
 
 ```
-dfu-util -D obj/cleanflight_SPARKY.bin --alt 0 -R -s 0x08000000
+dfu-util -D obj/inav_SPARKY.bin --alt 0 -R -s 0x08000000
 ```
 
 The output should be similar to this:
@@ -161,7 +161,7 @@ See Sparky schematic for CONN2 pinouts.
 
 ## TauLabs bootloader
 
-Flashing cleanflight will erase the TauLabs bootloader, this is not a problem and can easily be restored using the st flashloader tool.
+Flashing INAV will erase the TauLabs bootloader, this is not a problem and can easily be restored using the st flashloader tool.
 
 # Serial Ports
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -20,11 +20,11 @@ __Due to ongoing development, the fact that the GUI cannot yet backup all your s
 The GUI tool is the preferred way of configuration.  The GUI tool also includes a terminal which
 can be used to interact with the CLI.
 
-[INAV Configurator on Chrome store](https://chrome.google.com/webstore/detail/cleanflight-configurator/enacoimjcgeinfnnnpajinjgmkahmfgb)
+[INAV Configurator on Chrome store](https://chrome.google.com/webstore/detail/inav-configurator/fmaidjmgkdkpafmbnmigkpdnpdhopgel)
 
 If you cannot use the latest version of the GUI to access the FC due to firmware compatibility issues you can still access the FC via the CLI to backup your settings, or you can install an old version of the configurator.
 
-Old versions of the configurator can be downloaded from the configurator releases page: https://github.com/cleanflight/cleanflight-configurator/releases
+Old versions of the configurator can be downloaded from the configurator releases page: https://github.com/iNavFlight/inav-configurator/releases
 See the README file that comes with the configurator for installation instructions.
 
 

--- a/docs/Failsafe.md
+++ b/docs/Failsafe.md
@@ -7,7 +7,7 @@ There are two types of failsafe:
 
 Receiver based failsafe is where you, from your transmitter and receiver, configure channels to output desired signals if your receiver detects signal loss and goes to the __failsafe mode__. The idea is that you set throttle and other controls so the aircraft descends in a controlled manner.  See your receiver's documentation for this method.
 
-Flight controller based failsafe is where the flight controller attempts to detect signal loss and/or the __failsafe mode__ of your receiver and upon detection goes to __failsafe stage 1__. The idea is that the flight controller starts using __fallback settings__ for all controls, which are set by you, using the CLI command `rxfail` (see `rxfail` section in rx documentation) or the cleanflight-configurator GUI.
+Flight controller based failsafe is where the flight controller attempts to detect signal loss and/or the __failsafe mode__ of your receiver and upon detection goes to __failsafe stage 1__. The idea is that the flight controller starts using __fallback settings__ for all controls, which are set by you, using the CLI command `rxfail` (see `rxfail` section in rx documentation) or the inav-configurator GUI.
 
 It is possible to use both types at the same time, which may be desirable.  Flight controller failsafe can even help if your receiver signal wires come loose, get damaged or your receiver malfunctions in a way the receiver itself cannot detect.
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -97,11 +97,11 @@ Go to the field, turn Tx on, place aircraft on the ground, connect flight batter
 Some advanced configurations and features are documented in the following pages, but have not been touched-upon earlier:
 
 * [Profiles](Profiles.md)
-* [PID tuning](PID tuning.md)
-* [In-flight Adjustments](Inflight Adjustments.md)
+* [PID tuning](PID%20tuning.md)
+* [In-flight Adjustments](Inflight%20Adjustments.md)
 * [Blackbox logging](Blackbox.md)
 * [Using a Sonar](Sonar.md)
-* [Spektrum Bind](Spektrum bind.md)
+* [Spektrum Bind](Spektrum%20bind.md)
 * [Telemetry](Telemetry.md)
 * [Using a Display](Display.md)
 * [Using a LED strip](LedStrip.md)

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -32,7 +32,7 @@ For an overview of the hardware INAV (hereby CF) can run on, see [Boards.md](Boa
 
 ## Software setup
 
-Now that your board has pins on it, you are ready to connect it to your PC and flash it with CF. Install the Chromium browser or Google Chrome to your PC, if you don't have it already, add the [INAV Configurator](https://chrome.google.com/webstore/detail/cleanflight-configurator/enacoimjcgeinfnnnpajinjgmkahmfgb) to it, and start it.
+Now that your board has pins on it, you are ready to connect it to your PC and flash it with CF. Install the Chromium browser or Google Chrome to your PC, if you don't have it already, add the [INAV Configurator](https://chrome.google.com/webstore/detail/inav-configurator/fmaidjmgkdkpafmbnmigkpdnpdhopgel) to it, and start it.
 
 Then follow these instructions for [Installation](Installation.md) of the firmware to the FC.
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -28,8 +28,8 @@ We welcome all feedback.  If you love it we want to hear from you, if you have p
 
 If you want to contribute please see the notes here:
 
-https://github.com/cleanflight/cleanflight#contributing
+https://github.com/iNavFlight/inav#contributing
 
 Developers should read this:
 
-https://github.com/cleanflight/cleanflight/blob/master/CONTRIBUTING.md
+https://github.com/iNavFlight/inav/blob/master/CONTRIBUTING.md

--- a/docs/Mixer.md
+++ b/docs/Mixer.md
@@ -211,7 +211,7 @@ smix reverse 5 2 r
 Here is an example of a custom twin engine plane with [Differential Thrust](http://rcvehicles.about.com/od/rcairplanes/ss/RCAirplaneBasic.htm#step8)
 Motors take the first 2 pins, the servos take pins as indicated in the [Servo slot] chart above.
 Settings bellow have motor yaw influence at "0.3", you can change this nuber to have more or less differential thrust over the two motors.
-Note: You can look at the Motors tab in [INAV Cofigurator](https://chrome.google.com/webstore/detail/cleanflight-configurator/enacoimjcgeinfnnnpajinjgmkahmfgb?hl=en) to see motor and servo outputs.
+Note: You can look at the Motors tab in [INAV Cofigurator](https://chrome.google.com/webstore/detail/inav-configurator/fmaidjmgkdkpafmbnmigkpdnpdhopgel) to see motor and servo outputs.
 
 | Pins | Outputs          |
 |------|------------------|

--- a/docs/Rx.md
+++ b/docs/Rx.md
@@ -99,7 +99,7 @@ These receivers are reported working:
 XG14 14ch DMSS System w/RG731BX XBus Receiver
 http://www.jramericas.com/233794/JRP00631/
 
-There exist a remote receiver made for small BNF-models like the Align T-Rex 150 helicopter. The code also supports using the Align DMSS RJ01 receiver directly with the cleanflight software.
+There exist a remote receiver made for small BNF-models like the Align T-Rex 150 helicopter. The code also supports using the Align DMSS RJ01 receiver directly with the INAV software.
 To use this receiver you must power it with 3V from the hardware, and then connect the serial line as other serial RX receivers.
 In order for this receiver to work, you need to specify the XBUS_MODE_B_RJ01 for serialrx_provider. Note that you need to set your radio mode for XBUS "MODE B" also for this receiver to work.
 Receiver name: Align DMSS RJ01 (HER15001)

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -19,7 +19,7 @@ All telemetry systems use serial ports, configure serial ports to use the teleme
 
 FrSky telemetry is transmit only and just requires a single connection from the TX pin of a serial port to the RX pin on an FrSky telemetry receiver.
 
-FrSky telemetry signals are inverted.  To connect a cleanflight capable board to an FrSKy receiver you have some options.
+FrSky telemetry signals are inverted.  To connect a INAV capable board to an FrSKy receiver you have some options.
 
 1. A hardware inverter - Built in to some flight controllers.
 2. Use software serial and enable frsky_inversion.
@@ -126,10 +126,10 @@ found at https://github.com/iNavFlight/inav/wiki/Lightweight-Telemetry-(LTM).
 ## MAVLink telemetry
 
 MAVLink is a very lightweight, header-only message marshalling library for micro air vehicles.
-Cleanflight supports MAVLink for compatibility with ground stations, OSDs and antenna trackers built
+INAV supports MAVLink for compatibility with ground stations, OSDs and antenna trackers built
 for PX4, PIXHAWK, APM and Parrot AR.Drone platforms.
 
-MAVLink implementation in Cleanflight is transmit-only and usable on low baud rates and can be used over soft serial.
+MAVLink implementation in INAV is transmit-only and usable on low baud rates and can be used over soft serial.
 
 ## SmartPort (S.Port)
 

--- a/docs/development/Blackbox Internals.md
+++ b/docs/development/Blackbox Internals.md
@@ -11,9 +11,9 @@ rate of 900Hz. That's about 25,000 bytes per second, which is 250,000 baud with 
 
 Please refer to the source code to clarify anything this document leaves unclear:
 
-* INAV's Blackbox logger: [blackbox.c](https://github.com/cleanflight/cleanflight/blob/master/src/main/blackbox/blackbox.c),
-[blackbox_io.c](https://github.com/cleanflight/cleanflight/blob/master/src/main/blackbox/blackbox_io.c),
-[blackbox_fielddefs.h](https://github.com/cleanflight/cleanflight/blob/master/src/main/blackbox/blackbox_fielddefs.h)
+* INAV's Blackbox logger: [blackbox.c](https://github.com/iNavFlight/inav/blob/master/src/main/blackbox/blackbox.c),
+[blackbox_io.c](https://github.com/iNavFlight/inav/blob/master/src/main/blackbox/blackbox_io.c),
+[blackbox_fielddefs.h](https://github.com/iNavFlight/inav/blob/master/src/main/blackbox/blackbox_fielddefs.h)
 * [C implementation of the Blackbox log decoder](https://github.com/cleanflight/blackbox-tools/blob/master/src/parser.c)
 * [JavaScript implementation of the Blackbox log decoder](https://github.com/cleanflight/blackbox-log-viewer/blob/master/js/flightlog_parser.js)
 

--- a/docs/development/Building in Eclipse.md
+++ b/docs/development/Building in Eclipse.md
@@ -23,7 +23,7 @@ Make sure you have a valid ARM toolchain in the path
 * Create a new C project in Eclipse and choose ARM Cross Target Application and your ARM toolchain.
 * Import the Git project into the C project in Eclipse via *File > Import > General > File System*.
 * Activate Git via *Project > Team > Share Project*.
-* Switch to the master branch in Eclipse (*Project > Team > Switch To > master*).
+* Switch to the development branch in Eclipse (*Project > Team > Switch To > development*).
 * The next thing you need to do is adjust the project configuration. There is a Makefile included that works but you might want to use GNU ARM Eclipse's automatic Makefile generation. Open the Project configuration and go to *C/C++ Build > Settings*
 	* Under *Target Processor* choose "cortex-m3"
 	* Under *ARM Yagarto [Windows/Mac OS] Linker > General* (or whatever toolchain you chose)

--- a/docs/development/Building in Mac OS X.md
+++ b/docs/development/Building in Mac OS X.md
@@ -73,29 +73,29 @@ If `arm-none-eabi-gcc` couldn't be found, go back and check that you entered the
 [GNU Tools for ARM Embedded Processors project]: https://launchpad.net/gcc-arm-embedded
 [the older releases]: https://launchpad.net/gcc-arm-embedded/+download
 
-## Checkout CleanFlight sourcecode through git
+## Checkout INAV sourcecode through git
 
 Enter your development directory and clone the [INAV repository][] using the "HTTPS clone URL" which is shown on
 the right side of the INAV GitHub page, like so:
 
 ```
-git clone https://github.com/cleanflight/cleanflight.git
+git clone https://github.com/iNavFlight/inav
 ```
 
-This will download the entire INAV repository for you into a new folder called "cleanflight".
+This will download the entire INAV repository for you into a new folder called "inav".
 
-[CleanFlight repository]: https://github.com/cleanflight/cleanflight
+[INAV repository]: https://github.com/iNavFlight/inav.git
 
 ## Build the code
 
-Enter the cleanflight directory and run `make TARGET=NAZE` to build firmware for the Naze32. When the build completes,
-the .hex firmware should be available as `obj/cleanflight_NAZE.hex` for you to flash using the INAV
+Enter the inav directory and run `make TARGET=NAZE` to build firmware for the Naze32. When the build completes,
+the .hex firmware should be available as `obj/inav_NAZE.hex` for you to flash using the INAV
 Configurator.
 
 ## Updating to the latest source
 
 If you want to erase your local changes and update to the latest version of the INAV source, enter your
-cleanflight directory and run these commands to first erase your local changes, fetch and merge the latest
+inav directory and run these commands to first erase your local changes, fetch and merge the latest
 changes from the repository, then rebuild the firmware:
 
 ```

--- a/docs/development/Building in Ubuntu.md
+++ b/docs/development/Building in Ubuntu.md
@@ -55,23 +55,23 @@ sudo apt-get install gcc-arm-none-eabi=4.9.3.2014q4-0precise12
 After the ARM toolchain from Terry is installed, you should be able to build from source.
 ```
 cd src
-git clone git@github.com:cleanflight/cleanflight.git
-cd cleanflight
+git clone git@github.com:iNavFlight/inav.git
+cd inav
 make TARGET=NAZE
 ```
 
 You'll see a set of files being compiled, and finally linked, yielding both an ELF and then a HEX:
 ```
 ...
-arm-none-eabi-size ./obj/main/cleanflight_NAZE.elf
+arm-none-eabi-size ./obj/main/inav_NAZE.elf
    text    data     bss     dec     hex filename
-  97164     320   11080  108564   1a814 ./obj/main/cleanflight_NAZE.elf
-arm-none-eabi-objcopy -O ihex --set-start 0x8000000 obj/main/cleanflight_NAZE.elf obj/cleanflight_NAZE.hex
-$ ls -la obj/cleanflight_NAZE.hex                                                                                                                                                 
--rw-rw-r-- 1 pim pim 274258 Jan 12 21:45 obj/cleanflight_NAZE.hex
+  97164     320   11080  108564   1a814 ./obj/main/inav_NAZE.elf
+arm-none-eabi-objcopy -O ihex --set-start 0x8000000 obj/main/inav_NAZE.elf obj/inav_NAZE.hex
+$ ls -la obj/inav_NAZE.hex                                                                                                                                                 
+-rw-rw-r-- 1 pim pim 274258 Jan 12 21:45 obj/inav_NAZE.hex
 ```
 
-You can use the INAV-Configurator to flash the ```obj/cleanflight_NAZE.hex``` file.
+You can use the INAV-Configurator to flash the ```obj/inav_NAZE.hex``` file.
 
 ## Bricked/Bad build?
 
@@ -89,10 +89,10 @@ Make sure to remove `obj/` and `make clean`, before building again.
 
 ## Updating and rebuilding
 
-Navigate to the local cleanflight repository and use the following steps to pull the latest changes and rebuild your version of cleanflight:
+Navigate to the local INAV repository and use the following steps to pull the latest changes and rebuild your version of INAV:
 
 ```
-cd src/cleanflight
+cd src/inav
 git reset --hard
 git pull
 make clean TARGET=NAZE

--- a/docs/development/Configuration Storage.md
+++ b/docs/development/Configuration Storage.md
@@ -1,6 +1,6 @@
 # Configuration
 
-The configuration in cleanflight is stored at the end of the flash ram, currently it uses 2KB of flash.
+The configuration in INAV is stored at the end of the flash ram, currently it uses 2KB of flash.
 
 Sometimes it's necesaary to erase this during development.
 

--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -76,24 +76,24 @@ The main flow for a contributing is as follows:
 
 1. Login to github, go to the INAV repository and press `fork`.
 2. Then using the command line/terminal on your computer: `git clone <url to YOUR fork>`
-3. `cd cleanflight`
+3. `cd inav`
 4. `git checkout master`
 5. `git checkout -b my-new-code`
 6. Make changes
 7. `git add <files that have changed>`
 8. `git commit`
 9. `git push origin my-new-code`
-10. Create pull request using github UI to merge your changes from your new branch into `cleanflight/master`
+10. Create pull request using github UI to merge your changes from your new branch into `inav/master`
 11. Repeat from step 4 for new other changes.
 
 The primary thing to remember is that separate pull requests should be created for separate branches.  Never create a pull request from your `master` branch.
 
-Later, you can get the changes from the cleanflight repo into your `master` branch by adding cleanflight as a git remote and merging from it as follows:
+Later, you can get the changes from the INAV repo into your `master` branch by adding INAV as a git remote and merging from it as follows:
 
-1. `git remote add cleanflight https://github.com/cleanflight/cleanflight.git`
+1. `git remote add upstream https://github.com/iNavFlight/inav.git`
 2. `git checkout master`
-3. `git fetch cleanflight`
-4. `git merge cleanflight/master`
+3. `git fetch upstream`
+4. `git merge upstream/master`
 5. `git push origin master` is an optional step that will update your fork on github
 
 

--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -77,24 +77,24 @@ The main flow for a contributing is as follows:
 1. Login to github, go to the INAV repository and press `fork`.
 2. Then using the command line/terminal on your computer: `git clone <url to YOUR fork>`
 3. `cd inav`
-4. `git checkout master`
+4. `git checkout development`
 5. `git checkout -b my-new-code`
 6. Make changes
 7. `git add <files that have changed>`
 8. `git commit`
 9. `git push origin my-new-code`
-10. Create pull request using github UI to merge your changes from your new branch into `inav/master`
+10. Create pull request using github UI to merge your changes from your new branch into `inav/development`
 11. Repeat from step 4 for new other changes.
 
-The primary thing to remember is that separate pull requests should be created for separate branches.  Never create a pull request from your `master` branch.
+The primary thing to remember is that separate pull requests should be created for separate branches.  Never create a pull request from your `development` branch.
 
-Later, you can get the changes from the INAV repo into your `master` branch by adding INAV as a git remote and merging from it as follows:
+Later, you can get the changes from the INAV repo into your `development` branch by adding INAV as a git remote and merging from it as follows:
 
 1. `git remote add upstream https://github.com/iNavFlight/inav.git`
-2. `git checkout master`
+2. `git checkout development`
 3. `git fetch upstream`
-4. `git merge upstream/master`
-5. `git push origin master` is an optional step that will update your fork on github
+4. `git merge upstream/development`
+5. `git push origin development` is an optional step that will update your fork on github
 
 
 You can also perform the git commands using the git client inside Eclipse.  Refer to the Eclipse git manual.

--- a/docs/development/Hardware Debugging in Eclipse.md
+++ b/docs/development/Hardware Debugging in Eclipse.md
@@ -25,7 +25,7 @@ stop the board, flash the firmware, restart:
      sleep 100
      poll
      flash probe 0
-     flash write_image erase /home/user/git/cleanflight/obj/cleanflight_NAZE.hex 0x08000000
+     flash write_image erase /home/user/git/inav/obj/inav_NAZE.hex 0x08000000
      sleep 200
      soft_reset_halt
      wait_halt


### PR DESCRIPTION
I noticed that there are a few left overs in the documentation from the initial CleanFlight fork. I cleaned that up a bit and fixe a few links that pointed to the wrong repository, configurator or were just not working at all. 

