### PR TITLE
Fix incorrect handling of setting type in cliPrintVarRange()

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -437,7 +437,7 @@ static void cliPrintVar(const setting_t *var, uint32_t full)
 
 static void cliPrintVarRange(const setting_t *var)
 {
-    switch (SETTING_TYPE(var)) {
+    switch (SETTING_MODE(var)) {
     case (MODE_DIRECT):
         cliPrintLinef("Allowed range: %d - %u", setting_get_min(var), setting_get_max(var));
         break;


### PR DESCRIPTION
Code was testing for the VAR bits in the setting type rather than
the MODE bits.