### PR TITLE
Add a 3rd state for nav_rth_allow_landing

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -78,6 +78,9 @@ tables:
   - name: osd_sidebar_scroll
     values: ["NONE", "ALTITUDE", "GROUND_SPEED", "HOME_DISTANCE"]
     enum: osd_sidebar_scroll_e
+  - name: nav_rth_allow_landing
+    values: ["NEVER", "ALWAYS", "FS_ONLY"]
+    enum: navRTHAllowLanding_e
 
 groups:
   - name: PG_GYRO_CONFIG
@@ -1104,7 +1107,7 @@ groups:
         type: bool
       - name: nav_rth_allow_landing
         field: general.flags.rth_allow_landing
-        type: bool
+        table: nav_rth_allow_landing
       - name: nav_rth_alt_mode
         field: general.flags.rth_alt_control_mode
         table: nav_rth_alt_mode

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -634,7 +634,7 @@ static const char * navigationStateMessage(void)
         case MW_NAV_STATE_LAND_START:
             return OSD_MESSAGE_STR("STARTING EMERGENCY LANDING");
         case MW_NAV_STATE_LAND_IN_PROGRESS:
-            if (!navConfig()->general.flags.rth_allow_landing) {
+            if (!navigationRTHAllowsLanding()) {
                 if (STATE(FIXED_WING)) {
                     return OSD_MESSAGE_STR("LOITERING AROUND HOME");
                 }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -81,7 +81,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
             .rth_climb_ignore_emerg = 0,            // Ignore GPS loss on initial climb
             .rth_tail_first = 0,
             .disarm_on_landing = 0,
-            .rth_allow_landing = 1,
+            .rth_allow_landing = NAV_RTH_ALLOW_LANDING_ALWAYS,
         },
 
         // General navigation parameters
@@ -993,7 +993,7 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_LANDING(navigationF
             return NAV_FSM_EVENT_SWITCH_TO_EMERGENCY_LANDING;
         }
 
-        if (navConfig()->general.flags.rth_allow_landing) {
+        if (navigationRTHAllowsLanding()) {
             float descentVelLimited = 0;
 
             // A safeguard - if surface altitude sensors is available and it is reading < 50cm altitude - drop to low descend speed
@@ -2703,6 +2703,13 @@ bool navigationIsFlyingAutonomousMode(void)
 {
     navigationFSMStateFlags_t stateFlags = navGetCurrentStateFlags();
     return (stateFlags & (NAV_AUTO_RTH | NAV_AUTO_WP));
+}
+
+bool navigationRTHAllowsLanding(void)
+{
+    navRTHAllowLanding_e allow = navConfig()->general.flags.rth_allow_landing;
+    return allow == NAV_RTH_ALLOW_LANDING_ALWAYS ||
+        (allow == NAV_RTH_ALLOW_LANDING_FS_ONLY && FLIGHT_MODE(FAILSAFE_MODE));
 }
 
 #else // NAV

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -65,6 +65,12 @@ enum {
     NAV_RESET_ALTITUDE_ON_EACH_ARM,
 };
 
+typedef enum {
+    NAV_RTH_ALLOW_LANDING_NEVER = 0,
+    NAV_RTH_ALLOW_LANDING_ALWAYS = 1,
+    NAV_RTH_ALLOW_LANDING_FS_ONLY = 2, // Allow landing only if RTH was triggered by failsafe
+} navRTHAllowLanding_e;
+
 typedef struct positionEstimationConfig_s {
     uint8_t automatic_mag_declination;
     uint8_t reset_altitude_type;
@@ -107,7 +113,7 @@ typedef struct navConfig_s {
             uint8_t rth_climb_first;            // Controls the logic for initial RTH climbout
             uint8_t rth_tail_first;             // Return to home tail first
             uint8_t disarm_on_landing;          //
-            uint8_t rth_allow_landing;          // Enable landing as last stage of RTH
+            uint8_t rth_allow_landing;          // Enable landing as last stage of RTH. Use constants in navRTHAllowLanding_e.
             uint8_t rth_climb_ignore_emerg;     // Option to ignore GPS loss on initial climb stage of RTH
         } flags;
 
@@ -303,6 +309,10 @@ rthState_e getStateOfForcedRTH(void);
 /* Getter functions which return data about the state of the navigation system */
 bool navigationIsControllingThrottle(void);
 bool navigationIsFlyingAutonomousMode(void);
+/* Returns true iff navConfig()->general.flags.rth_allow_landing is NAV_RTH_ALLOW_LANDING_ALWAYS
+ * or if it's NAV_RTH_ALLOW_LANDING_FAILSAFE and failsafe mode is active.
+ */
+bool navigationRTHAllowsLanding(void);
 
 /* Compatibility data */
 extern navSystemStatus_t    NAV_Status;
@@ -326,5 +336,6 @@ extern int16_t navAccNEU[3];
 #define navigationRequiresThrottleTiltCompensation() (0)
 #define getEstimatedActualVelocity(axis) (0)
 #define navigationIsControllingThrottle() (0)
+#define navigationRTHAllowsLanding() (0)
 
 #endif

--- a/src/main/target/FALCORE/config.c
+++ b/src/main/target/FALCORE/config.c
@@ -118,7 +118,7 @@ void targetConfiguration(void)
     navConfigMutable()->general.flags.disarm_on_landing = 1;
     navConfigMutable()->general.flags.use_thr_mid_for_althold = 1;
     navConfigMutable()->general.flags.extra_arming_safety = 1;
-    navConfigMutable()->general.flags.rth_allow_landing = 1;
+    navConfigMutable()->general.flags.rth_allow_landing = NAV_RTH_ALLOW_LANDING_ALWAYS;
     
     navConfigMutable()->general.max_auto_speed = 500;
     navConfigMutable()->general.max_auto_climb_rate = 200;


### PR DESCRIPTION
New state FS_ONLY allows landing only when RTH is enabled at the
same time as the failsafe mode. This allows the aircraft to land
itself when there's no way to regain control.

Fixes #2344 

Configurator PR at https://github.com/iNavFlight/inav-configurator/pull/281