### PR TITLE
Add BOXMOTORSTOP mode to selectively enable MOTOR_STOP

### DIFF
--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -70,6 +70,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXCAMERA1, "CAMERA CONTROL 1;", 39 },
     { BOXCAMERA2, "CAMERA CONTROL 2;", 40 },
     { BOXCAMERA3, "CAMERA CONTROL 3;", 41 },
+    { BOXMOTORSTOP, "MOTOR STOP;", 42 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -158,6 +159,10 @@ void initActiveBoxIds(void)
 
     if (!feature(FEATURE_AIRMODE)) {
         activeBoxIds[activeBoxIdCount++] = BOXAIRMODE;
+    }
+
+    if (!feature(FEATURE_MOTOR_STOP)) {
+        activeBoxIds[activeBoxIdCount++] = BOXMOTORSTOP;
     }
 
     activeBoxIds[activeBoxIdCount++] = BOXHEADINGHOLD;
@@ -265,6 +270,7 @@ void packBoxModeFlags(boxBitmask_t * mspBoxModeFlags)
     CHECK_ACTIVE_BOX(IS_ENABLED(FLIGHT_MODE(NAV_RTH_MODE)),         BOXNAVRTH);
     CHECK_ACTIVE_BOX(IS_ENABLED(FLIGHT_MODE(NAV_WP_MODE)),          BOXNAVWP);
     CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXAIRMODE)),     BOXAIRMODE);
+    CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXMOTORSTOP)),   BOXMOTORSTOP);
     CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXGCSNAV)),      BOXGCSNAV);
     CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXSURFACE)),     BOXSURFACE);
 #ifdef USE_FLM_FLAPERON

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -19,8 +19,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "rc_modes.h"
-
 #include "common/bitarray.h"
 #include "common/maths.h"
 #include "common/utils.h"
@@ -31,6 +29,7 @@
 
 #include "fc/config.h"
 #include "fc/rc_controls.h"
+#include "fc/rc_modes.h"
 
 #include "rx/rx.h"
 
@@ -41,7 +40,7 @@ static bool isUsingNAVModes = false;
 #endif
 
 boxBitmask_t rcModeActivationMask; // one bit per mode defined in boxId_e
-STATIC_ASSERT(CHECKBOX_ITEM_COUNT <= 32, too_many_box_modes);
+STATIC_ASSERT(CHECKBOX_ITEM_COUNT <= 52, too_many_box_modes);   // Configurator/JS limitation
 
 PG_REGISTER_ARRAY(modeActivationCondition_t, MAX_MODE_ACTIVATION_CONDITION_COUNT, modeActivationConditions, PG_MODE_ACTIVATION_PROFILE, 0);
 PG_REGISTER(modeActivationOperatorConfig_t, modeActivationOperatorConfig, PG_MODE_ACTIVATION_OPERATOR_CONFIG, 0);

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -56,6 +56,7 @@ typedef enum {
     BOXCAMERA1      = 29,
     BOXCAMERA2      = 30,
     BOXCAMERA3      = 31,
+    BOXMOTORSTOP    = 32,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -38,6 +38,7 @@
 
 #include "fc/config.h"
 #include "fc/rc_controls.h"
+#include "fc/rc_modes.h"
 #include "fc/runtime_config.h"
 
 #include "flight/failsafe.h"
@@ -561,7 +562,7 @@ void mixTable(void)
             }
 
             // Motor stop handling
-            if (feature(FEATURE_MOTOR_STOP) && ARMING_FLAG(ARMED)) {
+            if ((feature(FEATURE_MOTOR_STOP) || IS_RC_MODE_ACTIVE(BOXMOTORSTOP)) && ARMING_FLAG(ARMED)) {
                 bool failsafeMotorStop = failsafeRequiresMotorStop();
                 bool navMotorStop = !failsafeIsActive() && STATE(NAV_MOTOR_STOP_OR_IDLE);
                 bool userMotorStop = !failsafeIsActive() && (rcData[THROTTLE] < rxConfig()->mincheck);


### PR DESCRIPTION
Allow user to have fine-grained control over modes where MOTOR STOP should be enabled. 
Feature "MOTOR_STOP" will permanently enable the feature as it does now.
A solution to #1940