### PR TITLE
Updated docker toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-FROM ubuntu:wily
-LABEL maintainer Alexandr Kuzmitsky <brat002@gmail.com>
+FROM ubuntu:xenial
+LABEL maintainer Andy Schwarz <flyandi@yahoo.com>
 
+# Configuration
 VOLUME /home/src/
 WORKDIR /home/src/
 
-RUN mkdir -p /home/src && apt-get update && \
-    apt-get install -y software-properties-common python-software-properties && \
-    apt-get remove -y binutils-arm-none-eabi gcc-arm-none-eabi && \
-    add-apt-repository -y ppa:terry.guo/gcc-arm-embedded && \
+# Essentials
+RUN mkdir -p /home/src && \
     apt-get update && \
-    apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi make git gcc ruby
+    apt-get install -y software-properties-common python-software-properties ruby make git gcc wget curl bzip2 lib32ncurses5 lib32z1
+
+# Toolchain
+ENV TOOLCHAIN=
+ENV TOOLCHAIN_ID=
+RUN wget -P /tmp https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2
+RUN mkdir -p /opt && \
+	cd /opt && \
+    tar xvjf /tmp/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -C /opt && \
+	chmod -R -w /opt/gcc-arm-none-eabi-6-2017-q2-update
+
+ENV PATH="/opt/gcc-arm-none-eabi-6-2017-q2-update/bin:${PATH}"

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 echo "Building target" $1
-docker run --rm -v `pwd`:/home/src/ inav make TARGET=$1
+docker run --rm -v `pwd`:/home/src/ flyandi/docker-inav make TARGET=$1


### PR DESCRIPTION
I updated and upgraded the docker build environment so it can be used with the new arm q2 2017 toolchain. 

Also uploaded pre-build images to docker hub so it's easier for people to build local binaries instead running into conflict with building the docker image.

Uses latest Ubuntu release.