### PR TITLE
Activating AltHold While Inverted Issue #1793 and 3D Neutral Not Symmetrical Issue #1879

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -61,9 +61,9 @@ static bool motorLimitReached = false;
 PG_REGISTER_WITH_RESET_TEMPLATE(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);
 
 PG_RESET_TEMPLATE(flight3DConfig_t, flight3DConfig,
-    .deadband3d_low = 1406,
-    .deadband3d_high = 1514,
-    .neutral3d = 1460
+    .deadband3d_low = 1400,
+    .deadband3d_high = 1600,
+    .neutral3d = 1500
 );
 
 
@@ -499,17 +499,17 @@ void mixTable(void)
 
     // Find min and max throttle based on condition.
     if (feature(FEATURE_3D)) {
-        if (!ARMING_FLAG(ARMED)) throttlePrevious = rxConfig()->midrc; // When disarmed set to mid_rc. It always results in positive direction after arming.
+        if (!ARMING_FLAG(ARMED)) throttlePrevious = flight3DConfig()->neutral3d; // When disarmed set to mid_rc. It always results in positive direction after arming.
 
-        if ((rcCommand[THROTTLE] <= (rxConfig()->midrc - rcControlsConfig()->deadband3d_throttle))) { // Out of band handling
+        if ((rcCommand[THROTTLE] <= (flight3DConfig()->neutral3d - rcControlsConfig()->deadband3d_throttle))) { // Out of band handling
             throttleMax = flight3DConfig()->deadband3d_low;
             throttleMin = motorConfig()->minthrottle;
             throttlePrevious = throttleCommand = rcCommand[THROTTLE];
-        } else if (rcCommand[THROTTLE] >= (rxConfig()->midrc + rcControlsConfig()->deadband3d_throttle)) { // Positive handling
+        } else if (rcCommand[THROTTLE] >= (flight3DConfig()->neutral3d + rcControlsConfig()->deadband3d_throttle)) { // Positive handling
             throttleMax = motorConfig()->maxthrottle;
             throttleMin = flight3DConfig()->deadband3d_high;
             throttlePrevious = throttleCommand = rcCommand[THROTTLE];
-        } else if ((throttlePrevious <= (rxConfig()->midrc - rcControlsConfig()->deadband3d_throttle)))  { // Deadband handling from negative to positive
+        } else if ((throttlePrevious <= (flight3DConfig()->neutral3d - rcControlsConfig()->deadband3d_throttle)))  { // Deadband handling from negative to positive
             throttleCommand = throttleMax = flight3DConfig()->deadband3d_low;
             throttleMin = motorConfig()->minthrottle;
         } else {  // Deadband handling from positive to negative
@@ -551,7 +551,7 @@ void mixTable(void)
             if (failsafeIsActive()) {
                 motor[i] = constrain(motor[i], motorConfig()->mincommand, motorConfig()->maxthrottle);
             } else if (feature(FEATURE_3D)) {
-                if (throttlePrevious <= (rxConfig()->midrc - rcControlsConfig()->deadband3d_throttle)) {
+                if (throttlePrevious <= (flight3DConfig()->neutral3d - rcControlsConfig()->deadband3d_throttle)) {
                     motor[i] = constrain(motor[i], motorConfig()->minthrottle, flight3DConfig()->deadband3d_low);
                 } else {
                     motor[i] = constrain(motor[i], flight3DConfig()->deadband3d_high, motorConfig()->maxthrottle);
@@ -567,7 +567,7 @@ void mixTable(void)
                 bool userMotorStop = !failsafeIsActive() && (rcData[THROTTLE] < rxConfig()->mincheck);
                 if (failsafeMotorStop || navMotorStop || userMotorStop) {
                     if (feature(FEATURE_3D)) {
-                        motor[i] = rxConfig()->midrc;
+                        motor[i] = flight3DConfig()->neutral3d;
                     }
                     else {
                         motor[i] = motorConfig()->mincommand;


### PR DESCRIPTION
Issue #1793 Activating AltHold While Inverted:
If inverted when activating ALT-Hold, reverse motors then at the top of the flip change motors to the normal direction and reset the hold position to the current position. This is a big improvement (see video link under issue #1793) and I have made some more progress since the video was made.  More work such as first level-out, punch-out, then flip would be beneficial.  Event just leveling the pitch before the flip would smooth out the transition.  After this is perfected, it would be great to add other exciting features such as hard-deck to automatically activate this feature when a certain altitude is reached making it nearly impossible to crash.  This would be a revolutionary improvement to our hobby that would re-establish 3D Quads/Helicopter-modes that would attract and bring back many people to this exciting hobby. 

Issue #10879 3D Not Symmetrical Issued:
As a work-around, I changed the 3D Neutral variable to use the Configurator-[3D Neutral] value to adjust the center stick transition point.

I also changed the [Deadband Low] and [Deadband High] defaults as the existing values are too close to each other and do not work well.  These values keep the motors spinning faster in the Deadband zone, which make the quad much smoother and prevents the severe jitters when the throttle is reapplied. 

For 3D the configuration setting [hover throttle] needs to be around 1650 as the default 1500 is zero throttle in 3D mode.
