### PR TITLE
Reduce SPI clock for SDCARD to 10MHz; Add system clocks to status command

### DIFF
--- a/src/main/drivers/sdcard.c
+++ b/src/main/drivers/sdcard.c
@@ -57,6 +57,10 @@
  */
 #define SDCARD_NON_DMA_CHUNK_SIZE 256
 
+#ifndef SDCARD_SPI_CLOCK
+#define SDCARD_SPI_CLOCK    SPI_CLOCK_STANDARD
+#endif
+
 typedef enum {
     // In these states we run at the initialization 400kHz clockspeed:
     SDCARD_STATE_NOT_PRESENT = 0,
@@ -727,7 +731,7 @@ bool sdcard_poll(void)
                 }
 
                 // Now we're done with init and we can switch to the full speed clock (<25MHz)
-                spiSetSpeed(SDCARD_SPI_INSTANCE, SPI_CLOCK_FAST);
+                spiSetSpeed(SDCARD_SPI_INSTANCE, SDCARD_SPI_CLOCK);
 
                 sdcard.multiWriteBlocksRemain = 0;
 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2348,6 +2348,21 @@ static void cliStatus(char *cmdline)
     }
     cliPrintLinefeed();
 
+    cliPrintLine("STM32 system clocks:");
+#if defined(USE_HAL_DRIVER)
+    cliPrintLinef("  SYSCLK = %d MHz", HAL_RCC_GetSysClockFreq() / 1000000);
+    cliPrintLinef("  HCLK   = %d MHz", HAL_RCC_GetHCLKFreq() / 1000000);
+    cliPrintLinef("  PCLK1  = %d MHz", HAL_RCC_GetPCLK1Freq() / 1000000);
+    cliPrintLinef("  PCLK2  = %d MHz", HAL_RCC_GetPCLK2Freq() / 1000000);
+#else
+    RCC_ClocksTypeDef clocks;
+    RCC_GetClocksFreq(&clocks);
+    cliPrintLinef("  SYSCLK = %d MHz", clocks.SYSCLK_Frequency / 1000000);
+    cliPrintLinef("  HCLK   = %d MHz", clocks.HCLK_Frequency / 1000000);
+    cliPrintLinef("  PCLK1  = %d MHz", clocks.PCLK1_Frequency / 1000000);
+    cliPrintLinef("  PCLK2  = %d MHz", clocks.PCLK2_Frequency / 1000000);
+#endif
+
     cliPrintLinef("Sensor status: GYRO=%s, ACC=%s, MAG=%s, BARO=%s, RANGEFINDER=%s, GPS=%s",
         hardwareSensorStatusNames[getHwGyroStatus()],
         hardwareSensorStatusNames[getHwAccelerometerStatus()],


### PR DESCRIPTION
Fixes a bug revealed by #2138.

On our boards SD-Card usually users SPI2 or SPI3 which means that SPI clock divider that was intended to set the clock speed to ~20MHz was actually setting clock rate to ~10MHz.

Fixing this bug in #2138 revealed that many SD-Cards actually can't function at 20MHz and caused the board to lock up.

This PR changes back to slower clock rate for SD-Cards.