### PR TITLE
Implement bitArrayFindFirstSet()

### DIFF
--- a/src/main/common/bitarray.c
+++ b/src/main/common/bitarray.c
@@ -20,7 +20,9 @@
 
 #include "bitarray.h"
 
-#define BITARRAY_BIT_OP(array, bit, op) ((array)[(bit) / (sizeof((array)[0]) * 8)] op (1 << ((bit) % (sizeof((array)[0]) * 8))))
+// bit[0] in an element must be the MSB to allow using clz
+// to find set bits faster.
+#define BITARRAY_BIT_OP(array, bit, op) ((array)[(bit) / (sizeof((array)[0]) * 8)] op ((1u<<31) >> ((bit) % (sizeof((array)[0]) * 8))))
 
 bool bitArrayGet(const void *array, unsigned bit)
 {

--- a/src/main/common/bitarray.c
+++ b/src/main/common/bitarray.c
@@ -24,17 +24,17 @@
 // to find set bits faster.
 #define BITARRAY_BIT_OP(array, bit, op) ((array)[(bit) / (sizeof((array)[0]) * 8)] op ((1u<<31) >> ((bit) % (sizeof((array)[0]) * 8))))
 
-bool bitArrayGet(const void *array, unsigned bit)
+bool bitArrayGet(const bitarrayElement_t *array, unsigned bit)
 {
     return BITARRAY_BIT_OP((uint32_t*)array, bit, &);
 }
 
-void bitArraySet(void *array, unsigned bit)
+void bitArraySet(bitarrayElement_t *array, unsigned bit)
 {
     BITARRAY_BIT_OP((uint32_t*)array, bit, |=);
 }
 
-void bitArrayClr(void *array, unsigned bit)
+void bitArrayClr(bitarrayElement_t *array, unsigned bit)
 {
     BITARRAY_BIT_OP((uint32_t*)array, bit, &=~);
 }
@@ -52,7 +52,7 @@ __attribute__((always_inline)) static inline uint8_t __CLZ(uint32_t val)
 #endif
 }
 
-int bitArrayFindFirstSet(const void *array, unsigned start, size_t size)
+int bitArrayFindFirstSet(const bitarrayElement_t *array, unsigned start, size_t size)
 {
     const uint32_t *ptr = (uint32_t*)array;
     const uint32_t *end = ptr + (size / 4);

--- a/src/main/common/bitarray.h
+++ b/src/main/common/bitarray.h
@@ -17,6 +17,11 @@
 
 #include <stdbool.h>
 
+/*
+ * These functions expect array to be 4-byte aligned since they alias array
+ * to an uint32_t pointer in order to work fast.
+ */
+
 bool bitArrayGet(const void *array, unsigned bit);
 void bitArraySet(void *array, unsigned bit);
 void bitArrayClr(void *array, unsigned bit);

--- a/src/main/common/bitarray.h
+++ b/src/main/common/bitarray.h
@@ -20,16 +20,22 @@
 
 /*
  * These functions expect array to be 4-byte aligned since they alias array
- * to an uint32_t pointer in order to work fast.
+ * to an uint32_t pointer in order to work fast. Use the BITARRAY_DECLARE()
+ * macro to declare a bit array that can be safely used by them.
  */
 
-bool bitArrayGet(const void *array, unsigned bit);
-void bitArraySet(void *array, unsigned bit);
-void bitArrayClr(void *array, unsigned bit);
+typedef uint32_t bitarrayElement_t;
+
+#define BITARRAY_DECLARE(name, bits) bitarrayElement_t name[(bits + 31) / 32]
+
+bool bitArrayGet(const bitarrayElement_t *array, unsigned bit);
+void bitArraySet(bitarrayElement_t *array, unsigned bit);
+void bitArrayClr(bitarrayElement_t *array, unsigned bit);
+
 // Returns the first set bit with pos >= start_bit, or -1 if all bits
-// are zero.
-// Note that size must indicate the size of array in bytes.
-//
-// WARNING: This function only works for arrays where size is a multiple
-// of 4.
-int bitArrayFindFirstSet(const void *array, unsigned start_bit, size_t size);
+// are zero. Note that size must indicate the size of array in bytes.
+// In most cases, you should use the BITARRAY_FIND_FIRST_SET() macro
+// to call this function.
+int bitArrayFindFirstSet(const bitarrayElement_t *array, unsigned start_bit, size_t size);
+
+#define BITARRAY_FIND_FIRST_SET(array, start_bit) bitArrayFindFirstSet(array, start_bit, sizeof(array))

--- a/src/main/common/bitarray.h
+++ b/src/main/common/bitarray.h
@@ -15,6 +15,8 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
+
 bool bitArrayGet(const void *array, unsigned bit);
 void bitArraySet(void *array, unsigned bit);
 void bitArrayClr(void *array, unsigned bit);

--- a/src/main/common/bitarray.h
+++ b/src/main/common/bitarray.h
@@ -16,6 +16,7 @@
  */
 
 #include <stdbool.h>
+#include <stddef.h>
 
 /*
  * These functions expect array to be 4-byte aligned since they alias array
@@ -25,3 +26,10 @@
 bool bitArrayGet(const void *array, unsigned bit);
 void bitArraySet(void *array, unsigned bit);
 void bitArrayClr(void *array, unsigned bit);
+// Returns the first set bit with pos >= start_bit, or -1 if all bits
+// are zero.
+// Note that size must indicate the size of array in bytes.
+//
+// WARNING: This function only works for arrays where size is a multiple
+// of 4.
+int bitArrayFindFirstSet(const void *array, unsigned start_bit, size_t size);

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -183,7 +183,7 @@ uint16_t maxScreenSize = VIDEO_BUFFER_CHARS_PAL;
 // in screenIsDirty to upgrade only changed chars this solution
 // is faster than redrawing the whole screen on each frame
 static uint8_t screenBuffer[VIDEO_BUFFER_CHARS_PAL] ALIGNED(4);
-static uint8_t screenIsDirty[VIDEO_BUFFER_CHARS_PAL/8] ALIGNED(4) = {0,};
+static BITARRAY_DECLARE(screenIsDirty, VIDEO_BUFFER_CHARS_PAL);
 
 //max chars to update in one idle
 #define MAX_CHARS2UPDATE    5

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -417,7 +417,7 @@ static void packBoxModeFlags(boxBitmask_t * mspBoxModeFlags)
     memset(mspBoxModeFlags, 0, sizeof(boxBitmask_t));
     for (uint32_t i = 0; i < activeBoxIdCount; i++) {
         if (activeBoxes[activeBoxIds[i]]) {
-            bitArraySet(mspBoxModeFlags, i);
+            bitArraySet(mspBoxModeFlags->bits, i);
         }
     }
 }

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -66,7 +66,7 @@ bool isUsingNavigationModes(void)
 
 bool IS_RC_MODE_ACTIVE(boxId_e boxId)
 {
-    return bitArrayGet(&rcModeActivationMask, boxId);
+    return bitArrayGet(rcModeActivationMask.bits, boxId);
 }
 
 void rcModeUpdate(boxBitmask_t *newState)
@@ -124,13 +124,13 @@ void updateActivatedModes(void)
             if (modeActivationOperatorConfig()->modeActivationOperator == MODE_OPERATOR_AND) {
                 // AND the conditions
                 if (activeConditionCountPerMode[modeIndex] == specifiedConditionCountPerMode[modeIndex]) {
-                    bitArraySet(&newMask, modeIndex);
+                    bitArraySet(newMask.bits, modeIndex);
                 }
             }
             else {
                 // OR the conditions
                 if (activeConditionCountPerMode[modeIndex] > 0) {
-                    bitArraySet(&newMask, modeIndex);
+                    bitArraySet(newMask.bits, modeIndex);
                 }
             }
         }

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -19,6 +19,8 @@
 
 #include <stdbool.h>
 
+#include "common/bitarray.h"
+
 #include "config/parameter_group.h"
 
 typedef enum {
@@ -58,7 +60,7 @@ typedef enum {
 } boxId_e;
 
 // type to hold enough bits for CHECKBOX_ITEM_COUNT. Struct used for value-like behavior
-typedef struct boxBitmask_s { uint32_t bits[(CHECKBOX_ITEM_COUNT + 31) / 32]; } boxBitmask_t;
+typedef struct boxBitmask_s { BITARRAY_DECLARE(bits, CHECKBOX_ITEM_COUNT); } boxBitmask_t;
 
 #define MAX_MODE_ACTIVATION_CONDITION_COUNT 20
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -706,6 +706,20 @@ $(OBJECT_DIR)/time_unittest : \
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
 
+$(OBJECT_DIR)/bitarray_unittest.o : \
+	$(TEST_DIR)/bitarray_unittest.cc \
+	$(USER_DIR)/common/bitarray.h \
+	$(GTEST_HEADERS)
+
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXX_FLAGS) $(TEST_CFLAGS) -c $(TEST_DIR)/bitarray_unittest.cc -o $@
+
+$(OBJECT_DIR)/bitarray_unittest : \
+	$(OBJECT_DIR)/common/bitarray.o \
+	$(OBJECT_DIR)/bitarray_unittest.o \
+	$(OBJECT_DIR)/gtest_main.a
+
+	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
 
 
 test: $(TESTS:%=test-%)

--- a/src/test/unit/bitarray_unittest.cc
+++ b/src/test/unit/bitarray_unittest.cc
@@ -33,3 +33,34 @@ TEST(BitArrayTest, TestClr)
     bitArrayClr(p, 31);
     EXPECT_EQ(bitArrayGet(p, 31), false);
 }
+
+TEST(BitArrayTest, TestFind)
+{
+    uint32_t array[4] = {0, 0, 0, 0};
+    void *p = array;
+
+    EXPECT_EQ(bitArrayFindFirstSet(p, 0, sizeof(array)), -1);
+
+    bitArraySet(p, 17);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 0, sizeof(array)), 17);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 16, sizeof(array)), 17);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 17, sizeof(array)), 17);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 18, sizeof(array)), -1);
+
+    bitArraySet(p, 44);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 0, sizeof(array)), 17);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 16, sizeof(array)), 17);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 17, sizeof(array)), 17);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 18, sizeof(array)), 44);
+
+    bitArrayClr(p, 17);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 0, sizeof(array)), 44);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 16, sizeof(array)), 44);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 17, sizeof(array)), 44);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 18, sizeof(array)), 44);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 45, sizeof(array)), -1);
+
+    bitArrayClr(p, 44);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 0, sizeof(array)), -1);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 64, sizeof(array)), -1);
+}

--- a/src/test/unit/bitarray_unittest.cc
+++ b/src/test/unit/bitarray_unittest.cc
@@ -1,0 +1,35 @@
+#include <cstdint>
+
+extern "C" {
+#include "common/bitarray.h"
+}
+
+#include "gtest/gtest.h"
+
+TEST(BitArrayTest, TestGetSet)
+{
+    uint32_t array[1] = {0};
+    void *p = array;
+
+    bitArraySet(p, 14);
+    EXPECT_EQ(bitArrayGet(p, 14), true);
+    EXPECT_EQ(bitArrayGet(p, 13), false);
+    EXPECT_EQ(bitArrayGet(p, 15), false);
+
+    EXPECT_EQ(bitArrayGet(p, 0), false);
+    bitArraySet(p, 0);
+    EXPECT_EQ(bitArrayGet(p, 0), true);
+}
+
+TEST(BitArrayTest, TestClr)
+{
+    uint32_t array[1] = {0};
+    void *p = array;
+
+    bitArraySet(p, 31);
+    EXPECT_EQ(bitArrayGet(p, 31), true);
+    EXPECT_EQ(bitArrayGet(p, 30), false);
+    EXPECT_EQ(bitArrayGet(p, 0), false);
+    bitArrayClr(p, 31);
+    EXPECT_EQ(bitArrayGet(p, 31), false);
+}


### PR DESCRIPTION
Returns the 1st bit set from a bitarray from a given starting
index. Can be used to quickly iterate over the set bits.

Will be used at least by the MAX7456 driver to iterate over the dirty chars which need to be sent to the MAX7456 to be updated.