### PR TITLE
Implement roll_to_pitch compensation for FW (angle)

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -286,6 +286,12 @@ void annexCode(void)
         rcCommand[PITCH] = getAxisRcCommand(rcData[PITCH], currentControlRateProfile->rcExpo8, rcControlsConfig()->deadband);
         rcCommand[YAW] = -getAxisRcCommand(rcData[YAW], currentControlRateProfile->rcYawExpo8, rcControlsConfig()->yaw_deadband);
 
+	// Apply FW roll2pitch compensation
+	if (STATE(FIXED_WING) && FLIGHT_MODE(ANGLE_MODE)) {
+	  rcCommand[PITCH] -= (uint16_t)abs(rcCommand[ROLL]) * mixerConfig()->fw_roll2pitch_comp / 100;
+	  if (rcCommand[PITCH] < -500) rcCommand[PITCH] = -500;
+	}
+
         //Compute THROTTLE command
         throttleValue = constrain(rcData[THROTTLE], rxConfig()->mincheck, PWM_RANGE_MAX);
         throttleValue = (uint32_t)(throttleValue - rxConfig()->mincheck) * PWM_RANGE_MIN / (PWM_RANGE_MAX - rxConfig()->mincheck);       // [MINCHECK;2000] -> [0;1000]

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -495,6 +495,9 @@ groups:
       - name: yaw_jump_prevention_limit
         min: YAW_JUMP_PREVENTION_LIMIT_LOW
         max: YAW_JUMP_PREVENTION_LIMIT_HIGH
+      - name: fw_roll2pitch_comp
+        min: 0
+        max: 100
 
   - name: PG_MOTOR_3D_CONFIG
     type: flight3DConfig_t

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -72,7 +72,8 @@ PG_REGISTER_WITH_RESET_TEMPLATE(mixerConfig_t, mixerConfig, PG_MIXER_CONFIG, 0);
 PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .mixerMode = MIXER_QUADX,
     .yaw_motor_direction = 1,
-    .yaw_jump_prevention_limit = 200
+    .yaw_jump_prevention_limit = 200,
+    .fw_roll2pitch_comp = 0
 );
 
 #ifdef BRUSHED_MOTORS

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -92,6 +92,7 @@ typedef struct mixerConfig_s {
     uint8_t mixerMode;
     int8_t yaw_motor_direction;
     uint16_t yaw_jump_prevention_limit;      // make limit configurable (original fixed value was 100)
+    uint8_t fw_roll2pitch_comp;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);


### PR DESCRIPTION
Allow automatic pitch compensation when rolling in angle mode to stay at the same altitude without manual compensation.

The fw_roll2pitch setting means % of roll input.