### PR TITLE
Respect feature AIRMODE

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -515,7 +515,7 @@ void processRx(timeUs_t currentTimeUs)
     }
     else {
         if (throttleStatus == THROTTLE_LOW) {
-            if (IS_RC_MODE_ACTIVE(BOXAIRMODE) && !failsafeIsActive() && ARMING_FLAG(ARMED)) {
+            if (isAirmodeActive() && !failsafeIsActive() && ARMING_FLAG(ARMED)) {
                 rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
 
                 // ANTI_WINDUP at centred stick with MOTOR_STOP is needed on MRs and not needed on FWs

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -265,7 +265,9 @@ static void initActiveBoxIds(void)
 #endif
     }
 
-    activeBoxIds[activeBoxIdCount++] = BOXAIRMODE;
+    if (!feature(FEATURE_AIRMODE)) {
+        activeBoxIds[activeBoxIdCount++] = BOXAIRMODE;
+    }
 
     activeBoxIds[activeBoxIdCount++] = BOXHEADINGHOLD;
 

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -51,6 +51,11 @@ bool isUsingSticksForArming(void)
     return isUsingSticksToArm;
 }
 
+bool isAirmodeActive(void)
+{
+    return feature(FEATURE_AIRMODE) || IS_RC_MODE_ACTIVE(BOXAIRMODE);
+}
+
 #if defined(NAV)
 bool isUsingNavigationModes(void)
 {

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -106,6 +106,7 @@ void rcModeUpdate(boxBitmask_t *newState);
 bool isModeActivationConditionPresent(boxId_e modeId);
 
 bool isUsingSticksForArming(void);
+bool isAirmodeActive(void);
 bool isUsingNavigationModes(void);
 bool isRangeActive(uint8_t auxChannelIndex, const channelRange_t *range);
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -59,6 +59,7 @@
 
 #include "fc/config.h"
 #include "fc/rc_controls.h"
+#include "fc/rc_modes.h"
 #include "fc/runtime_config.h"
 
 #include "flight/imu.h"
@@ -318,10 +319,9 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             char *p = "ACRO";
 
-#if 0
-            if (isAirmodeActive())
+            if (isAirmodeActive()) {
                 p = "AIR ";
-#endif
+            }
 
             if (FLIGHT_MODE(PASSTHRU_MODE))
                 p = "PASS";

--- a/src/main/target/FALCORE/config.c
+++ b/src/main/target/FALCORE/config.c
@@ -51,6 +51,7 @@ void targetConfiguration(void)
     featureSet(FEATURE_TELEMETRY);
     featureSet(FEATURE_LED_STRIP);
     featureSet(FEATURE_BLACKBOX);
+    featureSet(FEATURE_AIRMODE);
 
     serialConfigMutable()->portConfigs[0].functionMask = FUNCTION_MSP;          // VCP
     serialConfigMutable()->portConfigs[1].functionMask = FUNCTION_GPS;          // UART1
@@ -148,11 +149,10 @@ void targetConfiguration(void)
 
     configureModeActivationCondition(0, BOXARM,         0, 1150, 2100);
     configureModeActivationCondition(1, BOXANGLE,       0, 1300, 1700);
-    configureModeActivationCondition(2, BOXAIRMODE,     0, 1150, 2100);
-    configureModeActivationCondition(3, BOXNAVALTHOLD,  3, 1300, 1700);
-    configureModeActivationCondition(4, BOXNAVPOSHOLD,  3, 1300, 1700);
-    configureModeActivationCondition(5, BOXNAVRTH,      3, 1700, 2100);
-    configureModeActivationCondition(6, BOXANGLE,       3, 1700, 2100);
+    configureModeActivationCondition(2, BOXNAVALTHOLD,  3, 1300, 1700);
+    configureModeActivationCondition(3, BOXNAVPOSHOLD,  3, 1300, 1700);
+    configureModeActivationCondition(4, BOXNAVRTH,      3, 1700, 2100);
+    configureModeActivationCondition(5, BOXANGLE,       3, 1700, 2100);
     
     // Rates and PIDs
     setConfigProfile(0);


### PR DESCRIPTION
While the AIRMODE feature is available in the CLI, the current
code only takes BOXAIRMODE into account (triggered by an RC channel).

This PR introduces an isAirmodeActive() function which also returns
true when the AIRMODE feature has been set, not only when BOXAIRMODE
is active. Checks for IS_RC_MODE_ACTIVE(BOXAIRMODE) have been replaced
by calls to isAirmodeActive().

This will allow adding a simple switch in the configurator, as
reported in https://github.com/iNavFlight/inav-configurator/issues/154.

Eventually, isAirmodeActive() might be modified to always
return true in FW, since there's no reason to disable it in FW
models AFAIK.