### PR TITLE
Update fc_core.c

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -179,8 +179,11 @@ static void updateArmingStatus(void)
         /* CHECK: Throttle */
         if (calculateThrottleStatus() != THROTTLE_LOW) {
             ENABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
-        } else {
+        } else if (armingFlags & ARMING_DISABLED_THROTTLE ){ //Previous Throttle Not LOW- kbi
             DISABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
+            if ( (armingFlags & ARMING_DISABLED_ALL_FLAGS)==ARMING_DISABLED_ARM_SWITCH && IS_RC_MODE_ACTIVE(BOXARM)  ){
+                DISABLE_ARMING_FLAG(ARMING_DISABLED_ARM_SWITCH);  //Arm Now That Throttle is Fixed and No Other Flags Set
+            }
         }
 
         /* CHECK: Angle */


### PR DESCRIPTION
Address issue #2120 and now works as follows:
#1. The FC will immediately arm when the arm switch is enabled and no disarm flags are set.

#2. If the arm switch is enabled and the throttle disarm flag is set the FC will now arm when the throttle disarm flag is cleared provided that no other disarm flags are set.

#3. If the arm switch is enabled and all disarm flags are subsequently cleared and the throttle disarm flag is NOT the last flag cleared, the arm switch must be toggled to arm the FC.