### PR TITLE
Fix buffer overflow when formatting invalid date/time with non-zero TZ offset

### DIFF
--- a/src/main/common/time.c
+++ b/src/main/common/time.c
@@ -98,6 +98,17 @@ static void rtcTimeToDateTime(dateTime_t *dt, rtcTime_t t)
     dt->millis = t % MILLIS_PER_SECOND;
 }
 
+static bool rtcIsDateTimeValid(dateTime_t *dateTime)
+{
+    return (dateTime->year >= UNIX_REFERENCE_YEAR) &&
+           (dateTime->month >= 1 && dateTime->month <= 12) &&
+           (dateTime->day >= 1 && dateTime->day <= 31) &&
+           (dateTime->hours <= 23) &&
+           (dateTime->minutes <= 59) &&
+           (dateTime->seconds <= 59) &&
+           (dateTime->millis <= 999);
+}
+
 static void dateTimeFormat(char *buf, dateTime_t *dateTime, int16_t offset)
 {
     dateTime_t local;
@@ -107,7 +118,7 @@ static void dateTimeFormat(char *buf, dateTime_t *dateTime, int16_t offset)
     int tz_hours = 0;
     int tz_minutes = 0;
 
-    if (offset != 0) {
+    if (offset != 0 && rtcIsDateTimeValid(dateTime)) {
         tz_hours = offset / 60;
         tz_minutes = ABS(offset % 60);
         utcTime = dateTimeToRtcTime(dateTime);

--- a/src/main/common/time.c
+++ b/src/main/common/time.c
@@ -128,24 +128,22 @@ static bool dateTimeFormat(char *buf, dateTime_t *dateTime, int16_t offset)
 
     int tz_hours = 0;
     int tz_minutes = 0;
-    bool retVal = false;
-    
-    if (rtcIsDateTimeValid(dateTime)) {
-        if (offset != 0) {
-            tz_hours = offset / 60;
-            tz_minutes = ABS(offset % 60);
-            utcTime = dateTimeToRtcTime(dateTime);
-            localTime = rtcTimeMake(rtcTimeGetSeconds(&utcTime) + offset * 60, rtcTimeGetMillis(&utcTime));
-            rtcTimeToDateTime(&local, localTime);
-            dateTime = &local;
-        }
+    bool retVal = true;
 
-        retVal = true;
+    // Apply offset if necessary
+    if (offset != 0) {
+        tz_hours = offset / 60;
+        tz_minutes = ABS(offset % 60);
+        utcTime = dateTimeToRtcTime(dateTime);
+        localTime = rtcTimeMake(rtcTimeGetSeconds(&utcTime) + offset * 60, rtcTimeGetMillis(&utcTime));
+        rtcTimeToDateTime(&local, localTime);
+        dateTime = &local;
     }
-    else {
-        // If date is not valid - format the default one instead
+
+    if (!rtcIsDateTimeValid(dateTime)) {
         rtcGetDefaultDateTime(&local);
         dateTime = &local;
+        retVal = false;
     }
 
     tfp_sprintf(buf, "%04u-%02u-%02uT%02u:%02u:%02u.%03u%c%02d:%02d",

--- a/src/main/common/time.h
+++ b/src/main/common/time.h
@@ -72,8 +72,8 @@ typedef struct _dateTime_s {
 #define FORMATTED_DATE_TIME_BUFSIZE 30
 
 // buf must be at least FORMATTED_DATE_TIME_BUFSIZE
-void dateTimeFormatUTC(char *buf, dateTime_t *dt);
-void dateTimeFormatLocal(char *buf, dateTime_t *dt);
+bool dateTimeFormatUTC(char *buf, dateTime_t *dt);
+bool dateTimeFormatLocal(char *buf, dateTime_t *dt);
 
 bool rtcHasTime();
 


### PR DESCRIPTION
Fixes a bug with `dateTimeFormat` returning a string longer than `FORMATTED_DATE_TIME_BUFSIZE` when RTC is not set and `tz_offset != 0`.