### PR TITLE
Implement pitch_to_throttle for FW (angle)

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -767,7 +767,10 @@ void taskMainPidLoop(timeUs_t currentTimeUs)
         }
     }
     else {
-        // FIXME: throttle pitch comp for FW
+      if (FLIGHT_MODE(ANGLE_MODE)) {
+	const float angleTarget = pidRcCommandToAngle(rcCommand[PITCH], pidProfile()->max_angle_inclination[PITCH]);
+        rcCommand[THROTTLE] = constrain(rcCommand[THROTTLE] - DECIDEGREES_TO_DEGREES(angleTarget) * mixerConfig()->fw_pitch_to_throttle, motorConfig()->minthrottle, motorConfig()->maxthrottle);
+      }
     }
 
     // Update PID coefficients

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -495,6 +495,10 @@ groups:
       - name: yaw_jump_prevention_limit
         min: YAW_JUMP_PREVENTION_LIMIT_LOW
         max: YAW_JUMP_PREVENTION_LIMIT_HIGH
+      - name: fw_pitch2thr
+        field: fw_pitch_to_throttle
+        min: 0
+        max: 100
 
   - name: PG_MOTOR_3D_CONFIG
     type: flight3DConfig_t

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -72,7 +72,8 @@ PG_REGISTER_WITH_RESET_TEMPLATE(mixerConfig_t, mixerConfig, PG_MIXER_CONFIG, 0);
 PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .mixerMode = MIXER_QUADX,
     .yaw_motor_direction = 1,
-    .yaw_jump_prevention_limit = 200
+    .yaw_jump_prevention_limit = 200,
+    .fw_pitch_to_throttle = 0
 );
 
 #ifdef BRUSHED_MOTORS

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -92,6 +92,7 @@ typedef struct mixerConfig_s {
     uint8_t mixerMode;
     int8_t yaw_motor_direction;
     uint16_t yaw_jump_prevention_limit;      // make limit configurable (original fixed value was 100)
+    uint8_t fw_pitch_to_throttle;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -235,7 +235,7 @@ void pidResetErrorAccumulators(void)
     }
 }
 
-static float pidRcCommandToAngle(int16_t stick, int16_t maxInclination)
+float pidRcCommandToAngle(int16_t stick, int16_t maxInclination)
 {
     stick = constrain(stick, -500, 500);
     return scaleRangef((float) stick, -500.0f, 500.0f, (float) -maxInclination, (float) maxInclination);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -140,6 +140,7 @@ void schedulePidGainsUpdate(void);
 void updatePIDCoefficients(void);
 void pidController(void);
 
+float pidRcCommandToAngle(int16_t stick, int16_t maxInclination);
 float pidRateToRcCommand(float rateDPS, uint8_t rate);
 int16_t pidAngleToRcCommand(float angleDeciDegrees, int16_t maxInclination);
 


### PR DESCRIPTION
The fw_pitch2thr setting has the same meaning as nav_fw_pitch2thr but
for angle mode (rcCommand compensation for one degree pitch angle)