### PR TITLE
Improve build system error handling

### DIFF
--- a/src/utils/compiler.rb
+++ b/src/utils/compiler.rb
@@ -75,13 +75,14 @@ class Compiler
         return args
     end
 
-    def run(input, output, args = nil)
+    def run(input, output, args = nil, options = { noerror: false })
         all_args = default_args
         if args
             all_args.push(*args)
         end
         all_args << "-o" << output << input
-        stdout, stderr = Open3.capture3(join_args(all_args))
+        stdout, stderr, compile_status = Open3.capture3(join_args(all_args))
+	raise "Compiler error:\n#{all_args.join(' ')}\n#{stderr}" if not options[:noerror] and not compile_status.success?
         return stdout, stderr
     end
 

--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -651,7 +651,7 @@ class Generator
             file = File.join(dir, "test.cpp")
             File.open(file, 'w') {|file| file.write(buf.string)}
             dputs "Compiling #{buf.string}"
-            stdout, stderr = @compiler.run(file, File.join(dir, "test"))
+            stdout, stderr = @compiler.run(file, File.join(dir, "test"), '-c', noerror: true)
             dputs "Output: #{stderr}"
             stderr
         end


### PR DESCRIPTION
When I was trying to compile the code on a new computer I had an error because the stamp.cpp compilation failed. I was missing the `arm-none-eabi-newlib` package on Fedora but the error was less than obvious:

> ./src/utils/build_stamp.rb:68:in 'delete': No such file or directory @ unlink_internal - ./obj/stamp (Errno::ENOENT)
>	from ./src/utils/build_stamp.rb:68:in 'hash_config'
>	from ./src/utils/build_stamp.rb:44:in 'stamp'
>	from ./src/utils/build_stamp.rb:87:in 'main'
> make: *** [Makefile:956: obj/build.stamp] Error 1

With this patch we can see that the error was caused by the missing stdint.h file:

> iNav/src/utils/compiler.rb:89:in 'run': Compile error: (RuntimeError)
> /usr/bin/arm-none-eabi-g++ -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant -Wdouble-promotion -flto -fuse-linker-plugin -Os -I./src/main -I./src/main/target -I./lib/main/STM32F30x_StdPeriph_Driver/inc -I./lib/main/CMSIS/CM1/CoreSupport -I./lib/main/CMSIS/CM1/DeviceSupport/ST/STM32F30x -I./lib/main/STM32_USB-FS-Device_Driver/inc -I./src/main/vcp -I./lib/main/FatFS -I./lib/main/MAVLink -I./src/main/target/OMNIBUS -ggdb3 -DDEBUG -std=c++11 -Wall -Wextra -Wunsafe-loop-optimizations -Wdouble-promotion -ffunction-sections -fdata-sections -DSTM32F303xC -DSTM32F303 -DFLASH_SIZE=256 -DHSE_VALUE=8000000 -DUSE_STDPERIPH_DRIVER -DOMNIBUS -D__FORKNAME__=inav -D__TARGET__=OMNIBUS -D__REVISION__=0f1975ce -dM -E -o ./obj/stamp ./obj/stamp.cpp
> In file included from ./lib/main/CMSIS/CM1/CoreSupport/core_cm4.h:34:0,
>                 from ./lib/main/CMSIS/CM1/DeviceSupport/ST/STM32F30x/stm32f30x.h:364,
>                 from ./lib/main/STM32F30x_StdPeriph_Driver/inc/stm32f30x_adc.h:38,
>                 from ./lib/main/CMSIS/CM1/DeviceSupport/ST/STM32F30x/stm32f30x_conf.h:34,
>                 from ./src/main/platform.h:51,
>                 from ./obj/stamp.cpp:2:
> /usr/lib/gcc/arm-none-eabi/7.1.0/include/stdint.h:9:16: fatal error: stdint.h: No such file or directory  # include_next stdint.h
>                ^~~~~~~~~~
> compilation terminated.
>	from ./src/utils/build_stamp.rb:66:in 'hash_config'
>	from ./src/utils/build_stamp.rb:44:in 'stamp'
>	from ./src/utils/build_stamp.rb:87:in 'main'
> make: *** [Makefile:956: obj/build.stamp] Error 1