### PR TITLE
Fix missing and misnamed CLI values for OSD parameters

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1401,7 +1401,7 @@ groups:
         field: item_pos[OSD_POWER]
         min: 0
         max: OSD_POS_MAX_CLI
-      - name: osd_air_speed
+      - name: osd_air_speed_pos
         field: item_pos[OSD_AIR_SPEED]
         min: 0
         max: OSD_POS_MAX_CLI

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1405,6 +1405,12 @@ groups:
         field: item_pos[OSD_AIR_SPEED]
         min: 0
         max: OSD_POS_MAX_CLI
+      - name: osd_ontime_flytime_pos
+        field: item_pos[OSD_ONTIME_FLYTIME]
+        max: OSD_POS_MAX_CLI
+      - name: osd_rtc_time_pos
+        field: item_pos[OSD_RTC_TIME]
+        max: OSD_POS_MAX_CLI
 
   - name: PG_SYSTEM_CONFIG
     type: systemConfig_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1329,11 +1329,11 @@ groups:
         field: item_pos[OSD_VTX_CHANNEL]
         min: 0
         max: OSD_POS_MAX_CLI
-      - name: osd_crosshairs
+      - name: osd_crosshairs_pos
         field: item_pos[OSD_CROSSHAIRS]
         min: 0
         max: OSD_POS_MAX_CLI
-      - name: osd_artificial_horizon
+      - name: osd_artificial_horizon_pos
         field: item_pos[OSD_ARTIFICIAL_HORIZON]
         min: 0
         max: OSD_POS_MAX_CLI
@@ -1357,19 +1357,19 @@ groups:
         field: item_pos[OSD_GPS_SATS]
         min: 0
         max: OSD_POS_MAX_CLI
-      - name: osd_gps_lon
+      - name: osd_gps_lon_pos
         field: item_pos[OSD_GPS_LON]
         min: 0
         max: OSD_POS_MAX_CLI
-      - name: osd_gps_lat
+      - name: osd_gps_lat_pos
         field: item_pos[OSD_GPS_LAT]
         min: 0
         max: OSD_POS_MAX_CLI
-      - name: osd_home_dir
+      - name: osd_home_dir_pos
         field: item_pos[OSD_HOME_DIR]
         min: 0
         max: OSD_POS_MAX_CLI
-      - name: osd_home_dist
+      - name: osd_home_dist_pos
         field: item_pos[OSD_HOME_DIST]
         min: 0
         max: OSD_POS_MAX_CLI
@@ -1377,11 +1377,11 @@ groups:
         field: item_pos[OSD_ALTITUDE]
         min: 0
         max: OSD_POS_MAX_CLI
-      - name: osd_vario
+      - name: osd_vario_pos
         field: item_pos[OSD_VARIO]
         min: 0
         max: OSD_POS_MAX_CLI
-      - name: osd_vario_num
+      - name: osd_vario_num_pos
         field: item_pos[OSD_VARIO_NUM]
         min: 0
         max: OSD_POS_MAX_CLI


### PR DESCRIPTION
`osd_air_speed` has been renamed to `osd_air_speed_pos`, like all the other OSD values.

Note that `osd_air_speed` has never been mentioned in the release notes, but I think we should mention this change just in case.