### PR TITLE
Try to simplify build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:wily
+LABEL maintainer Alexandr Kuzmitsky <brat002@gmail.com>
+
+VOLUME /home/src/
+WORKDIR /home/src/
+
+RUN mkdir -p /home/src && apt-get update && \
+    apt-get install -y software-properties-common python-software-properties && \
+    apt-get remove -y binutils-arm-none-eabi gcc-arm-none-eabi && \
+    add-apt-repository -y ppa:terry.guo/gcc-arm-embedded && \
+    apt-get update && \
+    apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi make git gcc

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+echo "Building target" $1
+docker run --rm -v `pwd`:/home/src/ inav make TARGET=$1

--- a/docs/development/Building in Docker.md
+++ b/docs/development/Building in Docker.md
@@ -1,0 +1,14 @@
+# Building in Ubuntu
+
+Building in Docker is remarkably easy.
+
+## Build a container with toolchain
+
+```
+docker build -t inav .
+```
+
+Build specified target
+```
+sh build.sh SPRACINGF3
+```


### PR DESCRIPTION
It is my try to simplify building targets with docker. Will be great to see this code in project repository. Usage is pretty easy: 
1. Build container with toolchain.
2. Call script for build specified.
Benefits: you can use these scripts for any OS what you have: linux, osx, windows without or almost without big changes.

Here are much things which may be better, but I need to know if you want it.