### PR TITLE
Fix default value for frsky_unit in Cli.md

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -198,7 +198,7 @@ Re-apply any new defaults as desired.
 |  frsky_default_lattitude  | 0.000 | OpenTX needs a valid set of coordinates to show compass value. A fake value defined in this setting is sent while no fix is acquired. |
 |  frsky_default_longitude  | 0.000 | OpenTX needs a valid set of coordinates to show compass value. A fake value defined in this setting is sent while no fix is acquired. |
 |  frsky_coordinates_format  | 0 | FRSKY_FORMAT_DMS (default), FRSKY_FORMAT_NMEA |
-|  frsky_unit  | IMPERIAL | IMPERIAL , METRIC |
+|  frsky_unit  | METRIC | METRIC , IMPERIAL |
 |  frsky_vfas_precision  | 0 | Set to 1 to send raw VBat value in 0.1V resolution for receivers that can handle it, or 0 (default) to use the standard method |
 |  frsky_vfas_cell_voltage  | OFF |  |
 |  hott_alarm_sound_interval  | 5 | Battery alarm delay in seconds for Hott telemetry |


### PR DESCRIPTION
Its default value was always metric, but due to a bug it would be
displayed as IMPERIAL in the CLI and dumps.