### PR TITLE
Add OSD alarms for distance and negative altitude. Refactor alarms to use SI units internally.

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -816,6 +816,8 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         sbufWriteU16(dst, osdConfig()->cap_alarm);
         sbufWriteU16(dst, osdConfig()->time_alarm);
         sbufWriteU16(dst, osdConfig()->alt_alarm);
+        sbufWriteU16(dst, osdConfig()->dist_alarm);
+        sbufWriteU16(dst, osdConfig()->neg_alt_alarm);
         for (int i = 0; i < OSD_ITEM_COUNT; i++) {
             sbufWriteU16(dst, osdConfig()->item_pos[i]);
         }
@@ -1657,6 +1659,9 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
                 osdConfigMutable()->cap_alarm = sbufReadU16(src);
                 osdConfigMutable()->time_alarm = sbufReadU16(src);
                 osdConfigMutable()->alt_alarm = sbufReadU16(src);
+                // Won't be read if they weren't provided
+                sbufReadU16Safe(&osdConfigMutable()->dist_alarm, src);
+                sbufReadU16Safe(&osdConfigMutable()->neg_alt_alarm, src);
             } else {
                 // set a position setting
                 const uint16_t pos  = sbufReadU16(src);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1510,10 +1510,10 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 
     osdConfig->rssi_alarm = 20;
     osdConfig->cap_alarm = 2200;
-    osdConfig->time_alarm = 10; // in minutes
-    osdConfig->alt_alarm = 100; // meters
-    osdConfig->dist_alarm = 1000; // meters - lets end this madness and convert in the UI
-    osdConfig->neg_alt_alarm = 5; // meters
+    osdConfig->time_alarm = 10;
+    osdConfig->alt_alarm = 100;
+    osdConfig->dist_alarm = 1000;
+    osdConfig->neg_alt_alarm = 5;
 
     osdConfig->video_system = 0;
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -830,7 +830,7 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_MAH_DRAWN:
         buff[0] = SYM_MAH;
         tfp_sprintf(buff + 1, "%-4d", abs(mAhDrawn));
-        if (mAhDrawn >= osdConfig()->cap_alarm) {
+        if (osdConfig()->cap_alarm > 0 && mAhDrawn >= osdConfig()->cap_alarm) {
             TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
         }
         break;
@@ -1509,7 +1509,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[OSD_MESSAGES] = OSD_POS(1, 13) | VISIBLE_FLAG;
 
     osdConfig->rssi_alarm = 20;
-    osdConfig->cap_alarm = 2200;
+    osdConfig->cap_alarm = 0;
     osdConfig->time_alarm = 10;
     osdConfig->alt_alarm = 100;
     osdConfig->dist_alarm = 1000;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -892,7 +892,13 @@ static bool osdDrawSingleElement(uint8_t item)
         }
 
     case OSD_HOME_DIST:
-        osdFormatDistanceSymbol(buff, GPS_distanceToHome * 100);
+        {
+            osdFormatDistanceSymbol(buff, GPS_distanceToHome * 100);
+            uint16_t dist_alarm = osdConfig()->dist_alarm;
+            if (dist_alarm > 0 && GPS_distanceToHome > dist_alarm) {
+                TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
+            }
+        }
         break;
 
     case OSD_HEADING:
@@ -918,7 +924,9 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             int32_t alt = osdGetAltitude();
             osdFormatAltitudeSymbol(buff, alt);
-            if ((osdConvertDistanceToUnit(alt) / 100) >= osdConfig()->alt_alarm) {
+            uint16_t neg_alt_alarm = osdConfig()->neg_alt_alarm;
+            if ((osdConvertDistanceToUnit(alt) / 100) >= osdConfig()->alt_alarm ||
+                (neg_alt_alarm > 0 && alt < 0 && -CENTIMETERS_TO_METERS(alt) > neg_alt_alarm)) {
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
             }
             break;
@@ -1520,6 +1528,8 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->cap_alarm = 2200;
     osdConfig->time_alarm = 10; // in minutes
     osdConfig->alt_alarm = 100; // meters or feet depend on configuration
+    osdConfig->dist_alarm = 1000; // meters - lets end this madness and convert in the UI
+    osdConfig->neg_alt_alarm = 5; // meters
 
     osdConfig->video_system = 0;
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -90,6 +90,8 @@ typedef struct osdConfig_s {
     uint16_t cap_alarm;
     uint16_t time_alarm;
     uint16_t alt_alarm;
+    uint16_t dist_alarm;
+    uint16_t neg_alt_alarm;
 
     uint8_t video_system;
     uint8_t row_shiftdown;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -86,12 +86,12 @@ typedef struct osdConfig_s {
     uint16_t item_pos[OSD_ITEM_COUNT];
 
     // Alarms
-    uint8_t rssi_alarm;
-    uint16_t cap_alarm;
-    uint16_t time_alarm;
-    uint16_t alt_alarm;
-    uint16_t dist_alarm;
-    uint16_t neg_alt_alarm;
+    uint8_t rssi_alarm; // rssi %
+    uint16_t cap_alarm; // used mah
+    uint16_t time_alarm; // fly minutes
+    uint16_t alt_alarm; // positive altitude in m
+    uint16_t dist_alarm; // home distance in m
+    uint16_t neg_alt_alarm; // abs(negative altitude) in m
 
     uint8_t video_system;
     uint8_t row_shiftdown;


### PR DESCRIPTION
Distance alarm makes the OSD blink when distance to home goes
above a given threshold. Default is 1000m and it always works
on meters to avoid performing unnecessary arithmetic operations
for displaying the distance indicator. Unit conversion is done
in the configurator instead. Zero disables the alarm.

Negative altitude alarm blinks when negative altitude is below
the given threshold. Note that the alarm is a positive number,
but will trigger with -ALT > NEG_ALT_ALARM. Default value is 5
(which means -5 meters). Again, conversion is pushed to the
configurator.

Fixes #2242 and #2199

Configurator PR at https://github.com/iNavFlight/inav-configurator/pull/276