### PR TITLE
Adding Revolt target

### DIFF
--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -15,6 +15,7 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
 struct dmaChannelDescriptor_s;
 typedef void (*dmaCallbackHandlerFuncPtr)(struct dmaChannelDescriptor_s *channelDescriptor);

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -17,11 +17,18 @@
 
 #pragma once
 
-#define TARGET_BOARD_IDENTIFIER "REVO"
+#if defined(REVOLT)
+#define TARGET_BOARD_IDENTIFIER "RVLT"
+#define USBD_PRODUCT_STRING     "Revolt"
 
+#else
+#define TARGET_BOARD_IDENTIFIER "REVO"
 #define USBD_PRODUCT_STRING     "Revolution"
+
 #ifdef OPBL
 #define USBD_SERIALNUMBER_STRING "0x8020000"
+#endif
+
 #endif
 
 #define LED0                    PB5
@@ -40,14 +47,26 @@
 #define MPU6000_CS_PIN          PA4
 #define MPU6000_SPI_INSTANCE    SPI1
 
+#define MPU6500_CS_PIN          PA4
+#define MPU6500_SPI_INSTANCE    SPI1
+
 #define GYRO
 #define USE_GYRO_SPI_MPU6000
 #define ACC_MPU6000_ALIGN       CW270_DEG
+
+#define USE_GYRO_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define GYRO_MPU9250_ALIGN      CW270_DEG
 
 #define ACC
 #define USE_ACC_SPI_MPU6000
 #define GYRO_MPU6000_ALIGN      CW270_DEG
 
+#define USE_ACC_MPU6500
+#define USE_ACC_SPI_MPU6500
+#define ACC_MPU6500_ALIGN       CW270_DEG
+
+#if !defined(REVOLT)
 #define MAG
 #define USE_MAG_AK8963
 #define USE_MAG_AK8975
@@ -62,6 +81,7 @@
 
 //#define PITOT
 //#define USE_PITOT_MS4525
+#endif
 #define PITOT_I2C_INSTANCE      I2C_DEVICE_EXT
 
 #define M25P16_CS_PIN           PB3

--- a/src/main/target/REVO/target.mk
+++ b/src/main/target/REVO/target.mk
@@ -3,6 +3,8 @@ FEATURES       += VCP ONBOARDFLASH
 
 TARGET_SRC = \
             drivers/accgyro_spi_mpu6000.c \
+            drivers/accgyro_mpu6500.c \
+            drivers/accgyro_spi_mpu6500.c \
             drivers/barometer_bmp085.c \
             drivers/barometer_bmp280.c \
             drivers/barometer_ms56xx.c \


### PR DESCRIPTION
Cherry-pick from Betaflight to support Revolt and AirbotF4. Tested only with Revolt.