### PR TITLE
Adds sdcard_detect_inverted setting to make detection configurable

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -253,6 +253,7 @@ Re-apply any new defaults as desired.
 |  blackbox_rate_num  | 1 | Blackbox logging rate numerator. Use num/denom settings to decide if a frame should be logged, allowing control of the portion of logged loop iterations |
 |  blackbox_rate_denom  | 1 | Blackbox logging rate denominator. See blackbox_rate_num. |
 |  blackbox_device  | SPIFLASH | Selection of where to write blackbox data |
+|  sdcard_detect_inverted  | `TARGET dependent` | This setting drives the way SD card is detected in card slot. On some targets (AnyFC F7 clone) different card slot was used and depending of hardware revision ON or OFF setting might be required. If card is not detected, change this value. |
 |  ledstrip_visual_beeper  | OFF |  |
 |  osd_video_system     | 0     |  |
 |  osd_row_shiftdown    | 0     |  |

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -89,6 +89,11 @@ PG_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig,
     .device = DEFAULT_BLACKBOX_DEVICE,
     .rate_num = 1,
     .rate_denom = 1,
+#ifdef SDCARD_DETECT_INVERTED
+    .invertedCardDetection = 1,
+#else 
+    .invertedCardDetection = 0,
+#endif
 );
 
 #define BLACKBOX_SHUTDOWN_TIMEOUT_MILLIS 200

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -25,6 +25,7 @@ typedef struct blackboxConfig_s {
     uint8_t rate_num;
     uint8_t rate_denom;
     uint8_t device;
+    uint8_t invertedCardDetection;
 } blackboxConfig_t;
 
 PG_DECLARE(blackboxConfig_t, blackboxConfig);

--- a/src/main/drivers/sdcard.c
+++ b/src/main/drivers/sdcard.c
@@ -31,6 +31,7 @@
 
 #include "sdcard.h"
 #include "sdcard_standard.h"
+#include "blackbox/blackbox.h"
 
 #include "build/debug.h"
 
@@ -156,9 +157,9 @@ bool sdcard_isInserted(void)
 
     result = IORead(sdCardDetectPin) != 0;
 
-#ifdef SDCARD_DETECT_INVERTED
-    result = !result;
-#endif
+    if (blackboxConfig()->invertedCardDetection) {
+        result = !result;
+    }
 
 #endif
 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -610,6 +610,10 @@ static const clivalue_t valueTable[] = {
     { "blackbox_device",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BLACKBOX_DEVICE }, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, device) },
 #endif
 
+#ifdef USE_SDCARD
+    { "sdcard_detect_inverted",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, invertedCardDetection) },
+#endif
+
 // PG_MOTOR_CONFIG
     { "min_throttle",               VAR_UINT16 | MASTER_VALUE, .config.minmax = { PWM_RANGE_ZERO,  PWM_RANGE_MAX }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, minthrottle) },
     { "max_throttle",               VAR_UINT16 | MASTER_VALUE, .config.minmax = { PWM_RANGE_ZERO,  PWM_RANGE_MAX }, PG_MOTOR_CONFIG, offsetof(motorConfig_t, maxthrottle) },


### PR DESCRIPTION
This will hopefully solve the problem of different HW revisions of AnyFC F7 clone from banggood. Card detection inversion is now configurable.

Addresses #1832 