### PR TITLE
Fixing display of negative longitudes on OSD

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -264,20 +264,13 @@ static void osdDrawSingleElement(uint8_t item)
                 val = gpsSol.llh.lon;
             }
 
-            if (val >= 0)
-            {
-                itoa(1000000000 + val, &buff[1], 10);
-                buff[1] = buff[2];
-                buff[2] = buff[3];
-                buff[3] = '.';
-            }
-            else
-            {
-                itoa(-1000000000 + val, &buff[1], 10);
-                buff[2] = buff[3];
-                buff[3] = buff[4];
-                buff[4] = '.';
-            }
+            char wholeDegreeString[5];
+            sprintf(wholeDegreeString, "%d", val / GPS_DEGREES_DIVIDER);
+
+            char wholeUnshifted[32];
+            sprintf(wholeUnshifted, "%d", val);
+
+            sprintf(buff + 1, "%s.%s", wholeDegreeString, wholeUnshifted + strlen(wholeDegreeString));
             break;
         }
 


### PR DESCRIPTION
With negative longitudes, GPS OSD display is incorrect:

![badgpsdisplay](https://cloud.githubusercontent.com/assets/7128339/26028212/c59ba71a-37d0-11e7-9e44-9963fc339302.png)

Rather than 268.740672, this should be more along the lines of -122.655. This patch should now work for all lat/lon, with proper display of negative, etc.
