### PR TITLE
Use OSD_MESSAGES to show failsafe phases

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -481,6 +481,9 @@ void failsafeUpdateState(void)
                     if (millis() > failsafeState.receivingRxDataPeriod) {
                         // rx link is good now, when arming via ARM switch, it must be OFF first
                         if (!(!isUsingSticksForArming() && IS_RC_MODE_ACTIVE(BOXARM))) {
+                            // XXX: Requirements for removing the ARMING_DISABLED_FAILSAFE_SYSTEM flag
+                            // are tested by osd.c to show the user how to re-arm. If these
+                            // requirements change, update osdArmingDisabledReasonMessage().
                             DISABLE_ARMING_FLAG(ARMING_DISABLED_FAILSAFE_SYSTEM);
                             failsafeState.phase = FAILSAFE_RX_LOSS_RECOVERED;
                             reprocessState = true;


### PR DESCRIPTION
Show FS phases in the OSD_MESSAGES item, removes the "overload"
from showing them in OSD_FLYMODE, indicating FS just with an F.

Added some comments in failsafe.c, indicating that changes to
the ARMING_DISABLED_FAILSAFE_SYSTEM logic should include changes
to the OSD messages, since we now tell the user how to re-arm.