### PR TITLE
tidy up ws2811strip memset for different CPUs

### DIFF
--- a/src/main/drivers/light_ws2811strip.c
+++ b/src/main/drivers/light_ws2811strip.c
@@ -90,7 +90,7 @@ void setStripColors(const hsvColor_t *colors)
 
 void ws2811LedStripInit(void)
 {
-    memset(&ledStripDMABuffer, 0, WS2811_DMA_BUFFER_SIZE);
+    memset(&ledStripDMABuffer, 0, sizeof(ledStripDMABuffer));
     ws2811LedStripHardwareInit();
     ws2811UpdateStrip();
 }


### PR DESCRIPTION
For some reason this one really annoys me in my quest for a clean compile. 
````
./src/main/drivers/light_ws2811strip.c: In function 'ws2811LedStripInit':
./src/main/drivers/light_ws2811strip.c:93:5: warning: 'memset' used with length equal to number of elements without multiplication by element size [-Wmemset-elt-size]
     memset(&ledStripDMABuffer, 0, WS2811_DMA_BUFFER_SIZE);
     ^~~~~~
````
Please delete the PR if this is not correct, or there is a more complex issue for F4/F7 v. the rest, which this warning exposes.
