### PR TITLE
rcCommand infrastructure overhaul

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -67,6 +67,7 @@
 
 stickPositions_e rcStickPositions;
 
+rcCommandState_t rcCmd;
 int16_t rcCommand[4];           // interval [1000;2000] for THROTTLE and [-500;+500] for ROLL/PITCH/YAW
 
 PG_REGISTER_WITH_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -69,6 +69,12 @@ typedef enum {
     THR_HI = (2 << (2 * THROTTLE))
 } stickPositions_e;
 
+typedef struct {
+    float   stick[4];       // Raw stick positions + EXPO. Range: [-1;1] for all RPYT sticks. This is set by RC processing code and is never modified
+    float   command[4];     // Command that is going to be sent to mixer. [-1;1] for RPY & THROTTLE
+} rcCommandState_t;
+
+extern rcCommandState_t rcCmd;
 extern int16_t rcCommand[4];
 
 typedef struct rcControlsConfig_s {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -24,6 +24,7 @@
 #define PID_SUM_LIMIT_MIN       100
 #define PID_SUM_LIMIT_MAX       1000
 #define PID_SUM_LIMIT_DEFAULT   500
+#define PID_MIXER_SCALING       1000.0f
 #define YAW_P_LIMIT_MIN 100                 // Maximum value for yaw P limiter
 #define YAW_P_LIMIT_MAX 500                 // Maximum value for yaw P limiter
 #define YAW_P_LIMIT_DEFAULT 300             // Default value for yaw P limiter
@@ -141,7 +142,7 @@ void updatePIDCoefficients(void);
 void pidController(void);
 
 float pidRateToRcCommand(float rateDPS, uint8_t rate);
-int16_t pidAngleToRcCommand(float angleDeciDegrees, int16_t maxInclination);
+float pidAngleToRcCommand(float angleDeciDegrees, float maxInclination);
 
 enum {
     HEADING_HOLD_DISABLED = 0,


### PR DESCRIPTION
Current `rcCommand` infrastructure has several serious flaws:

1. While processing user input we loose the actual pilot command
2. We have to mind the order of modifications to `rcCommand` to prevent treating automatic input as pilot command
3. Having `rcCommand` in uS (pwm units) is confusing (especially for throttle) and requires us to deal with `500` magic number and `minthrottle`, `maxthrottle` values all the time making code less efficient
4. We don't treat `rcCommand` uniformly for non-3D-mode and 3D-mode

This PR attempts to address this by doing the following:

1. Switching all processing to float and treating all 4 sticks like symmetric input in [-1;1] (-100% ... 100%) range.
2. Separating pilot input from command: `rcCmd.stick` values are always in range [-1;1] and always represent what pilot is commanding. `rcCmd.command` values are calculated based on pilot's command, flight mode and flight state.
3. Mixer ensures that `rcCmd.command[THROTTLE]` correctly maps to actual ESC command.

This PR is incomplete. PRs against this branch are most welcome!