### PR TITLE
Replacing 100 to HDOP_SCALE, a variable introduced by @fiam in PR#2168

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -527,7 +527,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             buff[0] = SYM_HDP_L;
             buff[1] = SYM_HDP_R;
-            tfp_sprintf(&buff[2], "%2d", gpsSol.hdop / 100);
+            tfp_sprintf(&buff[2], "%2d", gpsSol.hdop / HDOP_SCALE);
             break;
         }
 #endif // GPS


### PR DESCRIPTION
New variable introduced HDOP_SCALE in "io/gps.h" can be used.