### PR TITLE
Implement OSD_RTC_TIME

### DIFF
--- a/src/main/common/time.h
+++ b/src/main/common/time.h
@@ -75,6 +75,8 @@ typedef struct _dateTime_s {
 bool dateTimeFormatUTC(char *buf, dateTime_t *dt);
 bool dateTimeFormatLocal(char *buf, dateTime_t *dt);
 
+void dateTimeUTCToLocal(dateTime_t *utcDateTime, dateTime_t *localDateTime);
+
 bool rtcHasTime();
 
 bool rtcGet(rtcTime_t *t);

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -202,6 +202,7 @@
 #define SYM_FLY_M 0x9C
 #define SYM_ON_H  0x70
 #define SYM_FLY_H 0x71
+#define SYM_CLOCK 0xBC
 
 // Throttle Position (%)
 #define SYM_THR   0x04

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -596,6 +596,18 @@ static bool osdDrawSingleElement(uint8_t item)
             break;
         }
 
+    case OSD_RTC_TIME:
+        {
+            // RTC not configured will show 00:00
+            dateTime_t dateTime;
+            if (rtcGetDateTime(&dateTime)) {
+                dateTimeUTCToLocal(&dateTime, &dateTime);
+            }
+            buff[0] = SYM_CLOCK;
+            tfp_sprintf(buff + 1, "%02u:%02u", dateTime.hours, dateTime.minutes);
+            break;
+        }
+
     default:
         return false;
     }
@@ -665,9 +677,11 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_CRAFT_NAME] = OSD_POS(20, 2);
     osdConfig->item_pos[OSD_VTX_CHANNEL] = OSD_POS(8, 6);
 
-    osdConfig->item_pos[OSD_ONTIME] = OSD_POS(23, 9);
-    osdConfig->item_pos[OSD_FLYTIME] = OSD_POS(23, 10);
+    osdConfig->item_pos[OSD_ONTIME] = OSD_POS(23, 8);
+    osdConfig->item_pos[OSD_FLYTIME] = OSD_POS(23, 9);
     osdConfig->item_pos[OSD_ONTIME_FLYTIME] = OSD_POS(23, 11) | VISIBLE_FLAG;
+    osdConfig->item_pos[OSD_RTC_TIME] = OSD_POS(23, 12);
+
     osdConfig->item_pos[OSD_GPS_SATS] = OSD_POS(0, 11) | VISIBLE_FLAG;
 
     osdConfig->item_pos[OSD_GPS_LAT] = OSD_POS(0, 12);

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -58,6 +58,7 @@ typedef enum {
     OSD_VARIO_NUM,
     OSD_AIR_SPEED,
     OSD_ONTIME_FLYTIME,
+    OSD_RTC_TIME,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
Shows the RTC time in hours:minutes format when available. If
RTC is not available, it shows 00:00

Depends on https://github.com/iNavFlight/inav-configurator/pull/247
Fixes #2122