### PR TITLE
Force an OSD redraw after MSP_SET_OSD_CONFIG

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1878,6 +1878,11 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
                     osdConfigMutable()->item_pos[addr] = pos;
                 }
             }
+            // Either a element position change or a units change needs
+            // a full redraw, since an element can change size significantly
+            // and the old position or the now unused space due to the
+            // size change need to be erased.
+            osdStartFullRedraw();
         }
         break;
     case MSP_OSD_CHAR_WRITE:

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -104,6 +104,8 @@ static statistic_t stats;
 uint32_t resumeRefreshAt = 0;
 #define REFRESH_1S    (1000*1000)
 
+static bool fullRedraw = false;
+
 static uint8_t armState;
 
 static displayPort_t *osdDisplayPort;
@@ -949,6 +951,10 @@ static void osdRefresh(timeUs_t currentTimeUs)
 
 #ifdef CMS
     if (!displayIsGrabbed(osdDisplayPort)) {
+        if (fullRedraw) {
+            displayClearScreen(osdDisplayPort);
+            fullRedraw = false;
+        }
         osdUpdateAlarms();
         osdDrawNextElement();
         displayHeartbeat(osdDisplayPort);
@@ -997,4 +1003,10 @@ void osdUpdate(timeUs_t currentTimeUs)
     }
 #endif
 }
+
+void osdStartFullRedraw(void)
+{
+    fullRedraw = true;
+}
+
 #endif // OSD

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -87,3 +87,4 @@ struct displayPort_s;
 void osdInit(struct displayPort_s *osdDisplayPort);
 void osdResetAlarms(void);
 void osdUpdate(timeUs_t currentTimeUs);
+void osdStartFullRedraw(void);


### PR DESCRIPTION
Moving elements or changing the units could cause ghosting otherwise