### PR TITLE
Disable user-activated motor-stop if navigation system is doing RTH or WP

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -46,6 +46,8 @@
 #include "flight/pid.h"
 #include "flight/servos.h"
 
+#include "navigation/navigation.h"
+
 #include "rx/rx.h"
 
 
@@ -564,7 +566,7 @@ void mixTable(void)
             if (feature(FEATURE_MOTOR_STOP) && ARMING_FLAG(ARMED)) {
                 bool failsafeMotorStop = failsafeRequiresMotorStop();
                 bool navMotorStop = !failsafeIsActive() && STATE(NAV_MOTOR_STOP_OR_IDLE);
-                bool userMotorStop = !failsafeIsActive() && (rcData[THROTTLE] < rxConfig()->mincheck);
+                bool userMotorStop = !navigationIsFlyingAutonomousMode() && !failsafeIsActive() && (rcData[THROTTLE] < rxConfig()->mincheck);
                 if (failsafeMotorStop || navMotorStop || userMotorStop) {
                     if (feature(FEATURE_3D)) {
                         motor[i] = rxConfig()->midrc;

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2699,6 +2699,12 @@ bool navigationIsControllingThrottle(void)
     return (stateFlags & (NAV_CTL_ALT | NAV_CTL_EMERG | NAV_CTL_LAUNCH | NAV_CTL_LAND)) || (STATE(FIXED_WING) && (stateFlags & (NAV_CTL_POS)));
 }
 
+bool navigationIsFlyingAutonomousMode(void)
+{
+    navigationFSMStateFlags_t stateFlags = navGetCurrentStateFlags();
+    return (stateFlags & (NAV_AUTO_RTH | NAV_AUTO_WP));
+}
+
 #else // NAV
 
 #ifdef GPS

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -301,6 +301,7 @@ rthState_e getStateOfForcedRTH(void);
 
 /* Getter functions which return data about the state of the navigation system */
 bool navigationIsControllingThrottle(void);
+bool navigationIsFlyingAutonomousMode(void);
 
 /* Compatibility data */
 extern navSystemStatus_t    NAV_Status;


### PR DESCRIPTION
If navigation is flying autonomously - disregard zero throttle stick position in scope of MOTOR_STOP. This will ensure that user-activated RTH will always have control over motors even if throttle stick is at zero.

Fixes #1940