### PR TITLE
Add support for showing GPS HDOP in the OSD

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -29,6 +29,8 @@
 // Satellite Graphics
 #define SYM_SAT_L 0x1E
 #define SYM_SAT_R 0x1F
+#define SYM_HDP_L 0xBD
+#define SYM_HDP_R 0xBE
 //#define SYM_SAT 0x0F  // Not used
 
 // Degrees symbol (°) for HEADING/DIRECTION HOME

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1414,6 +1414,9 @@ groups:
       - name: osd_messages_pos
         field: item_pos[OSD_MESSAGES]
         max: OSD_POS_MAX_CLI
+      - name: osd_gps_hdop_pos
+        field: item_pos[OSD_GPS_HDOP]
+        max: OSD_POS_MAX_CLI
 
   - name: PG_SYSTEM_CONFIG
     type: systemConfig_t

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -108,6 +108,8 @@ typedef struct gpsLocation_s {
     int32_t alt;    // Altitude in centimeters (meters * 100)
 } gpsLocation_t;
 
+#define HDOP_SCALE (100)
+
 typedef struct gpsSolutionData_s {
     struct {
         bool gpsHeartbeat;  // Toggle each update
@@ -131,7 +133,7 @@ typedef struct gpsSolutionData_s {
     uint16_t eph;   // horizontal accuracy (cm)
     uint16_t epv;   // vertical accuracy (cm)
 
-    uint16_t hdop;  // generic HDOP value (*100)
+    uint16_t hdop;  // generic HDOP value (*HDOP_SCALE)
 
     dateTime_t time; // GPS time in UTC
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -523,6 +523,13 @@ static bool osdDrawSingleElement(uint8_t item)
             tfp_sprintf(&buff[1], "%3d%c", h , SYM_DEGREES);
             break;
         }
+    case OSD_GPS_HDOP:
+        {
+            buff[0] = SYM_HDP_L;
+            buff[1] = SYM_HDP_R;
+            tfp_sprintf(&buff[2], "%2d", gpsSol.hdop / 100);
+            break;
+        }
 #endif // GPS
 
     case OSD_ALTITUDE:
@@ -848,6 +855,12 @@ static uint8_t osdIncElementIndex(uint8_t elementIndex)
         if (elementIndex == OSD_GPS_LON) {
             elementIndex = OSD_VARIO;
         }
+        if (elementIndex == OSD_GPS_HDOP) {
+            STATIC_ASSERT(OSD_GPS_HDOP + 1 == OSD_ITEM_COUNT, OSD_GPS_HDOP_not_last_item__update_next_line);
+            // XXX: This needs to be updated if a new OSD
+            // item is added after OSD_GPS_HDOP
+            elementIndex = OSD_ITEM_COUNT;
+        }
     }
 
     if (elementIndex == OSD_ITEM_COUNT) {
@@ -894,6 +907,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_RTC_TIME] = OSD_POS(23, 12);
 
     osdConfig->item_pos[OSD_GPS_SATS] = OSD_POS(0, 11) | VISIBLE_FLAG;
+    osdConfig->item_pos[OSD_GPS_HDOP] = OSD_POS(0, 10);
 
     osdConfig->item_pos[OSD_GPS_LAT] = OSD_POS(0, 12);
     osdConfig->item_pos[OSD_FLYMODE] = OSD_POS(12, 12) | VISIBLE_FLAG;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -57,6 +57,7 @@ typedef enum {
     OSD_ONTIME_FLYTIME,
     OSD_RTC_TIME,
     OSD_MESSAGES,
+    OSD_GPS_HDOP,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
Requires https://github.com/iNavFlight/inav-configurator/pull/252
from the configurator side.

Fixes #1767