### PR TITLE
Allow free orientation of the mag sensor

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -222,6 +222,18 @@ groups:
         field: magCalibrationTimeLimit
         min: 30
         max: 120
+      - name: align_mag_roll
+        field: rollDeciDegrees
+        min: -1800
+        max: 3600
+      - name: align_mag_pitch
+        field: pitchDeciDegrees
+        min: -1800
+        max: 3600
+      - name: align_mag_yaw
+        field: yawDeciDegrees
+        min: -1800
+        max: 3600
 
   - name: PG_BAROMETER_CONFIG
     type: barometerConfig_t

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -371,7 +371,33 @@ void compassUpdate(timeUs_t currentTimeUs)
         }
     }
 
-    alignSensors(mag.magADC, mag.dev.magAlign);
+    if (compassConfig()->rollDeciDegrees != 0 ||
+        compassConfig()->pitchDeciDegrees != 0 ||
+        compassConfig()->yawDeciDegrees != 0) {
+
+        // Externally aligned compass
+        struct fp_vector v = {
+            .X = mag.magADC[X],
+            .Y = mag.magADC[Y],
+            .Z = mag.magADC[Z],
+         };
+
+         fp_angles_t r = {
+             .angles.roll = DECIDEGREES_TO_RADIANS(compassConfig()->rollDeciDegrees),
+             .angles.pitch = DECIDEGREES_TO_RADIANS(compassConfig()->pitchDeciDegrees),
+             .angles.yaw = DECIDEGREES_TO_RADIANS(compassConfig()->yawDeciDegrees),
+         };
+
+         rotateV(&v, &r);
+
+         mag.magADC[X] = v.X;
+         mag.magADC[Y] = v.Y;
+         mag.magADC[Z] = v.Z;
+
+    } else {
+        // On-board compass
+        alignSensors(mag.magADC, mag.dev.magAlign);
+    }
 
     magUpdatedAtLeastOnce = 1;
 }

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -51,9 +51,12 @@ typedef struct mag_s {
 extern mag_t mag;
 
 typedef struct compassConfig_s {
-    int16_t mag_declination;                // Get your magnetic decliniation from here : http://magnetic-declination.com/
+    int16_t mag_declination;                // Get your magnetic declination from here : http://magnetic-declination.com/
                                             // For example, -6deg 37min, = -637 Japan, format is [sign]dddmm (degreesminutes) default is zero.
-    sensor_align_e mag_align;               // mag alignment
+    sensor_align_e mag_align;               // on-board mag alignment. Ignored if externally aligned via *DeciDegrees.
+    int16_t rollDeciDegrees;                // external mag-alignment (roll)
+    int16_t pitchDeciDegrees;               // external mag-alignment (pitch)
+    int16_t yawDeciDegrees;                 // external mag-alignment (yaw)
     uint8_t mag_hardware;                   // Which mag hardware to use on boards with more than one device
     flightDynamicsTrims_t magZero;
     uint8_t __dummy_1;                      // Maximum rotation rate MAG_HOLD mode can feed to yaw rate PID controller


### PR DESCRIPTION
Introduce 3 new variables which allow setting the decidegrees
for the mag sensor alignment. When any of these 3 variables
are non-zero, mag is assumed to be mounted off-board and
"align_mag" as well as the board alignment are ignored.

Settings are named align_mag_roll, align_mag_pitch and
align_mag_yaw.

Fixes #86
Fixes #1029

**NOTE:** Don't merge this yet, I haven't tested this code. This is just to get the ball rolling.