### PR TITLE
Add support for getting and setting arbitrary settings via MSPv2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ README.pdf
 # build generated files
 /src/main/fc/settings_generated.h
 /src/main/fc/settings_generated.c
+/settings.json

--- a/Makefile
+++ b/Makefile
@@ -939,7 +939,7 @@ CLEAN_ARTIFACTS += $(TARGET_ELF) $(TARGET_OBJS) $(TARGET_MAP)
 $(OBJECT_DIR)/$(TARGET)/build/version.o : $(TARGET_SRC)
 
 # Settings generator
-.PHONY: .FORCE clean-settings
+.PHONY: .FORCE settings clean-settings
 UTILS_DIR		= $(ROOT)/src/utils
 SETTINGS_GENERATOR	= $(UTILS_DIR)/settings.rb
 BUILD_STAMP		= $(UTILS_DIR)/build_stamp.rb
@@ -958,6 +958,9 @@ $(STAMP): .FORCE
 %generated.h %generated.c:
 	$(V1) echo "settings.yaml -> settings_generated.h, settings_generated.c" "$(STDOUT)"
 	$(V1) CFLAGS="$(CFLAGS)" TARGET=$(TARGET) ruby $(SETTINGS_GENERATOR) . $(SETTINGS_FILE)
+
+settings-json:
+	$(V0) CFLAGS="$(CFLAGS)" TARGET=$(TARGET) ruby $(SETTINGS_GENERATOR) . $(SETTINGS_FILE) --json settings.json
 
 clean-settings:
 	$(V1) $(RM) $(GENERATED_SETTINGS)

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2010,7 +2010,6 @@ static bool mspSettingCommand(sbuf_t *dst, sbuf_t *src)
             break;
         case VAR_UINT16:
             FALLTHROUGH;
-            break;
         case VAR_INT16:
             sbufWriteU16(dst, *((uint16_t*)ptr));
             break;

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2001,28 +2001,8 @@ static bool mspSettingCommand(sbuf_t *dst, sbuf_t *src)
     }
 
     const void *ptr = setting_get_value_pointer(setting);
-
-    switch (SETTING_TYPE(setting)) {
-        case VAR_UINT8:
-            FALLTHROUGH;
-        case VAR_INT8:
-            sbufWriteU8(dst, *((uint8_t*)ptr));
-            break;
-        case VAR_UINT16:
-            FALLTHROUGH;
-        case VAR_INT16:
-            sbufWriteU16(dst, *((uint16_t*)ptr));
-            break;
-        case VAR_UINT32:
-            sbufWriteU32(dst, *((uint32_t*)ptr));
-            break;
-        case VAR_FLOAT:
-            {
-                float *val = (float *)ptr;
-                sbufWriteData(dst, val, sizeof(float));
-            }
-            break;
-    }
+    size_t size = setting_get_value_size(setting);
+    sbufWriteDataSafe(dst, ptr, size);
     return true;
 }
 

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -54,6 +54,7 @@
 #include "fc/rc_controls.h"
 #include "fc/rc_modes.h"
 #include "fc/runtime_config.h"
+#include "fc/settings.h"
 
 #include "flight/failsafe.h"
 #include "flight/imu.h"
@@ -1971,6 +1972,148 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
     return MSP_RESULT_ACK;
 }
 
+static const setting_t *mspReadSettingName(sbuf_t *src)
+{
+    char name[SETTING_MAX_NAME_LENGTH];
+    uint8_t c;
+    size_t s = 0;
+    while (1) {
+        if (!sbufReadU8Safe(&c, src)) {
+            return NULL;
+        }
+        name[s++] = c;
+        if (c == '\0') {
+            break;
+        }
+        if (s == SETTING_MAX_NAME_LENGTH) {
+            // Name is too long
+            return NULL;
+        }
+    }
+    return setting_find(name);
+}
+
+static bool mspSettingCommand(sbuf_t *dst, sbuf_t *src)
+{
+    const setting_t *setting = mspReadSettingName(src);
+    if (!setting) {
+        return false;
+    }
+
+    const void *ptr = setting_get_value_pointer(setting);
+
+    switch (SETTING_TYPE(setting)) {
+        case VAR_UINT8:
+            FALLTHROUGH;
+        case VAR_INT8:
+            sbufWriteU8(dst, *((uint8_t*)ptr));
+            break;
+        case VAR_UINT16:
+            FALLTHROUGH;
+            break;
+        case VAR_INT16:
+            sbufWriteU16(dst, *((uint16_t*)ptr));
+            break;
+        case VAR_UINT32:
+            sbufWriteU32(dst, *((uint32_t*)ptr));
+            break;
+        case VAR_FLOAT:
+            {
+                float *val = (float *)ptr;
+                sbufWriteData(dst, val, sizeof(float));
+            }
+            break;
+    }
+    return true;
+}
+
+static bool mspSetSettingCommand(sbuf_t *dst, sbuf_t *src)
+{
+    UNUSED(dst);
+
+    const setting_t *setting = mspReadSettingName(src);
+    if (!setting) {
+        return false;
+    }
+
+    setting_min_t min = setting_get_min(setting);
+    setting_max_t max = setting_get_max(setting);
+
+    void *ptr = setting_get_value_pointer(setting);
+    switch (SETTING_TYPE(setting)) {
+        case VAR_UINT8:
+            {
+                uint8_t val;
+                if (!sbufReadU8Safe(&val, src)) {
+                    return false;
+                }
+                if (val > max) {
+                    return false;
+                }
+                *((uint8_t*)ptr) = val;
+            }
+            break;
+        case VAR_INT8:
+            {
+                int8_t val;
+                if (!sbufReadI8Safe(&val, src)) {
+                    return false;
+                }
+                if (val < min || val > (int8_t)max) {
+                    return false;
+                }
+                *((int8_t*)ptr) = val;
+            }
+            break;
+        case VAR_UINT16:
+            {
+                uint16_t val;
+                if (!sbufReadU16Safe(&val, src)) {
+                    return false;
+                }
+                if (val > max) {
+                    return false;
+                }
+                *((uint16_t*)ptr) = val;
+            }
+            break;
+        case VAR_INT16:
+            {
+                int16_t val;
+                if (!sbufReadI16Safe(&val, src)) {
+                    return false;
+                }
+                if (val < min || val > (int16_t)max) {
+                    return false;
+                }
+                *((int16_t*)ptr) = val;
+            }
+            break;
+        case VAR_UINT32:
+            {
+                uint32_t val;
+                if (!sbufReadU32Safe(&val, src)) {
+                    return false;
+                }
+                if (val > max) {
+                    return false;
+                }
+                *((uint32_t*)ptr) = val;
+            }
+            break;
+        case VAR_FLOAT:
+            {
+                float val;
+                if (!sbufReadDataSafe(src, &val, sizeof(float))) {
+                    return false;
+                }
+                *((float*)ptr) = val;
+            }
+            break;
+    }
+
+    return true;
+}
 /*
  * Returns MSP_RESULT_ACK, MSP_RESULT_ERROR or MSP_RESULT_NO_REPLY
  */
@@ -2000,6 +2143,10 @@ mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostPro
         mspFcDataFlashReadCommand(dst, src);
         ret = MSP_RESULT_ACK;
 #endif
+    } else if (cmdMSP == MSP2_COMMON_SETTING) {
+        ret = mspSettingCommand(dst, src) ? MSP_RESULT_ACK : MSP_RESULT_ERROR;
+    } else if (cmdMSP == MSP2_COMMON_SET_SETTING) {
+        ret = mspSetSettingCommand(dst, src) ? MSP_RESULT_ACK : MSP_RESULT_ERROR;
     } else {
         ret = mspFcProcessInCommand(cmdMSP, src);
     }

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2106,6 +2106,9 @@ static bool mspSetSettingCommand(sbuf_t *dst, sbuf_t *src)
                 if (!sbufReadDataSafe(src, &val, sizeof(float))) {
                     return false;
                 }
+                if (val < (float)min || val > (float)max) {
+                    return false;
+                }
                 *((float*)ptr) = val;
             }
             break;

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 
 #include "common/string_light.h"
+#include "common/utils.h"
 
 #include "fc/settings_generated.h"
 #include "fc/settings.h"
@@ -73,6 +74,25 @@ const setting_t *setting_find(const char *name)
 		}
 	}
 	return NULL;
+}
+
+size_t setting_get_value_size(const setting_t *val)
+{
+	switch (SETTING_TYPE(val)) {
+		case VAR_UINT8:
+			FALLTHROUGH;
+		case VAR_INT8:
+			return 1;
+		case VAR_UINT16:
+			FALLTHROUGH;
+		case VAR_INT16:
+			return 2;
+		case VAR_UINT32:
+			FALLTHROUGH;
+		case VAR_FLOAT:
+			return 4;
+	}
+	return 0; // Unreachable
 }
 
 pgn_t setting_get_pgn(const setting_t *val)

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -62,6 +62,19 @@ bool setting_name_exact_match(const setting_t *val, char *buf, const char *cmdli
 	return sl_strncasecmp(cmdline, buf, strlen(buf)) == 0 && var_name_length == strlen(buf);
 }
 
+const setting_t *setting_find(const char *name)
+{
+	char buf[SETTING_MAX_NAME_LENGTH];
+	for (int ii = 0; ii < SETTINGS_TABLE_COUNT; ii++) {
+		const setting_t *setting = &settingsTable[ii];
+		setting_get_name(setting, buf);
+		if (strcmp(buf, name) == 0) {
+			return setting;
+		}
+	}
+	return NULL;
+}
+
 pgn_t setting_get_pgn(const setting_t *val)
 {
 	uint16_t pos = val - (const setting_t *)settingsTable;

--- a/src/main/fc/settings.h
+++ b/src/main/fc/settings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "config/parameter_group.h"
@@ -73,6 +74,8 @@ bool setting_name_exact_match(const setting_t *val, char *buf, const char *cmdli
 // Returns a setting_t with the exact name (case sensitive), or
 // NULL if no setting with that name exists.
 const setting_t *setting_find(const char *name);
+// Returns the size in bytes of the setting value.
+size_t setting_get_value_size(const setting_t *val);
 pgn_t setting_get_pgn(const setting_t *val);
 // Returns a pointer to the actual value stored by
 // the setting_t. The returned value might be modified.

--- a/src/main/fc/settings.h
+++ b/src/main/fc/settings.h
@@ -70,6 +70,9 @@ extern const setting_t settingsTable[];
 void setting_get_name(const setting_t *val, char *buf);
 bool setting_name_contains(const setting_t *val, char *buf, const char *cmdline);
 bool setting_name_exact_match(const setting_t *val, char *buf, const char *cmdline, uint8_t var_name_length);
+// Returns a setting_t with the exact name (case sensitive), or
+// NULL if no setting with that name exists.
+const setting_t *setting_find(const char *name);
 pgn_t setting_get_pgn(const setting_t *val);
 // Returns a pointer to the actual value stored by
 // the setting_t. The returned value might be modified.

--- a/src/main/msp/msp_protocol_v2_common.h
+++ b/src/main/msp/msp_protocol_v2_common.h
@@ -17,3 +17,5 @@
 
 #define MSP2_COMMON_TZ              0x1001  //out message   Gets the TZ offset for the local time (returns: minutes(i16))
 #define MSP2_COMMON_SET_TZ          0x1002  //in message    Sets the TZ offset for the local time (args: minutes(i16))
+#define MSP2_COMMON_SETTING         0x1003  //in/out message   Returns the value for a setting
+#define MSP2_COMMON_SET_SETTING     0x1004  //in message    Sets the value for a setting


### PR DESCRIPTION
Add MSP2_COMMON_SETTING for retrieving arbitrary settings and
MSP2_COMMON_SET_SETTING for setting them. This exposes any setting
which was only available from the CLI via MSP now.

Add support in settings.rb to generate a JSON file with all the
settings, their types and their possible values for settings using
a table. This file can be used by clients to properly format
messages for settings over MSP.

PR for the configurator: https://github.com/iNavFlight/inav-configurator/pull/279