### PR TITLE
Fix incorrectly formatted distances in OSD stats

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -166,7 +166,7 @@
 #define SYM_DIST_M      181
 #define SYM_DIST_KM     182
 #define SYM_M           185
-#define SYM_KM          187
+#define SYM_KM          186
 
 // Unit Icon´s (Imperial)
 #define SYM_FTS         0x99

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -294,7 +294,7 @@ static void osdFormatDistanceSymbol(char *buff, int32_t dist)
         } else {
             // Show miles when dist >= 0.5mi
             tfp_sprintf(buff, "%d.%02d%c", centifeet / (100*FEET_PER_MILE),
-            abs(centifeet) % (100 * FEET_PER_MILE), SYM_MI);
+            abs(centifeet) % (100 * FEET_PER_MILE) / 10, SYM_MI);
         }
         break;
      case OSD_UNIT_UK:
@@ -306,7 +306,7 @@ static void osdFormatDistanceSymbol(char *buff, int32_t dist)
         } else {
             // Show kilometers when dist >= 1km
             tfp_sprintf(buff, "%d.%02d%c", dist / (100*METERS_PER_KILOMETER),
-                abs(dist) % (100 * METERS_PER_KILOMETER), SYM_KM);
+                abs(dist) % (100 * METERS_PER_KILOMETER) / 100, SYM_KM);
          }
          break;
      }


### PR DESCRIPTION
- OSD was using the "mi" rather than the "km" symbol
- Both KM and MI were using too many decimals, show 3 now.

Kudos to @giacomo892 for noticing these issues.