### PR TITLE
telemTemperature1 removed as unused

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -100,7 +100,6 @@ int16_t headFreeModeHold;
 
 uint8_t motorControlEnable = false;
 
-int16_t telemTemperature1;      // gyro sensor temperature
 static uint32_t disarmAt;     // Time of automatic disarm when "Don't spin the motors when armed" is enabled and auto_disarm_delay is nonzero
 
 static bool isRXDataNew;

--- a/src/main/fc/fc_core.h
+++ b/src/main/fc/fc_core.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-extern int16_t telemTemperature1;
-
 typedef enum disarmReason_e {
     DISARM_NONE         = 0,
     DISARM_TIMEOUT      = 1,

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -68,9 +68,6 @@ static serialPortConfig_t *portConfig;
 static bool frskyTelemetryEnabled =  false;
 static portSharing_e frskyPortSharing;
 
-
-extern int16_t telemTemperature1; // FIXME dependency on mw.c
-
 #define CYCLETIME             125
 
 #define PROTOCOL_HEADER       0x5E
@@ -210,7 +207,10 @@ static void sendTemperature1(void)
 #ifdef BARO
     serialize16((baro.baroTemperature + 50)/ 100); //Airmamaf
 #else
-    serialize16(telemTemperature1 / 10);
+    /*
+     * There is no temperature information, so send 0
+     */
+    serialize16(0);
 #endif
 }
 

--- a/src/main/telemetry/ibus_shared.c
+++ b/src/main/telemetry/ibus_shared.c
@@ -125,8 +125,16 @@ static uint8_t dispatchMeasurementRequest(ibusAddress_t address) {
     if (address == 1) { //2. VBAT
         return sendIbusMeasurement(address, vbat * 10);
     } else if (address == 2) { //3. BARO_TEMP\GYRO_TEMP
-        if (sensors(SENSOR_BARO)) return sendIbusMeasurement(address, (uint16_t) ((baro.baroTemperature + 50) / 10  + IBUS_TEMPERATURE_OFFSET)); //int32_t
-        else return sendIbusMeasurement(address, (uint16_t) (telemTemperature1 + IBUS_TEMPERATURE_OFFSET)); //int16_t
+        if (sensors(SENSOR_BARO)) {
+            return sendIbusMeasurement(address, (uint16_t) ((baro.baroTemperature + 50) / 10  + IBUS_TEMPERATURE_OFFSET)); //int32_t
+        } else {
+            /*
+             * There is no temperature data
+             * assuming (baro.baroTemperature + 50) / 10
+             * 0 degrees (no sensor) equals 50 / 10 = 5
+             */
+            return sendIbusMeasurement(address, (uint16_t) (5 + IBUS_TEMPERATURE_OFFSET)); //int16_t
+        }
     } else if (address == 3) { //4. STATUS (sat num AS #0, FIX AS 0, HDOP AS 0, Mode AS 0)
         int16_t status = flightModeToIBusTelemetryMode[getFlightModeForTelemetry()];
 #if defined(GPS)


### PR DESCRIPTION
It was there, but always without any value assigned. Getting temperature from gyro makes no sense, so just removed