### PR TITLE
Remove locale aware functions from BB, SD and OSD

### DIFF
--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -30,6 +30,7 @@
 #include "common/encoding.h"
 #include "common/maths.h"
 #include "common/printf.h"
+#include "common/typeconversion.h"
 
 #include "config/parameter_group.h"
 #include "config/parameter_group_ids.h"
@@ -389,7 +390,7 @@ static bool blackboxSDCardBeginLog()
                     memcpy(logSequenceNumberString, directoryEntry->filename + 3, 5);
                     logSequenceNumberString[5] = '\0';
 
-                    blackboxSDCard.largestLogFileNumber = MAX((uint32_t) atoi(logSequenceNumberString), blackboxSDCard.largestLogFileNumber);
+                    blackboxSDCard.largestLogFileNumber = MAX((uint32_t) fastA2I(logSequenceNumberString), blackboxSDCard.largestLogFileNumber);
                 }
             } else {
                 // We're done checking all the files on the card, now we can create a new log file

--- a/src/main/io/asyncfatfs/fat_standard.c
+++ b/src/main/io/asyncfatfs/fat_standard.c
@@ -15,7 +15,7 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <ctype.h>
+#include "common/string_light.h"
 
 #include "fat_standard.h"
 
@@ -67,7 +67,7 @@ void fat_convertFilenameToFATStyle(const char *filename, uint8_t *fatFilename)
         if (*filename == '\0' || *filename == '.') {
             *fatFilename = ' ';
         } else {
-            *fatFilename = toupper((unsigned char)*filename);
+            *fatFilename = sl_toupper((unsigned char)*filename);
             filename++;
         }
         fatFilename++;
@@ -81,7 +81,7 @@ void fat_convertFilenameToFATStyle(const char *filename, uint8_t *fatFilename)
          if (*filename == '\0') {
              *fatFilename = ' ';
          } else {
-             *fatFilename = toupper((unsigned char)*filename);
+             *fatFilename = sl_toupper((unsigned char)*filename);
              filename++;
          }
          fatFilename++;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -41,6 +41,7 @@
 
 #include "common/axis.h"
 #include "common/printf.h"
+#include "common/string_light.h"
 #include "common/utils.h"
 
 #include "config/feature.h"
@@ -395,7 +396,7 @@ static bool osdDrawSingleElement(uint8_t item)
             strcpy(buff, "CRAFT_NAME");
         else {
             for (int i = 0; i < MAX_NAME_LENGTH; i++) {
-                buff[i] = toupper((unsigned char)systemConfig()->name[i]);
+                buff[i] = sl_toupper((unsigned char)systemConfig()->name[i]);
                 if (systemConfig()->name[i] == 0)
                     break;
             }


### PR DESCRIPTION
BB was using atoi(), replaced with fastA2I()
SD was using toupper(), replaced with sl_toupper()
OSD was using toupper(), replaced with sl_toupper()

After these changes, __locale_ctype_ptr no longer appears in the
.map files when using any of those 3 features. Saves ~1K flash and
~360 bytes of RAM.

Before:
arm-none-eabi-size ./obj/main/inav_OMNIBUS.elf
   text    data     bss     dec     hex filename
 200294    7908   33908  242110   3b1be ./obj/main/inav_OMNIBUS.elf

After:
arm-none-eabi-size ./obj/main/inav_OMNIBUS.elf
   text    data     bss     dec     hex filename
 199574    7544   33908  241026   3ad82 ./obj/main/inav_OMNIBUS.elf