### PR TITLE
Fix F7 compiler warning

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -119,7 +119,7 @@ static void pwmOutConfigTimer(pwmOutputPort_t * p, const timerHardware_t *timerH
 {
 #if defined(USE_HAL_DRIVER)
     TIM_HandleTypeDef* Handle = timerFindTimerHandle(timerHardware->tim);
-    if (Handle == NULL) return p;
+    if (Handle == NULL) return;
 #endif
 
     configTimeBase(timerHardware->tim, period, mhz);


### PR DESCRIPTION
closes #2064 

This works on gcc 6.3, solution still fails on 4.8: builds but OmnibusF7 fails to boot and VCP is not available