### PR TITLE
Add a new OSD indicator for the NAV modes

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -105,6 +105,18 @@
 #define SYM_GLAND     0xB7
 #define SYM_GLAND1    0xB8
 
+// INAV navigation modes
+#define SYM_ALTH0      178
+#define SYM_ALTH1      179
+#define SYM_POSH0      180
+#define SYM_POSH1      181
+#define SYM_ALTPOSH0   182
+#define SYM_ALTPOSH1   183
+#define SYM_WPT0       184
+#define SYM_WPT1       185
+#define SYM_RTH0       186
+#define SYM_RTH1       187
+
 // Gimbal active Mode
 #define SYM_GIMBAL  0x16
 #define SYM_GIMBAL1 0x17

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -983,6 +983,7 @@ static const clivalue_t valueTable[] = {
     { "osd_pid_yaw_pos",            VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, OSD_POS_MAX_CLI }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_YAW_PIDS]) },
     { "osd_power_pos",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, OSD_POS_MAX_CLI }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_POWER]) },
     { "osd_air_speed",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, OSD_POS_MAX_CLI }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_AIR_SPEED]) },
+    { "osd_nav_mode",               VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, OSD_POS_MAX_CLI }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_NAV_MODE]) },
 #endif
 // PG_SYSTEM_CONFIG
 #ifdef USE_I2C

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -357,14 +357,6 @@ static bool osdDrawSingleElement(uint8_t item)
                 }
             } else if (FLIGHT_MODE(HEADFREE_MODE))
                 p = "!HF!";
-            else if (FLIGHT_MODE(NAV_RTH_MODE))
-                p = "RTL ";
-            else if (FLIGHT_MODE(NAV_POSHOLD_MODE))
-                p = " PH ";
-            else if (FLIGHT_MODE(NAV_WP_MODE))
-                p = " WP ";
-            else if (FLIGHT_MODE(NAV_ALTHOLD_MODE))
-                p = " AH ";
             else if (FLIGHT_MODE(ANGLE_MODE))
                 p = "STAB";
             else if (FLIGHT_MODE(HORIZON_MODE))
@@ -553,12 +545,42 @@ static bool osdDrawSingleElement(uint8_t item)
         {
         #ifdef PITOT
             osdFormatVelocityStr(buff, pitot.airSpeed);
-        #else 
-            return false;
+        #else
+            buff[0] = '\0';
         #endif
             break;
         }
-
+    case OSD_NAV_MODE:
+        {
+#ifdef NAV
+            if (FLIGHT_MODE(NAV_RTH_MODE)) {
+                buff[0] = SYM_RTH0;
+                buff[1] = SYM_RTH1;
+            } else if (FLIGHT_MODE(NAV_WP_MODE)) {
+                buff[0] = SYM_WPT0;
+                buff[1] = SYM_WPT1;
+            } else if (FLIGHT_MODE(NAV_POSHOLD_MODE)) {
+                if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
+                    buff[0] = SYM_ALTPOSH0;
+                    buff[1] = SYM_ALTPOSH1;
+                } else {
+                    buff[0] = SYM_POSH0;
+                    buff[1] = SYM_POSH1;
+                }
+            } else if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
+                buff[0] = SYM_ALTH0;
+                buff[1] = SYM_ALTH1;
+            } else {
+#else
+                buff[0] = SYM_BLANK;
+                buff[1] = SYM_BLANK;
+#endif
+#ifdef NAV
+            }
+#endif
+            buff[2] = '\0';
+            break;
+        }
     default:
         return false;
     }
@@ -710,6 +732,8 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_POWER] = OSD_POS(15, 1);
 
     osdConfig->item_pos[OSD_AIR_SPEED] = OSD_POS(3, 5);
+    // TODO: By default put this just above FLYMODE, centered
+    osdConfig->item_pos[OSD_NAV_MODE] = OSD_POS(13, 11) | VISIBLE_FLAG;
 
     osdConfig->rssi_alarm = 20;
     osdConfig->cap_alarm = 2200;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -59,6 +59,7 @@ typedef enum {
     OSD_VARIO,
     OSD_VARIO_NUM,
     OSD_AIR_SPEED,
+    OSD_NAV_MODE,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
Displays RTH, WP, ALT-HOLD, POS-HOLD and ALT+POS-HOLD modes
using icons. The text base indicator OSD_FLYMODE doesn't show
those modes anymore.

Fixes #2032
References #1993

Depends on https://github.com/iNavFlight/inav-configurator/pull/226,
since the code uses the new NAV symbols.