### PR TITLE
BF Software Serial Port

### DIFF
--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -15,6 +15,12 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*
+ * Cleanflight (or Baseflight): original
+ * jflyper: Mono-timer and single-wire half-duplex
+ * jflyper: Ported to iNav
+ */
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -25,15 +31,18 @@
 #include "build/build_config.h"
 #include "build/atomic.h"
 
+#include "build/debug.h"
+
 #include "common/utils.h"
 
 #include "drivers/nvic.h"
-#include "drivers/time.h"
 #include "drivers/io.h"
 #include "timer.h"
 
 #include "serial.h"
 #include "serial_softserial.h"
+
+#include "fc/config.h" //!!TODO remove this dependency
 
 #define RX_TOTAL_BITS 10
 #define TX_TOTAL_BITS 10
@@ -44,21 +53,34 @@
 #define MAX_SOFTSERIAL_PORTS 1
 #endif
 
+typedef enum {
+    TIMER_MODE_SINGLE,
+    TIMER_MODE_DUAL,
+} timerMode_e;
+
+#define ICPOLARITY_RISING true
+#define ICPOLARITY_FALLING false
+
 typedef struct softSerial_s {
     serialPort_t     port;
 
     IO_t rxIO;
     IO_t txIO;
-    const timerHardware_t *rxTimerHardware;
-    volatile uint8_t rxBuffer[SOFTSERIAL_BUFFER_SIZE];
 
-    const timerHardware_t *txTimerHardware;
+    const timerHardware_t *timerHardware;
+#ifdef USE_HAL_DRIVER
+    const TIM_HandleTypeDef *timerHandle;
+#endif
+    const timerHardware_t *exTimerHardware;
+
+    volatile uint8_t rxBuffer[SOFTSERIAL_BUFFER_SIZE];
     volatile uint8_t txBuffer[SOFTSERIAL_BUFFER_SIZE];
 
     uint8_t          isSearchingForStartBit;
     uint8_t          rxBitIndex;
     uint8_t          rxLastLeadingEdgeAtBitIndex;
     uint8_t          rxEdge;
+    uint8_t          rxActive;
 
     uint8_t          isTransmittingData;
     int8_t           bitsLeftToTransmit;
@@ -70,22 +92,20 @@ typedef struct softSerial_s {
     uint16_t         receiveErrors;
 
     uint8_t          softSerialPortIndex;
+    timerMode_e      timerMode;
 
-    timerCCHandlerRec_t timerCb;
+    timerOvrHandlerRec_t overCb;
     timerCCHandlerRec_t edgeCb;
 } softSerial_t;
 
-extern timerHardware_t* serialTimerHardware;
+static const struct serialPortVTable softSerialVTable; // Forward
 
-extern const struct serialPortVTable softSerialVTable[];
+static softSerial_t softSerialPorts[MAX_SOFTSERIAL_PORTS];
 
-
-softSerial_t softSerialPorts[MAX_SOFTSERIAL_PORTS];
-
-void onSerialTimer(timerCCHandlerRec_t *cbRec, captureCompare_t capture);
+void onSerialTimerOverflow(timerOvrHandlerRec_t *cbRec, captureCompare_t capture);
 void onSerialRxPinChange(timerCCHandlerRec_t *cbRec, captureCompare_t capture);
 
-void setTxSignal(softSerial_t *softSerial, uint8_t state)
+static void setTxSignal(softSerial_t *softSerial, uint8_t state)
 {
     if (softSerial->port.options & SERIAL_INVERTED) {
         state = !state;
@@ -98,20 +118,80 @@ void setTxSignal(softSerial_t *softSerial, uint8_t state)
     }
 }
 
-void serialInputPortConfig(ioTag_t pin, uint8_t portIndex)
+static void serialEnableCC(softSerial_t *softSerial)
 {
-    IOInit(IOGetByTag(pin), OWNER_SOFTSERIAL, RESOURCE_UART_RX, RESOURCE_INDEX(portIndex));
-#ifdef STM32F1
-    IOConfigGPIO(IOGetByTag(pin), IOCFG_IPU);
+#ifdef USE_HAL_DRIVER
+    TIM_CCxChannelCmd(softSerial->timerHardware->tim, softSerial->timerHardware->channel, TIM_CCx_ENABLE);
 #else
-    IOConfigGPIO(IOGetByTag(pin), IOCFG_AF_PP_UP);
+    TIM_CCxCmd(softSerial->timerHardware->tim, softSerial->timerHardware->channel, TIM_CCx_Enable);
 #endif
 }
 
-static void serialOutputPortConfig(ioTag_t pin, uint8_t portIndex)
+static void serialInputPortActivate(softSerial_t *softSerial)
 {
-    IOInit(IOGetByTag(pin), OWNER_SOFTSERIAL, RESOURCE_UART_TX, RESOURCE_INDEX(portIndex));
-    IOConfigGPIO(IOGetByTag(pin), IOCFG_OUT_PP);
+    if (softSerial->port.options & SERIAL_INVERTED) {
+#ifdef STM32F1
+        IOConfigGPIO(softSerial->rxIO, IOCFG_IPD);
+#else
+        IOConfigGPIOAF(softSerial->rxIO, IOCFG_AF_PP_PD, softSerial->timerHardware->alternateFunction);
+#endif
+    } else {
+#ifdef STM32F1
+        IOConfigGPIO(softSerial->rxIO, IOCFG_IPU);
+#else
+        IOConfigGPIOAF(softSerial->rxIO, IOCFG_AF_PP_UP, softSerial->timerHardware->alternateFunction);
+#endif
+    }
+
+    softSerial->rxActive = true;
+    softSerial->isSearchingForStartBit = true;
+    softSerial->rxBitIndex = 0;
+
+    // Enable input capture
+
+    serialEnableCC(softSerial);
+}
+
+static void serialInputPortDeActivate(softSerial_t *softSerial)
+{
+    // Disable input capture
+
+#ifdef USE_HAL_DRIVER
+    TIM_CCxChannelCmd(softSerial->timerHardware->tim, softSerial->timerHardware->channel, TIM_CCx_DISABLE);
+#else
+    TIM_CCxCmd(softSerial->timerHardware->tim, softSerial->timerHardware->channel, TIM_CCx_Disable);
+#endif
+
+#ifdef STM32F1
+    IOConfigGPIO(softSerial->rxIO, IOCFG_IN_FLOATING);
+#else
+    IOConfigGPIOAF(softSerial->rxIO, IOCFG_IN_FLOATING, softSerial->timerHardware->alternateFunction);
+#endif
+    softSerial->rxActive = false;
+}
+
+static void serialOutputPortActivate(softSerial_t *softSerial)
+{
+#ifdef STM32F1
+    IOConfigGPIO(softSerial->txIO, IOCFG_OUT_PP);
+#else
+    if (softSerial->exTimerHardware)
+        IOConfigGPIOAF(softSerial->txIO, IOCFG_OUT_PP, softSerial->exTimerHardware->alternateFunction);
+    else
+        IOConfigGPIO(softSerial->txIO, IOCFG_OUT_PP);
+#endif
+}
+
+static void serialOutputPortDeActivate(softSerial_t *softSerial)
+{
+#ifdef STM32F1
+    IOConfigGPIO(softSerial->txIO, IOCFG_IN_FLOATING);
+#else
+    if (softSerial->exTimerHardware)
+        IOConfigGPIOAF(softSerial->txIO, IOCFG_IN_FLOATING, softSerial->exTimerHardware->alternateFunction);
+    else
+        IOConfigGPIO(softSerial->txIO, IOCFG_IN_FLOATING);
+#endif
 }
 
 static bool isTimerPeriodTooLarge(uint32_t timerPeriod)
@@ -119,10 +199,12 @@ static bool isTimerPeriodTooLarge(uint32_t timerPeriod)
     return timerPeriod > 0xFFFF;
 }
 
-static void serialTimerTxConfig(const timerHardware_t *timerHardwarePtr, uint8_t reference, uint32_t baud)
+static void serialTimerConfigureTimebase(const timerHardware_t *timerHardwarePtr, uint32_t baud)
 {
-    uint32_t clock = SystemCoreClock;
+    uint32_t baseClock = SystemCoreClock/timerClockDivisor(timerHardwarePtr->tim);
+    uint32_t clock = baseClock;
     uint32_t timerPeriod;
+
     do {
         timerPeriod = clock / baud;
         if (isTimerPeriodTooLarge(timerPeriod)) {
@@ -135,18 +217,9 @@ static void serialTimerTxConfig(const timerHardware_t *timerHardwarePtr, uint8_t
         }
     } while (isTimerPeriodTooLarge(timerPeriod));
 
-    uint8_t mhz = SystemCoreClock / 1000000;
-    timerConfigure(timerHardwarePtr, timerPeriod, mhz);
-    timerChCCHandlerInit(&softSerialPorts[reference].timerCb, onSerialTimer);
-    timerChConfigCallbacks(timerHardwarePtr, &softSerialPorts[reference].timerCb, NULL);
-}
+    uint16_t mhz = baseClock / 1000000; // XXX Prepare for mhz > 255
 
-static void serialTimerRxConfig(const timerHardware_t *timerHardwarePtr, uint8_t reference, portOptions_t options)
-{
-    // start bit is usually a FALLING signal
-    timerChConfigIC(timerHardwarePtr, (options & SERIAL_INVERTED), 0);
-    timerChCCHandlerInit(&softSerialPorts[reference].edgeCb, onSerialRxPinChange);
-    timerChConfigCallbacks(timerHardwarePtr, &softSerialPorts[reference].edgeCb, NULL);
+    timerConfigure(timerHardwarePtr, timerPeriod, mhz);
 }
 
 static void resetBuffers(softSerial_t *softSerial)
@@ -162,80 +235,152 @@ static void resetBuffers(softSerial_t *softSerial)
     softSerial->port.txBufferHead = 0;
 }
 
-serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallbackPtr rxCallback, uint32_t baud, portOptions_t options)
+serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallbackPtr rxCallback, uint32_t baud, portMode_t mode, portOptions_t options)
 {
     softSerial_t *softSerial = &(softSerialPorts[portIndex]);
+    ioTag_t tagRx;
+    ioTag_t tagTx;
 
 #ifdef USE_SOFTSERIAL1
     if (portIndex == SOFTSERIAL1) {
-        softSerial->rxTimerHardware = timerGetByTag(IO_TAG(SOFTSERIAL_1_RX_PIN), TIM_USE_ANY);;
-        softSerial->txTimerHardware = timerGetByTag(IO_TAG(SOFTSERIAL_1_TX_PIN), TIM_USE_ANY);;
+        tagRx = IO_TAG(SOFTSERIAL_1_RX_PIN);
+        tagTx = IO_TAG(SOFTSERIAL_1_TX_PIN);
     }
 #endif
 
 #ifdef USE_SOFTSERIAL2
     if (portIndex == SOFTSERIAL2) {
-        softSerial->rxTimerHardware = timerGetByTag(IO_TAG(SOFTSERIAL_2_RX_PIN), TIM_USE_ANY);;
-        softSerial->txTimerHardware = timerGetByTag(IO_TAG(SOFTSERIAL_2_TX_PIN), TIM_USE_ANY);;
+        tagRx = IO_TAG(SOFTSERIAL_2_RX_PIN);
+        tagTx = IO_TAG(SOFTSERIAL_2_TX_PIN);
     }
 #endif
 
-    softSerial->port.vTable = softSerialVTable;
+    const timerHardware_t *timerRx = timerGetByTag(tagRx, TIM_USE_ANY);
+    const timerHardware_t *timerTx = timerGetByTag(tagTx, TIM_USE_ANY);
+
+    IO_t rxIO = IOGetByTag(tagRx);
+    IO_t txIO = IOGetByTag(tagTx);
+
+    if (options & SERIAL_BIDIR) {
+        // If RX and TX pins are both assigned, we CAN use either with a timer.
+        // However, for consistency with hardware UARTs, we only use TX pin,
+        // and this pin must have a timer, and it should not be N-Channel.
+        if (!timerTx || (timerTx->output & TIMER_OUTPUT_N_CHANNEL)) {
+            return NULL;
+        }
+
+        softSerial->timerHardware = timerTx;
+        softSerial->txIO = txIO;
+        softSerial->rxIO = txIO;
+        IOInit(txIO, OWNER_SOFTSERIAL, RESOURCE_UART_TXRX, RESOURCE_INDEX(portIndex));
+    } else {
+        if (mode & MODE_RX) {
+            // Need a pin & a timer on RX. Channel should not be N-Channel.
+            if (!timerRx || (timerRx->output & TIMER_OUTPUT_N_CHANNEL)) {
+                return NULL;
+            }
+
+            softSerial->rxIO = rxIO;
+            softSerial->timerHardware = timerRx;
+            IOInit(rxIO, OWNER_SOFTSERIAL, RESOURCE_UART_RX, RESOURCE_INDEX(portIndex));
+        }
+
+        if (mode & MODE_TX) {
+            // Need a pin on TX
+            if (!tagTx)
+                return NULL;
+
+            softSerial->txIO = txIO;
+
+            if (!(mode & MODE_RX)) {
+                // TX Simplex, must have a timer
+                if (!timerTx)
+                    return NULL;
+                softSerial->timerHardware = timerTx;
+            } else {
+                // Duplex
+                softSerial->exTimerHardware = timerTx;
+            }
+            IOInit(txIO, OWNER_SOFTSERIAL, RESOURCE_UART_TX, RESOURCE_INDEX(portIndex));
+        }
+    }
+
+    softSerial->port.vTable = &softSerialVTable;
     softSerial->port.baudRate = baud;
-    softSerial->port.mode = MODE_RXTX;
+    softSerial->port.mode = mode;
     softSerial->port.options = options;
     softSerial->port.rxCallback = rxCallback;
 
     resetBuffers(softSerial);
 
-    softSerial->isTransmittingData = false;
-
-    softSerial->isSearchingForStartBit = true;
-    softSerial->rxBitIndex = 0;
+    softSerial->softSerialPortIndex = portIndex;
 
     softSerial->transmissionErrors = 0;
     softSerial->receiveErrors = 0;
 
-    softSerial->softSerialPortIndex = portIndex;
+    softSerial->rxActive = false;
+    softSerial->isTransmittingData = false;
 
-    softSerial->txIO = IOGetByTag(softSerial->txTimerHardware->tag);
-    serialOutputPortConfig(softSerial->txTimerHardware->tag, portIndex);
+    // Configure master timer (on RX); time base and input capture
 
-    softSerial->rxIO = IOGetByTag(softSerial->rxTimerHardware->tag);
-    serialInputPortConfig(softSerial->rxTimerHardware->tag, portIndex);
+    serialTimerConfigureTimebase(softSerial->timerHardware, baud);
+    timerChConfigIC(softSerial->timerHardware, (options & SERIAL_INVERTED) ? ICPOLARITY_RISING : ICPOLARITY_FALLING, 0);
 
-    setTxSignal(softSerial, ENABLE);
-    delay(50);
+    // Initialize callbacks
+    timerChCCHandlerInit(&softSerial->edgeCb, onSerialRxPinChange);
+    timerChOvrHandlerInit(&softSerial->overCb, onSerialTimerOverflow);
 
-    serialTimerTxConfig(softSerial->txTimerHardware, portIndex, baud);
-    serialTimerRxConfig(softSerial->rxTimerHardware, portIndex, options);
+    // Configure bit clock interrupt & handler.
+    // If we have an extra timer (on TX), it is initialized and configured
+    // for overflow interrupt.
+    // Receiver input capture is configured when input is activated.
+
+    if ((mode & MODE_TX) && softSerial->exTimerHardware && softSerial->exTimerHardware->tim != softSerial->timerHardware->tim) {
+        softSerial->timerMode = TIMER_MODE_DUAL;
+        serialTimerConfigureTimebase(softSerial->exTimerHardware, baud);
+        timerChConfigCallbacks(softSerial->exTimerHardware, NULL, &softSerial->overCb);
+        timerChConfigCallbacks(softSerial->timerHardware, &softSerial->edgeCb, NULL);
+    } else {
+        softSerial->timerMode = TIMER_MODE_SINGLE;
+        timerChConfigCallbacks(softSerial->timerHardware, &softSerial->edgeCb, &softSerial->overCb);
+    }
+
+#ifdef USE_HAL_DRIVER
+    softSerial->timerHandle = timerFindTimerHandle(softSerial->timerHardware->tim);
+#endif
+
+    if (!(options & SERIAL_BIDIR)) {
+        serialOutputPortActivate(softSerial);
+        setTxSignal(softSerial, ENABLE);
+    }
+
+    serialInputPortActivate(softSerial);
 
     return &softSerial->port;
 }
 
-serialPort_t *softSerialLoopbackPort(void)
-{
-    serialPort_t *loopbackPort = (serialPort_t*)&(softSerialPorts[0]);
-    if (!loopbackPort->vTable) {
-        loopbackPort = openSoftSerial(0, NULL, 19200, SERIAL_NOT_INVERTED);
-    }
-    return loopbackPort;
-}
 
-/*********************************************/
+/*
+ * Serial Engine
+ */
 
 void processTxState(softSerial_t *softSerial)
 {
     uint8_t mask;
 
     if (!softSerial->isTransmittingData) {
-        char byteToSend;
         if (isSoftSerialTransmitBufferEmpty((serialPort_t *)softSerial)) {
+            // Transmit buffer empty.
+            // Start listening if not already in if half-duplex
+            if (!softSerial->rxActive && softSerial->port.options & SERIAL_BIDIR) {
+                serialOutputPortDeActivate(softSerial);
+                serialInputPortActivate(softSerial);
+            }
             return;
         }
 
         // data to send
-        byteToSend = softSerial->port.txBuffer[softSerial->port.txBufferTail++];
+        uint8_t byteToSend = softSerial->port.txBuffer[softSerial->port.txBufferTail++];
         if (softSerial->port.txBufferTail >= softSerial->port.txBufferSize) {
             softSerial->port.txBufferTail = 0;
         }
@@ -244,6 +389,12 @@ void processTxState(softSerial_t *softSerial)
         softSerial->internalTxBuffer = (1 << (TX_TOTAL_BITS - 1)) | (byteToSend << 1);
         softSerial->bitsLeftToTransmit = TX_TOTAL_BITS;
         softSerial->isTransmittingData = true;
+
+        if (softSerial->rxActive && (softSerial->port.options & SERIAL_BIDIR)) {
+            // Half-duplex: Deactivate receiver, activate transmitter
+            serialInputPortDeActivate(softSerial);
+            serialOutputPortActivate(softSerial);
+        }
 
         return;
     }
@@ -282,7 +433,8 @@ void prepareForNextRxByte(softSerial_t *softSerial)
     softSerial->isSearchingForStartBit = true;
     if (softSerial->rxEdge == LEADING) {
         softSerial->rxEdge = TRAILING;
-        timerChConfigIC(softSerial->rxTimerHardware, (softSerial->port.options & SERIAL_INVERTED), 0);
+        timerChConfigIC(softSerial->timerHardware, (softSerial->port.options & SERIAL_INVERTED) ? ICPOLARITY_RISING : ICPOLARITY_FALLING, 0);
+        serialEnableCC(softSerial);
     }
 }
 
@@ -337,59 +489,84 @@ void processRxState(softSerial_t *softSerial)
     }
 }
 
-void onSerialTimer(timerCCHandlerRec_t *cbRec, captureCompare_t capture)
+void onSerialTimerOverflow(timerOvrHandlerRec_t *cbRec, captureCompare_t capture)
 {
     UNUSED(capture);
-    softSerial_t *softSerial = container_of(cbRec, softSerial_t, timerCb);
 
-    processTxState(softSerial);
-    processRxState(softSerial);
+    softSerial_t *self = container_of(cbRec, softSerial_t, overCb);
+
+    if (self->port.mode & MODE_TX)
+        processTxState(self);
+
+    if (self->port.mode & MODE_RX)
+        processRxState(self);
 }
 
 void onSerialRxPinChange(timerCCHandlerRec_t *cbRec, captureCompare_t capture)
 {
     UNUSED(capture);
 
-    softSerial_t *softSerial = container_of(cbRec, softSerial_t, edgeCb);
-    bool inverted = softSerial->port.options & SERIAL_INVERTED;
+    softSerial_t *self = container_of(cbRec, softSerial_t, edgeCb);
+    bool inverted = self->port.options & SERIAL_INVERTED;
 
-    if ((softSerial->port.mode & MODE_RX) == 0) {
+    if ((self->port.mode & MODE_RX) == 0) {
         return;
     }
 
-    if (softSerial->isSearchingForStartBit) {
-        // synchronise bit counter
-        // FIXME this reduces functionality somewhat as receiving breaks concurrent transmission on all ports because
-        // the next callback to the onSerialTimer will happen too early causing transmission errors.
-        TIM_SetCounter(softSerial->rxTimerHardware->tim, softSerial->rxTimerHardware->tim->ARR / 2);
-        if (softSerial->isTransmittingData) {
-            softSerial->transmissionErrors++;
+    if (self->isSearchingForStartBit) {
+        // Synchronize the bit timing so that it will interrupt at the center
+        // of the bit period.
+
+#ifdef USE_HAL_DRIVER
+        __HAL_TIM_SetCounter(self->timerHandle, __HAL_TIM_GetAutoreload(self->timerHandle) / 2);
+#else
+        TIM_SetCounter(self->timerHardware->tim, self->timerHardware->tim->ARR / 2);
+#endif
+
+        // For a mono-timer full duplex configuration, this may clobber the
+        // transmission because the next callback to the onSerialTimerOverflow
+        // will happen too early causing transmission errors.
+        // For a dual-timer configuration, there is no problem.
+
+        if ((self->timerMode != TIMER_MODE_DUAL) && self->isTransmittingData) {
+            self->transmissionErrors++;
         }
 
-        timerChConfigIC(softSerial->rxTimerHardware, !inverted, 0);
-        softSerial->rxEdge = LEADING;
+        timerChConfigIC(self->timerHardware, inverted ? ICPOLARITY_FALLING : ICPOLARITY_RISING, 0);
+#ifdef STM32F7
+        serialEnableCC(self);
+#endif
+        self->rxEdge = LEADING;
 
-        softSerial->rxBitIndex = 0;
-        softSerial->rxLastLeadingEdgeAtBitIndex = 0;
-        softSerial->internalRxBuffer = 0;
-        softSerial->isSearchingForStartBit = false;
+        self->rxBitIndex = 0;
+        self->rxLastLeadingEdgeAtBitIndex = 0;
+        self->internalRxBuffer = 0;
+        self->isSearchingForStartBit = false;
         return;
     }
 
-    if (softSerial->rxEdge == LEADING) {
-        softSerial->rxLastLeadingEdgeAtBitIndex = softSerial->rxBitIndex;
+    if (self->rxEdge == LEADING) {
+        self->rxLastLeadingEdgeAtBitIndex = self->rxBitIndex;
     }
 
-    applyChangedBits(softSerial);
+    applyChangedBits(self);
 
-    if (softSerial->rxEdge == TRAILING) {
-        softSerial->rxEdge = LEADING;
-        timerChConfigIC(softSerial->rxTimerHardware, !inverted, 0);
+    if (self->rxEdge == TRAILING) {
+        self->rxEdge = LEADING;
+        timerChConfigIC(self->timerHardware, inverted ? ICPOLARITY_FALLING : ICPOLARITY_RISING, 0);
     } else {
-        softSerial->rxEdge = TRAILING;
-        timerChConfigIC(softSerial->rxTimerHardware, inverted, 0);
+        self->rxEdge = TRAILING;
+        timerChConfigIC(self->timerHardware, inverted ? ICPOLARITY_RISING : ICPOLARITY_FALLING, 0);
     }
+#ifdef STM32F7
+    serialEnableCC(self);
+#endif
 }
+
+
+/*
+ * Standard serial driver API
+ */
 
 uint32_t softSerialRxBytesWaiting(const serialPort_t *instance)
 {
@@ -445,7 +622,10 @@ void softSerialWriteByte(serialPort_t *s, uint8_t ch)
 void softSerialSetBaudRate(serialPort_t *s, uint32_t baudRate)
 {
     softSerial_t *softSerial = (softSerial_t *)s;
-    openSoftSerial(softSerial->softSerialPortIndex, s->rxCallback, baudRate, softSerial->port.options);
+
+    softSerial->port.baudRate = baudRate;
+
+    serialTimerConfigureTimebase(softSerial->timerHardware, baudRate);
 }
 
 void softSerialSetMode(serialPort_t *instance, portMode_t mode)
@@ -458,19 +638,17 @@ bool isSoftSerialTransmitBufferEmpty(const serialPort_t *instance)
     return instance->txBufferHead == instance->txBufferTail;
 }
 
-const struct serialPortVTable softSerialVTable[] = {
-    {
-        .serialWrite = softSerialWriteByte,
-        .serialTotalRxWaiting = softSerialRxBytesWaiting,
-        .serialTotalTxFree = softSerialTxBytesFree,
-        .serialRead = softSerialReadByte,
-        .serialSetBaudRate = softSerialSetBaudRate,
-        .isSerialTransmitBufferEmpty = isSoftSerialTransmitBufferEmpty,
-        .setMode = softSerialSetMode,
-        .writeBuf = NULL,
-        .beginWrite = NULL,
-        .endWrite = NULL
-    }
+static const struct serialPortVTable softSerialVTable = {
+    .serialWrite = softSerialWriteByte,
+    .serialTotalRxWaiting = softSerialRxBytesWaiting,
+    .serialTotalTxFree = softSerialTxBytesFree,
+    .serialRead = softSerialReadByte,
+    .serialSetBaudRate = softSerialSetBaudRate,
+    .isSerialTransmitBufferEmpty = isSoftSerialTransmitBufferEmpty,
+    .setMode = softSerialSetMode,
+    .writeBuf = NULL,
+    .beginWrite = NULL,
+    .endWrite = NULL
 };
 
 #endif

--- a/src/main/drivers/serial_softserial.h
+++ b/src/main/drivers/serial_softserial.h
@@ -24,8 +24,7 @@ typedef enum {
     SOFTSERIAL2
 } softSerialPortIndex_e;
 
-serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallbackPtr rxCallback, uint32_t baud, portOptions_t options);
-serialPort_t *softSerialLoopbackPort(void);
+serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallbackPtr rxCallback, uint32_t baud, portMode_t mode, portOptions_t options);
 
 // serialPort API
 void softSerialWriteByte(serialPort_t *instance, uint8_t ch);
@@ -34,4 +33,3 @@ uint32_t softSerialTxBytesFree(const serialPort_t *instance);
 uint8_t softSerialReadByte(serialPort_t *instance);
 void softSerialSetBaudRate(serialPort_t *s, uint32_t baudRate);
 bool isSoftSerialTransmitBufferEmpty(const serialPort_t *s);
-

--- a/src/main/drivers/timer_stm32f4xx.c
+++ b/src/main/drivers/timer_stm32f4xx.c
@@ -72,12 +72,16 @@ void TIM_SelectOCxM_NoDisable(TIM_TypeDef* TIMx, uint16_t TIM_Channel, uint16_t 
 
 uint8_t timerClockDivisor(TIM_TypeDef *tim)
 {
-#if defined (STM32F40_41xxx)
-    if (tim == TIM8) return 1;
-#endif
-    if (tim == TIM1 || tim == TIM9 || tim == TIM10 || tim == TIM11) {
+#if defined (STM32F411xE)
+    UNUSED(tim);
+    return 1;
+#elif defined (STM32F40_41xxx) || defined (STM32F427_437xx)
+    if (tim == TIM1 || tim == TIM8 || tim == TIM9 || tim == TIM10 || tim == TIM11) {
         return 1;
     } else {
         return 2;
     }
+#else
+    #error "No timer clock defined correctly for the MCU"
+#endif
 }

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -391,14 +391,12 @@ serialPort_t *openSerialPort(
 #endif
 #ifdef USE_SOFTSERIAL1
         case SERIAL_PORT_SOFTSERIAL1:
-            serialPort = openSoftSerial(SOFTSERIAL1, rxCallback, baudRate, options);
-            serialSetMode(serialPort, mode);
+            serialPort = openSoftSerial(SOFTSERIAL1, rxCallback, baudRate, mode, options);
             break;
 #endif
 #ifdef USE_SOFTSERIAL2
         case SERIAL_PORT_SOFTSERIAL2:
-            serialPort = openSoftSerial(SOFTSERIAL2, rxCallback, baudRate, options);
-            serialSetMode(serialPort, mode);
+            serialPort = openSoftSerial(SOFTSERIAL2, rxCallback, baudRate, mode, options);
             break;
 #endif
         default:


### PR DESCRIPTION
PR status: Need review and testing

Port of BF Software Serial to iNav.

New features
- Capable of handling single-wire half-duplex using TX.
- TX and RX can be on different timers, and in which case true full-duplex is provided. In legacy softserial which used two channels of the same timer, active transmission was clobbered when a first edge of a new character is detected.
- Simplex configuration is allowed (TX only or RX only) as long as a user use the port in the configured way.