### PR TITLE
Optimize gpsSolutionData_t flags

### DIFF
--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #include "config/parameter_group.h"
 
 #define GPS_DBHZ_MIN 0
@@ -106,11 +108,11 @@ typedef struct gpsLocation_s {
 
 typedef struct gpsSolutionData_s {
     struct {
-        unsigned gpsHeartbeat   : 1;     // Toggle each update
-        unsigned validVelNE     : 1;
-        unsigned validVelD      : 1;
-        unsigned validMag       : 1;
-        unsigned validEPE       : 1;    // EPH/EPV values are valid - actual accuracy
+        bool gpsHeartbeat;  // Toggle each update
+        bool validVelNE;
+        bool validVelD;
+        bool validMag;
+        bool validEPE;      // EPH/EPV values are valid - actual accuracy
     } flags;
 
     gpsFixType_e fixType;


### PR DESCRIPTION
Use bool rather than bitfields for the boolean fields. This allows
the compiler to emit shorter assembly while keeping
sizeof(gpsSolutionData_t) at 44 bytes.

```
| Filename              | Prev size | Cur size | Change |
---------------------------------------------------------
|         inav_CC3D.elf |    125264 |   125248 |    -16 |
|    inav_OMNIBUSF4.elf |    197420 |   197356 |    -64 |
| inav_OMNIBUSF4PRO.elf |    205262 |   205182 |    -80 |
|   inav_SPRACINGF3.elf |    180948 |   180868 |    -80 |
```