### PR TITLE
Add missing #pragma once to bitarray.h

### DIFF
--- a/src/main/common/bitarray.h
+++ b/src/main/common/bitarray.h
@@ -15,6 +15,8 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include <stdbool.h>
 #include <stddef.h>
 


### PR DESCRIPTION
Fixes warning during compilation of some targets