### PR TITLE
add guard time to CLI entry

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -504,6 +504,16 @@ void serialEvaluateNonMspData(serialPort_t *serialPort, uint8_t receivedChar)
     UNUSED(serialPort);
 #else
     if (receivedChar == '#') {
+            // A 100ms guard delay to make sure CLI is followed by silence
+        // If anything is received during the guard period - CLI character is ignored
+        // Note: duplicating code is 8 bytes shorter than a new function()
+
+        for (int i = 0; i < 10; i++) {
+            delay(10);
+            if (serialRxBytesWaiting(serialPort)) {
+                return;
+            }
+        }
         cliEnter(serialPort);
     }
 #endif


### PR DESCRIPTION
Experiment to see if this solves an issue that the iphone MobileFlight tool is having.

Note, duplicating the code is 8 bytes shorter than a dedicated function, perhaps because the compiler is much smarter than I.

Do not merge, it may not help.