### PR TITLE
add missing crc.h to crsf.c

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -27,6 +27,7 @@
 #include "build/build_config.h"
 #include "build/debug.h"
 
+#include "common/crc.h"
 #include "common/maths.h"
 #include "common/utils.h"
 


### PR DESCRIPTION
trivial update to add an include missing from the crc modularisation