### PR TITLE
Implement MSP2_INAV_STATUS

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -355,6 +355,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         }
         break;
 
+    case MSP2_INAV_STATUS:
     case MSP_STATUS_EX:
     case MSP_STATUS:
         {
@@ -371,9 +372,12 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
             sbufWriteData(dst, &mspBoxModeFlags, 4);
             sbufWriteU8(dst, getConfigProfile());
 
-            if (cmdMSP == MSP_STATUS_EX) {
+            if (cmdMSP != MSP_STATUS) {
                 sbufWriteU16(dst, averageSystemLoadPercent);
-                sbufWriteU16(dst, armingFlags);
+                if (cmdMSP == MSP2_INAV_STATUS)
+                    sbufWriteU32(dst, armingFlags);
+                else
+                    sbufWriteU16(dst, armingFlags);
                 sbufWriteU8(dst, accGetCalibrationAxisFlags());
             }
         }
@@ -1099,13 +1103,13 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
 
                 uint8_t band=0, channel=0;
                 vtxCommonGetBandAndChannel(&band,&channel);
-                
+
                 uint8_t powerIdx=0; // debug
                 vtxCommonGetPowerIndex(&powerIdx);
-                
+
                 uint8_t pitmode=0;
                 vtxCommonGetPitMode(&pitmode);
-                
+
                 sbufWriteU8(dst, deviceType);
                 sbufWriteU8(dst, band);
                 sbufWriteU8(dst, channel);

--- a/src/main/msp/msp_protocol_v2_inav.h
+++ b/src/main/msp/msp_protocol_v2_inav.h
@@ -15,4 +15,7 @@
  * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//#define MSP2_INAV_STATUS            0x1000
+// iNav specific IDs start from 0x2000
+// See https://github.com/iNavFlight/inav/wiki/MSP-V2#msp-v2-message-catalogue
+
+#define MSP2_INAV_STATUS            0x2000


### PR DESCRIPTION
Implement MSP2_INAV_STATUS as an improved MSP_STATUS_EX, providing a 32 bit armingFlags (no other changes). This provides MSP consumers with the full range of arming status, rather than just the first 16 bits in MSP_STATUS_EX.