### PR TITLE
Detect sbuf overflow; Don't send truncated MSP responses

### DIFF
--- a/src/main/common/crc.c
+++ b/src/main/common/crc.c
@@ -82,7 +82,7 @@ uint8_t crc8_dvb_s2_update(uint8_t crc, const void *data, uint32_t length)
 void crc8_dvb_s2_sbuf_append(sbuf_t *dst, uint8_t *start)
 {
     uint8_t crc = 0;
-    const uint8_t * const end = dst->ptr;
+    const uint8_t * const end = sbufPtr(dst);
     for (const uint8_t *ptr = start; ptr < end; ++ptr) {
         crc = crc8_dvb_s2(crc, *ptr);
     }

--- a/src/main/common/streambuf.c
+++ b/src/main/common/streambuf.c
@@ -20,11 +20,21 @@
 
 #include "streambuf.h"
 
+void sbufInitialize(sbuf_t *buf, uint8_t *base, uint8_t *end)
+{
+    buf->bufPtr = base;
+    buf->bufEnd = end;
+    buf->overflow = false;
+}
+
 void sbufWriteU8(sbuf_t *dst, uint8_t val)
 {
     // Silently discard if buffer is overflown
-    if (dst->ptr < dst->end) {
-        *dst->ptr++ = val;
+    if (dst->bufPtr < dst->bufEnd) {
+        *dst->bufPtr++ = val;
+    }
+    else {
+        dst->overflow = true;
     }
 }
 
@@ -62,10 +72,11 @@ void sbufWriteData(sbuf_t *dst, const void *data, int len)
     const int remainingBytes = sbufBytesRemaining(dst);
     if (remainingBytes < len) {
         len = remainingBytes;
+        dst->overflow = true;
     }
 
-    memcpy(dst->ptr, data, len);
-    dst->ptr += len;
+    memcpy(dst->bufPtr, data, len);
+    dst->bufPtr += len;
 }
 
 void sbufWriteString(sbuf_t *dst, const char *string)
@@ -76,10 +87,11 @@ void sbufWriteString(sbuf_t *dst, const char *string)
 uint8_t sbufReadU8(sbuf_t *src)
 {
     // Return zero if buffer is overrun
-    if (src->ptr < src->end) {
-        return *src->ptr++;
+    if (src->bufPtr < src->bufEnd) {
+        return *src->bufPtr++;
     }
     else {
+        src->overflow = true;
         return 0;
     }
 }
@@ -104,24 +116,24 @@ uint32_t sbufReadU32(sbuf_t *src)
 
 void sbufReadData(const sbuf_t *src, void *data, int len)
 {
-    memcpy(data, src->ptr, len);
+    memcpy(data, src->bufPtr, len);
 }
 
 // reader - return bytes remaining in buffer
 // writer - return available space
 int sbufBytesRemaining(const sbuf_t *buf)
 {
-    return buf->end - buf->ptr;
+    return buf->bufEnd - buf->bufPtr;
 }
 
 uint8_t* sbufPtr(sbuf_t *buf)
 {
-    return buf->ptr;
+    return buf->bufPtr;
 }
 
 const uint8_t* sbufConstPtr(const sbuf_t *buf)
 {
-    return buf->ptr;
+    return buf->bufPtr;
 }
 
 // advance buffer pointer
@@ -129,12 +141,17 @@ const uint8_t* sbufConstPtr(const sbuf_t *buf)
 // writer - commit written data
 void sbufAdvance(sbuf_t *buf, int size)
 {
-    buf->ptr += size;
+    buf->bufPtr += size;
 }
 
 // modifies streambuf so that written data are prepared for reading
 void sbufSwitchToReader(sbuf_t *buf, uint8_t *base)
 {
-    buf->end = buf->ptr;
-    buf->ptr = base;
+    buf->bufEnd = buf->bufPtr;
+    buf->bufPtr = base;
+}
+
+bool sbufWasOverflown(sbuf_t *buf)
+{
+    return buf->overflow;
 }

--- a/src/main/common/streambuf.h
+++ b/src/main/common/streambuf.h
@@ -18,14 +18,18 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 // simple buffer-based serializer/deserializer without implicit size check
 // little-endian encoding implemneted now
 
 typedef struct sbuf_s {
-    uint8_t *ptr;          // data pointer must be first (sbuff_t* is equivalent to uint8_t **)
-    uint8_t *end;
+    uint8_t *bufPtr;          // data pointer must be first (sbuff_t* is equivalent to uint8_t **)
+    uint8_t *bufEnd;
+    bool overflow;
 } sbuf_t;
+
+void sbufInitialize(sbuf_t *buf, uint8_t *base, uint8_t *end);
 
 void sbufWriteU8(sbuf_t *dst, uint8_t val);
 void sbufWriteU16(sbuf_t *dst, uint16_t val);
@@ -46,3 +50,5 @@ const uint8_t* sbufConstPtr(const sbuf_t *buf);
 void sbufAdvance(sbuf_t *buf, int size);
 
 void sbufSwitchToReader(sbuf_t *buf, uint8_t * base);
+
+bool sbufWasOverflown(sbuf_t *buf);

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -66,9 +66,7 @@ static uint8_t crsfFrame[CRSF_FRAME_SIZE_MAX];
 static void crsfInitializeFrame(sbuf_t *dst)
 {
     crsfCrc = 0;
-    dst->ptr = crsfFrame;
-    dst->end = ARRAYEND(crsfFrame);
-
+    sbufInitialize(dst, crsfFrame, ARRAYEND(crsfFrame));
     sbufWriteU8(dst, CRSF_ADDRESS_BROADCAST);
 }
 

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -91,8 +91,7 @@ static uint8_t ltm_x_counter;
 
 static void ltm_initialise_packet(sbuf_t *dst)
 {
-    dst->ptr = ltmFrame;
-    dst->end = ARRAYEND(ltmFrame);
+    sbufInitialize(dst, ltmFrame, ARRAYEND(ltmFrame));
 
     sbufWriteU8(dst, '$');
     sbufWriteU8(dst, 'T');
@@ -101,7 +100,7 @@ static void ltm_initialise_packet(sbuf_t *dst)
 static void ltm_finalise(sbuf_t *dst)
 {
     uint8_t crc = 0;
-    for (const uint8_t *ptr = &ltmFrame[3]; ptr < dst->ptr; ++ptr) {
+    for (const uint8_t *ptr = &ltmFrame[3]; ptr < sbufPtr(dst); ++ptr) {
         crc ^= *ptr;
     }
     sbufWriteU8(dst, crc);
@@ -454,8 +453,9 @@ int getLtmFrame(uint8_t *frame, ltm_frame_e ltmFrameType)
 {
     static uint8_t ltmFrame[LTM_MAX_MESSAGE_SIZE];
 
-    sbuf_t ltmFrameBuf = { .ptr = ltmFrame, .end =ARRAYEND(ltmFrame) };
+    sbuf_t ltmFrameBuf;
     sbuf_t * const sbuf = &ltmFrameBuf;
+    sbufInitialize(sbuf, ltmFrame, ARRAYEND(ltmFrame));
 
     switch (ltmFrameType) {
     default:

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -345,9 +345,7 @@ void checkSmartPortTelemetryState(void)
 
 static void initSmartPortMspReply(int16_t cmd)
 {
-    smartPortMspReply.buf.ptr    = smartPortMspTxBuffer;
-    smartPortMspReply.buf.end    = ARRAYEND(smartPortMspTxBuffer);
-
+    sbufInitialize(&smartPortMspReply.buf, smartPortMspTxBuffer, ARRAYEND(smartPortMspTxBuffer));
     smartPortMspReply.cmd    = cmd;
     smartPortMspReply.result = 0;
 }
@@ -397,7 +395,7 @@ bool smartPortSendMspReply()
     sbuf_t* txBuf = &smartPortMspReply.buf;
 
     // detect first reply packet
-    if (txBuf->ptr == smartPortMspTxBuffer) {
+    if (sbufPtr(txBuf) == smartPortMspTxBuffer) {
 
         // header
         uint8_t head = SMARTPORT_MSP_START_FLAG | (seq++ & SMARTPORT_MSP_SEQ_MASK);
@@ -490,8 +488,7 @@ void handleSmartPortMspFrame(smartPortFrame_t* sp_frame)
         cmd.cmd = *p++;
         cmd.result = 0;
 
-        cmd.buf.ptr = mspBuffer;
-        cmd.buf.end = mspBuffer + p_size;
+        sbufInitialize(&cmd.buf, mspBuffer, mspBuffer + p_size);
 
         checksum = p_size ^ cmd.cmd;
         mspStarted = 1;


### PR DESCRIPTION
Silently discarding sbuf overflow may cause incomplete MSP responses to be sent. This PR will detect overflow and discard incomplete MSP responses.