### PR TITLE
Fix incorrect section syntax on OSX

### DIFF
--- a/src/main/build/build_config.h
+++ b/src/main/build/build_config.h
@@ -39,6 +39,10 @@
 #define REQUIRE_PRINTF_LONG_SUPPORT
 #endif
 
+#ifdef __APPLE__
+#define FASTRAM                     __attribute__ ((section("__DATA,__.fastram_bss"), aligned(4)))
+#else
 #define FASTRAM                     __attribute__ ((section(".fastram_bss"), aligned(4)))
+#endif
 #define STATIC_FASTRAM              static FASTRAM
 #define STATIC_FASTRAM_UNIT_TESTED  STATIC_UNIT_TESTED FASTRAM


### PR DESCRIPTION
Fix incorrect section syntax on OSX