### PR TITLE
remove gcc7 warning of duplicate const

### DIFF
--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -37,7 +37,7 @@ typedef struct vtxDeviceCapability_s {
 } vtxDeviceCapability_t;
 
 typedef struct vtxDevice_s {
-    const struct vtxVTable_s const *vTable;
+    const struct vtxVTable_s *vTable;
 
     vtxDeviceCapability_t capability;
 

--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -37,7 +37,7 @@ typedef struct vtxDeviceCapability_s {
 } vtxDeviceCapability_t;
 
 typedef struct vtxDevice_s {
-    const struct vtxVTable_s *vTable;
+    const struct vtxVTable_s * const vTable;
 
     vtxDeviceCapability_t capability;
 


### PR DESCRIPTION
trivial gcc 7 warning removal

````
In file included from ./src/main/fc/fc_init.c:79:0:
./src/main/drivers/vtx_common.h:40:30: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
     const struct vtxVTable_s const *vTable;
                              ^~~~~
````