### PR TITLE
allow maximal baud rates for MSP

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1755,7 +1755,7 @@ static void cliSerial(char *cmdline)
 
         switch(i) {
             case 0:
-                if (baudRateIndex < BAUD_1200 || baudRateIndex > BAUD_115200) {
+                if (baudRateIndex < BAUD_1200 || baudRateIndex > BAUD_921600) {
                     continue;
                 }
                 portConfig.msp_baudrateIndex = baudRateIndex;


### PR DESCRIPTION
Allow all (high) baud rates for MSP, apropos #1464 
Does wonders for blackbox download with `USE_FLASH_TOOLS=1`