### PR TITLE
Make lookup tables for generated settings 'const'

### DIFF
--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -346,7 +346,7 @@ class Generator
         buf << "};\n"
         # Write table pointers
         table_names.each do |name|
-            buf << "extern const char *#{table_variable_name(name)}[];\n"
+            buf << "extern const char * const #{table_variable_name(name)}[];\n"
         end
 
         File.open(file, 'w') {|file| file.write(buf.string)}
@@ -403,7 +403,7 @@ class Generator
         # Write the tables
         table_names = ordered_table_names()
         table_names.each do |name|
-            buf << "const char *#{table_variable_name(name)}[] = {\n"
+            buf << "const char * const #{table_variable_name(name)}[] = {\n"
             tbl = @tables[name]
             tbl["values"].each do |v|
                 buf << "\t#{v.inspect},\n"


### PR DESCRIPTION
Without being `const` these tables end up in RAM which is much more limited resource compared to ROM.

```
Before: 
   text    data     bss     dec     hex filename
 188650   10260   38236  237146   39e5a ./obj/main/inav_REVO.elf

 After:
    text    data     bss     dec     hex filename
 189170    9740   38236  237146   39e5a ./obj/main/inav_REVO.elf
```