### PR TITLE
Fix non-working fixed_wing_auto_arm

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -178,10 +178,13 @@ static void updateArmingStatus(void)
         }
 
         /* CHECK: Throttle */
-        if (calculateThrottleStatus() != THROTTLE_LOW) {
-            ENABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
-        } else {
-            DISABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
+        if (!armingConfig()->fixed_wing_auto_arm) {
+            // Don't want this check if fixed_wing_auto_arm is in use - machine arms on throttle > LOW
+            if (calculateThrottleStatus() != THROTTLE_LOW) {
+                ENABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
+            } else {
+                DISABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
+            }
         }
 
         /* CHECK: Angle */


### PR DESCRIPTION
Bug caused by pre-arming check that disabled arming if throttle is above zero.
Fixes #2406