### PR TITLE
HDOP 99.99m limit Typo in gps.c

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -320,12 +320,12 @@ void gpsFinalizeChangeBaud(void)
 
 uint16_t gpsConstrainEPE(uint32_t epe)
 {
-    return (epe > 99999) ? 9999 : epe; // max 99.99m error
+    return (epe > 9999) ? 9999 : epe; // max 99.99m error
 }
 
 uint16_t gpsConstrainHDOP(uint32_t hdop)
 {
-    return (hdop > 99999) ? 9999 : hdop; // max 99.99m error
+    return (hdop > 9999) ? 9999 : hdop; // max 99.99m error
 }
 
 void gpsThread(void)


### PR DESCRIPTION
Limiting HDOP and epe to 99.99m should be compared with '9999' not '9……9999'