### PR TITLE
Added auto tune and flaperon modes, moved home reset

### DIFF
--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -64,13 +64,13 @@ The following sensors are transmitted
 * **Hdg** : heading, North is 0°, South is 180°.
 * **AccX,Y,Z** : accelerometer values.
 * **Tmp1** : flight mode, sent as 5 digits. Number is sent as **ABCDE** detailed below. The numbers are additives (for example: if digit C is 6, it means both position hold and altitude hold are active) :
-  * **A** : 1 = placeholder so flight mode is always 5 digits long, 2 = home reset, 4 = failsafe mode
+  * **A** : 1 = flaperon mode, 2 = auto tune mode, 4 = failsafe mode
   * **B** : 1 = return to home, 2 = waypoint mode, 4 = headfree mode
   * **C** : 1 = heading hold, 2 = altitude hold, 4 = position hold
   * **D** : 1 = angle mode, 2 = horizon mode, 4 = passthru mode
   * **E** : 1 = ok to arm, 2 = arming is prevented, 4 = armed
-* **Tmp2** : GPS lock status, accuracy, and number of satellites. Additive number is sent as **ABCD** detailed below. Typical minimum GPS 3D lock value is 3906 (GPS locked and home fixed, HDOP highest accuracy, 6 satellites).
-  * **A** : 1 = GPS fix, 2 = GPS home fix (numbers are additive)
+* **Tmp2** : GPS lock status, accuracy, home reset trigger, and number of satellites. Number is sent as **ABCD** detailed below. Typical minimum GPS 3D lock value is 3906 (GPS locked and home fixed, HDOP highest accuracy, 6 satellites).
+  * **A** : 1 = GPS fix, 2 = GPS home fix, 4 = home reset (numbers are additive)
   * **B** : GPS accuracy based on HDOP (0 = lowest to 9 = highest accuracy)
   * **C** : number of satellites locked (digit C & D are the number of locked satellites)
   * **D** : number of satellites locked (if 14 satellites are locked, C = 1 & D = 4)

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -650,7 +650,7 @@ void handleSmartPortTelemetry(void)
                 break;
             case FSSP_DATAID_T1         :
                 {
-                    uint32_t tmpi = 10000; // start off with at least one digit so the most significant 0 won't be cut off
+                    uint32_t tmpi = 0;
 
                     // ones column
                     if (!isArmingDisabled())
@@ -686,7 +686,9 @@ void handleSmartPortTelemetry(void)
                         tmpi += 4000;
 
                     // ten thousands column
-                    if (ARMING_FLAG(ARMED) && IS_RC_MODE_ACTIVE(BOXHOMERESET) && !FLIGHT_MODE(NAV_RTH_MODE) && !FLIGHT_MODE(NAV_WP_MODE))
+                    if (FLIGHT_MODE(FLAPERON))
+                        tmpi += 10000;
+                    if (FLIGHT_MODE(AUTO_TUNE))
                         tmpi += 20000;
                     if (FLIGHT_MODE(FAILSAFE_MODE))
                         tmpi += 40000;
@@ -710,6 +712,8 @@ void handleSmartPortTelemetry(void)
                         tmpi += 1000;
                     if (STATE(GPS_FIX_HOME))
                         tmpi += 2000;
+                    if (ARMING_FLAG(ARMED) && IS_RC_MODE_ACTIVE(BOXHOMERESET) && !FLIGHT_MODE(NAV_RTH_MODE) && !FLIGHT_MODE(NAV_WP_MODE))
+                        tmpi += 4000;
 
                     smartPortSendPackage(id, tmpi);
 #endif


### PR DESCRIPTION
As suggested by a fixed wing flyer, this adds a couple fixed wing specific flight modes (`FLAPERON` and `AUTO_TUNE`).  After much discussion, other suggested flight modes and flight modifiers were not added as there's already a clear indication that they're active.

This change addresses the removed `AUTO_TUNE` mode (which triggered this discussion even though it never worked correctly and could cause a rollover problem).  I also moved home reset to a more logical position (with the rest of the GPS information).  Home reset was just added in this RC cycle, so there's no compatibility issue moving it.

This keeps with the long-standing method of additive digits so multiple modes can be detected at the same time.  By keeping this method, existing Lua scripts using bit logic are not effected (for example the INAV Lua Telemetry script).