### PR TITLE
ANYFCF7_EXTERNAL_BARO target for AnyFc F7 from BG

### DIFF
--- a/src/main/target/ANYFCF7/target.h
+++ b/src/main/target/ANYFCF7/target.h
@@ -52,6 +52,12 @@
 #define BARO
 #define USE_BARO_MS5611
 
+#ifdef ANYFCF7_EXTERNAL_BARO
+    #define USE_BARO_BMP085
+    #define USE_BARO_BMP280
+    #define BARO_I2C_INSTANCE I2C_DEVICE_EXT
+#endif
+
 #define PITOT
 #define USE_PITOT_MS4525
 #define PITOT_I2C_INSTANCE I2C_DEVICE_EXT

--- a/src/main/target/ANYFCF7/target.mk
+++ b/src/main/target/ANYFCF7/target.mk
@@ -4,6 +4,8 @@ FEATURES       += SDCARD VCP
 TARGET_SRC = \
             drivers/accgyro/accgyro_spi_mpu6000.c \
             drivers/barometer/barometer_ms56xx.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_bmp085.c \
             drivers/compass/compass_hmc5883l.c \
             drivers/light_ws2811strip.c \
             drivers/light_ws2811strip_hal.c \


### PR DESCRIPTION
Temporary solution for #1810 , target named **ANYFCF7_EXTERNAL_BARO** that uses external I2C for barometers. 

@Gavsv8 could you test? I'm not sure I will be able to test today

@digitalentity waiting for a better solution you mentioned :)