### PR TITLE
Replace STAB with ANGL for OSD and CRSF telemetry

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -976,7 +976,7 @@ static bool osdDrawSingleElement(uint8_t item)
             } else if (FLIGHT_MODE(NAV_WP_MODE))
                 p = " WP ";
             else if (FLIGHT_MODE(ANGLE_MODE))
-                p = "STAB";
+                p = "ANGL";
             else if (FLIGHT_MODE(HORIZON_MODE))
                 p = "HOR ";
 

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -233,7 +233,7 @@ void crsfFrameFlightMode(sbuf_t *dst)
     if (FLIGHT_MODE(FAILSAFE_MODE)) {
         flightMode = "!FS";
     } else if (FLIGHT_MODE(ANGLE_MODE)) {
-        flightMode = "STAB";
+        flightMode = "ANGL";
     } else if (FLIGHT_MODE(HORIZON_MODE)) {
         flightMode = "HOR";
     }


### PR DESCRIPTION
`STAB` is ambiguous as even Acro mode is stabilized.  Also, everywhere it's referred to as Angle mode, furthering confusion.

Changed the two places where `STAB` was shown instead of `ANGL` to make flight modes more clear.

Reference #2393