### PR TITLE
Show HOME position and RTC on ARMED screen

### DIFF
--- a/src/main/common/time.c
+++ b/src/main/common/time.c
@@ -149,6 +149,8 @@ static bool dateTimeFormat(char *buf, dateTime_t *dateTime, int16_t offset)
         retVal = false;
     }
 
+    // XXX: Changes to this format might require updates in
+    // dateTimeSplitFormatted()
     tfp_sprintf(buf, "%04u-%02u-%02uT%02u:%02u:%02u.%03u%c%02d:%02d",
         dateTime->year, dateTime->month, dateTime->day,
         dateTime->hours, dateTime->minutes, dateTime->seconds, dateTime->millis,
@@ -185,6 +187,21 @@ bool dateTimeFormatLocal(char *buf, dateTime_t *dt)
 void dateTimeUTCToLocal(dateTime_t *utcDateTime, dateTime_t *localDateTime)
 {
     dateTimeWithOffset(localDateTime, utcDateTime, timeConfig()->tz_offset);
+}
+
+bool dateTimeSplitFormatted(char *formatted, char **date, char **time)
+{
+    // Just look for the T and replace it with a zero
+    // XXX: Keep in sync with dateTimeFormat()
+    for (char *p = formatted; *p; p++) {
+        if (*p == 'T') {
+            *date = formatted;
+            *time = (p+1);
+            *p = '\0';
+            return true;
+        }
+    }
+    return false;
 }
 
 bool rtcHasTime()

--- a/src/main/common/time.h
+++ b/src/main/common/time.h
@@ -76,6 +76,10 @@ bool dateTimeFormatUTC(char *buf, dateTime_t *dt);
 bool dateTimeFormatLocal(char *buf, dateTime_t *dt);
 
 void dateTimeUTCToLocal(dateTime_t *utcDateTime, dateTime_t *localDateTime);
+// dateTimeSplitFormatted splits a formatted date into its date
+// and time parts. Note that the string pointed by formatted will
+// be modifed and will become invalid after calling this function.
+bool dateTimeSplitFormatted(char *formatted, char **date, char **time);
 
 bool rtcHasTime();
 

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -88,8 +88,8 @@
 #define SYM_DIRECTION  0x72
 
 // GPS Coordinates and Altitude
-#define SYM_LAT 0xCA
-#define SYM_LON 0xCB
+#define SYM_LAT 0xA6
+#define SYM_LON 0xA7
 #define SYM_ALT 0xAA
 
 // GPS Mode and Autopilot


### PR DESCRIPTION
- Fix SYM_LAT and SYM_LON, use them in osd.c
- Add osdFormatCoordinate() to format lat and lon
- Add dateTimeSplitFormatted() to split a formatted date time
into date and time
- Draw the HOME position on the ARMED screen when it's available
- Draw the RTC local time on the ARMED screen when it's available