### PR TITLE
OSD_MESSAGES initial implementation 

### DIFF
--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -20,8 +20,6 @@
 
 #include "platform.h"
 
-#include "common/utils.h"
-
 #include "fc/runtime_config.h"
 
 #include "io/beeper.h"
@@ -32,31 +30,13 @@ uint32_t flightModeFlags = 0;
 
 static uint32_t enabledSensors = 0;
 
-// XXX: This function assumes that all flags in ARMING_DISABLED_ALL_FLAGS
-// are contiguous
 armingFlag_e isArmingDisabledReason(void)
 {
-    STATIC_ASSERT(sizeof(armingFlag_e) == 4, size_of_armingFlag_e_not_4);
-
     armingFlag_e flag;
-    uint8_t first_flag;
-    uint8_t last_flag;
-    uint8_t clz;
-
-    __asm__ ("clz %0, %1"
-            : "=r" (clz)
-            : "r" ((uint32_t)ARMING_DISABLED_ALL_FLAGS));
-
-    __asm__ ("rbit %1, %1\n\t"
-            "clz %0, %1"
-            : "=r" (first_flag)
-            : "r" ((uint32_t)ARMING_DISABLED_ALL_FLAGS));
-
-    last_flag = 32 - clz - 1;
-
-    for (uint8_t ii = first_flag; ii <= last_flag; ii++) {
-        flag = 1 << ii;
-        if (armingFlags & flag) {
+    armingFlag_e reasons = armingFlags & ARMING_DISABLED_ALL_FLAGS;
+    for (unsigned ii = 0; ii < sizeof(armingFlag_e) * 8; ii++) {
+        flag = 1u << ii;
+        if (flag & reasons) {
             return flag;
         }
     }

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -53,6 +53,10 @@ extern uint32_t armingFlags;
 #define ENABLE_ARMING_FLAG(mask)    (armingFlags |= (mask))
 #define ARMING_FLAG(mask)           (armingFlags & (mask))
 
+// Returns the 1st flag from ARMING_DISABLED_ALL_FLAGS which is
+// preventing arming, or zero is arming is not disabled.
+armingFlag_e isArmingDisabledReason(void);
+
 typedef enum {
     ANGLE_MODE      = (1 << 0),
     HORIZON_MODE    = (1 << 1),

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1411,6 +1411,9 @@ groups:
       - name: osd_rtc_time_pos
         field: item_pos[OSD_RTC_TIME]
         max: OSD_POS_MAX_CLI
+      - name: osd_messages_pos
+        field: item_pos[OSD_MESSAGES]
+        max: OSD_POS_MAX_CLI
 
   - name: PG_SYSTEM_CONFIG
     type: systemConfig_t

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -843,8 +843,6 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_AIR_SPEED] = OSD_POS(3, 5);
 
     // Under OSD_FLYMODE. TODO: Might not be visible on NTSC?
-    // FIXME: | VISIBLE_FLAG for testing. Will be probably
-    // removed before merging final version.
     osdConfig->item_pos[OSD_MESSAGES] = OSD_POS(1, 13) | VISIBLE_FLAG;
 
     osdConfig->rssi_alarm = 20;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -322,11 +322,11 @@ static const char * osdArmingDisabledReasonMessage(void)
             return OSD_MESSAGE_STR("THROTTLE IS NOT LOW");
         case ARMING_DISABLED_CLI:
             return OSD_MESSAGE_STR("CLI IS ACTIVE");
+            // Cases without message
         case ARMING_DISABLED_CMS_MENU:
-            return OSD_MESSAGE_STR("CMS MODE IS ACTIVE");
+            FALLTHROUGH;
         case ARMING_DISABLED_OSD_MENU:
-            return OSD_MESSAGE_STR("OSD MENU IS ACTIVE");
-        // Cases without message
+            FALLTHROUGH;
         case ARMING_DISABLED_ALL_FLAGS:
             FALLTHROUGH;
         case ARMED:

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -741,8 +741,8 @@ static bool osdDrawSingleElement(uint8_t item)
             const char *message = NULL;
             if (ARMING_FLAG(ARMED)) {
                 // TODO: Add some messages here
-            } else if (IS_RC_MODE_ACTIVE(BOXARM)) {
-                TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
+            } else if (ARMING_FLAG(ARMING_DISABLED_ALL_FLAGS)) {
+                // Check if we're unable to arm for some reason
                 if (OSD_ALTERNATING_TEXT(1000, 2) == 0) {
                     message = "UNABLE TO ARM";
                     TEXT_ATTRIBUTES_ADD_INVERTED(elemAttr);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -70,6 +70,7 @@
 #include "rx/rx.h"
 
 #include "sensors/battery.h"
+#include "sensors/diagnostics.h"
 #include "sensors/sensors.h"
 #include "sensors/pitotmeter.h"
 
@@ -280,6 +281,29 @@ static const char * osdArmingDisabledReasonMessage(void)
         case ARMING_DISABLED_ARM_SWITCH:
             return "DISABLE ARM SWITCH FIRST";
         case ARMING_DISABLED_HARDWARE_FAILURE:
+            {
+                if (!HW_SENSOR_IS_HEALTHY(getHwGyroStatus())) {
+                    return "GYRO FAILURE";
+                }
+                if (!HW_SENSOR_IS_HEALTHY(getHwAccelerometerStatus())) {
+                    return "ACCELEROMETER FAILURE";
+                }
+                if (!HW_SENSOR_IS_HEALTHY(getHwCompassStatus())) {
+                    return "COMPASS FAILURE";
+                }
+                if (!HW_SENSOR_IS_HEALTHY(getHwBarometerStatus())) {
+                    return "BAROMETER FAILURE";
+                }
+                if (!HW_SENSOR_IS_HEALTHY(getHwGPSStatus())) {
+                    return "GPS FAILURE";
+                }
+                if (!HW_SENSOR_IS_HEALTHY(getHwRangefinderStatus())) {
+                    return "RANGE FINDER FAILURE";
+                }
+                if (!HW_SENSOR_IS_HEALTHY(getHwPitotmeterStatus())) {
+                    return "PITOT METER FAILURE";
+                }
+            }
             return "HARDWARE FAILURE";
         case ARMING_DISABLED_BOXFAILSAFE:
             return "FAILSAFE MODE ENABLED";

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -89,6 +89,13 @@
 // changing OSD_MESSAGE_LENGTH
 #define OSD_MESSAGE_LENGTH 28
 #define OSD_ALTERNATING_TEXT(ms, num_choices) ((millis() / ms) % num_choices)
+#define _CONST_STR_SIZE(s) ((sizeof(s)/sizeof(s[0]))-1) // -1 to avoid counting final '\0'
+// Wrap all string constants intenteded for display as messages with
+// this macro to ensure compile time length validation.
+#define OSD_MESSAGE_STR(x) ({ \
+    STATIC_ASSERT(_CONST_STR_SIZE(x) <= OSD_MESSAGE_LENGTH, message_string_ ## __COUNTER__ ## _too_long); \
+    x; \
+})
 
 // Things in both OSD and CMS
 
@@ -265,60 +272,60 @@ static const char * osdArmingDisabledReasonMessage(void)
 {
     switch (isArmingDisabledReason()) {
         case ARMING_DISABLED_FAILSAFE_SYSTEM:
-            return "FAILSAFE SYSTEM IS ACTIVE";
+            return OSD_MESSAGE_STR("FAILSAFE SYSTEM IS ACTIVE");
         case ARMING_DISABLED_NOT_LEVEL:
-            return "AIRCRAFT IS NOT LEVEL";
+            return OSD_MESSAGE_STR("AIRCRAFT IS NOT LEVEL");
         case ARMING_DISABLED_SENSORS_CALIBRATING:
-            return "SENSORS CALIBRATING";
+            return OSD_MESSAGE_STR("SENSORS CALIBRATING");
         case ARMING_DISABLED_SYSTEM_OVERLOADED:
-            return "SYSTEM OVERLOADED";
+            return OSD_MESSAGE_STR("SYSTEM OVERLOADED");
         case ARMING_DISABLED_NAVIGATION_UNSAFE:
-            return "NAVIGATION IS UNSAFE";
+            return OSD_MESSAGE_STR("NAVIGATION IS UNSAFE");
         case ARMING_DISABLED_COMPASS_NOT_CALIBRATED:
-            return "COMPASS NOT CALIBRATED";
+            return OSD_MESSAGE_STR("COMPASS NOT CALIBRATED");
         case ARMING_DISABLED_ACCELEROMETER_NOT_CALIBRATED:
-            return "ACCELEROMETER NOT CALIBRATED";
+            return OSD_MESSAGE_STR("ACCELEROMETER NOT CALIBRATED");
         case ARMING_DISABLED_ARM_SWITCH:
-            return "DISABLE ARM SWITCH FIRST";
+            return OSD_MESSAGE_STR("DISABLE ARM SWITCH FIRST");
         case ARMING_DISABLED_HARDWARE_FAILURE:
             {
                 if (!HW_SENSOR_IS_HEALTHY(getHwGyroStatus())) {
-                    return "GYRO FAILURE";
+                    return OSD_MESSAGE_STR("GYRO FAILURE");
                 }
                 if (!HW_SENSOR_IS_HEALTHY(getHwAccelerometerStatus())) {
-                    return "ACCELEROMETER FAILURE";
+                    return OSD_MESSAGE_STR("ACCELEROMETER FAILURE");
                 }
                 if (!HW_SENSOR_IS_HEALTHY(getHwCompassStatus())) {
-                    return "COMPASS FAILURE";
+                    return OSD_MESSAGE_STR("COMPASS FAILURE");
                 }
                 if (!HW_SENSOR_IS_HEALTHY(getHwBarometerStatus())) {
-                    return "BAROMETER FAILURE";
+                    return OSD_MESSAGE_STR("BAROMETER FAILURE");
                 }
                 if (!HW_SENSOR_IS_HEALTHY(getHwGPSStatus())) {
-                    return "GPS FAILURE";
+                    return OSD_MESSAGE_STR("GPS FAILURE");
                 }
                 if (!HW_SENSOR_IS_HEALTHY(getHwRangefinderStatus())) {
-                    return "RANGE FINDER FAILURE";
+                    return OSD_MESSAGE_STR("RANGE FINDER FAILURE");
                 }
                 if (!HW_SENSOR_IS_HEALTHY(getHwPitotmeterStatus())) {
-                    return "PITOT METER FAILURE";
+                    return OSD_MESSAGE_STR("PITOT METER FAILURE");
                 }
             }
-            return "HARDWARE FAILURE";
+            return OSD_MESSAGE_STR("HARDWARE FAILURE");
         case ARMING_DISABLED_BOXFAILSAFE:
-            return "FAILSAFE MODE ENABLED";
+            return OSD_MESSAGE_STR("FAILSAFE MODE ENABLED");
         case ARMING_DISABLED_BOXKILLSWITCH:
-            return "KILLSWITCH MODE ENABLED";
+            return OSD_MESSAGE_STR("KILLSWITCH MODE ENABLED");
         case ARMING_DISABLED_RC_LINK:
-            return "NO RC LINK";
+            return OSD_MESSAGE_STR("NO RC LINK");
         case ARMING_DISABLED_THROTTLE:
-            return "THROTTLE IS NOT LOW";
+            return OSD_MESSAGE_STR("THROTTLE IS NOT LOW");
         case ARMING_DISABLED_CLI:
-            return "CLI IS ACTIVE";
+            return OSD_MESSAGE_STR("CLI IS ACTIVE");
         case ARMING_DISABLED_CMS_MENU:
-            return "CMS MODE IS ACTIVE";
+            return OSD_MESSAGE_STR("CMS MODE IS ACTIVE");
         case ARMING_DISABLED_OSD_MENU:
-            return "OSD MENU IS ACTIVE";
+            return OSD_MESSAGE_STR("OSD MENU IS ACTIVE");
         // Cases without message
         case ARMING_DISABLED_ALL_FLAGS:
             FALLTHROUGH;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -56,6 +56,7 @@ typedef enum {
     OSD_AIR_SPEED,
     OSD_ONTIME_FLYTIME,
     OSD_RTC_TIME,
+    OSD_MESSAGES,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/main/sensors/diagnostics.h
+++ b/src/main/sensors/diagnostics.h
@@ -12,6 +12,10 @@ typedef enum {
     HW_SENSOR_UNHEALTHY     = 3,    // Selected, detected but is reported as not healthy
 } hardwareSensorStatus_e;
 
+// Sensor is considered healthy if it's either
+// not configured or either configured and working.
+#define HW_SENSOR_IS_HEALTHY(status)    (status == HW_SENSOR_NONE || status == HW_SENSOR_OK)
+
 hardwareSensorStatus_e getHwGyroStatus(void);
 hardwareSensorStatus_e getHwAccelerometerStatus(void);
 hardwareSensorStatus_e getHwCompassStatus(void);


### PR DESCRIPTION
Experimental implementation of the OSD_MESSAGES element. Allows displaying arbitrary text messages, taking a whole line of text. It's intended to display non-essential messages, so the initial idea is not enabling it by default (subject to change).

Currently used while the aircraft can't be armed to show the reason it's failing to arm.

Potential future uses include:

- Failsafe stages
- RTH stages
- WPT stages
- Autotune & Autotrim indicators
- Modifier modes which might be combined with the self-contained ones (e.g. AltHold)

Potential issues fixed by this include: #1959, #1993 and #2032 