### PR TITLE
Always clear a display when it's released

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -630,11 +630,11 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
 
     cmsInMenu = false;
 
-    displayClearScreen(pDisplay);
     displayRelease(pDisplay);
     currentCtx.menu = NULL;
 
     if (exitType == CMS_EXIT_SAVEREBOOT) {
+        displayClearScreen(pDisplay);
         displayWrite(pDisplay, 5, 3, "REBOOTING...");
 
         displayResync(pDisplay); // Was max7456RefreshAll(); why at this timing?

--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -52,6 +52,9 @@ void displayGrab(displayPort_t *instance)
 void displayRelease(displayPort_t *instance)
 {
     instance->vTable->release(instance);
+    // displayPort_t is changing owner. Clear it, since
+    // the new owner might expect a clear canvas.
+    instance->vTable->clearScreen(instance);
     --instance->grabCount;
 }
 


### PR DESCRIPTION
This is cleaner than clearing it from CMS, since displayGrab()
also performs a screen clear and it will work in the future
if we add another users of display ports.