### PR TITLE
Aileron differential

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -658,7 +658,7 @@ static const clivalue_t valueTable[] = {
     { "servo_lpf_hz",               VAR_INT16  | MASTER_VALUE, .config.minmax = { 0,  400}, PG_SERVO_CONFIG, offsetof(servoConfig_t, servo_lowpass_freq) },
     { "flaperon_throw_offset",      VAR_INT16  | MASTER_VALUE, .config.minmax = { FLAPERON_THROW_MIN,  FLAPERON_THROW_MAX}, PG_SERVO_CONFIG, offsetof(servoConfig_t, flaperon_throw_offset) },
     { "tri_unarmed_servo",          VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SERVO_CONFIG, offsetof(servoConfig_t, tri_unarmed_servo) },
-    { "aileron_differential",		VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_SERVO_CONFIG, offsetof(servoConfig_t, aileron_differential) },
+    { "aileron_differential",       VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_SERVO_CONFIG, offsetof(servoConfig_t, aileron_differential) },
 #endif
 
 // PG_CONTROLRATE_PROFILE

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -658,6 +658,7 @@ static const clivalue_t valueTable[] = {
     { "servo_lpf_hz",               VAR_INT16  | MASTER_VALUE, .config.minmax = { 0,  400}, PG_SERVO_CONFIG, offsetof(servoConfig_t, servo_lowpass_freq) },
     { "flaperon_throw_offset",      VAR_INT16  | MASTER_VALUE, .config.minmax = { FLAPERON_THROW_MIN,  FLAPERON_THROW_MAX}, PG_SERVO_CONFIG, offsetof(servoConfig_t, flaperon_throw_offset) },
     { "tri_unarmed_servo",          VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SERVO_CONFIG, offsetof(servoConfig_t, tri_unarmed_servo) },
+    { "aileron_differential",		VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_SERVO_CONFIG, offsetof(servoConfig_t, aileron_differential) },
 #endif
 
 // PG_CONTROLRATE_PROFILE

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -418,6 +418,12 @@ void servoMixer(void)
 
     for (int i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
         servo[i] = ((int32_t)servoParams(i)->rate * servo[i]) / 100L;
+        if (servoConfig()->aileron_differential && !FLIGHT_MODE(FLAPERON)) {
+        	if ((servo[i] > 0 && i == SERVO_FLAPPERON_1) ||
+        			(servo[i] < 0 && i == SERVO_FLAPPERON_2)) {
+        		servo[i] = (servo[i] * (100L - ((int32_t)servoConfig()->aileron_differential))) / 100L;
+        	}
+        }
         servo[i] += determineServoMiddleOrForwardFromChannel(i);
     }
 }

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -118,6 +118,7 @@ typedef struct servoConfig_s {
     uint16_t flaperon_throw_offset;
     uint8_t __reserved;
     uint8_t tri_unarmed_servo;              // send tail servo correction pulses even when unarmed
+    uint8_t aileron_differential;			// 0 to 100 - the greater, the less down deflections of ailerons
 } servoConfig_t;
 
 PG_DECLARE(servoConfig_t, servoConfig);

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -118,7 +118,7 @@ typedef struct servoConfig_s {
     uint16_t flaperon_throw_offset;
     uint8_t __reserved;
     uint8_t tri_unarmed_servo;              // send tail servo correction pulses even when unarmed
-    uint8_t aileron_differential;			// 0 to 100 - the greater, the less down deflections of ailerons
+    uint8_t aileron_differential;           // 0 to 100 - the greater, the less down deflections of ailerons
 } servoConfig_t;
 
 PG_DECLARE(servoConfig_t, servoConfig);


### PR DESCRIPTION
A very simple yet effective implementation of aileron differential for AIRPLANEs. Set the newly introduced Servo setting "aileron_differential" to a value from 1 to 100 to use it (0 = no differential). The higher the value, the less down deflection will be applied to the ailerons (with the up deflection of the other aileron unchanged). E.g. aileron_differential = 40 => 40% reduction of down deflection of ailerons.

For me, this works fine, but maybe the implementation is too simple and does not consider any but the standard cases...
