### PR TITLE
Replace RTL with RTH across all the code and comments

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -562,8 +562,7 @@ static const char * osdFailsafePhaseMessage(void)
 #ifdef NAV
         case FAILSAFE_RETURN_TO_HOME:
             // XXX: Keep this in sync with OSD_FLYMODE.
-            // Should we show RTH instead?
-            return OSD_MESSAGE_STR("(RTL)");
+            return OSD_MESSAGE_STR("(RTH)");
 #endif
         case FAILSAFE_LANDING:
             // This should be considered an emergengy landing
@@ -961,7 +960,7 @@ static bool osdDrawSingleElement(uint8_t item)
             } else if (FLIGHT_MODE(HEADFREE_MODE))
                 p = "!HF!";
             else if (FLIGHT_MODE(NAV_RTH_MODE))
-                p = "RTL ";
+                p = "RTH ";
             else if (FLIGHT_MODE(NAV_POSHOLD_MODE)) {
                 if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
                     // 3D HOLD

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -129,7 +129,7 @@ typedef struct navConfig_s {
         uint16_t land_slowdown_maxalt;          // Altitude to start lowering descent rate during RTH descend
         uint16_t emerg_descent_rate;            // emergency landing descent rate
         uint16_t rth_altitude;                  // altitude to maintain when RTH is active (depends on rth_alt_control_mode) (cm)
-        uint16_t min_rth_distance;              // 0 Disables. Minimal distance for RTL in cm, otherwise it will just autoland
+        uint16_t min_rth_distance;              // 0 Disables. Minimal distance for RTH in cm, otherwise it will just autoland
         uint16_t rth_abort_threshold;           // Initiate emergency landing if during RTH we get this much [cm] away from home
     } general;
 


### PR DESCRIPTION
RTL was only used in the highly visible OSD flight modes and in
a comment in navigation.h, everywhere else we were using RTH.

References #2393