### PR TITLE
Replace strtoul with custom parsing function

### DIFF
--- a/src/main/common/typeconversion.c
+++ b/src/main/common/typeconversion.c
@@ -284,3 +284,22 @@ float fastA2F(const char *p)
     return sign * (frac ? (value / scale) : (value * scale));
 }
 
+unsigned long int fastA2UL(const char *p)
+{
+    unsigned long int result = 0;
+    unsigned char digit;
+
+    while (white_space(*p)) {
+        p += 1;
+    }
+
+    for ( ; ; p++) {
+        digit = *p - '0';
+        if (digit > 9) {
+            break;
+        }
+        result *= 10;
+        result += digit;
+    }
+    return result;
+}

--- a/src/main/common/typeconversion.h
+++ b/src/main/common/typeconversion.h
@@ -25,6 +25,7 @@ void i2a(int num, char *bf);
 char a2i(char ch, const char **src, int base, int *nump);
 char *ftoa(float x, char *floatString);
 float fastA2F(const char *p);
+unsigned long int fastA2UL(const char *p);
 
 #ifndef HAVE_ITOA_FUNCTION
 char *itoa(int i, char *a, int r);

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -3064,7 +3064,7 @@ static void cliSet(char *cmdline)
 
                                 value = atoi(eqptr);
                                 valuef = fastA2F(eqptr);
-                                uvalue = strtoul(eqptr, NULL, 10);
+                                uvalue = fastA2UL(eqptr);
                                 // note: compare float values
                                 if ((mode == MODE_DIRECT && (valuef >= valueTable[i].config.minmax.min && valuef <= valueTable[i].config.minmax.max))
                                      || (mode == MODE_MAX && (valuef >= 0 && valuef <= valueTable[i].config.max.max))) {


### PR DESCRIPTION
Add fastA2UL: Converts ASCII to unsigned long

Since we don't need to support bases different than 10, we can just
implement a simpler version which saves 264 bytes of flash space,
allowing NAZE to compile on the development branch again.

Note that I haven't re-enabled the NAZE target, since I can't commit to making sure it still works for the next release. I do plan to implement some more space saving measures in cli.c, but supporting NAZE it's not an explicit goal.