### PR TITLE
Very Minor modification in 'posEstimator' (VERY MINOR)

### DIFF
--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -162,9 +162,9 @@ typedef struct {
 
     // Extra state variables
     navPositionEstimatorSTATE_t state;
-} navigationPosEstimator_s;
+} navigationPosEstimator_t;
 
-static navigationPosEstimator_s posEstimator;
+static navigationPosEstimator_t posEstimator;
 
 PG_REGISTER_WITH_RESET_TEMPLATE(positionEstimationConfig_t, positionEstimationConfig, PG_POSITION_ESTIMATION_CONFIG, 1);
 


### PR DESCRIPTION
just changed this. Because usually 

typedef struct foo_s{

} foo_t;

is done.

I was looking around and just found it, is there reason for it, or is it okay to change it like this?