### PR TITLE
Fix missing initializer for gyroUpdateUs

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -654,7 +654,7 @@ void taskGyro(timeUs_t currentTimeUs) {
     // getTaskDeltaTime() returns delta time frozen at the moment of entering the scheduler. currentTime is frozen at the very same point.
     // To make busy-waiting timeout work we need to account for time spent within busy-waiting loop
     const timeDelta_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
-    timeUs_t gyroUpdateUs;
+    timeUs_t gyroUpdateUs = currentTimeUs;
 
     if (gyroConfig()->gyroSync) {
         while (true) {


### PR DESCRIPTION
Issue only present with `set gyro_sync = OFF`

 ```// Function for loop trigger
void taskGyro(timeUs_t currentTimeUs) {
    // getTaskDeltaTime() returns delta time frozen at the moment of entering the scheduler. currentTime is frozen at the very same point.
    // To make busy-waiting timeout work we need to account for time spent within busy-waiting loop
    const timeDelta_t currentDeltaTime = getTaskDeltaTime(TASK_SELF);
    timeUs_t gyroUpdateUs;

    if (gyroConfig()->gyroSync) {
        while (true) {
            gyroUpdateUs = micros();
            if (gyroSyncCheckUpdate() || ((currentDeltaTime + cmpTimeUs(gyroUpdateUs, currentTimeUs)) >= (getGyroUpdateRate() + GYRO_WATCHDOG_DELAY))) {
                break;
            }
        }
    }

    /* Update actual hardware readings */
    gyroUpdate();

#ifdef ASYNC_GYRO_PROCESSING
    /* Update IMU for better accuracy */
    imuUpdateGyroscope((timeUs_t)currentDeltaTime + (gyroUpdateUs - currentTimeUs));
#endif

#ifdef USE_OPTICAL_FLOW
    if (sensors(SENSOR_OPFLOW)) {
        opflowGyroUpdateCallback((timeUs_t)currentDeltaTime + (gyroUpdateUs - currentTimeUs));
    }
#endif
}
```

In this functuion when `gyroSync == false`, variable `gyroUpdateUs` is never initialized, however it's used for calculating delta time for `imuUpdateGyroscope`

This caused delta time to be random which caused some small jitter in attitude, but in some random cases it also caused float-point operations to yield `NaN` and trigger attitude reset.

Fixes #2414