### PR TITLE
Replace locale-aware libc functions with simpler versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,6 +549,7 @@ COMMON_SRC = \
             common/printf.c \
             common/streambuf.c \
             common/typeconversion.c \
+            common/string_light.c \
             config/config_eeprom.c \
             config/config_streamer.c \
             config/feature.c \

--- a/src/main/common/gps_conversion.c
+++ b/src/main/common/gps_conversion.c
@@ -22,6 +22,8 @@
 
 #include "platform.h"
 
+#include "common/string_light.h"
+
 #ifdef GPS
 
 
@@ -34,7 +36,7 @@ uint32_t GPS_coord_to_degrees(const char* coordinateString)
     uint8_t digitIndex;
 
     // scan for decimal point or end of field
-    for (fieldSeparator = coordinateString; isdigit((unsigned char)*fieldSeparator); fieldSeparator++) {
+    for (fieldSeparator = coordinateString; sl_isdigit((unsigned char)*fieldSeparator); fieldSeparator++) {
         if (fieldSeparator >= coordinateString + 15)
             return 0; // stop potential fail
     }
@@ -59,7 +61,7 @@ uint32_t GPS_coord_to_degrees(const char* coordinateString)
         remainingString = fieldSeparator + 1;
         for (digitIndex = 0; digitIndex < 4; digitIndex++) {
             fractionalMinutes *= 10;
-            if (isdigit((unsigned char)*remainingString))
+            if (sl_isdigit((unsigned char)*remainingString))
                 fractionalMinutes += *remainingString++ - '0';
         }
     }

--- a/src/main/common/string_light.c
+++ b/src/main/common/string_light.c
@@ -53,19 +53,6 @@ int sl_toupper(int c)
 int sl_strcasecmp(const char * s1, const char * s2)
 {
     return sl_strncasecmp(s1, s2, INT_MAX);
-    // const unsigned char * ucs1 = (const unsigned char *) s1;
-    // const unsigned char * ucs2 = (const unsigned char *) s2;
-
-    // int d = 0;
-
-    // for ( ; ; ) {
-        // const int c1 = sl_tolower(*ucs1++);
-        // const int c2 = sl_tolower(*ucs2++);
-        // if (((d = c1 - c2) != 0) || (c2 == '\0')) {
-            // break;
-        // }
-    // }
-    // return d;
 }
 
 int sl_strncasecmp(const char * s1, const char * s2, int n)
@@ -84,19 +71,4 @@ int sl_strncasecmp(const char * s1, const char * s2, int n)
     }
 
     return d;
-}
-
-int sl_atoi(const char * s)
-{
-    int num = 0;
-    int digit;
-
-    while ((digit = a2d(*s)) >= 0) {
-        if (digit > 10)
-            break;
-        num = num * 10 + digit;
-        s++;
-    }
-
-    return num;
 }

--- a/src/main/common/string_light.c
+++ b/src/main/common/string_light.c
@@ -1,0 +1,102 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <limits.h>
+
+#include "string_light.h"
+#include "typeconversion.h"
+
+int sl_isalnum(int c)
+{
+    return sl_isdigit(c) || sl_isupper(c) || sl_islower(c);
+}
+
+int sl_isdigit(int c)
+{
+    return (c >= '0' && c <= '9');
+}
+
+int sl_isupper(int c)
+{
+    return (c >= 'A' && c <= 'Z');
+}
+
+int sl_islower(int c)
+{
+    return (c >= 'a' && c <= 'z');
+}
+
+int sl_tolower(int c)
+{
+    return sl_isupper(c) ? (c) - 'A' + 'a' : c;
+}
+
+int sl_toupper(int c)
+{
+    return sl_islower(c) ? (c) - 'a' + 'A' : c;
+}
+
+int sl_strcasecmp(const char * s1, const char * s2)
+{
+    return sl_strncasecmp(s1, s2, INT_MAX);
+    // const unsigned char * ucs1 = (const unsigned char *) s1;
+    // const unsigned char * ucs2 = (const unsigned char *) s2;
+
+    // int d = 0;
+
+    // for ( ; ; ) {
+        // const int c1 = sl_tolower(*ucs1++);
+        // const int c2 = sl_tolower(*ucs2++);
+        // if (((d = c1 - c2) != 0) || (c2 == '\0')) {
+            // break;
+        // }
+    // }
+    // return d;
+}
+
+int sl_strncasecmp(const char * s1, const char * s2, int n)
+{
+    const unsigned char * ucs1 = (const unsigned char *) s1;
+    const unsigned char * ucs2 = (const unsigned char *) s2;
+
+    int d = 0;
+
+    for ( ; n != 0; n--) {
+        const int c1 = sl_tolower(*ucs1++);
+        const int c2 = sl_tolower(*ucs2++);
+        if (((d = c1 - c2) != 0) || (c2 == '\0')) {
+            break;
+        }
+    }
+
+    return d;
+}
+
+int sl_atoi(const char * s)
+{
+    int num = 0;
+    int digit;
+
+    while ((digit = a2d(*s)) >= 0) {
+        if (digit > 10)
+            break;
+        num = num * 10 + digit;
+        s++;
+    }
+
+    return num;
+}

--- a/src/main/common/string_light.h
+++ b/src/main/common/string_light.h
@@ -14,20 +14,16 @@
  * You should have received a copy of the GNU General Public License
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
-#define FTOA_BUFFER_SIZE 13
+int sl_isalnum(int c);
+int sl_isdigit(int c);
+int sl_isupper(int c);
+int sl_islower(int c);
+int sl_tolower(int c);
+int sl_toupper(int c);
 
-void uli2a(unsigned long int num, unsigned int base, int uc, char *bf);
-void li2a(long num, char *bf);
-void ui2a(unsigned int num, unsigned int base, int uc, char *bf);
-void i2a(int num, char *bf);
-int a2d(char ch);
-char a2i(char ch, const char **src, int base, int *nump);
-char *ftoa(float x, char *floatString);
-float fastA2F(const char *p);
-unsigned long int fastA2UL(const char *p);
-
-#ifndef HAVE_ITOA_FUNCTION
-char *itoa(int i, char *a, int r);
-#endif
+int sl_strcasecmp(const char * s1, const char * s2);
+int sl_strncasecmp(const char * s1, const char * s2, int n);
+int sl_atoi(const char * s);

--- a/src/main/common/string_light.h
+++ b/src/main/common/string_light.h
@@ -26,4 +26,3 @@ int sl_toupper(int c);
 
 int sl_strcasecmp(const char * s1, const char * s2);
 int sl_strncasecmp(const char * s1, const char * s2, int n);
-int sl_atoi(const char * s);

--- a/src/main/common/typeconversion.c
+++ b/src/main/common/typeconversion.c
@@ -303,3 +303,28 @@ unsigned long int fastA2UL(const char *p)
     }
     return result;
 }
+
+int fastA2I(const char *s)
+{
+    int sign = 1;
+    int num = 0;
+    int digit;
+
+    while (white_space(*s)) {
+        s++;
+    }
+
+    if (*s == '-') {
+        sign = -1;
+        s++;
+    }
+
+    while ((digit = a2d(*s)) >= 0) {
+        if (digit > 10)
+            break;
+        num = num * 10 + digit;
+        s++;
+    }
+
+    return sign * num;
+}

--- a/src/main/common/typeconversion.h
+++ b/src/main/common/typeconversion.h
@@ -27,6 +27,7 @@ char a2i(char ch, const char **src, int base, int *nump);
 char *ftoa(float x, char *floatString);
 float fastA2F(const char *p);
 unsigned long int fastA2UL(const char *p);
+int fastA2I(const char *s);
 
 #ifndef HAVE_ITOA_FUNCTION
 char *itoa(int i, char *a, int r);

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1331,7 +1331,7 @@ static const char *processChannelRangeArgs(const char *ptr, channelRange_t *rang
     for (uint32_t argIndex = 0; argIndex < 2; argIndex++) {
         ptr = nextArg(ptr);
         if (ptr) {
-            int val = sl_atoi(ptr);
+            int val = fastA2I(ptr);
             val = CHANNEL_VALUE_TO_STEP(val);
             if (val >= MIN_MODE_RANGE_STEP && val <= MAX_MODE_RANGE_STEP) {
                 if (argIndex == 0) {
@@ -1452,13 +1452,13 @@ static void cliAux(char *cmdline)
         printAux(DUMP_MASTER, modeActivationConditions(0), NULL);
     } else {
         ptr = cmdline;
-        i = sl_atoi(ptr++);
+        i = fastA2I(ptr++);
         if (i < MAX_MODE_ACTIVATION_CONDITION_COUNT) {
             modeActivationCondition_t *mac = modeActivationConditionsMutable(i);
             uint8_t validArgumentCount = 0;
             ptr = nextArg(ptr);
             if (ptr) {
-                val = sl_atoi(ptr);
+                val = fastA2I(ptr);
                 if (val >= 0 && val < CHECKBOX_ITEM_COUNT) {
                     mac->modeId = val;
                     validArgumentCount++;
@@ -1466,7 +1466,7 @@ static void cliAux(char *cmdline)
             }
             ptr = nextArg(ptr);
             if (ptr) {
-                val = sl_atoi(ptr);
+                val = fastA2I(ptr);
                 if (val >= 0 && val < MAX_AUX_CHANNEL_COUNT) {
                     mac->auxChannelIndex = val;
                     validArgumentCount++;
@@ -1533,7 +1533,7 @@ static void cliSerial(char *cmdline)
 
     const char *ptr = cmdline;
 
-    int val = sl_atoi(ptr++);
+    int val = fastA2I(ptr++);
     currentConfig = serialFindPortConfiguration(val);
     if (currentConfig) {
         portConfig.identifier = val;
@@ -1542,7 +1542,7 @@ static void cliSerial(char *cmdline)
 
     ptr = nextArg(ptr);
     if (ptr) {
-        val = sl_atoi(ptr);
+        val = fastA2I(ptr);
         portConfig.functionMask = val & 0xFFFF;
         validArgumentCount++;
     }
@@ -1553,7 +1553,7 @@ static void cliSerial(char *cmdline)
             break;
         }
 
-        val = sl_atoi(ptr);
+        val = fastA2I(ptr);
 
         uint8_t baudRateIndex = lookupBaudRateIndex(val);
         if (baudRates[baudRateIndex] != (uint32_t) val) {
@@ -1615,10 +1615,10 @@ static void cliSerialPassthrough(char *cmdline)
     while (tok != NULL) {
         switch (index) {
             case 0:
-                id = sl_atoi(tok);
+                id = fastA2I(tok);
                 break;
             case 1:
-                baud = sl_atoi(tok);
+                baud = fastA2I(tok);
                 break;
             case 2:
                 if (strstr(tok, "rx") || strstr(tok, "RX"))
@@ -1719,14 +1719,14 @@ static void cliAdjustmentRange(char *cmdline)
         printAdjustmentRange(DUMP_MASTER, adjustmentRanges(0), NULL);
     } else {
         ptr = cmdline;
-        i = sl_atoi(ptr++);
+        i = fastA2I(ptr++);
         if (i < MAX_ADJUSTMENT_RANGE_COUNT) {
             adjustmentRange_t *ar = adjustmentRangesMutable(i);
             uint8_t validArgumentCount = 0;
 
             ptr = nextArg(ptr);
             if (ptr) {
-                val = sl_atoi(ptr);
+                val = fastA2I(ptr);
                 if (val >= 0 && val < MAX_SIMULTANEOUS_ADJUSTMENT_COUNT) {
                     ar->adjustmentIndex = val;
                     validArgumentCount++;
@@ -1734,7 +1734,7 @@ static void cliAdjustmentRange(char *cmdline)
             }
             ptr = nextArg(ptr);
             if (ptr) {
-                val = sl_atoi(ptr);
+                val = fastA2I(ptr);
                 if (val >= 0 && val < MAX_AUX_CHANNEL_COUNT) {
                     ar->auxChannelIndex = val;
                     validArgumentCount++;
@@ -1745,7 +1745,7 @@ static void cliAdjustmentRange(char *cmdline)
 
             ptr = nextArg(ptr);
             if (ptr) {
-                val = sl_atoi(ptr);
+                val = fastA2I(ptr);
                 if (val >= 0 && val < ADJUSTMENT_FUNCTION_COUNT) {
                     ar->adjustmentFunction = val;
                     validArgumentCount++;
@@ -1753,7 +1753,7 @@ static void cliAdjustmentRange(char *cmdline)
             }
             ptr = nextArg(ptr);
             if (ptr) {
-                val = sl_atoi(ptr);
+                val = fastA2I(ptr);
                 if (val >= 0 && val < MAX_AUX_CHANNEL_COUNT) {
                     ar->auxSwitchChannelIndex = val;
                     validArgumentCount++;
@@ -1841,7 +1841,7 @@ static void cliMotorMix(char *cmdline)
         }
     } else {
         ptr = cmdline;
-        uint32_t i = sl_atoi(ptr); // get motor number
+        uint32_t i = fastA2I(ptr); // get motor number
         if (i < MAX_SUPPORTED_MOTORS) {
             ptr = nextArg(ptr);
             if (ptr) {
@@ -1908,19 +1908,19 @@ static void cliRxRange(char *cmdline)
         resetAllRxChannelRangeConfigurations();
     } else {
         ptr = cmdline;
-        i = sl_atoi(ptr);
+        i = fastA2I(ptr);
         if (i >= 0 && i < NON_AUX_CHANNEL_COUNT) {
             int rangeMin, rangeMax;
 
             ptr = nextArg(ptr);
             if (ptr) {
-                rangeMin = sl_atoi(ptr);
+                rangeMin = fastA2I(ptr);
                 validArgumentCount++;
             }
 
             ptr = nextArg(ptr);
             if (ptr) {
-                rangeMax = sl_atoi(ptr);
+                rangeMax = fastA2I(ptr);
                 validArgumentCount++;
             }
 
@@ -1968,7 +1968,7 @@ static void cliLed(char *cmdline)
         printLed(DUMP_MASTER, ledStripConfig()->ledConfigs, NULL);
     } else {
         ptr = cmdline;
-        i = sl_atoi(ptr);
+        i = fastA2I(ptr);
         if (i < LED_MAX_STRIP_LENGTH) {
             ptr = nextArg(cmdline);
             if (!parseLedStripConfig(i, ptr)) {
@@ -2003,7 +2003,7 @@ static void cliColor(char *cmdline)
         printColor(DUMP_MASTER, ledStripConfig()->colors, NULL);
     } else {
         const char *ptr = cmdline;
-        const int i = sl_atoi(ptr);
+        const int i = fastA2I(ptr);
         if (i < LED_CONFIGURABLE_COLOR_COUNT) {
             ptr = nextArg(cmdline);
             if (!parseColor(i, ptr)) {
@@ -2053,7 +2053,7 @@ static void cliModeColor(char *cmdline)
         int argNo = 0;
         const char* ptr = strtok(cmdline, " ");
         while (ptr && argNo < ARGS_COUNT) {
-            args[argNo++] = sl_atoi(ptr);
+            args[argNo++] = fastA2I(ptr);
             ptr = strtok(NULL, " ");
         }
 
@@ -2156,7 +2156,7 @@ static void cliServo(char *cmdline)
                     return;
                 }
 
-                arguments[validArgumentCount++] = sl_atoi(ptr);
+                arguments[validArgumentCount++] = fastA2I(ptr);
 
                 do {
                     ptr++;
@@ -2290,7 +2290,7 @@ static void cliServoMix(char *cmdline)
 
         ptr = strtok(ptr, " ");
         while (ptr != NULL && check < ARGS_COUNT - 1) {
-            args[check++] = sl_atoi(ptr);
+            args[check++] = fastA2I(ptr);
             ptr = strtok(NULL, " ");
         }
 
@@ -2314,7 +2314,7 @@ static void cliServoMix(char *cmdline)
         enum {RULE = 0, TARGET, INPUT, RATE, SPEED, ARGS_COUNT};
         ptr = strtok(cmdline, " ");
         while (ptr != NULL && check < ARGS_COUNT) {
-            args[check++] = sl_atoi(ptr);
+            args[check++] = fastA2I(ptr);
             ptr = strtok(NULL, " ");
         }
 
@@ -2443,7 +2443,7 @@ static void cliFlashErase(char *cmdline)
 
 static void cliFlashWrite(char *cmdline)
 {
-    uint32_t address = sl_atoi(cmdline);
+    uint32_t address = fastA2I(cmdline);
     char *text = strchr(cmdline, ' ');
 
     if (!text) {
@@ -2459,7 +2459,7 @@ static void cliFlashWrite(char *cmdline)
 
 static void cliFlashRead(char *cmdline)
 {
-    uint32_t address = sl_atoi(cmdline);
+    uint32_t address = fastA2I(cmdline);
     uint32_t length;
 
     uint8_t buffer[32];
@@ -2469,7 +2469,7 @@ static void cliFlashRead(char *cmdline)
     if (!nextArg) {
         cliShowParseError();
     } else {
-        length = sl_atoi(nextArg);
+        length = fastA2I(nextArg);
 
         cliPrintf("Reading %u bytes at %u:\r\n", length, address);
 
@@ -2862,10 +2862,10 @@ static void cliMotor(char *cmdline)
     while (pch != NULL) {
         switch (index) {
             case 0:
-                motor_index = sl_atoi(pch);
+                motor_index = fastA2I(pch);
                 break;
             case 1:
-                motor_value = sl_atoi(pch);
+                motor_value = fastA2I(pch);
                 break;
         }
         index++;
@@ -2929,7 +2929,7 @@ static void cliPlaySound(char *cmdline)
             }
         }
     } else {       //index value was given
-        i = sl_atoi(cmdline);
+        i = fastA2I(cmdline);
         if ((name=beeperNameForTableIndex(i)) == NULL) {
             cliPrintf("No sound for index %d\r\n", i);
             return;
@@ -2949,7 +2949,7 @@ static void cliProfile(char *cmdline)
         cliPrintf("profile %d\r\n", getConfigProfile() + 1);
         return;
     } else {
-        const int i = sl_atoi(cmdline) - 1;
+        const int i = fastA2I(cmdline) - 1;
         if (i >= 0 && i < MAX_PROFILE_COUNT) {
             setConfigProfileAndWriteEEPROM(i);
             cliProfile("");
@@ -3064,7 +3064,7 @@ static void cliSet(char *cmdline)
                                 uint32_t uvalue = 0;
                                 float valuef = 0;
 
-                                value = sl_atoi(eqptr);
+                                value = fastA2I(eqptr);
                                 valuef = fastA2F(eqptr);
                                 uvalue = fastA2UL(eqptr);
                                 // note: compare float values

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -44,6 +44,7 @@ extern uint8_t __config_end;
 #include "common/maths.h"
 #include "common/printf.h"
 #include "common/typeconversion.h"
+#include "common/string_light.h"
 
 #include "config/config_eeprom.h"
 #include "config/feature.h"
@@ -1330,7 +1331,7 @@ static const char *processChannelRangeArgs(const char *ptr, channelRange_t *rang
     for (uint32_t argIndex = 0; argIndex < 2; argIndex++) {
         ptr = nextArg(ptr);
         if (ptr) {
-            int val = atoi(ptr);
+            int val = sl_atoi(ptr);
             val = CHANNEL_VALUE_TO_STEP(val);
             if (val >= MIN_MODE_RANGE_STEP && val <= MAX_MODE_RANGE_STEP) {
                 if (argIndex == 0) {
@@ -1451,13 +1452,13 @@ static void cliAux(char *cmdline)
         printAux(DUMP_MASTER, modeActivationConditions(0), NULL);
     } else {
         ptr = cmdline;
-        i = atoi(ptr++);
+        i = sl_atoi(ptr++);
         if (i < MAX_MODE_ACTIVATION_CONDITION_COUNT) {
             modeActivationCondition_t *mac = modeActivationConditionsMutable(i);
             uint8_t validArgumentCount = 0;
             ptr = nextArg(ptr);
             if (ptr) {
-                val = atoi(ptr);
+                val = sl_atoi(ptr);
                 if (val >= 0 && val < CHECKBOX_ITEM_COUNT) {
                     mac->modeId = val;
                     validArgumentCount++;
@@ -1465,7 +1466,7 @@ static void cliAux(char *cmdline)
             }
             ptr = nextArg(ptr);
             if (ptr) {
-                val = atoi(ptr);
+                val = sl_atoi(ptr);
                 if (val >= 0 && val < MAX_AUX_CHANNEL_COUNT) {
                     mac->auxChannelIndex = val;
                     validArgumentCount++;
@@ -1532,7 +1533,7 @@ static void cliSerial(char *cmdline)
 
     const char *ptr = cmdline;
 
-    int val = atoi(ptr++);
+    int val = sl_atoi(ptr++);
     currentConfig = serialFindPortConfiguration(val);
     if (currentConfig) {
         portConfig.identifier = val;
@@ -1541,7 +1542,7 @@ static void cliSerial(char *cmdline)
 
     ptr = nextArg(ptr);
     if (ptr) {
-        val = atoi(ptr);
+        val = sl_atoi(ptr);
         portConfig.functionMask = val & 0xFFFF;
         validArgumentCount++;
     }
@@ -1552,7 +1553,7 @@ static void cliSerial(char *cmdline)
             break;
         }
 
-        val = atoi(ptr);
+        val = sl_atoi(ptr);
 
         uint8_t baudRateIndex = lookupBaudRateIndex(val);
         if (baudRates[baudRateIndex] != (uint32_t) val) {
@@ -1614,10 +1615,10 @@ static void cliSerialPassthrough(char *cmdline)
     while (tok != NULL) {
         switch (index) {
             case 0:
-                id = atoi(tok);
+                id = sl_atoi(tok);
                 break;
             case 1:
-                baud = atoi(tok);
+                baud = sl_atoi(tok);
                 break;
             case 2:
                 if (strstr(tok, "rx") || strstr(tok, "RX"))
@@ -1718,14 +1719,14 @@ static void cliAdjustmentRange(char *cmdline)
         printAdjustmentRange(DUMP_MASTER, adjustmentRanges(0), NULL);
     } else {
         ptr = cmdline;
-        i = atoi(ptr++);
+        i = sl_atoi(ptr++);
         if (i < MAX_ADJUSTMENT_RANGE_COUNT) {
             adjustmentRange_t *ar = adjustmentRangesMutable(i);
             uint8_t validArgumentCount = 0;
 
             ptr = nextArg(ptr);
             if (ptr) {
-                val = atoi(ptr);
+                val = sl_atoi(ptr);
                 if (val >= 0 && val < MAX_SIMULTANEOUS_ADJUSTMENT_COUNT) {
                     ar->adjustmentIndex = val;
                     validArgumentCount++;
@@ -1733,7 +1734,7 @@ static void cliAdjustmentRange(char *cmdline)
             }
             ptr = nextArg(ptr);
             if (ptr) {
-                val = atoi(ptr);
+                val = sl_atoi(ptr);
                 if (val >= 0 && val < MAX_AUX_CHANNEL_COUNT) {
                     ar->auxChannelIndex = val;
                     validArgumentCount++;
@@ -1744,7 +1745,7 @@ static void cliAdjustmentRange(char *cmdline)
 
             ptr = nextArg(ptr);
             if (ptr) {
-                val = atoi(ptr);
+                val = sl_atoi(ptr);
                 if (val >= 0 && val < ADJUSTMENT_FUNCTION_COUNT) {
                     ar->adjustmentFunction = val;
                     validArgumentCount++;
@@ -1752,7 +1753,7 @@ static void cliAdjustmentRange(char *cmdline)
             }
             ptr = nextArg(ptr);
             if (ptr) {
-                val = atoi(ptr);
+                val = sl_atoi(ptr);
                 if (val >= 0 && val < MAX_AUX_CHANNEL_COUNT) {
                     ar->auxSwitchChannelIndex = val;
                     validArgumentCount++;
@@ -1816,12 +1817,12 @@ static void cliMotorMix(char *cmdline)
 
     if (isEmpty(cmdline)) {
         printMotorMix(DUMP_MASTER, customMotorMixer(0), NULL);
-    } else if (strncasecmp(cmdline, "reset", 5) == 0) {
+    } else if (sl_strncasecmp(cmdline, "reset", 5) == 0) {
         // erase custom mixer
         for (uint32_t i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
             customMotorMixerMutable(i)->throttle = 0.0f;
         }
-    } else if (strncasecmp(cmdline, "load", 4) == 0) {
+    } else if (sl_strncasecmp(cmdline, "load", 4) == 0) {
         ptr = nextArg(cmdline);
         if (ptr) {
             len = strlen(ptr);
@@ -1830,7 +1831,7 @@ static void cliMotorMix(char *cmdline)
                     cliPrint("Invalid name\r\n");
                     break;
                 }
-                if (strncasecmp(ptr, mixerNames[i], len) == 0) {
+                if (sl_strncasecmp(ptr, mixerNames[i], len) == 0) {
                     mixerLoadMix(i, customMotorMixerMutable(0));
                     cliPrintf("Loaded %s\r\n", mixerNames[i]);
                     cliMotorMix("");
@@ -1840,7 +1841,7 @@ static void cliMotorMix(char *cmdline)
         }
     } else {
         ptr = cmdline;
-        uint32_t i = atoi(ptr); // get motor number
+        uint32_t i = sl_atoi(ptr); // get motor number
         if (i < MAX_SUPPORTED_MOTORS) {
             ptr = nextArg(ptr);
             if (ptr) {
@@ -1903,23 +1904,23 @@ static void cliRxRange(char *cmdline)
 
     if (isEmpty(cmdline)) {
         printRxRange(DUMP_MASTER, rxChannelRangeConfigs(0), NULL);
-    } else if (strcasecmp(cmdline, "reset") == 0) {
+    } else if (sl_strcasecmp(cmdline, "reset") == 0) {
         resetAllRxChannelRangeConfigurations();
     } else {
         ptr = cmdline;
-        i = atoi(ptr);
+        i = sl_atoi(ptr);
         if (i >= 0 && i < NON_AUX_CHANNEL_COUNT) {
             int rangeMin, rangeMax;
 
             ptr = nextArg(ptr);
             if (ptr) {
-                rangeMin = atoi(ptr);
+                rangeMin = sl_atoi(ptr);
                 validArgumentCount++;
             }
 
             ptr = nextArg(ptr);
             if (ptr) {
-                rangeMax = atoi(ptr);
+                rangeMax = sl_atoi(ptr);
                 validArgumentCount++;
             }
 
@@ -1967,7 +1968,7 @@ static void cliLed(char *cmdline)
         printLed(DUMP_MASTER, ledStripConfig()->ledConfigs, NULL);
     } else {
         ptr = cmdline;
-        i = atoi(ptr);
+        i = sl_atoi(ptr);
         if (i < LED_MAX_STRIP_LENGTH) {
             ptr = nextArg(cmdline);
             if (!parseLedStripConfig(i, ptr)) {
@@ -2002,7 +2003,7 @@ static void cliColor(char *cmdline)
         printColor(DUMP_MASTER, ledStripConfig()->colors, NULL);
     } else {
         const char *ptr = cmdline;
-        const int i = atoi(ptr);
+        const int i = sl_atoi(ptr);
         if (i < LED_CONFIGURABLE_COLOR_COUNT) {
             ptr = nextArg(cmdline);
             if (!parseColor(i, ptr)) {
@@ -2052,7 +2053,7 @@ static void cliModeColor(char *cmdline)
         int argNo = 0;
         const char* ptr = strtok(cmdline, " ");
         while (ptr && argNo < ARGS_COUNT) {
-            args[argNo++] = atoi(ptr);
+            args[argNo++] = sl_atoi(ptr);
             ptr = strtok(NULL, " ");
         }
 
@@ -2155,7 +2156,7 @@ static void cliServo(char *cmdline)
                     return;
                 }
 
-                arguments[validArgumentCount++] = atoi(ptr);
+                arguments[validArgumentCount++] = sl_atoi(ptr);
 
                 do {
                     ptr++;
@@ -2244,13 +2245,13 @@ static void cliServoMix(char *cmdline)
 
     if (len == 0) {
         printServoMix(DUMP_MASTER, customServoMixers(0), NULL);
-    } else if (strncasecmp(cmdline, "reset", 5) == 0) {
+    } else if (sl_strncasecmp(cmdline, "reset", 5) == 0) {
         // erase custom mixer
         pgResetCopy(customServoMixersMutable(0), PG_SERVO_MIXER);
         for (uint32_t i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
             servoParamsMutable(i)->reversedSources = 0;
         }
-    } else if (strncasecmp(cmdline, "load", 4) == 0) {
+    } else if (sl_strncasecmp(cmdline, "load", 4) == 0) {
         ptr = nextArg(cmdline);
         if (ptr) {
             len = strlen(ptr);
@@ -2259,7 +2260,7 @@ static void cliServoMix(char *cmdline)
                     cliPrintf("Invalid name\r\n");
                     break;
                 }
-                if (strncasecmp(ptr, mixerNames[i], len) == 0) {
+                if (sl_strncasecmp(ptr, mixerNames[i], len) == 0) {
                     servoMixerLoadMix(i);
                     cliPrintf("Loaded %s\r\n", mixerNames[i]);
                     cliServoMix("");
@@ -2267,7 +2268,7 @@ static void cliServoMix(char *cmdline)
                 }
             }
         }
-    } else if (strncasecmp(cmdline, "reverse", 7) == 0) {
+    } else if (sl_strncasecmp(cmdline, "reverse", 7) == 0) {
         enum {SERVO = 0, INPUT, REVERSE, ARGS_COUNT};
         char *ptr = strchr(cmdline, ' ');
 
@@ -2289,7 +2290,7 @@ static void cliServoMix(char *cmdline)
 
         ptr = strtok(ptr, " ");
         while (ptr != NULL && check < ARGS_COUNT - 1) {
-            args[check++] = atoi(ptr);
+            args[check++] = sl_atoi(ptr);
             ptr = strtok(NULL, " ");
         }
 
@@ -2313,7 +2314,7 @@ static void cliServoMix(char *cmdline)
         enum {RULE = 0, TARGET, INPUT, RATE, SPEED, ARGS_COUNT};
         ptr = strtok(cmdline, " ");
         while (ptr != NULL && check < ARGS_COUNT) {
-            args[check++] = atoi(ptr);
+            args[check++] = sl_atoi(ptr);
             ptr = strtok(NULL, " ");
         }
 
@@ -2442,7 +2443,7 @@ static void cliFlashErase(char *cmdline)
 
 static void cliFlashWrite(char *cmdline)
 {
-    uint32_t address = atoi(cmdline);
+    uint32_t address = sl_atoi(cmdline);
     char *text = strchr(cmdline, ' ');
 
     if (!text) {
@@ -2458,7 +2459,7 @@ static void cliFlashWrite(char *cmdline)
 
 static void cliFlashRead(char *cmdline)
 {
-    uint32_t address = atoi(cmdline);
+    uint32_t address = sl_atoi(cmdline);
     uint32_t length;
 
     uint8_t buffer[32];
@@ -2468,7 +2469,7 @@ static void cliFlashRead(char *cmdline)
     if (!nextArg) {
         cliShowParseError();
     } else {
-        length = atoi(nextArg);
+        length = sl_atoi(nextArg);
 
         cliPrintf("Reading %u bytes at %u:\r\n", length, address);
 
@@ -2539,7 +2540,7 @@ static void cliFeature(char *cmdline)
                 cliPrintf("%s ", featureNames[i]);
         }
         cliPrint("\r\n");
-    } else if (strncasecmp(cmdline, "list", len) == 0) {
+    } else if (sl_strncasecmp(cmdline, "list", len) == 0) {
         cliPrint("Available: ");
         for (uint32_t i = 0; ; i++) {
             if (featureNames[i] == NULL)
@@ -2565,7 +2566,7 @@ static void cliFeature(char *cmdline)
                 break;
             }
 
-            if (strncasecmp(cmdline, featureNames[i], len) == 0) {
+            if (sl_strncasecmp(cmdline, featureNames[i], len) == 0) {
 
                 mask = 1 << i;
 #ifndef GPS
@@ -2620,7 +2621,7 @@ static void cliBeeper(char *cmdline)
                 cliPrintf("  %s", beeperNameForTableIndex(i));
         }
         cliPrint("\r\n");
-    } else if (strncasecmp(cmdline, "list", len) == 0) {
+    } else if (sl_strncasecmp(cmdline, "list", len) == 0) {
         cliPrint("Available:");
         for (uint32_t i = 0; i < beeperCount; i++)
             cliPrintf("  %s", beeperNameForTableIndex(i));
@@ -2639,7 +2640,7 @@ static void cliBeeper(char *cmdline)
                 cliPrint("Invalid name\r\n");
                 break;
             }
-            if (strncasecmp(cmdline, beeperNameForTableIndex(i), len) == 0) {
+            if (sl_strncasecmp(cmdline, beeperNameForTableIndex(i), len) == 0) {
                 if (remove) { // beeper off
                     if (i == BEEPER_ALL-1)
                         beeperOffSetAll(beeperCount-2);
@@ -2702,7 +2703,7 @@ static void cliMap(char *cmdline)
     if (len == 8) {
         // uppercase it
         for (uint32_t i = 0; i < 8; i++)
-            cmdline[i] = toupper((unsigned char)cmdline[i]);
+            cmdline[i] = sl_toupper((unsigned char)cmdline[i]);
         for (uint32_t i = 0; i < 8; i++) {
             if (strchr(rcChannelLetters, cmdline[i]) && !strchr(cmdline + i + 1, cmdline[i]))
                 continue;
@@ -2721,8 +2722,8 @@ static void cliMap(char *cmdline)
 
 static const char *checkCommand(const char *cmdLine, const char *command)
 {
-    if (!strncasecmp(cmdLine, command, strlen(command))   // command names match
-        && !isalnum((unsigned)cmdLine[strlen(command)])) {   // next characted in bufffer is not alphanumeric (command is correctly terminated)
+    if (!sl_strncasecmp(cmdLine, command, strlen(command))   // command names match
+        && !sl_isalnum((unsigned)cmdLine[strlen(command)])) {   // next characted in bufffer is not alphanumeric (command is correctly terminated)
         return cmdLine + strlen(command) + 1;
     } else {
         return 0;
@@ -2818,7 +2819,7 @@ static void cliMixer(char *cmdline)
     if (len == 0) {
         cliPrintf("Mixer: %s\r\n", mixerNames[mixerConfigMutable()->mixerMode - 1]);
         return;
-    } else if (strncasecmp(cmdline, "list", len) == 0) {
+    } else if (sl_strncasecmp(cmdline, "list", len) == 0) {
         cliPrint("Available mixers: ");
         for (uint32_t i = 0; ; i++) {
             if (mixerNames[i] == NULL)
@@ -2834,7 +2835,7 @@ static void cliMixer(char *cmdline)
             cliPrint("Invalid name\r\n");
             return;
         }
-        if (strncasecmp(cmdline, mixerNames[i], len) == 0) {
+        if (sl_strncasecmp(cmdline, mixerNames[i], len) == 0) {
             mixerConfigMutable()->mixerMode = i + 1;
             break;
         }
@@ -2861,10 +2862,10 @@ static void cliMotor(char *cmdline)
     while (pch != NULL) {
         switch (index) {
             case 0:
-                motor_index = atoi(pch);
+                motor_index = sl_atoi(pch);
                 break;
             case 1:
-                motor_value = atoi(pch);
+                motor_value = sl_atoi(pch);
                 break;
         }
         index++;
@@ -2928,7 +2929,7 @@ static void cliPlaySound(char *cmdline)
             }
         }
     } else {       //index value was given
-        i = atoi(cmdline);
+        i = sl_atoi(cmdline);
         if ((name=beeperNameForTableIndex(i)) == NULL) {
             cliPrintf("No sound for index %d\r\n", i);
             return;
@@ -2948,7 +2949,7 @@ static void cliProfile(char *cmdline)
         cliPrintf("profile %d\r\n", getConfigProfile() + 1);
         return;
     } else {
-        const int i = atoi(cmdline) - 1;
+        const int i = sl_atoi(cmdline) - 1;
         if (i >= 0 && i < MAX_PROFILE_COUNT) {
             setConfigProfileAndWriteEEPROM(i);
             cliProfile("");
@@ -3050,7 +3051,7 @@ static void cliSet(char *cmdline)
         for (uint32_t i = 0; i < ARRAYLEN(valueTable); i++) {
             val = &valueTable[i];
             // ensure exact match when setting to prevent setting variables with shorter names
-            if (strncasecmp(cmdline, valueTable[i].name, strlen(valueTable[i].name)) == 0 && variableNameLength == strlen(valueTable[i].name)) {
+            if (sl_strncasecmp(cmdline, valueTable[i].name, strlen(valueTable[i].name)) == 0 && variableNameLength == strlen(valueTable[i].name)) {
 
                 bool changeValue = false;
                 int_float_value_t tmp = {0};
@@ -3063,7 +3064,7 @@ static void cliSet(char *cmdline)
                                 uint32_t uvalue = 0;
                                 float valuef = 0;
 
-                                value = atoi(eqptr);
+                                value = sl_atoi(eqptr);
                                 valuef = fastA2F(eqptr);
                                 uvalue = fastA2UL(eqptr);
                                 // note: compare float values
@@ -3086,7 +3087,7 @@ static void cliSet(char *cmdline)
                             const lookupTableEntry_t *tableEntry = &lookupTables[valueTable[i].config.lookup.tableIndex];
                             bool matched = false;
                             for (uint32_t tableValueIndex = 0; tableValueIndex < tableEntry->valueCount && !matched; tableValueIndex++) {
-                                matched = strcasecmp(tableEntry->values[tableValueIndex], eqptr) == 0;
+                                matched = sl_strcasecmp(tableEntry->values[tableValueIndex], eqptr) == 0;
 
                                 if (matched) {
                                     tmp.int_value = tableValueIndex;
@@ -3599,7 +3600,7 @@ void cliProcess(void)
             const clicmd_t *cmd, *pstart = NULL, *pend = NULL;
             uint32_t i = bufferIndex;
             for (cmd = cmdTable; cmd < cmdTable + ARRAYLEN(cmdTable); cmd++) {
-                if (bufferIndex && (strncasecmp(cliBuffer, cmd->name, bufferIndex) != 0))
+                if (bufferIndex && (sl_strncasecmp(cliBuffer, cmd->name, bufferIndex) != 0))
                     continue;
                 if (!pstart)
                     pstart = cmd;
@@ -3659,8 +3660,8 @@ void cliProcess(void)
 
                 const clicmd_t *cmd;
                 for (cmd = cmdTable; cmd < cmdTable + ARRAYLEN(cmdTable); cmd++) {
-                    if (!strncasecmp(cliBuffer, cmd->name, strlen(cmd->name))   // command names match
-                       && !isalnum((unsigned)cliBuffer[strlen(cmd->name)]))    // next characted in bufffer is not alphanumeric (command is correctly terminated)
+                    if (!sl_strncasecmp(cliBuffer, cmd->name, strlen(cmd->name))   // command names match
+                       && !sl_isalnum((unsigned)cliBuffer[strlen(cmd->name)]))    // next characted in bufffer is not alphanumeric (command is correctly terminated)
                         break;
                 }
                 if (cmd < cmdTable + ARRAYLEN(cmdTable))

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -32,7 +32,7 @@
 
 
 #include "common/axis.h"
-#include "common/string_light.h"
+#include "common/typeconversion.h"
 #include "common/gps_conversion.h"
 #include "common/maths.h"
 #include "common/utils.h"
@@ -483,7 +483,7 @@ static bool gpsParceFrameUBLOX(void)
     case MSG_VER:
         if (_class == CLASS_MON) {
             //uint32_t swver = _buffer.ver.swVersion;
-            gpsState.hwVersion = sl_atoi(_buffer.ver.hwVersion);
+            gpsState.hwVersion = fastA2I(_buffer.ver.hwVersion);
         }
         break;
 #endif

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -32,6 +32,7 @@
 
 
 #include "common/axis.h"
+#include "common/string_light.h"
 #include "common/gps_conversion.h"
 #include "common/maths.h"
 #include "common/utils.h"
@@ -482,7 +483,7 @@ static bool gpsParceFrameUBLOX(void)
     case MSG_VER:
         if (_class == CLASS_MON) {
             //uint32_t swver = _buffer.ver.swVersion;
-            gpsState.hwVersion = atoi(_buffer.ver.hwVersion);
+            gpsState.hwVersion = sl_atoi(_buffer.ver.hwVersion);
         }
         break;
 #endif

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -285,10 +285,10 @@ bool parseLedStripConfig(int ledIndex, const char *config)
         }
         switch (parseState) {
             case X_COORDINATE:
-                x = sl_atoi(chunk);
+                x = fastA2I(chunk);
                 break;
             case Y_COORDINATE:
-                y = sl_atoi(chunk);
+                y = fastA2I(chunk);
                 break;
             case DIRECTIONS:
                 for (char *ch = chunk; *ch; ch++) {
@@ -318,7 +318,7 @@ bool parseLedStripConfig(int ledIndex, const char *config)
                 }
                 break;
             case RING_COLORS:
-                color = sl_atoi(chunk);
+                color = fastA2I(chunk);
                 if (color >= LED_CONFIGURABLE_COLOR_COUNT)
                     color = 0;
                 break;
@@ -994,7 +994,7 @@ bool parseColor(int index, const char *colorConfig)
         [HSV_VALUE] = HSV_VALUE_MAX,
     };
     for (int componentIndex = 0; result && componentIndex < HSV_COLOR_COMPONENT_COUNT; componentIndex++) {
-        int val = sl_atoi(remainingCharacters);
+        int val = fastA2I(remainingCharacters);
         if (val > hsv_limit[componentIndex]) {
             result = false;
             break;

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -32,6 +32,7 @@
 #include "common/maths.h"
 #include "common/printf.h"
 #include "common/typeconversion.h"
+#include "common/string_light.h"
 #include "common/utils.h"
 
 #include "config/feature.h"
@@ -284,10 +285,10 @@ bool parseLedStripConfig(int ledIndex, const char *config)
         }
         switch (parseState) {
             case X_COORDINATE:
-                x = atoi(chunk);
+                x = sl_atoi(chunk);
                 break;
             case Y_COORDINATE:
-                y = atoi(chunk);
+                y = sl_atoi(chunk);
                 break;
             case DIRECTIONS:
                 for (char *ch = chunk; *ch; ch++) {
@@ -317,7 +318,7 @@ bool parseLedStripConfig(int ledIndex, const char *config)
                 }
                 break;
             case RING_COLORS:
-                color = atoi(chunk);
+                color = sl_atoi(chunk);
                 if (color >= LED_CONFIGURABLE_COLOR_COUNT)
                     color = 0;
                 break;
@@ -993,7 +994,7 @@ bool parseColor(int index, const char *colorConfig)
         [HSV_VALUE] = HSV_VALUE_MAX,
     };
     for (int componentIndex = 0; result && componentIndex < HSV_COLOR_COMPONENT_COUNT; componentIndex++) {
-        int val = atoi(remainingCharacters);
+        int val = sl_atoi(remainingCharacters);
         if (val > hsv_limit[componentIndex]) {
             result = false;
             break;


### PR DESCRIPTION
Looks like `libc` pulls in locale-aware functions and lookup tables. This wastes a noticable amount of FLASH and RAM. This PR replaces locale-aware functions with simpler variants that assume ANSI locale.

On CC3D saves 688 bytes of FLASH and 364 bytes of RAM.

Before: 
```
arm-none-eabi-size ./obj/main/inav_CC3D.elf
   text    data     bss     dec     hex filename
 125186    1408   16096  142690   22d62 ./obj/main/inav_CC3D.elf
```

After:
```
arm-none-eabi-size ./obj/main/inav_CC3D.elf
   text    data     bss     dec     hex filename
 124498    1044   16096  141638   22946 ./obj/main/inav_CC3D.elf
arm-none-eabi-objcopy -O ihex --set-start 0x8000000 obj/main/inav_CC3D.elf obj/inav_1.7.3_CC3D.hex
```