### PR TITLE
Add OMNIBUSF4PRO_LEDSTRIPM5

### DIFF
--- a/src/main/target/OMNIBUSF4/OMNIBUSF4PRO_LEDSTRIPM5.mk
+++ b/src/main/target/OMNIBUSF4/OMNIBUSF4PRO_LEDSTRIPM5.mk
@@ -1,0 +1,2 @@
+# the OMNIBUSF4SD has an SDCARD instead of flash, a BMP280 baro and therefore a slightly different ppm/pwm and SPI mapping
+FEATURES       = VCP SDCARD

--- a/src/main/target/OMNIBUSF4/target.c
+++ b/src/main/target/OMNIBUSF4/target.c
@@ -38,7 +38,7 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     { TIM3,  IO_TAG(PB1),  TIM_Channel_4, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM3, TIM_USE_MC_MOTOR                    | TIM_USE_FW_MOTOR }, // MOTOR_2
     { TIM9,  IO_TAG(PA3),  TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM9, TIM_USE_MC_MOTOR                    | TIM_USE_FW_SERVO }, // MOTOR_3
     { TIM2,  IO_TAG(PA2),  TIM_Channel_3, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM2, TIM_USE_MC_MOTOR                    | TIM_USE_FW_SERVO }, // MOTOR_4
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if (defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)) && !defined(OMNIBUSF4PRO_LEDSTRIPM5)
     { TIM5,  IO_TAG(PA1),  TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM5, TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO }, // MOTOR_5
     { TIM4,  IO_TAG(PB6),  TIM_Channel_1, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM4, TIM_USE_LED                                            }, // LED strip for F4 V2 / F4-Pro-0X and later
 #else

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#ifdef OMNIBUSF4PRO_LEDSTRIPM5
+#define OMNIBUSF4PRO
+#endif
 #ifdef OMNIBUSF4PRO
 #define TARGET_BOARD_IDENTIFIER "OBSD"
 #elif defined(OMNIBUSF4V3)
@@ -201,7 +204,7 @@
 #define SENSORS_SET (SENSOR_ACC|SENSOR_MAG|SENSOR_BARO)
 
 #define LED_STRIP
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if (defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)) && !defined(OMNIBUSF4PRO_LEDSTRIPM5)
 #   define WS2811_PIN                      PB6
 #   define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST0_HANDLER
 #   define WS2811_DMA_STREAM               DMA1_Stream0


### PR DESCRIPTION
Same as OMNIBUSF4PRO target, but uses Motor 5 pin for LEDSTRIP.
Supports defective boards which didn't have the actual LEDSTRIP pin
correctly routed in the PCB.

Fixes #2386