### PR TITLE
add runcam split support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -605,6 +605,7 @@ COMMON_SRC = \
             io/serial_4way_avrootloader.c \
             io/serial_4way_stk500v2.c \
             io/statusindicator.c \
+            io/rcsplit.c \
             msp/msp_serial.c \
             rx/ibus.c \
             rx/jetiexbus.c \

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -85,6 +85,7 @@
 #include "io/pwmdriver_i2c.h"
 #include "io/osd.h"
 #include "io/displayport_msp.h"
+#include "io/rcsplit.h"
 
 #include "msp/msp_serial.h"
 
@@ -631,6 +632,10 @@ void init(void)
     motorControlEnable = true;
 
     fcTasksInit();
+
+#ifdef USE_RCSPLIT
+    rcSplitInit();
+#endif // USE_RCSPLIT
 
     addBootlogEvent2(BOOT_EVENT_SYSTEM_READY, BOOT_EVENT_FLAGS_NONE);
     systemState |= SYSTEM_STATE_READY;

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -141,6 +141,9 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXNAVLAUNCH, "NAV LAUNCH;", 36 },
     { BOXAUTOTRIM, "SERVO AUTOTRIM;", 37 },
     { BOXKILLSWITCH, "KILLSWITCH;", 38 },
+    { BOXCAMERA1, "CAMERA CONTROL 1;", 39 },
+    { BOXCAMERA2, "CAMERA CONTROL 2;", 40 },
+    { BOXCAMERA3, "CAMERA CONTROL 3;", 41 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -328,6 +331,12 @@ static void initActiveBoxIds(void)
 
     activeBoxIds[activeBoxIdCount++] = BOXKILLSWITCH;
     activeBoxIds[activeBoxIdCount++] = BOXFAILSAFE;
+
+#ifdef USE_RCSPLIT
+    activeBoxIds[activeBoxIdCount++] = BOXCAMERA1;
+    activeBoxIds[activeBoxIdCount++] = BOXCAMERA2;
+    activeBoxIds[activeBoxIdCount++] = BOXCAMERA3;
+#endif
 }
 
 #define IS_ENABLED(mask) (mask == 0 ? 0 : 1)

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -54,6 +54,7 @@
 #include "io/osd.h"
 #include "io/pwmdriver_i2c.h"
 #include "io/serial.h"
+#include "io/rcsplit.h"
 
 #include "msp/msp_serial.h"
 
@@ -522,6 +523,15 @@ cfTask_t cfTasks[TASK_COUNT] = {
         .taskFunc = cmsHandler,
         .desiredPeriod = 1000000 / 60,          // 60 Hz
         .staticPriority = TASK_PRIORITY_LOW,
+    },
+#endif
+
+#ifdef USE_RCSPLIT
+    [TASK_RCSPLIT] = {
+        .taskName = "RCSPLIT",
+        .taskFunc = rcSplitProcess,
+        .desiredPeriod = TASK_PERIOD_HZ(10),        // 10 Hz, 100ms
+        .staticPriority = TASK_PRIORITY_MEDIUM,
     },
 #endif
 };

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -49,6 +49,9 @@ typedef enum {
     BOXTURNASSIST   = 26,
     BOXAUTOTRIM     = 27,
     BOXAUTOTUNE     = 28,
+    BOXCAMERA1      = 29,
+    BOXCAMERA2      = 30,
+    BOXCAMERA3      = 31,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/io/rcsplit.c
+++ b/src/main/io/rcsplit.c
@@ -1,0 +1,166 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#include <platform.h>
+
+#include "common/utils.h"
+
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+
+#include "fc/rc_controls.h"
+
+#include "io/beeper.h"
+#include "io/serial.h"
+
+#include "scheduler/scheduler.h"
+
+#include "drivers/serial.h"
+
+#include "io/rcsplit.h"
+
+// communicate with camera device variables
+serialPort_t *rcSplitSerialPort = NULL;
+rcsplit_switch_state_t switchStates[BOXCAMERA3 - BOXCAMERA1 + 1];
+rcsplit_state_e cameraState = RCSPLIT_STATE_UNKNOWN;
+
+static uint8_t crc_high_first(uint8_t *ptr, uint8_t len)
+{
+    uint8_t i; 
+    uint8_t crc=0x00;
+    while (len--) {
+        crc ^= *ptr++;  
+        for (i=8; i>0; --i) { 
+            if (crc & 0x80)
+                crc = (crc << 1) ^ 0x31;
+            else
+                crc = (crc << 1);
+        }
+    }
+    return (crc); 
+}
+
+static void sendCtrlCommand(rcsplit_ctrl_argument_e argument)
+{
+    if (!rcSplitSerialPort)
+        return ;
+
+    uint8_t uart_buffer[5] = {0};
+    uint8_t crc = 0;
+
+    uart_buffer[0] = RCSPLIT_PACKET_HEADER;
+    uart_buffer[1] = RCSPLIT_PACKET_CMD_CTRL;
+    uart_buffer[2] = argument;
+    uart_buffer[3] = RCSPLIT_PACKET_TAIL;
+    crc = crc_high_first(uart_buffer, 4);
+
+    // build up a full request [header]+[command]+[argument]+[crc]+[tail]
+    uart_buffer[3] = crc;
+    uart_buffer[4] = RCSPLIT_PACKET_TAIL;
+
+    // write to device
+    serialWriteBuf(rcSplitSerialPort, uart_buffer, 5);
+}
+
+static void rcSplitProcessMode() 
+{
+    // if the device not ready, do not handle any mode change event
+    if (RCSPLIT_STATE_IS_READY != cameraState) {
+        printf("device not ready");
+        return ;
+    }
+        
+
+    for (boxId_e i = BOXCAMERA1; i <= BOXCAMERA3; i++) {
+        uint8_t switchIndex = i - BOXCAMERA1;
+        if (IS_RC_MODE_ACTIVE(i)) {
+            // check last state of this mode, if it's true, then ignore it. 
+            // Here is a logic to make a toggle control for this mode
+            if (switchStates[switchIndex].isActivated) {
+                continue;
+            }
+
+            uint8_t argument = RCSPLIT_CTRL_ARGU_INVALID;
+            switch (i) {
+            case BOXCAMERA1:
+                argument = RCSPLIT_CTRL_ARGU_WIFI_BTN;
+                break;
+            case BOXCAMERA2:
+                argument = RCSPLIT_CTRL_ARGU_POWER_BTN;
+                break;
+            case BOXCAMERA3:
+                argument = RCSPLIT_CTRL_ARGU_CHANGE_MODE;
+                break;
+            default:
+                argument = RCSPLIT_CTRL_ARGU_INVALID;
+                break;
+            }
+            
+            if (argument != RCSPLIT_CTRL_ARGU_INVALID) {
+                sendCtrlCommand(argument);
+                switchStates[switchIndex].isActivated = true;
+            }
+        } else {
+            switchStates[switchIndex].isActivated = false;
+        }
+    }
+}
+
+bool rcSplitInit(void)
+{
+    // found the port config with FUNCTION_RUNCAM_SPLIT_CONTROL
+    // User must set some UART inteface with RunCam Split at peripherals column in Ports tab
+    serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RCSPLIT);
+    if (portConfig) {
+        rcSplitSerialPort = openSerialPort(portConfig->identifier, FUNCTION_RCSPLIT, NULL, 115200, MODE_RXTX, 0);
+    }
+
+    if (!rcSplitSerialPort) {
+        return false;
+    }
+
+    // set init value to true, to avoid the action auto run when the flight board start and the switch is on.
+    for (boxId_e i = BOXCAMERA1; i <= BOXCAMERA3; i++) {
+        uint8_t switchIndex = i - BOXCAMERA1;
+        switchStates[switchIndex].boxId = 1 << i;
+        switchStates[switchIndex].isActivated = true; 
+    }
+    
+    cameraState = RCSPLIT_STATE_IS_READY;
+
+#ifdef USE_RCSPLIT
+    setTaskEnabled(TASK_RCSPLIT, true);
+#endif
+
+    return true;
+}
+
+void rcSplitProcess(timeUs_t currentTimeUs)
+{
+    UNUSED(currentTimeUs);
+
+    if (rcSplitSerialPort == NULL)
+        return ;
+
+    // process rcsplit custom mode if has any changed
+    rcSplitProcessMode();
+}

--- a/src/main/io/rcsplit.h
+++ b/src/main/io/rcsplit.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include "common/time.h"
+#include "fc/fc_msp.h"
+
+typedef struct {
+    uint8_t boxId;
+    bool isActivated;
+} rcsplit_switch_state_t;
+
+typedef enum {
+    RCSPLIT_STATE_UNKNOWN = 0,
+    RCSPLIT_STATE_INITIALIZING,
+    RCSPLIT_STATE_IS_READY,
+} rcsplit_state_e;
+
+// packet header and tail
+#define RCSPLIT_PACKET_HEADER           0x55
+#define RCSPLIT_PACKET_CMD_CTRL  0x01
+#define RCSPLIT_PACKET_TAIL     0xaa
+
+
+// the commands of RunCam Split serial protocol
+typedef enum {
+    RCSPLIT_CTRL_ARGU_INVALID = 0x0,
+    RCSPLIT_CTRL_ARGU_WIFI_BTN = 0x1,
+    RCSPLIT_CTRL_ARGU_POWER_BTN = 0x2,
+    RCSPLIT_CTRL_ARGU_CHANGE_MODE = 0x3,
+    RCSPLIT_CTRL_ARGU_WHO_ARE_YOU = 0xFF,
+} rcsplit_ctrl_argument_e;
+
+bool rcSplitInit(void);
+void rcSplitProcess(timeUs_t currentTimeUs);
+
+// only for unit test
+extern rcsplit_state_e cameraState;
+extern serialPort_t *rcSplitSerialPort;
+extern rcsplit_switch_state_t switchStates[BOXCAMERA3 - BOXCAMERA1 + 1];

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -40,7 +40,8 @@ typedef enum {
     FUNCTION_RX_SERIAL           = (1 << 6), // 64
     FUNCTION_BLACKBOX            = (1 << 7), // 128
     FUNCTION_TELEMETRY_MAVLINK   = (1 << 8), // 256
-    FUNCTION_TELEMETRY_IBUS      = (1 << 9) // 512
+    FUNCTION_TELEMETRY_IBUS      = (1 << 9), // 512
+    FUNCTION_RCSPLIT             = (1 << 10) // 1024
 } serialPortFunction_e;
 
 typedef enum {

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -60,7 +60,7 @@
 #define MSP_PROTOCOL_VERSION                0
 
 #define API_VERSION_MAJOR                   1 // increment when major changes are made
-#define API_VERSION_MINOR                   26 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   27 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -60,7 +60,7 @@
 #define MSP_PROTOCOL_VERSION                0
 
 #define API_VERSION_MAJOR                   1 // increment when major changes are made
-#define API_VERSION_MINOR                   27 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   26 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -101,6 +101,9 @@ typedef enum {
 #ifdef CMS
     TASK_CMS,
 #endif
+#ifdef USE_RCSPLIT
+    TASK_RCSPLIT,
+#endif
     /* Count of real tasks */
     TASK_COUNT,
 

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -40,6 +40,7 @@
 #define TELEMETRY
 #define TELEMETRY_LTM
 #define TELEMETRY_FRSKY
+#define USE_RCSPLIT
 #endif
 
 #if defined(STM_FAST_TARGET)

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -40,7 +40,6 @@
 #define TELEMETRY
 #define TELEMETRY_LTM
 #define TELEMETRY_FRSKY
-#define USE_RCSPLIT
 #endif
 
 #if defined(STM_FAST_TARGET)
@@ -90,6 +89,7 @@
 #define PWM_DRIVER_PCA9685
 #define NAV_MAX_WAYPOINTS       60
 #define MAX_BOOTLOG_ENTRIES     64
+#define USE_RCSPLIT
 #else
 #define CLI_MINIMAL_VERBOSITY
 #define SKIP_TASK_STATISTICS

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -243,17 +243,17 @@ $(OBJECT_DIR)/telemetry_hott_unittest : \
 
 
 
-$(OBJECT_DIR)/io/rc_controls.o : \
-	$(USER_DIR)/io/rc_controls.c \
-	$(USER_DIR)/io/rc_controls.h \
+$(OBJECT_DIR)/fc/rc_controls.o : \
+	$(USER_DIR)/fc/rc_controls.c \
+	$(USER_DIR)/fc/rc_controls.h \
 	$(GTEST_HEADERS)
 
 	@mkdir -p $(dir $@)
-	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -c $(USER_DIR)/io/rc_controls.c -o $@
+	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -c $(USER_DIR)/fc/rc_controls.c -o $@
 
 $(OBJECT_DIR)/rc_controls_unittest.o : \
 	$(TEST_DIR)/rc_controls_unittest.cc \
-	$(USER_DIR)/io/rc_controls.h \
+	$(USER_DIR)/fc/rc_controls.h \
 	$(GTEST_HEADERS)
 
 	@mkdir -p $(dir $@)
@@ -630,6 +630,30 @@ $(OBJECT_DIR)/sensor_gyro_unittest : \
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
 
+$(OBJECT_DIR)/io/rcsplit.o : \
+	$(USER_DIR)/io/rcsplit.c \
+	$(USER_DIR)/io/rcsplit.h
+
+	@mkdir -p $(dir $@)
+	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -c $(USER_DIR)/io/rcsplit.c -o $@
+
+$(OBJECT_DIR)/rcsplit_unittest.o : \
+	$(TEST_DIR)/rcsplit_unittest.cc \
+	$(GTEST_HEADERS)
+	
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXX_FLAGS) $(TEST_CFLAGS) -c $(TEST_DIR)/rcsplit_unittest.cc -o $@
+
+$(OBJECT_DIR)/rcsplit_unittest : \
+	$(OBJECT_DIR)/rcsplit_unittest.o \
+	$(OBJECT_DIR)/io/rcsplit.o \
+    $(OBJECT_DIR)/fc/rc_controls.o \
+	$(OBJECT_DIR)/rx/rx.o \
+	$(OBJECT_DIR)/common/maths.o \
+	$(OBJECT_DIR)/gtest_main.a 
+
+	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
+
 $(OBJECT_DIR)/drivers/system.o : \
 	$(USER_DIR)/drivers/system.c \
 	$(USER_DIR)/drivers/system.h \
@@ -661,3 +685,4 @@ test-%: $(OBJECT_DIR)/%
 	$<
 
 -include $(DEPS)
+

--- a/src/test/unit/rcsplit_unittest.cc
+++ b/src/test/unit/rcsplit_unittest.cc
@@ -1,0 +1,458 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+extern "C" {
+    #include <stdbool.h>
+    #include <stdint.h>
+    #include <ctype.h>
+
+    #include "platform.h"
+
+    #include "common/utils.h"
+    #include "common/maths.h"
+
+    #include "config/parameter_group.h"
+    #include "config/parameter_group_ids.h"
+
+    #include "fc/rc_controls.h"
+    
+
+    #include "io/beeper.h"
+    #include "io/serial.h"
+
+    #include "scheduler/scheduler.h"
+    #include "drivers/serial.h"
+    #include "io/rcsplit.h"
+
+    #include "rx/rx.h"
+
+    int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];     // interval [1000;2000]
+
+    rcsplit_state_e unitTestRCsplitState()
+    {
+        return cameraState;
+    }
+
+    bool unitTestIsSwitchActivited(boxId_e boxId)
+    {
+        uint8_t adjustBoxID = boxId - BOXCAMERA1;
+        rcsplit_switch_state_t switchState = switchStates[adjustBoxID];
+        return switchState.isActivated;
+    }
+
+    void unitTestResetRCSplit()
+    {
+        rcSplitSerialPort = NULL;
+        cameraState = RCSPLIT_STATE_UNKNOWN;
+    }
+}
+
+typedef struct testData_s {
+    bool isRunCamSplitPortConfigurated;
+    bool isRunCamSplitOpenPortSupported;
+    int8_t maxTimesOfRespDataAvailable;
+    bool isAllowBufferReadWrite;
+} testData_t;
+
+static testData_t testData;
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+TEST(RCSplitTest, TestRCSplitInitWithoutPortConfigurated)
+{
+    memset(&testData, 0, sizeof(testData));
+    unitTestResetRCSplit();
+    bool result = rcSplitInit();
+    EXPECT_EQ(false, result);
+    EXPECT_EQ(RCSPLIT_STATE_UNKNOWN, unitTestRCsplitState());
+}
+
+TEST(RCSplitTest, TestRCSplitInitWithoutOpenPortConfigurated)
+{
+    memset(&testData, 0, sizeof(testData));
+    unitTestResetRCSplit();
+    testData.isRunCamSplitOpenPortSupported = false;
+    testData.isRunCamSplitPortConfigurated = true;
+
+    bool result = rcSplitInit();
+    EXPECT_EQ(false, result);
+    EXPECT_EQ(RCSPLIT_STATE_UNKNOWN, unitTestRCsplitState());
+}
+
+TEST(RCSplitTest, TestRCSplitInit)
+{
+    memset(&testData, 0, sizeof(testData));
+    unitTestResetRCSplit();
+    testData.isRunCamSplitOpenPortSupported = true;
+    testData.isRunCamSplitPortConfigurated = true;
+
+    bool result = rcSplitInit();
+    EXPECT_EQ(true, result);
+    EXPECT_EQ(RCSPLIT_STATE_IS_READY, unitTestRCsplitState());
+}
+
+TEST(RCSplitTest, TestRecvWhoAreYouResponse)
+{
+    memset(&testData, 0, sizeof(testData));
+    unitTestResetRCSplit();
+    testData.isRunCamSplitOpenPortSupported = true;
+    testData.isRunCamSplitPortConfigurated = true;
+    
+    bool result = rcSplitInit();
+    EXPECT_EQ(true, result);
+
+    // here will generate a number in [6-255], it's make the serialRxBytesWaiting() and serialRead() run at least 5 times, 
+    // so the "who are you response" will full received, and cause the state change to RCSPLIT_STATE_IS_READY;
+    int8_t randNum = rand() % 127 + 6; 
+    testData.maxTimesOfRespDataAvailable = randNum;
+    rcSplitProcess((timeUs_t)0);
+
+    EXPECT_EQ(RCSPLIT_STATE_IS_READY, unitTestRCsplitState());
+}
+
+TEST(RCSplitTest, TestWifiModeChangeWithDeviceUnready)
+{
+    memset(&testData, 0, sizeof(testData));
+    unitTestResetRCSplit();
+    testData.isRunCamSplitOpenPortSupported = true;
+    testData.isRunCamSplitPortConfigurated = true;
+    testData.maxTimesOfRespDataAvailable = 0;
+    
+    bool result = rcSplitInit();
+    EXPECT_EQ(true, result);
+
+    // bind aux1, aux2, aux3 channel to wifi button, power button and change mode
+    for (uint8_t i = 0; i <= (BOXCAMERA3 - BOXCAMERA1); i++) {
+        memset(modeActivationConditionsMutable(i), 0, sizeof(modeActivationCondition_t));
+    }
+
+    // bind aux1 to wifi button with range [900,1600]
+    modeActivationConditionsMutable(0)->auxChannelIndex = 0;
+    modeActivationConditionsMutable(0)->modeId = BOXCAMERA1;
+    modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MIN);
+    modeActivationConditionsMutable(0)->range.endStep = CHANNEL_VALUE_TO_STEP(1600);
+
+    // bind aux2 to power button with range [1900, 2100]
+    modeActivationConditionsMutable(1)->auxChannelIndex = 1;
+    modeActivationConditionsMutable(1)->modeId = BOXCAMERA2;
+    modeActivationConditionsMutable(1)->range.startStep = CHANNEL_VALUE_TO_STEP(1900);
+    modeActivationConditionsMutable(1)->range.endStep = CHANNEL_VALUE_TO_STEP(2100);
+
+    // bind aux3 to change mode with range [1300, 1600]
+    modeActivationConditionsMutable(2)->auxChannelIndex = 2;
+    modeActivationConditionsMutable(2)->modeId = BOXCAMERA3;
+    modeActivationConditionsMutable(2)->range.startStep = CHANNEL_VALUE_TO_STEP(1300);
+    modeActivationConditionsMutable(2)->range.endStep = CHANNEL_VALUE_TO_STEP(1600);
+
+    // make the binded mode inactive
+    rcData[modeActivationConditions(0)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 1800;
+    rcData[modeActivationConditions(1)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 900;
+    rcData[modeActivationConditions(2)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 900;
+
+    updateUsedModeActivationConditionFlags();
+    updateActivatedModes();
+
+    // runn process loop
+    rcSplitProcess(0);
+
+    EXPECT_EQ(false, unitTestIsSwitchActivited(BOXCAMERA1));
+    EXPECT_EQ(false, unitTestIsSwitchActivited(BOXCAMERA2));
+    EXPECT_EQ(false, unitTestIsSwitchActivited(BOXCAMERA3));
+}
+
+TEST(RCSplitTest, TestWifiModeChangeWithDeviceReady)
+{
+    memset(&testData, 0, sizeof(testData));
+    unitTestResetRCSplit();
+    testData.isRunCamSplitOpenPortSupported = true;
+    testData.isRunCamSplitPortConfigurated = true;
+    testData.maxTimesOfRespDataAvailable = 0;
+    
+    bool result = rcSplitInit();
+    EXPECT_EQ(true, result);
+
+    // bind aux1, aux2, aux3 channel to wifi button, power button and change mode
+    for (uint8_t i = 0; i <= BOXCAMERA3 - BOXCAMERA1; i++) {
+        memset(modeActivationConditionsMutable(i), 0, sizeof(modeActivationCondition_t));
+    }
+    
+
+    // bind aux1 to wifi button with range [900,1600]
+    modeActivationConditionsMutable(0)->auxChannelIndex = 0;
+    modeActivationConditionsMutable(0)->modeId = BOXCAMERA1;
+    modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MIN);
+    modeActivationConditionsMutable(0)->range.endStep = CHANNEL_VALUE_TO_STEP(1600);
+
+    // bind aux2 to power button with range [1900, 2100]
+    modeActivationConditionsMutable(1)->auxChannelIndex = 1;
+    modeActivationConditionsMutable(1)->modeId = BOXCAMERA2;
+    modeActivationConditionsMutable(1)->range.startStep = CHANNEL_VALUE_TO_STEP(1900);
+    modeActivationConditionsMutable(1)->range.endStep = CHANNEL_VALUE_TO_STEP(2100);
+
+    // bind aux3 to change mode with range [1300, 1600]
+    modeActivationConditionsMutable(2)->auxChannelIndex = 2;
+    modeActivationConditionsMutable(2)->modeId = BOXCAMERA3;
+    modeActivationConditionsMutable(2)->range.startStep = CHANNEL_VALUE_TO_STEP(1900);
+    modeActivationConditionsMutable(2)->range.endStep = CHANNEL_VALUE_TO_STEP(2100);
+
+    rcData[modeActivationConditions(0)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 1700;
+    rcData[modeActivationConditions(1)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 2000;
+    rcData[modeActivationConditions(2)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 1700;
+
+    updateUsedModeActivationConditionFlags();
+    updateActivatedModes();
+
+    // runn process loop
+    int8_t randNum = rand() % 127 + 6; 
+    testData.maxTimesOfRespDataAvailable = randNum;
+    rcSplitProcess((timeUs_t)0);
+
+    EXPECT_EQ(RCSPLIT_STATE_IS_READY, unitTestRCsplitState());
+
+    EXPECT_EQ(false, unitTestIsSwitchActivited(BOXCAMERA1));
+    EXPECT_EQ(true, unitTestIsSwitchActivited(BOXCAMERA2));
+    EXPECT_EQ(false, unitTestIsSwitchActivited(BOXCAMERA3));
+}
+
+TEST(RCSplitTest, TestWifiModeChangeCombine)
+{
+    memset(&testData, 0, sizeof(testData));
+    unitTestResetRCSplit();
+    testData.isRunCamSplitOpenPortSupported = true;
+    testData.isRunCamSplitPortConfigurated = true;
+    testData.maxTimesOfRespDataAvailable = 0;
+    
+    bool result = rcSplitInit();
+    EXPECT_EQ(true, result);
+
+    // bind aux1, aux2, aux3 channel to wifi button, power button and change mode
+    for (uint8_t i = 0; i <= BOXCAMERA3 - BOXCAMERA1; i++) {
+        memset(modeActivationConditionsMutable(i), 0, sizeof(modeActivationCondition_t));
+    }
+    
+
+    // bind aux1 to wifi button with range [900,1600]
+    modeActivationConditionsMutable(0)->auxChannelIndex = 0;
+    modeActivationConditionsMutable(0)->modeId = BOXCAMERA1;
+    modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MIN);
+    modeActivationConditionsMutable(0)->range.endStep = CHANNEL_VALUE_TO_STEP(1600);
+
+    // bind aux2 to power button with range [1900, 2100]
+    modeActivationConditionsMutable(1)->auxChannelIndex = 1;
+    modeActivationConditionsMutable(1)->modeId = BOXCAMERA2;
+    modeActivationConditionsMutable(1)->range.startStep = CHANNEL_VALUE_TO_STEP(1900);
+    modeActivationConditionsMutable(1)->range.endStep = CHANNEL_VALUE_TO_STEP(2100);
+
+    // bind aux3 to change mode with range [1300, 1600]
+    modeActivationConditionsMutable(2)->auxChannelIndex = 2;
+    modeActivationConditionsMutable(2)->modeId = BOXCAMERA3;
+    modeActivationConditionsMutable(2)->range.startStep = CHANNEL_VALUE_TO_STEP(1900);
+    modeActivationConditionsMutable(2)->range.endStep = CHANNEL_VALUE_TO_STEP(2100);
+
+    // // make the binded mode inactive
+    rcData[modeActivationConditions(0)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 1700;
+    rcData[modeActivationConditions(1)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 2000;
+    rcData[modeActivationConditions(2)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 1700;
+
+    updateUsedModeActivationConditionFlags();
+    updateActivatedModes();
+
+    // runn process loop
+    int8_t randNum = rand() % 127 + 6; 
+    testData.maxTimesOfRespDataAvailable = randNum;
+    rcSplitProcess((timeUs_t)0);
+
+    EXPECT_EQ(RCSPLIT_STATE_IS_READY, unitTestRCsplitState());
+
+    EXPECT_EQ(false, unitTestIsSwitchActivited(BOXCAMERA1));
+    EXPECT_EQ(true, unitTestIsSwitchActivited(BOXCAMERA2));
+    EXPECT_EQ(false, unitTestIsSwitchActivited(BOXCAMERA3));
+
+
+    // // make the binded mode inactive
+    rcData[modeActivationConditions(0)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 1500;
+    rcData[modeActivationConditions(1)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 1300;
+    rcData[modeActivationConditions(2)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 1900;
+    updateUsedModeActivationConditionFlags();
+    updateActivatedModes();
+    rcSplitProcess((timeUs_t)0);
+    EXPECT_EQ(true, unitTestIsSwitchActivited(BOXCAMERA1));
+    EXPECT_EQ(false, unitTestIsSwitchActivited(BOXCAMERA2));
+    EXPECT_EQ(true, unitTestIsSwitchActivited(BOXCAMERA3));
+
+
+    rcData[modeActivationConditions(2)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 1899;
+    updateUsedModeActivationConditionFlags();
+    updateActivatedModes();
+    rcSplitProcess((timeUs_t)0);
+    EXPECT_EQ(false, unitTestIsSwitchActivited(BOXCAMERA3));
+
+    rcData[modeActivationConditions(1)->auxChannelIndex + NON_AUX_CHANNEL_COUNT] = 2001;
+    updateUsedModeActivationConditionFlags();
+    updateActivatedModes();
+    rcSplitProcess((timeUs_t)0);
+    EXPECT_EQ(true, unitTestIsSwitchActivited(BOXCAMERA1));
+    EXPECT_EQ(true, unitTestIsSwitchActivited(BOXCAMERA2));
+    EXPECT_EQ(false, unitTestIsSwitchActivited(BOXCAMERA3));
+}
+
+extern "C" {
+    serialPort_t *openSerialPort(serialPortIdentifier_e identifier, serialPortFunction_e functionMask, serialReceiveCallbackPtr callback, uint32_t baudRate, portMode_t mode, portOptions_t options)
+    {
+        UNUSED(identifier);
+        UNUSED(functionMask);
+        UNUSED(baudRate);
+        UNUSED(callback);
+        UNUSED(mode);
+        UNUSED(options);
+
+        if (testData.isRunCamSplitOpenPortSupported) {
+            static serialPort_t s;
+            s.vTable = NULL;
+
+            // common serial initialisation code should move to serialPort::init()
+            s.rxBufferHead = s.rxBufferTail = 0;
+            s.txBufferHead = s.txBufferTail = 0;
+            s.rxBufferSize = 0;
+            s.txBufferSize = 0;
+            s.rxBuffer = s.rxBuffer;
+            s.txBuffer = s.txBuffer;
+
+            // callback works for IRQ-based RX ONLY
+            s.rxCallback = NULL;
+            s.baudRate = 0;
+
+            return (serialPort_t *)&s;
+        }
+
+        return NULL;
+    }
+
+    serialPortConfig_t *findSerialPortConfig(serialPortFunction_e function)
+    {
+        UNUSED(function);
+        if (testData.isRunCamSplitPortConfigurated) {
+            static serialPortConfig_t portConfig;
+
+            portConfig.identifier = SERIAL_PORT_USART3;
+            portConfig.msp_baudrateIndex = BAUD_115200;
+            portConfig.gps_baudrateIndex = BAUD_57600;
+            portConfig.telemetry_baudrateIndex = BAUD_AUTO;
+            portConfig.blackbox_baudrateIndex = BAUD_115200;
+            portConfig.functionMask = FUNCTION_MSP;
+
+            return &portConfig;
+        }
+
+        return NULL;
+    }
+
+    uint32_t serialRxBytesWaiting(const serialPort_t *instance) 
+    { 
+        UNUSED(instance);
+
+        testData.maxTimesOfRespDataAvailable--;
+        if (testData.maxTimesOfRespDataAvailable > 0) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    uint8_t serialRead(serialPort_t *instance) 
+    { 
+        UNUSED(instance); 
+
+        if (testData.maxTimesOfRespDataAvailable > 0) {
+            static uint8_t i = 0;
+            static uint8_t buffer[] = { 0x55, 0x01, 0xFF, 0xad, 0xaa };
+
+            if (i >= 5) {
+                i = 0;
+            }
+
+            return buffer[i++];
+        }
+
+        return 0; 
+    }
+
+    void sbufWriteString(sbuf_t *dst, const char *string) 
+    { 
+        UNUSED(dst); UNUSED(string); 
+
+        if (testData.isAllowBufferReadWrite) {
+            sbufWriteData(dst, string, strlen(string));
+        }
+    }
+    void sbufWriteU8(sbuf_t *dst, uint8_t val) 
+    { 
+        UNUSED(dst); UNUSED(val); 
+
+        if (testData.isAllowBufferReadWrite) {
+            *dst->ptr++ = val;
+        }
+    }
+    
+    void sbufWriteData(sbuf_t *dst, const void *data, int len)
+    {
+        UNUSED(dst); UNUSED(data); UNUSED(len); 
+
+        if (testData.isAllowBufferReadWrite) {
+            memcpy(dst->ptr, data, len);
+            dst->ptr += len;
+            
+        }
+    }
+
+    // modifies streambuf so that written data are prepared for reading
+    void sbufSwitchToReader(sbuf_t *buf, uint8_t *base)
+    {
+        UNUSED(buf); UNUSED(base); 
+
+        if (testData.isAllowBufferReadWrite) {
+            buf->end = buf->ptr;
+            buf->ptr = base;
+        }
+    }
+
+    bool feature(uint32_t) { return false;}
+    void serialWriteBuf(serialPort_t *instance, const uint8_t *data, int count) { UNUSED(instance); UNUSED(data); UNUSED(count); }
+
+    void accSetCalibrationCycles(uint16_t calibrationCyclesRequired) { UNUSED(calibrationCyclesRequired); }
+    void applyAndSaveBoardAlignmentDelta(int16_t roll, int16_t pitch) { UNUSED(roll); UNUSED(pitch); }
+
+    uint16_t armingFlags = 0;
+    void beeper(beeperMode_e) {}
+    bool failsafeIsActive(void) { return false; }
+    void gyroSetCalibrationCycles(uint16_t calibrationCyclesRequired) { UNUSED(calibrationCyclesRequired); };
+    timeMs_t millis(void) { return 0; }
+    void mwArm(void) {}
+    void mwDisarm(void) {}
+    
+    void saveConfigAndNotify(void) {}
+    void setConfigProfileAndWriteEEPROM(uint8_t profileIndex) { UNUSED(profileIndex); }
+    uint8_t stateFlags;
+
+    void failsafeOnRxResume(void) {}
+    void failsafeOnRxSuspend(uint32_t usSuspendPeriod) { UNUSED(usSuspendPeriod); }
+    void failsafeOnValidDataFailed(void) { }
+    void failsafeOnValidDataReceived(void) { }
+    uint32_t micros(void) { return 0; }
+}


### PR DESCRIPTION
Hi there,

Here is azol, I'm adding runcam split control to iNav FC, and for compatibility with older versions that not support rcsplit, I've change the apiVersion to 1.27.0, so only the  iNav FC firmwares which apiVersion >= 1.27.0 can support rcsplit. Hope that is correctly place.

Thank you!