### PR TITLE
Rename blackbox_baudrate to peripheral_baudate

### DIFF
--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -213,7 +213,7 @@ bool blackboxDeviceOpen(void)
             }
 
             blackboxPortSharing = determinePortSharing(portConfig, FUNCTION_BLACKBOX);
-            baudRateIndex = portConfig->blackbox_baudrateIndex;
+            baudRateIndex = portConfig->peripheral_baudrateIndex;
 
             if (baudRates[baudRateIndex] == 230400) {
                 /*

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1495,14 +1495,14 @@ static void printSerial(uint8_t dumpMask, const serialConfig_t *serialConfig, co
                 && serialConfig->portConfigs[i].msp_baudrateIndex == serialConfigDefault->portConfigs[i].msp_baudrateIndex
                 && serialConfig->portConfigs[i].gps_baudrateIndex == serialConfigDefault->portConfigs[i].gps_baudrateIndex
                 && serialConfig->portConfigs[i].telemetry_baudrateIndex == serialConfigDefault->portConfigs[i].telemetry_baudrateIndex
-                && serialConfig->portConfigs[i].blackbox_baudrateIndex == serialConfigDefault->portConfigs[i].blackbox_baudrateIndex;
+                && serialConfig->portConfigs[i].peripheral_baudrateIndex == serialConfigDefault->portConfigs[i].peripheral_baudrateIndex;
             cliDefaultPrintf(dumpMask, equalsDefault, format,
                 serialConfigDefault->portConfigs[i].identifier,
                 serialConfigDefault->portConfigs[i].functionMask,
                 baudRates[serialConfigDefault->portConfigs[i].msp_baudrateIndex],
                 baudRates[serialConfigDefault->portConfigs[i].gps_baudrateIndex],
                 baudRates[serialConfigDefault->portConfigs[i].telemetry_baudrateIndex],
-                baudRates[serialConfigDefault->portConfigs[i].blackbox_baudrateIndex]
+                baudRates[serialConfigDefault->portConfigs[i].peripheral_baudrateIndex]
             );
         }
         cliDumpPrintf(dumpMask, equalsDefault, format,
@@ -1511,7 +1511,7 @@ static void printSerial(uint8_t dumpMask, const serialConfig_t *serialConfig, co
             baudRates[serialConfig->portConfigs[i].msp_baudrateIndex],
             baudRates[serialConfig->portConfigs[i].gps_baudrateIndex],
             baudRates[serialConfig->portConfigs[i].telemetry_baudrateIndex],
-            baudRates[serialConfig->portConfigs[i].blackbox_baudrateIndex]
+            baudRates[serialConfig->portConfigs[i].peripheral_baudrateIndex]
             );
     }
 }
@@ -1581,7 +1581,7 @@ static void cliSerial(char *cmdline)
                 if (baudRateIndex < BAUD_19200 || baudRateIndex > BAUD_250000) {
                     continue;
                 }
-                portConfig.blackbox_baudrateIndex = baudRateIndex;
+                portConfig.peripheral_baudrateIndex = baudRateIndex;
                 break;
         }
 

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -954,7 +954,7 @@ static bool mspFcProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFn
             sbufWriteU8(dst, serialConfig()->portConfigs[i].msp_baudrateIndex);
             sbufWriteU8(dst, serialConfig()->portConfigs[i].gps_baudrateIndex);
             sbufWriteU8(dst, serialConfig()->portConfigs[i].telemetry_baudrateIndex);
-            sbufWriteU8(dst, serialConfig()->portConfigs[i].blackbox_baudrateIndex);
+            sbufWriteU8(dst, serialConfig()->portConfigs[i].peripheral_baudrateIndex);
         }
         break;
 
@@ -2020,7 +2020,7 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
                 portConfig->msp_baudrateIndex = sbufReadU8(src);
                 portConfig->gps_baudrateIndex = sbufReadU8(src);
                 portConfig->telemetry_baudrateIndex = sbufReadU8(src);
-                portConfig->blackbox_baudrateIndex = sbufReadU8(src);
+                portConfig->peripheral_baudrateIndex = sbufReadU8(src);
             }
         }
         break;

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -112,7 +112,7 @@ void pgResetFn_serialConfig(serialConfig_t *serialConfig)
         serialConfig->portConfigs[i].msp_baudrateIndex = BAUD_115200;
         serialConfig->portConfigs[i].gps_baudrateIndex = BAUD_38400;
         serialConfig->portConfigs[i].telemetry_baudrateIndex = BAUD_AUTO;
-        serialConfig->portConfigs[i].blackbox_baudrateIndex = BAUD_115200;
+        serialConfig->portConfigs[i].peripheral_baudrateIndex = BAUD_115200;
     }
 
     serialConfig->portConfigs[0].functionMask = FUNCTION_MSP;

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -105,7 +105,7 @@ typedef struct serialPortConfig_s {
     serialPortIdentifier_e identifier;
     uint8_t msp_baudrateIndex;
     uint8_t gps_baudrateIndex;
-    uint8_t blackbox_baudrateIndex;
+    uint8_t peripheral_baudrateIndex;
     uint8_t telemetry_baudrateIndex; // not used for all telemetry systems, e.g. HoTT only works at 19200.
 } serialPortConfig_t;
 


### PR DESCRIPTION
Minor cleanup to be consistent with new concept of peripherals.