### PR TITLE
Fix warning calling tfp_sprintf() from CMS

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -434,9 +434,9 @@ static int cmsDrawMenuEntry(displayPort_t *pDisplay, OSD_Entry *p, uint8_t row)
                 switch (SETTING_MODE(var)) {
                     case MODE_DIRECT:
                         if (SETTING_TYPE(var) == VAR_UINT32) {
-                            tfp_sprintf(buff, "%u", value);
+                            tfp_sprintf(buff, "%u", (unsigned)value);
                         } else {
-                            tfp_sprintf(buff, "%d", value);
+                            tfp_sprintf(buff, "%d", (int)value);
                         }
                         break;
                     case MODE_LOOKUP:


### PR DESCRIPTION
Uncovered by #2338