### PR TITLE
OmnibusF7 V2: Switch to use onboard gyro by default

### DIFF
--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -49,10 +49,10 @@
 #   define MPU6000_SPI_INSTANCE    SPI1
 #   define MPU6500_CS_PIN          SPI3_NSS_PIN
 #   define MPU6500_SPI_INSTANCE    SPI3
-#   define GYRO_0_CS_PIN           MPU6500_CS_PIN
-#   define GYRO_1_CS_PIN           MPU6000_CS_PIN
-#   define GYRO_0_INT_EXTI         PD0
-#   define GYRO_1_INT_EXTI         PE8
+#   define GYRO_1_CS_PIN           MPU6500_CS_PIN
+#   define GYRO_0_CS_PIN           MPU6000_CS_PIN
+#   define GYRO_1_INT_EXTI         PD0
+#   define GYRO_0_INT_EXTI         PE8
 #   define GYRO_MPU6500_ALIGN      CW90_DEG
 #   define ACC_MPU6500_ALIGN       CW90_DEG
 #else


### PR DESCRIPTION
OmnibusF7 V2: Switch to use gyro that's soldered on the PCB by default.