### PR TITLE
BMP280 I2C data sanity check

### DIFF
--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -53,8 +53,8 @@ static uint8_t bmp280_chip_id = 0;
 static bool bmp280InitDone = false;
 STATIC_UNIT_TESTED bmp280_calib_param_t bmp280_cal;
 // uncompensated pressure and temperature
-static int32_t bmp280_up = 0;
-static int32_t bmp280_ut = 0;
+int32_t bmp280_up = 0;
+int32_t bmp280_ut = 0;
 
 static void bmp280_start_ut(void);
 static void bmp280_get_ut(void);
@@ -140,15 +140,31 @@ static void bmp280_get_up(void)
 {
     uint8_t data[BMP280_DATA_FRAME_SIZE];
     
+    //error free measurements
+    static int32_t bmp280_up_valid;
+    static int32_t bmp280_ut_valid;
+    
     //read data from sensor
-    bool ack=  i2cRead(BARO_I2C_INSTANCE, BMP280_I2C_ADDR, BMP280_PRESSURE_MSB_REG, BMP280_DATA_FRAME_SIZE, data);
+    bool ack =  i2cRead(BARO_I2C_INSTANCE, BMP280_I2C_ADDR, BMP280_PRESSURE_MSB_REG, BMP280_DATA_FRAME_SIZE, data);
   
-   //check if pressure and temperature readings are valid, otherwise use previous measurements from the moment
+    //check if pressure and temperature readings are valid, otherwise use previous measurements from the moment
 
-   if(ack){
-    bmp280_up = (int32_t)((((uint32_t)(data[0])) << 12) | (((uint32_t)(data[1])) << 4) | ((uint32_t)data[2] >> 4));
-    bmp280_ut = (int32_t)((((uint32_t)(data[3])) << 12) | (((uint32_t)(data[4])) << 4) | ((uint32_t)data[5] >> 4));
-    }
+    if(ack){
+    
+    	bmp280_up = (int32_t)((((uint32_t)(data[0])) << 12) | (((uint32_t)(data[1])) << 4) | ((uint32_t)data[2] >> 4));
+     	bmp280_ut = (int32_t)((((uint32_t)(data[3])) << 12) | (((uint32_t)(data[4])) << 4) | ((uint32_t)data[5] >> 4));
+     	
+     	bmp280_up_valid  = bmp280_up;
+     	bmp280_ut_valid  = bmp280_ut;
+     }
+     else
+     {
+    	 //assign previous valid measurements
+     	bmp280_up= bmp280_up_valid;
+     	bmp280_ut= bmp280_ut_valid; 
+     }
+    
+    
 }
 #endif
 

--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -19,7 +19,6 @@
 #include <stdint.h>
 
 #include <platform.h>
-
 #include "build/build_config.h"
 
 #include "drivers/barometer/barometer.h"
@@ -54,8 +53,8 @@ static uint8_t bmp280_chip_id = 0;
 static bool bmp280InitDone = false;
 STATIC_UNIT_TESTED bmp280_calib_param_t bmp280_cal;
 // uncompensated pressure and temperature
-int32_t bmp280_up = 0;
-int32_t bmp280_ut = 0;
+static int32_t bmp280_up = 0;
+static int32_t bmp280_ut = 0;
 
 static void bmp280_start_ut(void);
 static void bmp280_get_ut(void);
@@ -140,11 +139,16 @@ static void bmp280_start_up(void)
 static void bmp280_get_up(void)
 {
     uint8_t data[BMP280_DATA_FRAME_SIZE];
+    
+    //read data from sensor
+    bool ack=  i2cRead(BARO_I2C_INSTANCE, BMP280_I2C_ADDR, BMP280_PRESSURE_MSB_REG, BMP280_DATA_FRAME_SIZE, data);
+  
+   //check if pressure and temperature readings are valid, otherwise use previous measurements from the moment
 
-    // read data from sensor
-    i2cRead(BARO_I2C_INSTANCE, BMP280_I2C_ADDR, BMP280_PRESSURE_MSB_REG, BMP280_DATA_FRAME_SIZE, data);
+   if(ack){
     bmp280_up = (int32_t)((((uint32_t)(data[0])) << 12) | (((uint32_t)(data[1])) << 4) | ((uint32_t)data[2] >> 4));
     bmp280_ut = (int32_t)((((uint32_t)(data[3])) << 12) | (((uint32_t)(data[4])) << 4) | ((uint32_t)data[5] >> 4));
+    }
 }
 #endif
 

--- a/src/main/drivers/barometer/barometer_spi_bmp280.c
+++ b/src/main/drivers/barometer/barometer_spi_bmp280.c
@@ -30,8 +30,8 @@
 #define DISABLE_BMP280       IOHi(bmp280CsPin)
 #define ENABLE_BMP280        IOLo(bmp280CsPin)
 
-extern static int32_t bmp280_up;
-extern static int32_t bmp280_ut;
+static int32_t bmp280_up;
+static int32_t bmp280_ut;
 
 static IO_t bmp280CsPin = IO_NONE;
 

--- a/src/main/drivers/barometer/barometer_spi_bmp280.c
+++ b/src/main/drivers/barometer/barometer_spi_bmp280.c
@@ -30,8 +30,8 @@
 #define DISABLE_BMP280       IOHi(bmp280CsPin)
 #define ENABLE_BMP280        IOLo(bmp280CsPin)
 
-static int32_t bmp280_up;
-static int32_t bmp280_ut;
+extern int32_t bmp280_up;
+extern int32_t bmp280_ut;
 
 static IO_t bmp280CsPin = IO_NONE;
 

--- a/src/main/drivers/barometer/barometer_spi_bmp280.c
+++ b/src/main/drivers/barometer/barometer_spi_bmp280.c
@@ -30,8 +30,8 @@
 #define DISABLE_BMP280       IOHi(bmp280CsPin)
 #define ENABLE_BMP280        IOLo(bmp280CsPin)
 
-extern int32_t bmp280_up;
-extern int32_t bmp280_ut;
+extern static int32_t bmp280_up;
+extern static int32_t bmp280_ut;
 
 static IO_t bmp280CsPin = IO_NONE;
 


### PR DESCRIPTION
Since lot of us uses an external BMP280 (since most uses "acro" boards) the sensor is usually connected trought some (long) wires and now and then due to some noise the FC is unable the read correctly the device causing or not an I2C error.

At this time data validity is not checked and wathever is inside the buffer become raw pressure and temperature data.

Applying my fix and disturbing the bus by shorting SDA and SCL with a finger (wet is even better! ;) )  and doing some testing using debug array and the configurator I've noted that checking the bool output of i2cRead does the job. 

Even if there isn't an i2c error counted as soon I "short" for a fraction of second SDA and SCL the i2cRead return false and baro data remain stable without any spike.

I've seen a similar approach to gyro/acc and mag data. I know this fix is not definitive since we need to include a baro health function but for the moment it may prevent some troubles in the altitude estimator. 

This is nice since I am going to test the internal IIR filter, excluding the median filter, and a spike can even propagate more inside the system with the median filter turned off.

This causes important spikes in the baro data and spikes in navPos[2] consequently.

To check this PR just use the configurator and check baro data with and without this PR.
