### PR TITLE
Move ledstrip to PB6 on OBF4 PRO; Enable servo on M5/M6

### DIFF
--- a/src/main/target/OMNIBUSF4/target.c
+++ b/src/main/target/OMNIBUSF4/target.c
@@ -24,7 +24,7 @@
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
 #if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
-    { TIM4,  IO_TAG(PB8),  TIM_Channel_3, 0, IOCFG_AF_PP_PD, GPIO_AF_TIM4,  TIM_USE_PPM }, // PPM
+    { TIM10, IO_TAG(PB8),  TIM_Channel_1, 0, IOCFG_AF_PP_PD, GPIO_AF_TIM10, TIM_USE_PPM }, // PPM
     { TIM4,  IO_TAG(PB9),  TIM_Channel_4, 0, IOCFG_AF_PP_PD, GPIO_AF_TIM4,  TIM_USE_ANY }, // S2_IN
 #else
     { TIM12, IO_TAG(PB14), TIM_Channel_1, 0, IOCFG_AF_PP_PD, GPIO_AF_TIM12, TIM_USE_PPM }, // PPM / S.BUS input, above MOTOR1
@@ -38,7 +38,11 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     { TIM3,  IO_TAG(PB1),  TIM_Channel_4, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM3, TIM_USE_MC_MOTOR                    | TIM_USE_FW_MOTOR }, // MOTOR_2
     { TIM9,  IO_TAG(PA3),  TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM9, TIM_USE_MC_MOTOR                    | TIM_USE_FW_SERVO }, // MOTOR_3
     { TIM2,  IO_TAG(PA2),  TIM_Channel_3, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM2, TIM_USE_MC_MOTOR                    | TIM_USE_FW_SERVO }, // MOTOR_4
-    { TIM5,  IO_TAG(PA1),  TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM5, TIM_USE_MC_MOTOR                    | TIM_USE_FW_SERVO }, // MOTOR_5 - GPIO_PartialRemap_TIM3
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+    { TIM5,  IO_TAG(PA1),  TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM5, TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO }, // MOTOR_5
+    { TIM4,  IO_TAG(PB6),  TIM_Channel_1, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM5, TIM_USE_LED                                            }, // LED strip for F4 V2 / F4-Pro-0X and later
+#else
+    { TIM5,  IO_TAG(PA1),  TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM5, TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO }, // MOTOR_5
+#endif
     { TIM1,  IO_TAG(PA8),  TIM_Channel_1, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM1, TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO }, // MOTOR_6
-
 };

--- a/src/main/target/OMNIBUSF4/target.c
+++ b/src/main/target/OMNIBUSF4/target.c
@@ -40,7 +40,7 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     { TIM2,  IO_TAG(PA2),  TIM_Channel_3, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM2, TIM_USE_MC_MOTOR                    | TIM_USE_FW_SERVO }, // MOTOR_4
 #if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
     { TIM5,  IO_TAG(PA1),  TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM5, TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO }, // MOTOR_5
-    { TIM4,  IO_TAG(PB6),  TIM_Channel_1, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM5, TIM_USE_LED                                            }, // LED strip for F4 V2 / F4-Pro-0X and later
+    { TIM4,  IO_TAG(PB6),  TIM_Channel_1, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM4, TIM_USE_LED                                            }, // LED strip for F4 V2 / F4-Pro-0X and later
 #else
     { TIM5,  IO_TAG(PA1),  TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM5, TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO }, // MOTOR_5
 #endif

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -201,11 +201,17 @@
 #define SENSORS_SET (SENSOR_ACC|SENSOR_MAG|SENSOR_BARO)
 
 #define LED_STRIP
-// LED Strip can run off Pin 5 (PA1) of the MOTOR outputs.
-#define WS2811_PIN                      PA1
-#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST4_HANDLER
-#define WS2811_DMA_STREAM               DMA1_Stream4
-#define WS2811_DMA_CHANNEL              DMA_Channel_6
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#   define WS2811_PIN                      PB6
+#   define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST0_HANDLER
+#   define WS2811_DMA_STREAM               DMA1_Stream0
+#   define WS2811_DMA_CHANNEL              DMA_Channel_2
+#else
+#   define WS2811_PIN                      PA1
+#   define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST4_HANDLER
+#   define WS2811_DMA_STREAM               DMA1_Stream4
+#   define WS2811_DMA_CHANNEL              DMA_Channel_6
+#endif
 
 #define DEFAULT_RX_FEATURE      FEATURE_RX_PPM
 #define DISABLE_RX_PWM_FEATURE
@@ -225,14 +231,14 @@
 #define TARGET_IO_PORTC         0xffff
 #define TARGET_IO_PORTD         0xffff
 
-// #if defined(OMNIBUSF4V3)
-  // #define USABLE_TIMER_CHANNEL_COUNT 10
-// #else
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#define USABLE_TIMER_CHANNEL_COUNT 13
+#else
 #define USABLE_TIMER_CHANNEL_COUNT 12
-// #endif
+#endif
 
 #if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
-#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(4) | TIM_N(8) | TIM_N(9) )
+#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(4) | TIM_N(8) | TIM_N(9) | TIM_N(10) )
 #else
 #define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(5) | TIM_N(12) | TIM_N(8) | TIM_N(9) )
 #endif


### PR DESCRIPTION
Fixes #2117