### PR TITLE
Fixing missing initializer for field GCC compilation warnings 

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -87,9 +87,11 @@ static const char * const saPowerNames[] = {
 static const vtxVTable_t saVTable;    // Forward
 static vtxDevice_t vtxSmartAudio = {
     .vTable = &saVTable,
-    .capability.bandCount = 5,
-    .capability.channelCount = 8,
-    .capability.powerCount = 4,
+    .capability = {
+        .bandCount = 5,
+        .channelCount = 8,
+        .powerCount = 4,
+    },
     .bandNames = (char **)vtx58BandNames,
     .channelNames = (char **)vtx58ChannelNames,
     .powerNames = (char **)saPowerNames,

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -54,9 +54,11 @@ static const char * const trampPowerNames[] = {
 static const vtxVTable_t trampVTable; // forward
 static vtxDevice_t vtxTramp = {
     .vTable = &trampVTable,
-    .capability.bandCount = 5,
-    .capability.channelCount = 8,
-    .capability.powerCount = sizeof(trampPowerTable),
+    .capability = {
+        .bandCount = 5,
+        .channelCount = 8,
+        .powerCount = sizeof(trampPowerTable),
+    },
     .bandNames = (char **)vtx58BandNames,
     .channelNames = (char **)vtx58ChannelNames,
     .powerNames = (char **)trampPowerNames,


### PR DESCRIPTION
This change fixes a series of warnings about missing initializers like the following:

%% vtx_smartaudio.c 
./src/main/io/vtx_smartaudio.c:91:5: warning: missing initializer for field 'channelCount' of 'vtxDeviceCapability_t' [-Wmissing-field-initializers]
     .capability.channelCount = 8,

Full list of errors here:

[VTX field initalization Warnings.txt](https://github.com/iNavFlight/inav/files/1438167/VTX.field.initalization.Warnings.txt)