### PR TITLE
Test for GPS enabled rather than GPS present to draw GPS indicators

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -630,7 +630,7 @@ static uint8_t osdIncElementIndex(uint8_t elementIndex)
         }
 
     }
-    if (!sensors(SENSOR_GPS)) {
+    if (!feature(FEATURE_GPS)) {
         if (elementIndex == OSD_GPS_SPEED) {
             elementIndex = OSD_ALTITUDE;
         }


### PR DESCRIPTION
Drawing it only when GPS is present would cause the GPS related
information to disappear from the screen if the GPS goes bad
during a flight. This would erase the coordinates from the screen
and might difficult a successful recovery of and aircraft. It can
also be confusing while setting up a new model.