### PR TITLE
reduce the timeout for packet receive

### DIFF
--- a/src/main/io/rcdevice.c
+++ b/src/main/io/rcdevice.c
@@ -91,8 +91,8 @@ static uint8_t runcamDeviceReceivePacket(runcamDevice_t *device, uint8_t command
     uint8_t crc = 0;
     uint8_t responseDataLen = 0;
 
-    // wait 1000ms for reply
-    timeMs_t timeout = millis() + 1000;
+    // wait 500ms for reply
+    timeMs_t timeout = millis() + 500;
     bool isWaitingHeader = true;
     while (millis() < timeout) {
         if (serialRxBytesWaiting(device->serialPort) > 0) {


### PR DESCRIPTION
Some times if the camera hung, and user choose `RunCam Split` as peripherl device on UART, it will increase the time of FC booting, because the packet receive function will try 3 times to get response from rcsplit, and the timeout of each time is 1000ms, means it need 3 seconds to wait response when rcsplit hung.

Because there already has retry logic in packet receive function, so there is no need to use such 1000 ms as the value of timeout, and the max packets size is 64 bytes, so use 500 ms will more suitable.