### PR TITLE
CLI: status command shows arming disabled flags

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2419,6 +2419,18 @@ static void cliStatus(char *cmdline)
     const int rxRate = getTaskDeltaTime(TASK_RX) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_RX)));
     const int systemRate = getTaskDeltaTime(TASK_SYSTEM) == 0 ? 0 : (int)(1000000.0f / ((float)getTaskDeltaTime(TASK_SYSTEM)));
     cliPrintLinef(", cycle time: %d, PID rate: %d, RX rate: %d, System rate: %d",  (uint16_t)cycleTime, pidRate, rxRate, systemRate);
+#if !defined(CLI_MINIMAL_VERBOSITY)
+    cliPrint("Arming disabled flags:");
+    uint32_t flags = armingFlags & ARMING_DISABLED_ALL_FLAGS;
+    while (flags) {
+        int bitpos = ffs(flags) - 1;
+        flags &= ~(1 << bitpos);
+	if (bitpos > 6) cliPrintf(" %s", armingDisableFlagNames[bitpos - 7]);
+    }
+    cliPrintLinefeed();
+#else
+    cliPrintLinef("Arming disabled flags: 0x%lx", armingFlags & ARMING_DISABLED_ALL_FLAGS);
+#endif
 }
 
 #ifndef SKIP_TASK_STATISTICS

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -30,6 +30,14 @@ uint32_t flightModeFlags = 0;
 
 static uint32_t enabledSensors = 0;
 
+#if !defined(CLI_MINIMAL_VERBOSITY)
+const char *armingDisableFlagNames[]= {
+    "FS", "ANGLE", "CAL", "OVRLD", "NAV", "COMPASS",
+    "ACC", "ARMSW", "HWFAIL", "BOXFS", "KILLSW", "RX",
+    "THR", "CLI", "CMS", "OSD"
+};
+#endif
+
 armingFlag_e isArmingDisabledReason(void)
 {
     armingFlag_e flag;

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -48,6 +48,8 @@ typedef enum {
 
 extern uint32_t armingFlags;
 
+extern const char *armingDisableFlagNames[];
+
 #define isArmingDisabled()          (armingFlags & (ARMING_DISABLED_ALL_FLAGS))
 #define DISABLE_ARMING_FLAG(mask)   (armingFlags &= ~(mask))
 #define ENABLE_ARMING_FLAG(mask)    (armingFlags |= (mask))


### PR DESCRIPTION
Makes CLI status command show the reasons why the aircraft can't be armed (like in BF3.2).

If my other patch "FW: Add arming rollpitch center safety when NAV_LAUNCH is enabled" is pulled a corresponding flag name should be added in the armingDisableFlagNames array in the runtime_config.c file.