### PR TITLE
Use a do {} while loop in osdDrawNextElement()

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1448,10 +1448,9 @@ static uint8_t osdIncElementIndex(uint8_t elementIndex)
 void osdDrawNextElement(void)
 {
     static uint8_t elementIndex = 0;
-    while (osdDrawSingleElement(elementIndex) == false) {
+    do {
         elementIndex = osdIncElementIndex(elementIndex);
-    }
-    elementIndex = osdIncElementIndex(elementIndex);
+    } while(!osdDrawSingleElement(elementIndex));
 }
 
 void pgResetFn_osdConfig(osdConfig_t *osdConfig)


### PR DESCRIPTION
Saves 112 bytes of flash and reduces average execution time from
6us to 4us. Note that it will skip the 1st OSD element on the 1st
iteration, so it will start drawing at the 2nd one. Shouldn't make
any difference in user perception.