### PR TITLE
remove obsolete / misleading information from 'PID tuning.md'

### DIFF
--- a/docs/PID tuning.md
+++ b/docs/PID tuning.md
@@ -16,6 +16,11 @@ Basically, the goal of the PID controller is to bring the craft's rotation rate 
 you're commanding with your sticks. An error is computed which is the difference between your target rotation rate and
 the actual one measured by the gyroscopes, and the controller tries to bring this error to zero.
 
+Note that:
+
+* For fixed wing, a PIFF controller is used. Some documentation is available in the wiki and legacy release notes.
+* The iNav Configurator provides conservative example PID settings for various aircraft types. These will require tuning to a particular machine.
+
 ## PIDs
 
 **The P term** controls the strength of the correction that is applied to bring the craft toward the target angle or
@@ -50,7 +55,7 @@ An Example: With TPA = 50 (or .5 in the GUI) and tpa_breakpoint = 1500 (assumed 
 * At 1500 on the throttle channel, the PIDs will begin to be dampened.
 * At 3/4 throttle (1750), PIDs are reduced by approximately 25% (half way between 1500 and 2000 the dampening will be 50% of the total TPA value of 50% in this example)
 * At full throttle (2000) the full amount of dampening set in TPA is applied. (50% reduction in this example)
-* TPA can lead into increase of rotation rate when more throttle applied. You can get faster flips and rolls when more throttle applied due to coupling of PID's and rates. Only PID controllers MWREWRITE and LUX are using linear TPA implementation, where no rotation rates are affected when TPA is being used.
+* TPA can lead into increase of rotation rate when more throttle applied.
 
 ![tpa example chart](https://cloud.githubusercontent.com/assets/1668170/6053290/655255dc-ac92-11e4-9491-1a58d868c131.png "TPA Example Chart")
 
@@ -61,83 +66,14 @@ If you are getting oscillations starting at say 3/4 throttle, set tpa breakpoint
 
 ## PID controllers
 
-INAV has 3 built-in PID controllers which each have different flight behavior. Each controller requires
-different PID settings for best performance, so if you tune your craft using one PID controller, those settings will
-likely not work well on any of the other controllers.
+INAV has a single built-in PID controllers. The PID controller scaling
+means that Betaflight PIDs should be comparable.
 
-You can change between PID controllers by running `set pid_controller=x` on the CLI tab of the INAV
-Configurator, where `x` is the controller you want to use. Please read these notes first before trying one
-out.
+Note that very old INAV versions had more  PID controllers.
 
-Note that older INAV versions had 6 pid controllers, experimental and old ones were removed in 1.11.0 / API 1.14.0.
-
-### PID controller "MW23"
-
-This PID Controller is a direct port of the PID controller from MultiWii 2.3 and later.
-
-The algorithm is handling roll and pitch differently to yaw. Users with problems on yaw authority should try this one.
-
-In Horizon and Angle modes, this controller uses both the LEVEL "P" and "I" settings in order to tune the
-auto-leveling corrections in a similar way to the way that P and I settings are applied to roll and yaw axes in the acro
-flight modes. The LEVEL "D" term is used as a limiter to constrain the maximum correction applied by the LEVEL "P" term.
-
-### PID controller "MWREWRITE"
-
-This is a newer PID controller that is derived from the one in MultiWii 2.3 and later. It works better from
-all accounts, and fixes some inherent problems in the way the old one worked. From reports, tuning is apparently easier,
-and it tolerates a wider range of PID values well.
-
-In Angle mode, this controller uses the LEVEL "P" PID setting to decide how strong the auto-level correction should
-be. Note that the default value for P_Level is 90.  This is more than likely too high of a value for most, and will cause the model to be very unstable in Angle Mode, and could result in loss of control.  It is recommended to change this value to 20 before using PID Controller 1 in Angle Mode.
-
-In Horizon mode, this controller uses the LEVEL "I" PID setting to decide how much auto-level correction should be applied. Level "I" term: Strength of horizon auto-level. value of 0.030 in the configurator equals to 3.0 for Level P. Level "D" term: Strength of horizon transition. 0 is more stick travel on level and 255 is more rate mode what means very narrow angle of leveling.
-
-### PID controller "LUX"
-
-This is a new floating point based PID controller. MW23 and MWREWRITE use integer arithmetic, which was faster in the days of the
-slower 8-bit MultiWii controllers, but is less precise.
-
-This controller has code that attempts to compensate for variations in the looptime, which should mean that the PIDs
-don't have to be retuned when the looptime setting changes.
-
-There were initially some problems with horizon mode, and sluggishness in acro mode, that were recently fixed by
-nebbian in v1.6.0.
-
-It is the first PID Controller designed for 32-bit processors and not derived from MultiWii.
-
-The strength of the auto-leveling correction applied during Angle mode is set by the parameter "level_angle" which
-is labeled "LEVEL Proportional" in the GUI. This can be used to tune the auto-leveling strength in Angle mode compared to
-Horizon mode. The default is 5.0.
-
-The strength of the auto-leveling correction applied during Horizon mode is set by the parameter "level_horizon" which
-is labeled "LEVEL Integral" in the GUI. The default is 3.0, which makes the Horizon mode apply weaker self-leveling than
-the Angle mode. Note: There is currently a bug in the Configurator which shows this parameter divided by 100 (so it
-shows as 0.03 rather than 3.0).
-
-The transition between self-leveling and acro behavior in Horizon mode is controlled by the "sensitivity_horizon"
-parameter which is labeled "LEVEL Derivative" in the INAV Configurator GUI. This sets the percentage of your
-stick travel that should have self-leveling applied to it, so smaller values cause more of the stick area to fly using
-only the gyros. The default is 75%
-
-For example, at a setting of "100" for "sensitivity_horizon", 100% self-leveling strength will be applied at center
-stick, 50% self-leveling will be applied at 50% stick, and no self-leveling will be applied at 100% stick. If
-sensitivity is decreased to 75, 100% self-leveling will be applied at center stick, 50% will be applied at 63%
-stick, and no self-leveling will be applied at 75% stick and onwards.
 
 ## RC rate, Pitch and Roll Rates (P/R rate before they were separated), and Yaw rate
 
 ### RC Rate
 
 An overall multiplier on the RC stick inputs for pitch, rol;, and yaw.
-
-On PID Controller MW23 can be used to set the "feel" around center stick for small control movements. (RC Expo also affects this).For PID Controllers MWREWRITE and LUX, this basically sets the baseline stick sensitivity
-
-### Pitch and Roll rates
-
-In PID Controller MW23 the affect of the PID error terms for P and D are gradually lessened as the control sticks are moved away from center, ie 0.3 rate gives a 30% reduction of those terms at full throw, effectively making the stabilizing effect of the PID controller less at stick extremes. This results in faster rotation rates. So for these controllers, you can set center stick sensitivity to control movement with RC rate above, and yet have much faster rotation rates at stick extremes.
-
-For PID Controllers MWREWRITE and LUX, this is an multiplier on overall stick sensitivity, like RC rate, but for roll and pitch independently. Stablility (to outside factors like turbulence) is not reduced at stick extremes. A zero value is no increase in stick sensitivity over that set by RC rate above. Higher values increases stick sensitivity across the entire stick movement range.
-
-### Yaw Rate
-
-In PID Controllers MWREWRITE and LUX, it acts as a stick sensitivity multiplier, as explained above.

--- a/docs/PID tuning.md
+++ b/docs/PID tuning.md
@@ -66,10 +66,10 @@ If you are getting oscillations starting at say 3/4 throttle, set tpa breakpoint
 
 ## PID controllers
 
-INAV has a single built-in PID controllers. The PID controller scaling
+INAV has a single built-in PID controller. The PID controller scaling
 means that Betaflight PIDs should be comparable.
 
-Note that very old INAV versions had more  PID controllers.
+Note that very old INAV versions had more  PID controllers. These have been removed.
 
 
 ## RC rate, Pitch and Roll Rates (P/R rate before they were separated), and Yaw rate


### PR DESCRIPTION
Removal of ancient / misleading documentation from PID Tuning. Note that this does add any improved content, it just removes references to stuff that was changed in code a long time ago.