### PR TITLE
Software I2C for MATEK405 OSD target

### DIFF
--- a/src/main/drivers/bus_i2c_soft.c
+++ b/src/main/drivers/bus_i2c_soft.c
@@ -23,6 +23,7 @@
 #include "build/build_config.h"
 
 #include "drivers/bus_i2c.h"
+#include "drivers/time.h"
 #include "drivers/io.h"
 
 // Software I2C driver, using same pins as hardware I2C, with hw i2c module disabled.
@@ -47,11 +48,34 @@ static volatile uint16_t i2cErrorCount = 0;
 #error "Must define the software i2c pins (SOFT_I2C_SCL and SOFT_I2C_SDA) in target.h"
 #endif
 
+static uint32_t delayTicks = 90;
+
+void i2cSetSpeed(uint8_t speed)
+{
+    switch (speed) {
+        case I2C_SPEED_100KHZ:
+            delayTicks = SystemCoreClock / 100000 / 2;
+            break;
+
+        case I2C_SPEED_200KHZ:
+            delayTicks = SystemCoreClock / 200000 / 2;
+            break;
+
+        case I2C_SPEED_400KHZ:
+            delayTicks = SystemCoreClock / 400000 / 2;
+            break;
+
+        case I2C_SPEED_800KHZ:
+            delayTicks = SystemCoreClock / 800000 / 2;
+            break;
+    }
+}
+
 static void I2C_delay(void)
 {
-    volatile int i = 7;
-    while (i) {
-        i--;
+    uint32_t now = ticks();
+    while ((ticks() - now) < delayTicks) {
+        ;
     }
 }
 
@@ -172,8 +196,8 @@ void i2cInit(I2CDevice device)
     scl = IOGetByTag(IO_TAG(SOFT_I2C_SCL));
     sda = IOGetByTag(IO_TAG(SOFT_I2C_SDA));
 
-    IOConfigGPIO(scl, IOCFG_OUT_OD);
-    IOConfigGPIO(sda, IOCFG_OUT_OD);
+    IOConfigGPIOAF(scl, IOCFG_OUT_OD, 0);
+    IOConfigGPIOAF(sda, IOCFG_OUT_OD, 0);
 }
 
 bool i2cWriteBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t * data)

--- a/src/main/target/MATEKF405/target.h
+++ b/src/main/target/MATEKF405/target.h
@@ -120,10 +120,21 @@
 
 // *************** I2C ****************************
 // SLC clash with WS2812 LED
-#define USE_I2C
-#define I2C_DEVICE              (I2CDEV_1)
-#define I2C1_SCL                PB6
-#define I2C1_SDA                PB7
+#ifdef MATEKF405OSD
+    // OSD - no native I2C
+    #define USE_I2C
+    #define SOFT_I2C
+    #define I2C_DEVICE              (I2CINVALID)
+    #define SOFT_I2C_SCL            PC10
+    #define SOFT_I2C_SDA            PC11
+    #define I2C_DEVICE_SHARES_UART3
+#else
+    // AIO
+    #define USE_I2C
+    #define I2C_DEVICE              (I2CDEV_1)
+    #define I2C1_SCL                PB6
+    #define I2C1_SDA                PB7
+#endif
 
 
 #define BARO


### PR DESCRIPTION
Solves https://github.com/iNavFlight/inav/issues/2047

New target MATEKF405OSD is added. For this target UART3 is shared with emulated I2C. Known issue - I2C clock is lower than configured by `i2c_speed`