### PR TITLE
AutoTune indication removed from smartport telemetry

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -411,6 +411,7 @@ void handleSmartPortTelemetry(void)
                     tmpi += 1;
                 else
                     tmpi += 2;
+                    
                 if (ARMING_FLAG(ARMED))
                     tmpi += 4;
 
@@ -418,8 +419,6 @@ void handleSmartPortTelemetry(void)
                     tmpi += 10;
                 if (FLIGHT_MODE(HORIZON_MODE))
                     tmpi += 20;
-                if (FLIGHT_MODE(AUTO_TUNE))
-                    tmpi += 40;
                 if (FLIGHT_MODE(PASSTHRU_MODE))
                     tmpi += 40;
 


### PR DESCRIPTION
Removed, since it breaks flight mode indication over T1 frame 