### PR TITLE
Replace double buffering in OSD with single buffer+bitmask

### DIFF
--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -96,3 +96,5 @@ void * memcpy_fn ( void * destination, const void * source, size_t num ) asm("me
 #else
 #define FALLTHROUGH do {} while(0)
 #endif
+
+#define ALIGNED(x) __attribute__ ((aligned(x)))

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -403,7 +403,6 @@ void max7456Init(const vcdProfile_t *pVcdProfile)
     //real init will be made letter when driver idle detect
 }
 
-//just fill with spaces with some tricks
 void max7456ClearScreen(void)
 {
     memset(screenBuffer, 0x20, sizeof(screenBuffer));

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -186,7 +186,7 @@ static uint8_t screenBuffer[VIDEO_BUFFER_CHARS_PAL] ALIGNED(4);
 static uint8_t screenIsDirty[VIDEO_BUFFER_CHARS_PAL/8] ALIGNED(4) = {0,};
 
 //max chars to update in one idle
-#define MAX_CHARS2UPDATE    50
+#define MAX_CHARS2UPDATE    5
 #ifdef MAX7456_DMA_CHANNEL_TX
 volatile bool dmaTransactionInProgress = false;
 #endif

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -182,8 +182,8 @@ uint16_t maxScreenSize = VIDEO_BUFFER_CHARS_PAL;
 // we write everything in screenBuffer and set a dirty bit
 // in screenIsDirty to upgrade only changed chars this solution
 // is faster than redrawing the whole screen on each frame
-static uint8_t screenBuffer[VIDEO_BUFFER_CHARS_PAL];
-static uint8_t screenIsDirty[VIDEO_BUFFER_CHARS_PAL/8] = {0,};
+static uint8_t screenBuffer[VIDEO_BUFFER_CHARS_PAL] ALIGNED(4);
+static uint8_t screenIsDirty[VIDEO_BUFFER_CHARS_PAL/8] ALIGNED(4) = {0,};
 
 //max chars to update in one idle
 #define MAX_CHARS2UPDATE    50

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -529,8 +529,7 @@ void max7456DrawScreenPartial(void)
                 max7456SendDma(spiBuff, NULL, buff_len);
             #else
             ENABLE_MAX7456();
-            for (k=0; k < buff_len; k++)
-                spiTransferByte(MAX7456_SPI_INSTANCE, spiBuff[k]);
+            spiTransfer(MAX7456_SPI_INSTANCE, NULL, spiBuff, buff_len);
             DISABLE_MAX7456();
             #endif // MAX7456_DMA_CHANNEL_TX
         }

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -502,7 +502,10 @@ void max7456DrawScreenPartial(void)
 
         //------------   end of (re)init-------------------------------------
 
-        for (k=0; k< MAX_CHARS2UPDATE; k++) {
+        // Note that k should not be incremented on each
+        // iteration, only when we find a character that
+        // we need to send to the OSD.
+        for (k=0; k< MAX_CHARS2UPDATE;) {
             if (bitArrayGet(screenIsDirty, pos)) {
                 spiBuff[buff_len++] = MAX7456ADD_DMAH;
                 spiBuff[buff_len++] = pos >> 8;


### PR DESCRIPTION
Needs testing, since there are significant timing changes in the OSD code.