### PR TITLE
Fix fast looptime attitude computation of F7 boards (probably more)

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -50,9 +50,9 @@ void registerExtiCallbackHandler(IRQn_Type irqn, extiCallbackHandlerFunc *fn)
 }
 
 // cycles per microsecond
-STATIC_FASTRAM_UNIT_TESTED timeUs_t usTicks = 0;
+STATIC_UNIT_TESTED  timeUs_t usTicks = 0;
 // current uptime for 1kHz systick timer. will rollover after 49 days. hopefully we won't care.
-STATIC_FASTRAM_UNIT_TESTED volatile timeMs_t sysTickUptime = 0;
+STATIC_UNIT_TESTED  volatile timeMs_t sysTickUptime = 0;
 // cached value of RCC->CSR
 uint32_t cachedRccCsrValue;
 
@@ -76,7 +76,7 @@ void cycleCounterInit(void)
 
 // SysTick
 
-STATIC_FASTRAM volatile int sysTickPending = 0;
+static volatile int sysTickPending = 0;
 
 void SysTick_Handler(void)
 {


### PR DESCRIPTION
This apparently fixes #2127

@digitalentity @fiam @stronnag interesting discovery :)
Looks like FASTRAM and volatile do not mix well