### PR TITLE
Fixed OSD symbols for velocities and stats calculation

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -160,14 +160,14 @@
 
 // Unit Icon´s (Metric)
 #define SYM_MS          0x9F
-#define SYM_KMH         0xA5
+#define SYM_KMH         0xA1
 #define SYM_ALTM        0xA7
 #define SYM_DISTHOME_M  0xBB
 #define SYM_M           0x0C
 
 // Unit Icon´s (Imperial)
 #define SYM_FTS         0x99
-#define SYM_MPH         0xA6
+#define SYM_MPH         0x20
 #define SYM_ALTFT       0xA8
 #define SYM_DISTHOME_FT 0xB9
 #define SYM_FT          0x0F

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -772,7 +772,7 @@ static void osdUpdateStats(void)
 
     if (feature(FEATURE_GPS))
     {
-        value = gpsSol.groundSpeed * 36 / 1000;
+        value = gpsSol.groundSpeed;
         if (stats.max_speed < value)
             stats.max_speed = value;
             


### PR DESCRIPTION
Attempt to fix #1664. Bench tested for the correct symbols, but couldn't test velocity/stats.