### PR TITLE
Add OSD_THROTTLE_POS_AUTO_THR indicator

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -208,6 +208,9 @@
 #define SYM_THR   0x04
 #define SYM_THR1  0x05
 
+#define SYM_AUTO_THR0   202
+#define SYM_AUTO_THR1   203
+
 // RSSI
 #define SYM_RSSI 0x01
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1431,6 +1431,8 @@ groups:
         max: OSD_POS_MAX_CLI
       - name: osd_main_cell_voltage_pos
         field: item_pos[OSD_MAIN_BATT_CELL_VOLTAGE]
+      - name: osd_throttle_auto_thr_pos
+        field: item_pos[OSD_THROTTLE_POS_AUTO_THR]
         max: OSD_POS_MAX_CLI
 
   - name: PG_SYSTEM_CONFIG

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -59,6 +59,7 @@ typedef enum {
     OSD_MESSAGES,
     OSD_GPS_HDOP,
     OSD_MAIN_BATT_CELL_VOLTAGE,
+    OSD_THROTTLE_POS_AUTO_THR,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2693,6 +2693,11 @@ rthState_e getStateOfForcedRTH(void)
     }
 }
 
+bool navigationIsControllingThrottle(void)
+{
+    return posControl.navState != NAV_STATE_IDLE;
+}
+
 #else // NAV
 
 #ifdef GPS

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2695,7 +2695,8 @@ rthState_e getStateOfForcedRTH(void)
 
 bool navigationIsControllingThrottle(void)
 {
-    return posControl.navState != NAV_STATE_IDLE;
+    navigationFSMStateFlags_t stateFlags = navGetCurrentStateFlags();
+    return (stateFlags & (NAV_CTL_ALT | NAV_CTL_EMERG | NAV_CTL_LAUNCH | NAV_CTL_LAND)) || (STATE(FIXED_WING) && (stateFlags & (NAV_CTL_POS)));
 }
 
 #else // NAV

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -299,6 +299,9 @@ void activateForcedRTH(void);
 void abortForcedRTH(void);
 rthState_e getStateOfForcedRTH(void);
 
+/* Getter functions which return data about the state of the navigation system */
+bool navigationIsControllingThrottle(void);
+
 /* Compatibility data */
 extern navSystemStatus_t    NAV_Status;
 
@@ -320,5 +323,6 @@ extern int16_t navAccNEU[3];
 #define navigationGetHeadingControlState() (0)
 #define navigationRequiresThrottleTiltCompensation() (0)
 #define getEstimatedActualVelocity(axis) (0)
+#define navigationIsControllingThrottle() (0)
 
 #endif


### PR DESCRIPTION
Displays stick THR position when the user controls THR directly,
actual applied THR when the navigation system controls THR.

Fixes #2031

Requires updated font from https://github.com/iNavFlight/inav-configurator/pull/258 and support in the OSD tab at https://github.com/iNavFlight/inav-configurator/pull/261