### PR TITLE
Remove GPS_PROTO_UBLOX_NEO7PLUS from ANYFCF7

### DIFF
--- a/src/main/target/ANYFCF7/target.h
+++ b/src/main/target/ANYFCF7/target.h
@@ -146,7 +146,6 @@
 #define NAV
 #define NAV_AUTO_MAG_DECLINATION
 #define NAV_GPS_GLITCH_DETECTION
-#define GPS_PROTO_UBLOX_NEO7PLUS
 
 #define USE_ADC
 #define VBAT_ADC_PIN                PC0


### PR DESCRIPTION
Seems like a GPS_PROTO_UBLOX_NEO7PLUS definition slipped into the ANYFCF7 target. It has been removed from any other target (see #487), so I guess it should be removed from this one as well.