### PR TITLE
Update Board - MatekF405.md

### DIFF
--- a/docs/Board - MatekF405.md
+++ b/docs/Board - MatekF405.md
@@ -69,7 +69,13 @@ Matek Systems www.mateksys.com
 
 ## FAQ & Known Issues
 
-I2C requires that the WS2812 led strip is moved to S5, thus WS2812 is probably only usable on quadcopters.
+I2C requires that the WS2812 led strip is moved to S5
+
+F405 OSD requires a diffent wiring for fixed wings:
+* S1: ESC
+* S2: Servo 3
+* S3: Servo 4
+
 
 Setup Guide Matek F405: http://f405.mateksys.com
 


### PR DESCRIPTION
- Patch to the note WS2812 LEDs only usable on multi rotor: The F405 OSD works well with leds on S5
- Added notes on wiring for fixed wing
- at this point unsure it this applies to F405 AIO too