### PR TITLE
Always clear screen when exiting CMS

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -630,11 +630,11 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
 
     cmsInMenu = false;
 
+    displayClearScreen(pDisplay);
     displayRelease(pDisplay);
     currentCtx.menu = NULL;
 
     if (exitType == CMS_EXIT_SAVEREBOOT) {
-        displayClearScreen(pDisplay);
         displayWrite(pDisplay, 5, 3, "REBOOTING...");
 
         displayResync(pDisplay); // Was max7456RefreshAll(); why at this timing?


### PR DESCRIPTION
Otherwise part of the CMS will be left displayed on the screen
permanently.

Fixes #2140