### PR TITLE
Servo mapping for omnibusF4 changed to pin 4 for ergonomic purposes

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -265,8 +265,8 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
 #endif
 
 #if defined(OMNIBUSF4)
-            // remap PWM12 (OUT6) as servo
-            if (timerIndex == PWM12)
+            // remap PWM10 (OUT4) as servo
+            if (timerIndex == PWM10)
                 type = MAP_TO_SERVO_OUTPUT;
 #endif
 


### PR DESCRIPTION
I've changed the servo pin for the omnibusF4. This board only has 4 3pin headers (channels 1-4) so it would make sense to make use of these for servos. Channels 5 and 6 only have 2 pins so cannot power a servo directly. I've tested this on the hardware and it works fine.