### PR TITLE
Add support for accessing settings in RC devices, sync time

### DIFF
--- a/src/main/io/rcdevice.c
+++ b/src/main/io/rcdevice.c
@@ -558,7 +558,7 @@ bool runcamDeviceGetSettingDetail(runcamDevice_t *device, uint8_t settingID, run
 }
 
 // write new value with to the setting
-bool runcamDeviceWriteSetting(runcamDevice_t *device, uint8_t settingID, uint8_t *paramData, uint8_t paramDataLen, runcamDeviceWriteSettingResponse_t *response)
+bool runcamDeviceWriteSetting(runcamDevice_t *device, uint8_t settingID, const void *paramData, uint8_t paramDataLen, runcamDeviceWriteSettingResponse_t *response)
 {
     if (response == NULL || paramDataLen > (RCDEVICE_PROTOCOL_MAX_DATA_SIZE - 1)) {
         return false;

--- a/src/main/io/rcdevice.c
+++ b/src/main/io/rcdevice.c
@@ -38,20 +38,29 @@ typedef enum {
     RCDP_SETTING_PARSE_WAITING_VALUE,
 } runcamDeviceSettingParseStep_e;
 
-// return 0xFF if expected resonse data length is variable
+typedef struct runcamDeviceExpectedResponseLength_s {
+    uint8_t command;
+    uint8_t reponseLength;
+} runcamDeviceExpectedResponseLength_t;
+
+static runcamDeviceExpectedResponseLength_t expectedResponsesLength[] = {
+    { RCDEVICE_PROTOCOL_COMMAND_READ_SETTING_DETAIL,        0xFF},
+    { RCDEVICE_PROTOCOL_COMMAND_GET_DEVICE_INFO,            5},
+    { RCDEVICE_PROTOCOL_COMMAND_5KEY_SIMULATION_PRESS,      2},
+    { RCDEVICE_PROTOCOL_COMMAND_5KEY_SIMULATION_RELEASE,    2},
+    { RCDEVICE_PROTOCOL_COMMAND_5KEY_CONNECTION,            3},
+    { RCDEVICE_PROTOCOL_COMMAND_WRITE_SETTING,              4},
+};
+
 static uint8_t runcamDeviceGetResponseLength(uint8_t command)
 {
-    switch (command) {
-        case RCDEVICE_PROTOCOL_COMMAND_GET_DEVICE_INFO:
-            return 5;
-        case RCDEVICE_PROTOCOL_COMMAND_5KEY_SIMULATION_PRESS:
-        case RCDEVICE_PROTOCOL_COMMAND_5KEY_SIMULATION_RELEASE:
-            return 2;
-        case RCDEVICE_PROTOCOL_COMMAND_5KEY_CONNECTION:
-            return 3;
-        default:
-            return 0;
+    for (unsigned int i = 0; i < ARRAYLEN(expectedResponsesLength); i++) {
+        if (expectedResponsesLength[i].command == command) {
+            return expectedResponsesLength[i].reponseLength;
+        }
     }
+
+    return 0;
 }
 
 // Parse the variable length response, e.g the response of settings data and the detail of setting

--- a/src/main/io/rcdevice.c
+++ b/src/main/io/rcdevice.c
@@ -396,4 +396,193 @@ bool runcamDeviceSimulate5KeyOSDCableButtonRelease(runcamDevice_t *device)
     return runcamDeviceSendRequestAndWaitingResp(device, RCDEVICE_PROTOCOL_COMMAND_5KEY_SIMULATION_RELEASE, NULL, 0, NULL, NULL);
 }
 
+static bool runcamDeviceDecodeSettingDetail(sbuf_t *buf, runcamDeviceSettingDetail_t *outSettingDetail)
+{
+    if (outSettingDetail == NULL || sbufBytesRemaining(buf) == 0) {
+        return false;
+    }
+
+    rcdeviceSettingType_e settingType = sbufReadU8(buf);
+    outSettingDetail->type = settingType;
+    switch (settingType) {
+    case RCDEVICE_PROTOCOL_SETTINGTYPE_UINT8:
+    case RCDEVICE_PROTOCOL_SETTINGTYPE_INT8:
+        outSettingDetail->value = sbufReadU8(buf);
+        outSettingDetail->minValue = sbufReadU8(buf);
+        outSettingDetail->maxValue = sbufReadU8(buf);
+        outSettingDetail->stepSize = sbufReadU8(buf);
+        break;
+    case RCDEVICE_PROTOCOL_SETTINGTYPE_UINT16:
+    case RCDEVICE_PROTOCOL_SETTINGTYPE_INT16: 
+        outSettingDetail->value = sbufReadU16(buf);
+        outSettingDetail->minValue = sbufReadU16(buf);
+        outSettingDetail->maxValue = sbufReadU16(buf);
+        outSettingDetail->stepSize = sbufReadU8(buf);
+        break;
+    case RCDEVICE_PROTOCOL_SETTINGTYPE_FLOAT: 
+        outSettingDetail->value = sbufReadU32(buf);
+        outSettingDetail->minValue = sbufReadU32(buf);
+        outSettingDetail->maxValue = sbufReadU32(buf);
+        outSettingDetail->decimalPoint = sbufReadU8(buf);
+        outSettingDetail->stepSize = sbufReadU32(buf);
+        break;
+    case RCDEVICE_PROTOCOL_SETTINGTYPE_TEXT_SELECTION: {
+        outSettingDetail->value = sbufReadU8(buf);
+
+        const char *tmp = (const char *)sbufConstPtr(buf);
+        const uint16_t maxLen = RCDEVICE_PROTOCOL_MAX_DATA_SIZE * RCDEVICE_PROTOCOL_MAX_TEXT_SELECTIONS;
+        char textSels[maxLen];
+        memset(textSels, 0, maxLen);
+        strncpy(textSels, tmp, maxLen);
+        char delims[] = ";";
+        char *result = strtok(textSels, delims);
+        int i = 0;
+        runcamDeviceSettingTextSelection_t *iterator = outSettingDetail->textSelections;
+        while (result != NULL) {
+            if (i >= RCDEVICE_PROTOCOL_MAX_TEXT_SELECTIONS) {
+                break;
+            }
+
+            memset(iterator->text, 0, RCDEVICE_PROTOCOL_MAX_SETTING_VALUE_LENGTH);
+            strncpy(iterator->text, result, RCDEVICE_PROTOCOL_MAX_SETTING_VALUE_LENGTH);
+            iterator++;
+            result = strtok(NULL, delims);
+            i++;
+        }
+    } 
+        break;
+    case RCDEVICE_PROTOCOL_SETTINGTYPE_STRING: {
+        const char *tmp = (const char *)sbufConstPtr(buf);
+        strncpy(outSettingDetail->stringValue, tmp, RCDEVICE_PROTOCOL_MAX_STRING_LENGTH);
+        sbufAdvance(buf, strlen(tmp) + 1);
+
+        outSettingDetail->maxStringSize = sbufReadU8(buf);
+    } 
+        break;
+    case RCDEVICE_PROTOCOL_SETTINGTYPE_FOLDER:
+        break;
+    case RCDEVICE_PROTOCOL_SETTINGTYPE_INFO: {
+        const char *tmp = (const char *)sbufConstPtr(buf);
+        strncpy(outSettingDetail->stringValue, tmp, RCDEVICE_PROTOCOL_MAX_STRING_LENGTH);
+        sbufAdvance(buf, strlen(outSettingDetail->stringValue) + 1);
+    }
+        break;
+    case RCDEVICE_PROTOCOL_SETTINGTYPE_UNKNOWN:
+        break;
+    }
+
+    return true;
+}
+
+static bool runcamDeviceGetResponseWithMultipleChunk(runcamDevice_t *device, uint8_t command, uint8_t settingID, uint8_t *responseData, uint16_t *responseDatalen)
+{
+    if (responseData == NULL || responseDatalen == NULL) {
+        return false;
+    }
+
+    // fill parameters buf
+    uint8_t paramsBuf[2];
+    uint8_t chunkIndex = 0;
+    paramsBuf[0] = settingID; // parent setting id
+    paramsBuf[1] = chunkIndex; // chunk index
+
+    uint8_t outputBufLen = RCDEVICE_PROTOCOL_MAX_PACKET_SIZE;
+    uint8_t outputBuf[RCDEVICE_PROTOCOL_MAX_PACKET_SIZE];
+    bool result = runcamDeviceSendRequestAndWaitingResp(device, command, paramsBuf, sizeof(paramsBuf), outputBuf, &outputBufLen);
+    if (!result) {
+        return false;
+    }
+
+    uint8_t remainingChunk = outputBuf[1];
+    // Every response chunk count must less than or equal to RCDEVICE_PROTOCOL_MAX_CHUNK_PER_RESPONSE
+    if (remainingChunk >= RCDEVICE_PROTOCOL_MAX_CHUNK_PER_RESPONSE) {
+        return false;
+    }
+
+    // save setting data to sbuf_t object
+    const uint16_t maxDataLen = RCDEVICE_PROTOCOL_MAX_CHUNK_PER_RESPONSE * RCDEVICE_PROTOCOL_MAX_DATA_SIZE;
+    // uint8_t data[maxDataLen];
+    sbuf_t dataBuf;
+    dataBuf.ptr = responseData;
+    dataBuf.end = responseData + maxDataLen;
+    sbufWriteData(&dataBuf, outputBuf + 3, outputBufLen - 4);
+
+    // get the remaining chunks
+    while (remainingChunk > 0) {
+        paramsBuf[1] = ++chunkIndex; // chunk index
+
+        outputBufLen = RCDEVICE_PROTOCOL_MAX_PACKET_SIZE;
+        result = runcamDeviceSendRequestAndWaitingResp(device, command, paramsBuf, sizeof(paramsBuf), outputBuf, &outputBufLen);
+
+        if (!result) {
+            return false;
+        }
+
+        // append the trailing chunk to the sbuf_t object,
+        // but only append the actually setting data
+        sbufWriteData(&dataBuf, outputBuf + 3, outputBufLen - 4);
+
+        remainingChunk--;
+    }
+
+    sbufSwitchToReader(&dataBuf, responseData);
+    *responseDatalen = sbufBytesRemaining(&dataBuf);
+
+    return true;
+}
+
+// get the setting details with setting id
+// after this function called, the setting detail will fill into
+// outSettingDetail argument
+bool runcamDeviceGetSettingDetail(runcamDevice_t *device, uint8_t settingID, runcamDeviceSettingDetail_t *outSettingDetail)
+{
+    if (outSettingDetail == NULL)
+        return false;
+
+    uint16_t responseDataLength = 0;
+    uint8_t data[RCDEVICE_PROTOCOL_MAX_CHUNK_PER_RESPONSE * RCDEVICE_PROTOCOL_MAX_DATA_SIZE];
+    if (!runcamDeviceGetResponseWithMultipleChunk(device, RCDEVICE_PROTOCOL_COMMAND_READ_SETTING_DETAIL, settingID, data, &responseDataLength)) {
+        return false;
+    }
+
+    sbuf_t dataBuf;
+    dataBuf.ptr = data;
+    dataBuf.end = data + responseDataLength;
+
+    // parse the settings data and convert them into a runcamDeviceSettingDetail_t
+    if (!runcamDeviceDecodeSettingDetail(&dataBuf, outSettingDetail)) {
+        return false;
+    }
+
+    return true;
+}
+
+// write new value with to the setting
+bool runcamDeviceWriteSetting(runcamDevice_t *device, uint8_t settingID, uint8_t *paramData, uint8_t paramDataLen, runcamDeviceWriteSettingResponse_t *response)
+{
+    if (response == NULL || paramDataLen > (RCDEVICE_PROTOCOL_MAX_DATA_SIZE - 1)) {
+        return false;
+    }
+
+    memset(response, 0, sizeof(runcamDeviceWriteSettingResponse_t));
+    response->resultCode = 1; // initialize the result code to failed 
+
+    uint8_t paramsBufLen = sizeof(uint8_t) + paramDataLen;
+    uint8_t paramsBuf[RCDEVICE_PROTOCOL_MAX_DATA_SIZE];
+    paramsBuf[0] = settingID;
+    memcpy(paramsBuf + 1, paramData, paramDataLen);
+
+    uint8_t outputBufLen = RCDEVICE_PROTOCOL_MAX_PACKET_SIZE;
+    uint8_t outputBuf[RCDEVICE_PROTOCOL_MAX_PACKET_SIZE];
+    bool result = runcamDeviceSendRequestAndWaitingResp(device, RCDEVICE_PROTOCOL_COMMAND_WRITE_SETTING, paramsBuf, paramsBufLen, outputBuf, &outputBufLen);
+    if (!result) {
+        return false;
+    }
+
+    response->resultCode = outputBuf[1];
+    response->needUpdateMenuItems = outputBuf[2];
+
+    return true;
+}
+
 #endif

--- a/src/main/io/rcdevice.h
+++ b/src/main/io/rcdevice.h
@@ -205,4 +205,4 @@ bool runcamDeviceSimulate5KeyOSDCableButtonRelease(runcamDevice_t *device);
 
 // Device Setting Access
 bool runcamDeviceGetSettingDetail(runcamDevice_t *device, uint8_t settingID, runcamDeviceSettingDetail_t *outSettingDetail);
-bool runcamDeviceWriteSetting(runcamDevice_t *device, uint8_t settingID, uint8_t *data, uint8_t dataLen, runcamDeviceWriteSettingResponse_t *response);
+bool runcamDeviceWriteSetting(runcamDevice_t *device, uint8_t settingID, const void *data, uint8_t dataLen, runcamDeviceWriteSettingResponse_t *response);

--- a/src/main/io/rcdevice.h
+++ b/src/main/io/rcdevice.h
@@ -27,6 +27,11 @@
 #define RCDEVICE_PROTOCOL_MAX_PACKET_SIZE                           64
 #define RCDEVICE_PROTOCOL_MAX_DATA_SIZE                             62
 #define RCDEVICE_PROTOCOL_MAX_DATA_SIZE_WITH_CRC_FIELD              63
+#define RCDEVICE_PROTOCOL_MAX_SETTING_NAME_LENGTH                   20
+#define RCDEVICE_PROTOCOL_MAX_SETTING_VALUE_LENGTH                  20
+#define RCDEVICE_PROTOCOL_MAX_CHUNK_PER_RESPONSE                    12
+#define RCDEVICE_PROTOCOL_MAX_TEXT_SELECTIONS                       30
+#define RCDEVICE_PROTOCOL_MAX_STRING_LENGTH                         58
 
 // Commands
 #define RCDEVICE_PROTOCOL_COMMAND_GET_DEVICE_INFO                   0x00
@@ -36,6 +41,9 @@
 #define RCDEVICE_PROTOCOL_COMMAND_5KEY_SIMULATION_PRESS             0x02
 #define RCDEVICE_PROTOCOL_COMMAND_5KEY_SIMULATION_RELEASE           0x03
 #define RCDEVICE_PROTOCOL_COMMAND_5KEY_CONNECTION                   0x04
+// device setting access
+#define RCDEVICE_PROTOCOL_COMMAND_READ_SETTING_DETAIL               0x11
+#define RCDEVICE_PROTOCOL_COMMAND_WRITE_SETTING                     0x13
 
 // Feature Flag sets, it's a uint16_t flag
 typedef enum {
@@ -43,6 +51,8 @@ typedef enum {
     RCDEVICE_PROTOCOL_FEATURE_SIMULATE_WIFI_BUTTON     = (1 << 1),
     RCDEVICE_PROTOCOL_FEATURE_CHANGE_MODE              = (1 << 2),
     RCDEVICE_PROTOCOL_FEATURE_SIMULATE_5_KEY_OSD_CABLE = (1 << 3),
+    RCDEVICE_PROTOCOL_FEATURE_DEVICE_SETTINGS_ACCESS   = (1 << 4),
+    RCDEVICE_PROTOCOL_FEATURE_ADVANCE_CAM_CONTROL      = (1 << 6),
 } rcdevice_features_e;
 
 // Operation of Camera Button Simulation
@@ -50,6 +60,13 @@ typedef enum {
     RCDEVICE_PROTOCOL_CAM_CTRL_SIMULATE_WIFI_BTN        = 0x00,
     RCDEVICE_PROTOCOL_CAM_CTRL_SIMULATE_POWER_BTN       = 0x01,
     RCDEVICE_PROTOCOL_CAM_CTRL_CHANGE_MODE              = 0x02,
+    RCDEVICE_PROTOCOL_CAM_CTRL_START_RECORDING          = 0x03, // RCDEVICE_PROTOCOL_FEATURE_ADVANCE_CAM_CONTROL required
+    RCDEVICE_PROTOCOL_CAM_CTRL_STOP_RECORDING           = 0x04, // RCDEVICE_PROTOCOL_FEATURE_ADVANCE_CAM_CONTROL required
+    RCDEVICE_PROTOCOL_CAM_CTRL_TAKE_A_PHOTO             = 0X05, // RCDEVICE_PROTOCOL_FEATURE_ADVANCE_CAM_CONTROL required
+    RCDEVICE_PROTOCOL_CAM_CTRL_TURN_ON_WIFI             = 0X06, // RCDEVICE_PROTOCOL_FEATURE_ADVANCE_CAM_CONTROL required
+    RCDEVICE_PROTOCOL_CAM_CTRL_TURN_OFF_WIFI            = 0X07, // RCDEVICE_PROTOCOL_FEATURE_ADVANCE_CAM_CONTROL required
+    RCDEVICE_PROTOCOL_CAM_CTRL_OPEN_OSD_SETTING         = 0X08, // RCDEVICE_PROTOCOL_FEATURE_ADVANCE_CAM_CONTROL required
+    RCDEVICE_PROTOCOL_CAM_CTRL_CLOSE_OSD_SETTING        = 0X09, // RCDEVICE_PROTOCOL_FEATURE_ADVANCE_CAM_CONTROL required
     RCDEVICE_PROTOCOL_CAM_CTRL_UNKNOWN_CAMERA_OPERATION = 0xFF
 } rcdevice_camera_control_opeation_e;
 
@@ -89,15 +106,43 @@ typedef enum {
     RCDEVICE_PROTOCOL_UNKNOWN
 } rcdevice_protocol_version_e;
 
-typedef struct runcamDeviceConnectionEventResponse_s {
-    uint8_t type : 4;
-    uint8_t resultCode : 4;
-} runcamDeviceConnectionEventResponse_t;
+// Reserved setting ids
+typedef enum {
+    RCDEVICE_PROTOCOL_SETTINGID_DISP_CHARSET                = 0, // type: text_selection, read&write, 0: use charset with betaflight logo, 1 use
+                                                                 // charset with cleanflight logo, other id are not used
+    RCDEVICE_PROTOCOL_SETTINGID_DISP_COLUMNS                = 1, // type: uint8_t, read only, the column count of the OSD layer
+    RCDEVICE_PROTOCOL_SETTINGID_DISP_TV_MODE                = 2, // type: text_selection, read&write, 0:NTSC, 1:PAL
+    RCDEVICE_PROTOCOL_SETTINGID_SDCARD_CAPACITY             = 3, // type: info, read only, return sd card capacity
+    RCDEVICE_PROTOCOL_SETTINGID_REMAINING_RECORDING_TIME    = 4, // type: info, read only, return remaining recording time
+    RCDEVICE_PROTOCOL_SETTINGID_RESOLUTION                  = 5, // type: text selection, read&write, return the current resolution and all available resolutions
+    RCDEVICE_PROTOCOL_SETTINGID_CAMERA_TIME                 = 6, // type: string, read&write, update the camera time, the time attribute of  medias file in camera will use this time.
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED7                   = 7,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED8                   = 8,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED9                   = 9,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED10                  = 10,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED11                  = 11,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED12                  = 12,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED13                  = 13,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED14                  = 14,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED15                  = 15,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED16                  = 16,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED17                  = 17,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED18                  = 18,
+    RCDEVICE_PROTOCOL_SETTINGID_RESERVED19                  = 19,
+} rcdeviceReservedSettingID_e;
 
-typedef struct runcamDeviceGetDeviceInfoResponse_s {
-    uint8_t protocolVersion;
-    uint16_t features;
-} runcamDeviceGetDeviceInfoResponse_t;
+typedef enum {
+    RCDEVICE_PROTOCOL_SETTINGTYPE_UINT8          = 0,
+    RCDEVICE_PROTOCOL_SETTINGTYPE_INT8           = 1,
+    RCDEVICE_PROTOCOL_SETTINGTYPE_UINT16         = 2,
+    RCDEVICE_PROTOCOL_SETTINGTYPE_INT16          = 3,
+    RCDEVICE_PROTOCOL_SETTINGTYPE_FLOAT          = 8,
+    RCDEVICE_PROTOCOL_SETTINGTYPE_TEXT_SELECTION = 9,
+    RCDEVICE_PROTOCOL_SETTINGTYPE_STRING         = 10,
+    RCDEVICE_PROTOCOL_SETTINGTYPE_FOLDER         = 11,
+    RCDEVICE_PROTOCOL_SETTINGTYPE_INFO           = 12,
+    RCDEVICE_PROTOCOL_SETTINGTYPE_UNKNOWN
+} rcdeviceSettingType_e;
 // end of Runcam Device definition
 
 // Old version defination(RCSplit firmware v1.0.0 and v1.1.0)
@@ -126,6 +171,27 @@ typedef struct runcamDevice_s {
     runcamDeviceInfo_t info;
 } runcamDevice_t;
 
+typedef struct runcamDeviceSettingTextSelection_s {
+    char text[RCDEVICE_PROTOCOL_MAX_SETTING_VALUE_LENGTH];
+} runcamDeviceSettingTextSelection_t;
+
+typedef struct runcamDeviceSettingDetail_s {
+    uint8_t type;
+    uint32_t value;
+    uint32_t minValue;
+    uint32_t maxValue;
+    uint8_t decimalPoint;
+    uint32_t stepSize;
+    uint8_t maxStringSize;
+    char stringValue[RCDEVICE_PROTOCOL_MAX_STRING_LENGTH]; // when settingType is RCDEVICE_PROTOCOL_SETTINGTYPE_INFO or RCDEVICE_PROTOCOL_SETTINGTYPE_STRING, this field store the string/info value;
+    runcamDeviceSettingTextSelection_t textSelections[RCDEVICE_PROTOCOL_MAX_TEXT_SELECTIONS];
+} runcamDeviceSettingDetail_t;
+
+typedef struct runcamDeviceWriteSettingResponse_s {
+    uint8_t resultCode;
+    uint8_t needUpdateMenuItems;
+} runcamDeviceWriteSettingResponse_t;
+
 bool runcamDeviceInit(runcamDevice_t *device);
 
 // camera button simulation
@@ -136,3 +202,7 @@ bool runcamDeviceOpen5KeyOSDCableConnection(runcamDevice_t *device);
 bool runcamDeviceClose5KeyOSDCableConnection(runcamDevice_t *device);
 bool runcamDeviceSimulate5KeyOSDCableButtonPress(runcamDevice_t *device, uint8_t operation);
 bool runcamDeviceSimulate5KeyOSDCableButtonRelease(runcamDevice_t *device);
+
+// Device Setting Access
+bool runcamDeviceGetSettingDetail(runcamDevice_t *device, uint8_t settingID, runcamDeviceSettingDetail_t *outSettingDetail);
+bool runcamDeviceWriteSetting(runcamDevice_t *device, uint8_t settingID, uint8_t *data, uint8_t dataLen, runcamDeviceWriteSettingResponse_t *response);

--- a/src/main/io/rcdevice_cam.c
+++ b/src/main/io/rcdevice_cam.c
@@ -20,7 +20,9 @@
 #include <stddef.h>
 
 #include "cms/cms.h"
+
 #include "common/utils.h"
+
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
 

--- a/src/main/io/rcdevice_cam.c
+++ b/src/main/io/rcdevice_cam.c
@@ -95,10 +95,8 @@ static void rcdeviceCameraUpdateTime(void)
     static int retries = 0;
     runcamDeviceWriteSettingResponse_t updateSettingResponse;
     // Format is yyyyMMddThhmmss.0 plus null terminator, hence 18
-    // characters. However, the camera expects each character in
-    // an uint16_t, that's why we use two buffers.
+    // characters.
     char buf[18];
-    uint16_t payload[18] = {0x31, 0x39, 0x37, 0x32, 0x30, 0x32, 0x31, 0x36, 0x54, 0x31, 0x39, 0x31, 0x35, 0x33, 0x32, 0x2E, 0x30, 0x00};
     dateTime_t dt;
 
     debug[0] = isFeatureSupported(RCDEVICE_PROTOCOL_FEATURE_DEVICE_SETTINGS_ACCESS);
@@ -107,18 +105,14 @@ static void rcdeviceCameraUpdateTime(void)
         !hasSynchronizedTime && retries < 1) {
 
         if (rtcGetDateTime(&dt)) {
-            last_try = millis();
+            timeMs_t last_try = millis();
             retries++;
             tfp_sprintf(buf, "%04d%02d%02dT%02d%02d%02d.0",
                 dt.year, dt.month, dt.day,
                 dt.hours, dt.minutes, dt.seconds);
 
-            for (unsigned ii = 0; ii < sizeof(buf); ii++) {
-                payload[ii] = buf[ii];
-            }
-
             bool ok = runcamDeviceWriteSetting(camDevice, RCDEVICE_PROTOCOL_SETTINGID_CAMERA_TIME,
-                                                payload, sizeof(payload), &updateSettingResponse);
+                buf, sizeof(buf), &updateSettingResponse);
             debug[1] = ok ? 1 : 2;
             debug[2] = updateSettingResponse.resultCode;
             if (ok && updateSettingResponse.resultCode == 0) {

--- a/src/main/io/rcdevice_cam.c
+++ b/src/main/io/rcdevice_cam.c
@@ -19,8 +19,6 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include "build/debug.h"
-
 #include "cms/cms.h"
 
 #include "common/printf.h"
@@ -99,13 +97,10 @@ static void rcdeviceCameraUpdateTime(void)
     char buf[18];
     dateTime_t dt;
 
-    debug[0] = isFeatureSupported(RCDEVICE_PROTOCOL_FEATURE_DEVICE_SETTINGS_ACCESS);
-
     if (isFeatureSupported(RCDEVICE_PROTOCOL_FEATURE_DEVICE_SETTINGS_ACCESS) &&
-        !hasSynchronizedTime && retries < 1) {
+        !hasSynchronizedTime && retries < 3) {
 
         if (rtcGetDateTime(&dt)) {
-            timeMs_t last_try = millis();
             retries++;
             tfp_sprintf(buf, "%04d%02d%02dT%02d%02d%02d.0",
                 dt.year, dt.month, dt.day,
@@ -113,11 +108,8 @@ static void rcdeviceCameraUpdateTime(void)
 
             bool ok = runcamDeviceWriteSetting(camDevice, RCDEVICE_PROTOCOL_SETTINGID_CAMERA_TIME,
                 buf, sizeof(buf), &updateSettingResponse);
-            debug[1] = ok ? 1 : 2;
-            debug[2] = updateSettingResponse.resultCode;
             if (ok && updateSettingResponse.resultCode == 0) {
                 hasSynchronizedTime = true;
-                debug[3] = 42;
             }
         }
     }


### PR DESCRIPTION
- Add functions for accessing settings in RC devices like the RC split
- Synchronize FC time with RC device time the possible, to allow properly timestamped files in the RC split

Supersedes #2435