### PR TITLE
Enabled IIR internal filter for BMP280

### DIFF
--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -84,6 +84,8 @@ bool bmp280Detect(baroDev_t *baro)
         bmp280ReadRegister(BMP280_TEMPERATURE_CALIB_DIG_T1_LSB_REG, 24, (uint8_t *)&bmp280_cal);
         // set oversampling + power mode (forced), and start sampling
         bmp280WriteRegister(BMP280_CTRL_MEAS_REG, BMP280_MODE);
+        //set filter setting
+        bmp280WriteRegister(BMP280_CONFIG_REG, BMP280_FILTER);
 #else
         bool ack = i2cRead(BARO_I2C_INSTANCE, BMP280_I2C_ADDR, BMP280_CHIP_ID_REG, 1, &bmp280_chip_id);  /* read Chip Id */
         if (!ack || bmp280_chip_id != BMP280_DEFAULT_CHIP_ID)
@@ -93,6 +95,8 @@ bool bmp280Detect(baroDev_t *baro)
         i2cRead(BARO_I2C_INSTANCE, BMP280_I2C_ADDR, BMP280_TEMPERATURE_CALIB_DIG_T1_LSB_REG, 24, (uint8_t *)&bmp280_cal);
         // set oversampling + power mode (forced), and start sampling
         i2cWrite(BARO_I2C_INSTANCE, BMP280_I2C_ADDR, BMP280_CTRL_MEAS_REG, BMP280_MODE);
+        //set filter setting
+        i2cWrite(BARO_I2C_INSTANCE, BMP280_I2C_ADDR, BMP280_CONFIG_REG, BMP280_FILTER);
 #endif
 
         bmp280InitDone = true;

--- a/src/main/drivers/barometer/barometer_bmp280.h
+++ b/src/main/drivers/barometer/barometer_bmp280.h
@@ -57,7 +57,7 @@
 #define BMP280_MODE                      (BMP280_PRESSURE_OSR << 2 | BMP280_TEMPERATURE_OSR << 5 | BMP280_FORCED_MODE)
 
 //configure IIR pressure filter
-#define BMP280_FILTER                    (BMP280_FILTER_COEFF_4 << 2)
+#define BMP280_FILTER                    (BMP280_FILTER_COEFF_8 << 2)
 
 #define T_INIT_MAX                       (20)
 // 20/16 = 1.25 ms

--- a/src/main/drivers/barometer/barometer_bmp280.h
+++ b/src/main/drivers/barometer/barometer_bmp280.h
@@ -44,10 +44,20 @@
 #define BMP280_OVERSAMP_8X               (0x04)
 #define BMP280_OVERSAMP_16X              (0x05)
 
+#define BMP280_FILTER_COEFF_OFF               (0x00)
+#define BMP280_FILTER_COEFF_2                 (0x01)
+#define BMP280_FILTER_COEFF_4                 (0x02)
+#define BMP280_FILTER_COEFF_8                 (0x03)
+#define BMP280_FILTER_COEFF_16                (0x04)
+
+
 // configure pressure and temperature oversampling, forced sampling mode
 #define BMP280_PRESSURE_OSR              (BMP280_OVERSAMP_8X)
 #define BMP280_TEMPERATURE_OSR           (BMP280_OVERSAMP_1X)
 #define BMP280_MODE                      (BMP280_PRESSURE_OSR << 2 | BMP280_TEMPERATURE_OSR << 5 | BMP280_FORCED_MODE)
+
+//configure IIR pressure filter
+#define BMP280_FILTER                    (BMP280_FILTER_COEFF_4 << 2)
 
 #define T_INIT_MAX                       (20)
 // 20/16 = 1.25 ms


### PR DESCRIPTION
Taking advantage of BMP280 internal IIR filter can help to remove same baro noise even before samples enter INAV baro filters.

I've taken a look to the datasheet (https://cdn-shop.adafruit.com/datasheets/BST-BMP280-DS001-11.pdf) part 3.3.3 page 13 and I tough choosing a filter coefficient of 4 is a good compromise between filtering and delay.

I don't really know if this will affect climbing rate estimation since I don't really understand how it works. If so, discard my request, and sorry.

For the moment I'm pushing the code so you can say if it is worth or not and then I'll proceed to a deeper test.
