### PR TITLE
More safe RTH and Failsafe procedure defaults

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -68,8 +68,8 @@ PG_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig,
     .failsafe_recovery_delay = 5,       // 0.5 seconds (plus 200ms explicit delay)
     .failsafe_off_delay = 200,          // 20sec
     .failsafe_throttle = 1000,          // default throttle off.
-    .failsafe_throttle_low_delay = 100, // default throttle low delay for "just disarm" on failsafe condition
-    .failsafe_procedure = 0,            // default full failsafe procedure is 0: auto-landing, 1: drop, 2 : RTH
+    .failsafe_throttle_low_delay = 0, // default throttle low delay for "just disarm" on failsafe condition
+    .failsafe_procedure = 2,            // default full failsafe procedure is 0: auto-landing, 1: drop, 2 : RTH
     .failsafe_fw_roll_angle = -200,     // 20 deg left
     .failsafe_fw_pitch_angle = 100,     // 10 deg dive (yes, positive means dive)
     .failsafe_fw_yaw_rate = -45,        // 45 deg/s left yaw (left is negative, 8s for full turn)


### PR DESCRIPTION
Changed default failsafe action to RTH and deactivated throttle_low_delay to prohibit sudden disarm when gliding without throttle and failsafe activates.