### PR TITLE
Allow arming in 3D mode at full negative thrust

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -178,12 +178,18 @@ static void updateArmingStatus(void)
         }
 
         /* CHECK: Throttle */
-        if (!armingConfig()->fixed_wing_auto_arm) {
+        if (STATE(FIXED_WING) && armingConfig()->fixed_wing_auto_arm) {
             // Don't want this check if fixed_wing_auto_arm is in use - machine arms on throttle > LOW
-            if (calculateThrottleStatus() != THROTTLE_LOW) {
-                ENABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
-            } else {
+            DISABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
+        }
+        else {
+            const throttleStatus_e throttleStatus = calculateThrottleStatus();
+
+            // Allow arming when throttle is low (neutral in 3D mode) or if at full negative thrust in 3D mode
+            if ((throttleStatus == THROTTLE_LOW) || (feature(FEATURE_3D) && throttleStatus == THROTTLE_FULL_NEGATIVE)) {
                 DISABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
+            } else {
+                ENABLE_ARMING_FLAG(ARMING_DISABLED_THROTTLE);
             }
         }
 

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -93,12 +93,21 @@ bool areSticksInApModePosition(uint16_t ap_mode)
 throttleStatus_e calculateThrottleStatus(void)
 {
     const uint16_t deadband3d_throttle = rcControlsConfig()->deadband3d_throttle;
-    if (feature(FEATURE_3D) && (rcData[THROTTLE] > (rxConfig()->midrc - deadband3d_throttle) && rcData[THROTTLE] < (rxConfig()->midrc + deadband3d_throttle)))
-        return THROTTLE_LOW;
-    else if (!feature(FEATURE_3D) && (rcData[THROTTLE] < rxConfig()->mincheck))
-        return THROTTLE_LOW;
+    if (feature(FEATURE_3D)) {
+        if (rcData[THROTTLE] > (rxConfig()->midrc - deadband3d_throttle) && rcData[THROTTLE] < (rxConfig()->midrc + deadband3d_throttle)) {
+            return THROTTLE_LOW;
+        }
+        else if (rcData[THROTTLE] < rxConfig()->mincheck) {
+            return THROTTLE_FULL_NEGATIVE;
+        }
+    }
+    else {
+        if (rcData[THROTTLE] < rxConfig()->mincheck) {
+            return THROTTLE_LOW;
+        }
+    }
 
-    return THROTTLE_HIGH;
+    return THROTTLE_NOTLOW;
 }
 
 rollPitchStatus_e calculateRollPitchCenterStatus(void)

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -35,8 +35,9 @@ typedef enum rc_alias {
 } rc_alias_e;
 
 typedef enum {
-    THROTTLE_LOW = 0,
-    THROTTLE_HIGH
+    THROTTLE_LOW = 0,           // Zero throttle
+    THROTTLE_NOTLOW,           // Throttle above zero (or below zero in 3D mode)
+    THROTTLE_FULL_NEGATIVE,     // Throttle at full negative (only in 3D mode)
 } throttleStatus_e;
 
 typedef enum {

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -356,7 +356,7 @@ void failsafeUpdateState(void)
             case FAILSAFE_IDLE:
                 if (armed) {
                     // Track throttle command below minimum time
-                    if (THROTTLE_HIGH == calculateThrottleStatus()) {
+                    if (calculateThrottleStatus() != THROTTLE_LOW) {
                         failsafeState.throttleLowPeriod = millis() + failsafeConfig()->failsafe_throttle_low_delay * MILLIS_PER_TENTH_SECOND;
                     }
                     if (!receivingRxDataAndNotFailsafeMode) {


### PR DESCRIPTION
Work in progress. Easier arming in 3D mode. Allow arming when throttle is at full negative
References #2120, #2449

@KenImhof can you please have a look?