### PR TITLE
Update SYM_MPH to use the new mp/h char rather than a blank

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -167,7 +167,7 @@
 
 // Unit Icon´s (Imperial)
 #define SYM_FTS         0x99
-#define SYM_MPH         0x20
+#define SYM_MPH         0xB0
 #define SYM_ALTFT       0xA8
 #define SYM_DISTHOME_FT 0xB9
 #define SYM_FT          0x0F


### PR DESCRIPTION
Requires the new font that will be available in the next version
of the configurator (already on master).

Fixes #1933
References #1756