### PR TITLE
Use fixed-width numbers for all numeric indicators

### DIFF
--- a/src/main/common/printf.c
+++ b/src/main/common/printf.c
@@ -64,15 +64,27 @@ static int putchw(void *putp, putcf putf, int n, char z, char *bf)
 {
     int written = 0;
     char fc = z ? '0' : ' ';
+    char pr = 0;
+    if (n < 0) {
+        pr = 1;
+        n = -n;
+    }
     char ch;
     char *p = bf;
     while (*p++ && n > 0)
         n--;
-    while (n-- > 0) {
-        putf(putp, fc); written++;
+    if (pr == 0) {
+        while (n-- > 0) {
+            putf(putp, fc); written++;
+        }
     }
     while ((ch = *bf++)) {
         putf(putp, ch); written++;
+    }
+    if (pr == 1) {
+        while (n-- > 0) {
+            putf(putp, fc); written++;
+        }
     }
     return written;
 }
@@ -89,17 +101,25 @@ int tfp_format(void *putp, putcf putf, const char *fmt, va_list va)
             putf(putp, ch); written++;
         } else {
             char lz = 0;
+            char pr = 0; // padding at the right?
 #ifdef REQUIRE_PRINTF_LONG_SUPPORT
             char lng = 0;
 #endif
             int w = 0;
             ch = *(fmt++);
+            if (ch == '-') {
+                ch = *(fmt++);
+                pr = 1;
+            }
             if (ch == '0') {
                 ch = *(fmt++);
                 lz = 1;
             }
             if (ch >= '0' && ch <= '9') {
                 ch = a2i(ch, &fmt, 10, &w);
+                if (pr) {
+                    w = -w;
+                }
             }
 #ifdef REQUIRE_PRINTF_LONG_SUPPORT
             if (ch == 'l') {

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -200,6 +200,9 @@
 // Menu cursor
 #define SYM_CURSOR SYM_AH_LEFT
 
+// Air speed
+#define SYM_AIR 151
+
 //Misc
 #define SYM_COLON 0x2D
 #define SYM_ZERO_HALF_TRAILING_DOT 192

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -155,16 +155,22 @@
 // Unit Icon´s (Metric)
 #define SYM_MS          0x9F
 #define SYM_KMH         0xA1
-#define SYM_ALTM        0xA7
-#define SYM_DISTHOME_M  0xBB
-#define SYM_M           0x0C
+#define SYM_ALT_M       210
+#define SYM_ALT_KM      211
+#define SYM_DIST_M      214
+#define SYM_DIST_KM     215
+#define SYM_M           218
+#define SYM_KM          219
 
 // Unit Icon´s (Imperial)
 #define SYM_FTS         0x99
 #define SYM_MPH         0xB0
-#define SYM_ALTFT       0xA8
-#define SYM_DISTHOME_FT 0xB9
+#define SYM_ALT_FT      212
+#define SYM_ALT_KFT     213
+#define SYM_DIST_FT     216
+#define SYM_DIST_MI     217
 #define SYM_FT          0x0F
+#define SYM_MI          220
 
 // Voltage and amperage
 #define SYM_VOLT  0x06
@@ -210,6 +216,7 @@
 
 //Misc
 #define SYM_COLON 0x2D
+#define SYM_ZERO_DOT 200
 
 //sport
 #define SYM_MIN 0xB3

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -178,20 +178,6 @@
 #define SYM_MAH   0x07
 #define SYM_WATT  0x57
 
-// Flying Mode
-#define SYM_ACRO      0xAE
-#define SYM_ACROGY    0x98
-#define SYM_ACRO1     0xAF
-#define SYM_STABLE    0xAC
-#define SYM_STABLE1   0xAD
-#define SYM_HORIZON   0xC4
-#define SYM_HORIZON1  0xC5
-#define SYM_PASS      0xAA
-#define SYM_PASS1     0xAB
-#define SYM_AIR       0xEA
-#define SYM_AIR1      0xEB
-#define SYM_PLUS      0x89
-
 // Note, these change with scrolling enabled (scrolling is TODO)
 //#define SYM_AH_DECORATION_LEFT 0x13
 //#define SYM_AH_DECORATION_RIGHT 0x13

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -216,7 +216,8 @@
 
 //Misc
 #define SYM_COLON 0x2D
-#define SYM_ZERO_DOT 192
+#define SYM_ZERO_HALF_TRAILING_DOT 192
+#define SYM_ZERO_HALF_LEADING_DOT 208
 
 //sport
 #define SYM_MIN 0xB3

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -155,22 +155,22 @@
 // Unit Icon´s (Metric)
 #define SYM_MS          0x9F
 #define SYM_KMH         0xA1
-#define SYM_ALT_M       210
-#define SYM_ALT_KM      211
-#define SYM_DIST_M      214
-#define SYM_DIST_KM     215
-#define SYM_M           218
-#define SYM_KM          219
+#define SYM_ALT_M       177
+#define SYM_ALT_KM      178
+#define SYM_DIST_M      181
+#define SYM_DIST_KM     182
+#define SYM_M           185
+#define SYM_KM          187
 
 // Unit Icon´s (Imperial)
 #define SYM_FTS         0x99
 #define SYM_MPH         0xB0
-#define SYM_ALT_FT      212
-#define SYM_ALT_KFT     213
-#define SYM_DIST_FT     216
-#define SYM_DIST_MI     217
+#define SYM_ALT_FT      179
+#define SYM_ALT_KFT     180
+#define SYM_DIST_FT     183
+#define SYM_DIST_MI     184
 #define SYM_FT          0x0F
-#define SYM_MI          220
+#define SYM_MI          187
 
 // Voltage and amperage
 #define SYM_VOLT  0x06
@@ -216,7 +216,7 @@
 
 //Misc
 #define SYM_COLON 0x2D
-#define SYM_ZERO_DOT 200
+#define SYM_ZERO_DOT 192
 
 //sport
 #define SYM_MIN 0xB3

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -979,7 +979,21 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_VARIO_NUM:
         {
             int16_t value = getEstimatedActualVelocity(Z);
-            char sym = SYM_MS;
+            char sym;
+            switch (osdConfig()->units) {
+                case OSD_UNIT_IMPERIAL:
+                    // Convert to centifeet/s
+                    value = CENTIMETERS_TO_CENTIFEET(value);
+                    sym = SYM_FTS;
+                    break;
+                case OSD_UNIT_UK:
+                    FALLTHROUGH;
+                case OSD_UNIT_METRIC:
+                    // Already in cm/s
+                    sym = SYM_MS;
+                    break;
+            }
+
             osdFormatCentiNumber(buff, value, 0, 1, 0, 3);
             buff[3] = sym;
             buff[4] = '\0';

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1029,7 +1029,8 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_AIR_SPEED:
         {
         #ifdef PITOT
-            osdFormatVelocityStr(buff, pitot.airSpeed);
+            buff[0] = SYM_AIR;
+            osdFormatVelocityStr(buff + 1, pitot.airSpeed);
         #else
             return false;
         #endif

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -341,7 +341,7 @@ static void osdFormatVelocityStr(char* buff, int32_t vel)
     case OSD_UNIT_UK:
         FALLTHROUGH;
     case OSD_UNIT_IMPERIAL:
-        tfp_sprintf(buff, "%2d%c", osdConvertVelocityToUnit(vel), SYM_MPH);
+        tfp_sprintf(buff, "%3d%c", osdConvertVelocityToUnit(vel), SYM_MPH);
         break;
     case OSD_UNIT_METRIC:
         tfp_sprintf(buff, "%3d%c", osdConvertVelocityToUnit(vel), SYM_KMH);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -726,7 +726,8 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             buff[0] = SYM_HDP_L;
             buff[1] = SYM_HDP_R;
-            tfp_sprintf(&buff[2], "%2d", gpsSol.hdop / HDOP_SCALE);
+            int32_t centiHDOP = gpsSol.hdop / (HDOP_SCALE * 100);
+            osdFormatCentiNumber(&buff[2], centiHDOP, 0, 1, 0, 2);
             break;
         }
 #endif // GPS

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -662,12 +662,12 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_CURRENT_DRAW:
         buff[0] = SYM_AMP;
-        tfp_sprintf(buff + 1, "%d.%02d ", abs(amperage) / 100, abs(amperage) % 100);
+        osdFormatCentiNumber(buff + 1, amperage, 0, 2, 0, 3);
         break;
 
     case OSD_MAH_DRAWN:
         buff[0] = SYM_MAH;
-        tfp_sprintf(buff + 1, "%d", abs(mAhDrawn));
+        tfp_sprintf(buff + 1, "%-4d", abs(mAhDrawn));
         if (mAhDrawn >= osdConfig()->cap_alarm) {
             TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
         }
@@ -990,7 +990,8 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_POWER:
         {
-            tfp_sprintf(buff, "%dW", amperage * vbat / 1000);
+            // TODO: SYM_WATTS?
+            tfp_sprintf(buff, "W%-3d", amperage * vbat / 1000);
             break;
         }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -163,6 +163,7 @@ static int digitCount(int32_t value)
  static bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int maxDecimals, int maxScaledDecimals, int length)
  {
     char *ptr = buff;
+    char *dec;
     int decimals = maxDecimals;
     bool negative = false;
     bool scaled = false;
@@ -215,7 +216,8 @@ static int digitCount(int32_t value)
     ui2a(integerPart, 10, 0, ptr);
     ptr += digits;
     if (decimals > 0) {
-        *(ptr-1) += SYM_ZERO_DOT - '0';
+        *(ptr-1) += SYM_ZERO_HALF_TRAILING_DOT - '0';
+        dec = ptr;
         int decimalDigits = digitCount(millis);
         while (decimalDigits > decimals) {
             decimalDigits--;
@@ -226,6 +228,7 @@ static int digitCount(int32_t value)
             *ptr = '0';
             ptr++;
         }
+        *dec += SYM_ZERO_HALF_LEADING_DOT - '0';
         ui2a(millis, 10, 0, ptr);
     }
     return scaled;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -978,9 +978,11 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_VARIO_NUM:
         {
-            int16_t value = getEstimatedActualVelocity(Z) / 10; //limit precision to 10cm
-
-            tfp_sprintf(buff, "%c%d.%01d%c ", value < 0 ? '-' : ' ', abs(value / 10), abs((value % 10)), SYM_MS);
+            int16_t value = getEstimatedActualVelocity(Z);
+            char sym = SYM_MS;
+            osdFormatCentiNumber(buff, value, 0, 1, 0, 3);
+            buff[3] = sym;
+            buff[4] = '\0';
             break;
         }
 #endif

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -654,7 +654,9 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_MAIN_BATT_VOLTAGE:
         osdFormatBatteryChargeSymbol(buff);
-        tfp_sprintf(buff + 1, "%d.%1dV ", vbat / 10, vbat % 10);
+        osdFormatCentiNumber(buff + 1, vbat * 10, 0, 2, 0, 3);
+        buff[4] = 'V';
+        buff[5] = '\0';
         osdUpdateBatteryTextAttributes(&elemAttr);
         break;
 
@@ -1058,7 +1060,9 @@ static bool osdDrawSingleElement(uint8_t item)
             // cells might yield more significant digits
             uint16_t cellBattCentiVolts = vbat * 10 / batteryCellCount;
             osdFormatBatteryChargeSymbol(buff);
-            tfp_sprintf(buff + 1, "%d.%02dV", cellBattCentiVolts / 100, cellBattCentiVolts % 100);
+            osdFormatCentiNumber(buff + 1, cellBattCentiVolts, 0, 1, 0, 3);
+            buff[4] = 'V';
+            buff[5] = '\0';
             osdUpdateBatteryTextAttributes(&elemAttr);
             break;
         }


### PR DESCRIPTION
… left

Use different ALT characters which show the unit below the "ALT"
word.
Use characters with the dot embedded for separating the decimal
part in numbers. It saves one horizontal space.
Format altitude in feet and thousands of feet in IMPERIAL, while
using meters and kilometers in METRIC.

Use the same strategy DIST, showing feet and miles in IMPERIAL
while using meters and kilometers in METRIC.

Requires updated font from

https://github.com/iNavFlight/inav-configurator/pull/263