### PR TITLE
scaleRange() in <maths.c> edit

### DIFF
--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -194,13 +194,13 @@ float degreesToRadians(int16_t degrees)
 int scaleRange(int x, int srcMin, int srcMax, int destMin, int destMax) {
     long int a = ((long int) destMax - (long int) destMin) * ((long int) x - (long int) srcMin);
     long int b = (long int) srcMax - (long int) srcMin;
-    return ((a / b) - (destMax - destMin)) + destMax;
+    return ((a / b) + destMin);
 }
 
 float scaleRangef(float x, float srcMin, float srcMax, float destMin, float destMax) {
     float a = (destMax - destMin) * (x - srcMin);
     float b = srcMax - srcMin;
-    return ((a / b) - (destMax - destMin)) + destMax;
+    return ((a / b) + destMin);
 }
 
 // Normalize a vector


### PR DESCRIPTION
Are there any reason why it is done like 
(VALUE - (Max-Min) +Max )
not
(VALUE + Min) ???