### PR TITLE
Add CLRACINGF4AIR Target

### DIFF
--- a/src/main/target/CLRACINGF4AIR/README.md
+++ b/src/main/target/CLRACINGF4AIR/README.md
@@ -1,0 +1,20 @@
+# CLRACINGF4AIR
+*specially design for Wing or airplane
+## HW info
+
+* STM32F405RGT
+* MPU9250 SPI
+* BP280 baro
+* 2 motor OUTPUTS
+* 4 servo outputs
+* Build in 5V 5A bec dedicated for Servos
+* Build in 9V BEC dedicated for video and camera 
+* Build in PDB with 100A current sensor
+* Build in Voltage monitoring resistor
+* Rssi pin
+* Build in OSD
+* Led_strip share 5V with servo power
+* 4 UARTS: UART1(Serial rx ), UART3, UART4, UART 6(for gps)
+* Onboard direct solder buzzer pins
+* Build in Camera_setting pin near camera connection (future implement in Inav)
+* Tx4(uart 4 ) pin near VTX pins for smartaudio support(futurn implement in Inav)

--- a/src/main/target/CLRACINGF4AIR/README.md
+++ b/src/main/target/CLRACINGF4AIR/README.md
@@ -1,7 +1,6 @@
 # CLRACINGF4AIR
 *specially design for Wing or airplane
 ## HW info
-
 * STM32F405RGT
 * MPU9250 SPI
 * BP280 baro
@@ -18,3 +17,5 @@
 * Onboard direct solder buzzer pins
 * Build in Camera_setting pin near camera connection (future implement in Inav)
 * Tx4(uart 4 ) pin near VTX pins for smartaudio support(futurn implement in Inav)
+
+can be order later from  www.clracing.info. and www.clrpowered.com

--- a/src/main/target/CLRACINGF4AIR/target.c
+++ b/src/main/target/CLRACINGF4AIR/target.c
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdbool.h>
+ #include <platform.h>
+ #include "drivers/io.h"
+ #include "drivers/pwm_mapping.h"
+ #include "drivers/timer.h"
+
+ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+
+
+     { TIM4, IO_TAG(PB8), TIM_Channel_3, 1, IOCFG_AF_PP, GPIO_AF_TIM4,    TIM_USE_LED },                         // LED_STRIP
+     { TIM11, IO_TAG(PB9), TIM_Channel_1, 0, IOCFG_AF_PP, GPIO_AF_TIM11,    TIM_USE_PPM | TIM_USE_PWM },        // PPM
+
+     { TIM3, IO_TAG(PB0), TIM_Channel_3, 1,  IOCFG_AF_PP, GPIO_AF_TIM3, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR },  // MOTOR_1
+     { TIM3, IO_TAG(PB1), TIM_Channel_4, 1,  IOCFG_AF_PP, GPIO_AF_TIM3, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR },  // MOTOR_2
+     { TIM9, IO_TAG(PA3), TIM_Channel_2, 1,  IOCFG_AF_PP, GPIO_AF_TIM9, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO },   // SERVO_1
+     { TIM2, IO_TAG(PA2), TIM_Channel_3, 1,  IOCFG_AF_PP, GPIO_AF_TIM2, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO },   // SERVO_2
+     { TIM5, IO_TAG(PA1), TIM_Channel_2, 1,  IOCFG_AF_PP, GPIO_AF_TIM2, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO },   // SERVO_3
+     { TIM1, IO_TAG(PA8), TIM_Channel_1, 1,  IOCFG_AF_PP, GPIO_AF_TIM1, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO },   // SERVO_4
+
+ };
+

--- a/src/main/target/CLRACINGF4AIR/target.h
+++ b/src/main/target/CLRACINGF4AIR/target.h
@@ -1,0 +1,132 @@
+/*
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+
+#define TARGET_BOARD_IDENTIFIER "CLRAIR"
+
+#define USBD_PRODUCT_STRING "CLRACINGF4AIR"
+#ifdef OPBL
+#define USBD_SERIALNUMBER_STRING "0x8020000"
+#endif
+#define LED0                    PB5
+#define BEEPER                PB4
+#define BEEPER_INVERTED
+
+#define INVERTER_PIN_UART1      PC0 // PC0 used as inverter select GPIO
+// MPU-6000 GRYO
+#define MPU6000_CS_PIN          PA4
+#define MPU6000_SPI_INSTANCE    SPI1
+#define GYRO
+#define USE_GYRO_SPI_MPU6000
+#define GYRO_MPU6000_ALIGN      CW0_DEG
+#define ACC
+#define USE_ACC_SPI_MPU6000
+#define ACC_MPU6000_ALIGN       CW0_DEG
+
+//MPU-9250
+#define MPU6500_CS_PIN          PA4
+#define MPU6500_SPI_INSTANCE    SPI1
+#define GYRO
+#define USE_GYRO_SPI_MPU6500
+#define GYRO_MPU6500_ALIGN      CW0_DEG
+#define ACC
+#define USE_ACC_SPI_MPU6500
+#define ACC_MPU6500_ALIGN       CW0_DEG
+#define MAG
+#define USE_MPU9250_MAG // Enables bypass configuration
+#define USE_MAG_AK8963
+
+// MPU6 interrupts
+#define USE_EXTI
+#define MPU_INT_EXTI            PC4
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define BARO
+#define USE_BARO_BMP280
+#define USE_BARO_SPI_BMP280
+#define BMP280_SPI_INSTANCE     SPI3
+#define BMP280_CS_PIN                 PB3 // v1
+
+#define OSD
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE    SPI3
+#define MAX7456_SPI_CS_PIN      PA15
+#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD*2)
+#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
+
+#define USB_IO
+
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+#define UART1_AHB1_PERIPHERALS  RCC_AHB1Periph_DMA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+ #define USE_UART4
+ #define UART4_RX_PIN            PA1
+ #define UART4_TX_PIN            PA0
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define SERIAL_PORT_COUNT       5 //VCP, USART1, USART3,USART4, USART6,
+
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_HARDWARE 0 // PWM 1
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+/*#define USE_SPI_DEVICE_2
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+*/
+#define USE_SPI_DEVICE_3
+#define SPI3_NSS_PIN            PA15
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN          PC11
+#define SPI3_MOSI_PIN          PC12
+
+#define USE_ADC
+#define CURRENT_METER_ADC_PIN   PC1
+#define VBAT_ADC_PIN            PC2
+#define RSSI_ADC_PIN            PA0
+
+#define USE_ESC_SENSOR
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define DEFAULT_FEATURES         (FEATURE_CURRENT_METER | FEATURE_TELEMETRY| FEATURE_VBAT | FEATURE_OSD )
+
+#define SPEKTRUM_BIND_PIN       UART1_RX_PIN
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+// Number of available PWM outputs
+#define MAX_PWM_OUTPUT_PORTS    6
+#define TARGET_MOTOR_COUNT      6
+
+#define TARGET_IO_PORTA (0xffff & ~(BIT(14)|BIT(13)))
+#define TARGET_IO_PORTB (0xffff & ~(BIT(2)))
+#define TARGET_IO_PORTC (0xffff & ~(BIT(15)|BIT(14)|BIT(13)))
+#define TARGET_IO_PORTD BIT(2)
+
+#define USABLE_TIMER_CHANNEL_COUNT 8
+#define USED_TIMERS  ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(9) | TIM_N(11) )

--- a/src/main/target/CLRACINGF4AIR/target.mk
+++ b/src/main/target/CLRACINGF4AIR/target.mk
@@ -1,0 +1,21 @@
+F405_TARGETS   += $(TARGET)
+FEATURES       = VCP 
+
+TARGET_SRC = \
+             io/osd.c \
+            drivers/accgyro/accgyro_mpu.c \
+            drivers/accgyro/accgyro_fake.c \
+             drivers/accgyro/accgyro_mpu6500.c \
+            drivers/accgyro/accgyro_spi_mpu6500.c \
+			drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/barometer/barometer_bmp085.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_spi_bmp280.c \
+            drivers/barometer/barometer_ms56xx.c \
+            drivers/compass/compass_ak8963.c \
+            drivers/compass/compass_ak8975.c \
+            drivers/compass/compass_hmc5883l.c \
+            drivers/compass/compass_mag3110.c \
+            drivers/light_ws2811strip.c \
+            drivers/light_ws2811strip_stdperiph.c \
+            drivers/max7456.c


### PR DESCRIPTION
# CLRACINGF4AIR
*Specially design for Wing or airplane
## HW info
* STM32F405RGT
* MPU9250 SPI
* BMP280 baro
* 2 motor OUTPUTS
* 4 servo outputs
* Built-in 5V 5A bec dedicated for Servos
* Built-in 9V BEC dedicated for video and camera 
* Build-in PDB with 100A current sensor
* Built-in Voltage monitoring resistor
* RSSI pin
* Built-in OSD
* Led_strip share 5V with servo power
* 4 UARTS: UART1(Serial rx ), UART3, UART4, UART 6(for GPS)
* Onboard direct solder buzzer pins
* Build-in Camera_setting pin near camera connection (future implement in Inav)
* Tx4(Uart 4 ) pin near VTX pins for smart audio support(future implement in Inav)
