### PR TITLE
When rth_allow_landing is disabled, show LOITERING in OSD_MESSAGES

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -633,6 +633,12 @@ static const char * navigationStateMessage(void)
         case MW_NAV_STATE_LAND_START:
             return OSD_MESSAGE_STR("STARTING EMERGENCY LANDING");
         case MW_NAV_STATE_LAND_IN_PROGRESS:
+            if (!navConfig()->general.flags.rth_allow_landing) {
+                if (STATE(FIXED_WING)) {
+                    return OSD_MESSAGE_STR("LOITERING AROUND HOME");
+                }
+                return OSD_MESSAGE_STR("HOVERING");
+            }
             return OSD_MESSAGE_STR("LANDING");
         case MW_NAV_STATE_LANDED:
             return OSD_MESSAGE_STR("LANDED");


### PR DESCRIPTION
We were previously showing LANDING, which might confuse users.