### PR TITLE
CMS_DATA_TYPE needs to be static when compiling with DEBUG=GDB

### DIFF
--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -82,7 +82,7 @@ typedef enum {
 } CMSDataType_e;
 
 // Use a function and data type to make sure switches are exhaustive
-inline CMSDataType_e CMS_DATA_TYPE(const OSD_Entry *entry) { return entry->flags & 0xF0; }
+static inline CMSDataType_e CMS_DATA_TYPE(const OSD_Entry *entry) { return entry->flags & 0xF0; }
 
 #define IS_PRINTVALUE(p) ((p)->flags & PRINT_VALUE)
 #define SET_PRINTVALUE(p) { (p)->flags |= PRINT_VALUE; }


### PR DESCRIPTION
 For whatever reason, I believe this CMS_DATA_TYPE inline needs to be made static to compile properly when GDB debug information is on, at least for my target.

 Specifically:

    make TARGET=OMNIBUSF4

 will work without errors. But this will fail:

    make TARGET=OMNIBUSF4 DEBUG=GDB

 with the following error:

    ...
    %% fc_init.c
    Linking OMNIBUSF4
    obj/main/OMNIBUSF4/cms/cms.o: In function `cmsDrawMenuEntry':
    /home/stew/iNav-SLGFork/inav/./src/main/cms/cms.c:427: undefined reference to `CMS_DATA_TYPE'
    collect2: error: ld returned 1 exit status
    Makefile:975: recipe for target 'obj/main/inav_OMNIBUSF4.elf' failed
    make: *** [obj/main/inav_OMNIBUSF4.elf] Error 1

I don't have any deep insight about why this is, but I have tried upgrading my GCC to a recent version and this persists. I noticed too that a lot of other .h files use static inline as well.