### PR TITLE
Add AGL altitude estimation

### DIFF
--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -53,5 +53,6 @@ typedef enum {
     DEBUG_RANGEFINDER,
     DEBUG_RANGEFINDER_QUALITY,
     DEBUG_PITOT,
+    DEBUG_AGL,
     DEBUG_COUNT
 } debugType_e;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -66,7 +66,7 @@ tables:
   - name: i2c_speed
     values: ["400KHZ", "800KHZ", "100KHZ", "200KHZ"]
   - name: debug_modes
-    values: ["NONE", "GYRO", "NOTCH", "NAV_LANDING", "FW_ALTITUDE", "RFIND", "RFIND_Q", "PITOT"]
+    values: ["NONE", "GYRO", "NOTCH", "NAV_LANDING", "FW_ALTITUDE", "RFIND", "RFIND_Q", "PITOT", "AGL"]
   - name: async_mode
     values: ["NONE", "GYRO", "ALL"]
   - name: aux_operator

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -422,7 +422,7 @@ static void applyMulticopterPositionController(timeUs_t currentTimeUs)
 
     // Apply controller only if position source is valid. In absence of valid pos sensor (GPS loss), we'd stick in forced ANGLE mode
     // and pilots input would be passed thru to PID controller
-    if (posControl.flags.hasValidPositionSensor) {
+    if ((posControl.flags.estPosStatue >= EST_USABLE)) {
         // If we have new position - update velocity and acceleration controllers
         if (posControl.flags.horizontalPositionDataNew) {
             const timeDelta_t deltaMicrosPositionUpdate = currentTimeUs - previousTimePositionUpdate;
@@ -509,7 +509,7 @@ bool isMulticopterLandingDetected(void)
     }
 
     // If we have surface sensor (for example sonar) - use it to detect touchdown
-    if (posControl.flags.hasValidSurfaceSensor && posControl.actualState.surfaceMin >= 0) {
+    if ((posControl.flags.estSurfaceStatus == EST_TRUSTED) && (posControl.actualState.surfaceMin >= 0)) {
         // TODO: Come up with a clever way to let sonar increase detection performance, not just add extra safety.
         // TODO: Out of range sonar may give reading that looks like we landed, find a way to check if sonar is healthy.
         // surfaceMin is our ground reference. If we are less than 5cm above the ground - we are likely landed
@@ -540,9 +540,7 @@ static void applyMulticopterEmergencyLandingController(timeUs_t currentTimeUs)
     rcCommand[PITCH] = 0;
     rcCommand[YAW] = 0;
 
-    if (posControl.flags.hasValidAltitudeSensor) {
-        /* We have an altitude reference, apply AH-based landing controller */
-
+    if ((posControl.flags.estAltStatus >= EST_USABLE)) {
         // If last position update was too long in the past - ignore it (likely restarting altitude controller)
         if (deltaMicros > HZ2US(MIN_POSITION_UPDATE_RATE_HZ)) {
             previousTimeUpdate = currentTimeUs;

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -966,7 +966,8 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
         }
     }
     else {
-        posEstimator.est.aglVel = 0;
+        posEstimator.est.aglAlt = posEstimator.est.pos.V.Z - posEstimator.est.aglOffset;
+        posEstimator.est.aglVel = posEstimator.est.vel.V.Z;
         posEstimator.est.aglQual = SURFACE_QUAL_LOW;
     }
 #else
@@ -1007,6 +1008,13 @@ static void publishEstimatedTopic(timeUs_t currentTimeUs)
             updateActualAltitudeAndClimbRate(false, posEstimator.est.pos.V.Z, 0);
             updateActualAGLAndClimgRate(false, false, posEstimator.est.aglAlt, 0);
         }
+
+#if defined(NAV_BLACKBOX)
+        DEBUG_SET(DEBUG_AGL, 0, posEstimator.surface.reliability * 1000);
+        DEBUG_SET(DEBUG_AGL, 1, posEstimator.est.aglQual);
+        DEBUG_SET(DEBUG_AGL, 2, posEstimator.est.aglAlt);
+        DEBUG_SET(DEBUG_AGL, 3, posEstimator.est.aglVel);
+#endif
 
         /* Store history data */
         posEstimator.history.pos[posEstimator.history.index] = posEstimator.est.pos;

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -109,9 +109,16 @@ typedef struct {
     float       airspeed;            // airspeed (cm/s)
 } navPositionEstimatorPITOT_t;
 
+typedef enum {
+    SURFACE_QUAL_LOW,   // Surface sensor signal lost long ago - most likely surface distance is incorrect
+    SURFACE_QUAL_MID,   // Surface sensor is not available but we can somewhat trust the estimate
+    SURFACE_QUAL_HIGH   // All good
+} navAGLEstimateQuality_e;
+
 typedef struct {
     timeUs_t    lastUpdateTime; // Last update time (us)
     float       alt;            // Raw altitude measurement (cm)
+    float       reliability;
 } navPositionEstimatorSURFACE_t;
 
 typedef struct {
@@ -124,15 +131,18 @@ typedef struct {
 
 typedef struct {
     timeUs_t    lastUpdateTime; // Last update time (us)
+
     // 3D position, velocity and confidence
     t_fp_vector pos;
     t_fp_vector vel;
     float       eph;
     float       epv;
-    // Surface offset
-    float       surface;
-    float       surfaceVel;
-    bool        surfaceValid;
+
+    // AGL
+    navAGLEstimateQuality_e aglQual;
+    float                   aglOffset;  // Offset between surface and pos.Z
+    float                   aglAlt;
+    float                   aglVel;
 } navPositionEstimatorESTIMATE_t;
 
 typedef struct {
@@ -484,11 +494,39 @@ static void updatePitotTopic(timeUs_t currentTimeUs)
  * Read surface and update alt/vel topic
  *  Function is called from TASK_RANGEFINDER at arbitrary rate - as soon as new measurements are available
  */
+#define RANGEFINDER_RELIABILITY_RC_CONSTANT     (0.47802f)
+#define RANGEFINDER_RELIABILITY_LIGHT_THRESHOLD (0.15f)
+#define RANGEFINDER_RELIABILITY_LOW_THRESHOLD   (0.33f)
+#define RANGEFINDER_RELIABILITY_HIGH_THRESHOLD  (0.75f)
+
 void updatePositionEstimator_SurfaceTopic(timeUs_t currentTimeUs, float newSurfaceAlt)
 {
-    if (newSurfaceAlt > 0 && newSurfaceAlt <= positionEstimationConfig()->max_surface_altitude) {
-        posEstimator.surface.alt = newSurfaceAlt;
-        posEstimator.surface.lastUpdateTime = currentTimeUs;
+    const float dt = US2S(currentTimeUs - posEstimator.surface.lastUpdateTime);
+    float newReliabilityMeasurement = 0;
+
+    posEstimator.surface.lastUpdateTime = currentTimeUs;
+
+    if (newSurfaceAlt >= 0) {
+        if (newSurfaceAlt <= positionEstimationConfig()->max_surface_altitude) {
+            newReliabilityMeasurement = 1.0f;
+            posEstimator.surface.alt = newSurfaceAlt;
+        }
+        else {
+            newReliabilityMeasurement = 0.0f;
+        }
+    }
+    else {
+        // Negative values - out of range or failed hardware
+        newReliabilityMeasurement = 0.0f;
+    }
+
+    /* Reliability is a measure of confidence of rangefinder measurement. It's increased with each valid sample and decreased with each invalid sample */
+    if (dt > 0.5f) {
+        posEstimator.surface.reliability = 0.0f;
+    }
+    else {
+        const float relAlpha = dt / (dt + RANGEFINDER_RELIABILITY_RC_CONSTANT);
+        posEstimator.surface.reliability = posEstimator.surface.reliability * (1.0f - relAlpha) + newReliabilityMeasurement * relAlpha;
     }
 }
 #endif
@@ -831,32 +869,111 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
         }
     }
 
-    /* Surface offset */
-#ifdef USE_RANGEFINDER
-    posEstimator.est.surface = posEstimator.est.surface + posEstimator.est.surfaceVel * dt;
-
-    if (isSurfaceValid) {
-        const float surfaceResidual = posEstimator.surface.alt - posEstimator.est.surface;
-        const float bellCurveScaler = scaleRangef(bellCurve(surfaceResidual, 50.0f), 0.0f, 1.0f, 0.1f, 1.0f);
-
-        posEstimator.est.surface += surfaceResidual * positionEstimationConfig()->w_z_surface_p * bellCurveScaler * dt;
-        posEstimator.est.surfaceVel += surfaceResidual * positionEstimationConfig()->w_z_surface_v * sq(bellCurveScaler) * dt;
-        posEstimator.est.surfaceValid = true;
-    }
-    else {
-        posEstimator.est.surfaceVel = 0; // Zero out velocity to prevent estimate to drift away
-        posEstimator.est.surfaceValid = false;
-    }
-
-#else
-    posEstimator.est.surface = -1;
-    posEstimator.est.surfaceVel = 0;
-    posEstimator.est.surfaceValid = false;
-#endif
-
     /* Update uncertainty */
     posEstimator.est.eph = newEPH;
     posEstimator.est.epv = newEPV;
+
+#ifdef USE_RANGEFINDER
+    /* Surface offset */
+    if (isSurfaceValid) {   // If surface topic is updated in timely manner - do something smart
+        navAGLEstimateQuality_e newAglQuality = posEstimator.est.aglQual;
+        bool resetSurfaceEstimate = false;
+        switch (posEstimator.est.aglQual) {
+            case SURFACE_QUAL_LOW:
+                if (posEstimator.surface.reliability >= RANGEFINDER_RELIABILITY_HIGH_THRESHOLD) {
+                    newAglQuality = SURFACE_QUAL_HIGH;
+                    resetSurfaceEstimate = true;
+                }
+                else if (posEstimator.surface.reliability >= RANGEFINDER_RELIABILITY_LOW_THRESHOLD) {
+                    newAglQuality = SURFACE_QUAL_LOW;
+                }
+                else {
+                    newAglQuality = SURFACE_QUAL_LOW;
+                }
+                break;
+
+            case SURFACE_QUAL_MID:
+                if (posEstimator.surface.reliability >= RANGEFINDER_RELIABILITY_HIGH_THRESHOLD) {
+                    newAglQuality = SURFACE_QUAL_HIGH;
+                }
+                else if (posEstimator.surface.reliability >= RANGEFINDER_RELIABILITY_LOW_THRESHOLD) {
+                    newAglQuality = SURFACE_QUAL_MID;
+                }
+                else {
+                    newAglQuality = SURFACE_QUAL_LOW;
+                }
+                break;
+
+            case SURFACE_QUAL_HIGH:
+                if (posEstimator.surface.reliability >= RANGEFINDER_RELIABILITY_HIGH_THRESHOLD) {
+                    newAglQuality = SURFACE_QUAL_HIGH;
+                }
+                else if (posEstimator.surface.reliability >= RANGEFINDER_RELIABILITY_LOW_THRESHOLD) {
+                    newAglQuality = SURFACE_QUAL_MID;
+                }
+                else {
+                    newAglQuality = SURFACE_QUAL_LOW;
+                }
+                break;
+        }
+
+        posEstimator.est.aglQual = newAglQuality;
+
+        if (resetSurfaceEstimate) {
+            posEstimator.est.aglAlt = posEstimator.surface.alt;
+            if (posEstimator.est.epv < positionEstimationConfig()->max_eph_epv) {
+                posEstimator.est.aglVel = posEstimator.est.vel.V.Z;
+                posEstimator.est.aglOffset = posEstimator.est.pos.V.Z - posEstimator.surface.alt;
+            }
+            else {
+                posEstimator.est.aglVel = 0;
+                posEstimator.est.aglOffset = 0;
+            }
+        }
+
+        // Update estimate
+        posEstimator.est.aglAlt = posEstimator.est.aglAlt + posEstimator.est.aglVel * dt + posEstimator.imu.accelNEU.V.Z * dt * dt * 0.5f;
+        posEstimator.est.aglVel = posEstimator.est.aglVel + posEstimator.imu.accelNEU.V.Z * dt;
+
+        // Apply correction
+        if (posEstimator.est.aglQual == SURFACE_QUAL_HIGH) {
+            // Correct estimate from rangefinder
+            const float surfaceResidual = posEstimator.surface.alt - posEstimator.est.aglAlt;
+            const float bellCurveScaler = scaleRangef(bellCurve(surfaceResidual, 50.0f), 0.0f, 1.0f, 0.1f, 1.0f);
+
+            posEstimator.est.aglAlt += surfaceResidual * positionEstimationConfig()->w_z_surface_p * bellCurveScaler * posEstimator.surface.reliability * dt;
+            posEstimator.est.aglVel += surfaceResidual * positionEstimationConfig()->w_z_surface_v * sq(bellCurveScaler) * sq(posEstimator.surface.reliability) * dt;
+
+            // Update estimate offset
+            if ((posEstimator.est.aglQual == SURFACE_QUAL_HIGH) && (posEstimator.est.epv < positionEstimationConfig()->max_eph_epv)) {
+                posEstimator.est.aglOffset = posEstimator.est.pos.V.Z - posEstimator.surface.alt;
+            }
+        }
+        else if (posEstimator.est.aglQual == SURFACE_QUAL_MID) {
+            // Correct estimate from altitude fused from rangefinder and global altitude
+            const float estAltResidual = (posEstimator.est.pos.V.Z - posEstimator.est.aglOffset) - posEstimator.est.aglAlt;
+            const float surfaceResidual = posEstimator.surface.alt - posEstimator.est.aglAlt;
+            const float surfaceWeightScaler = scaleRangef(bellCurve(surfaceResidual, 50.0f), 0.0f, 1.0f, 0.1f, 1.0f) * posEstimator.surface.reliability;
+            const float mixedResidual = surfaceResidual * surfaceWeightScaler + estAltResidual * (1.0f - surfaceWeightScaler);
+            
+            posEstimator.est.aglAlt += mixedResidual * positionEstimationConfig()->w_z_surface_p * dt;
+            posEstimator.est.aglVel += mixedResidual * positionEstimationConfig()->w_z_surface_v * dt;
+        }
+        else {  // SURFACE_QUAL_LOW
+            // In this case rangefinder can't be trusted - simply use global altitude
+            posEstimator.est.aglAlt = posEstimator.est.pos.V.Z - posEstimator.est.aglOffset;
+            posEstimator.est.aglVel = posEstimator.est.vel.V.Z;
+        }
+    }
+    else {
+        posEstimator.est.aglVel = 0;
+        posEstimator.est.aglQual = SURFACE_QUAL_LOW;
+    }
+#else
+    posEstimator.est.aglAlt = posEstimator.est.pos.V.Z;
+    posEstimator.est.aglVel = posEstimator.est.vel.V.Z;
+    posEstimator.est.aglQual = SURFACE_QUAL_LOW;
+#endif
 }
 
 /**
@@ -882,14 +999,14 @@ static void publishEstimatedTopic(timeUs_t currentTimeUs)
 
         /* Publish altitude update and set altitude validity */
         if (posEstimator.est.epv < positionEstimationConfig()->max_eph_epv) {
+            const bool aglReliable = (posEstimator.est.aglQual == SURFACE_QUAL_HIGH);
             updateActualAltitudeAndClimbRate(true, posEstimator.est.pos.V.Z, posEstimator.est.vel.V.Z);
+            updateActualAGLAndClimgRate(true, aglReliable, posEstimator.est.aglAlt, posEstimator.est.aglVel);
         }
         else {
             updateActualAltitudeAndClimbRate(false, posEstimator.est.pos.V.Z, 0);
+            updateActualAGLAndClimgRate(false, false, posEstimator.est.aglAlt, 0);
         }
-
-        /* Publish surface distance */
-        updateActualSurfaceDistance(posEstimator.est.surfaceValid, posEstimator.est.surface, posEstimator.est.surfaceVel);
 
         /* Store history data */
         posEstimator.history.pos[posEstimator.history.index] = posEstimator.est.pos;
@@ -928,8 +1045,8 @@ void initializePositionEstimator(void)
     posEstimator.baro.lastUpdateTime = 0;
     posEstimator.surface.lastUpdateTime = 0;
 
-    posEstimator.est.surface = 0;
-    posEstimator.est.surfaceVel = 0;
+    posEstimator.est.aglAlt = 0;
+    posEstimator.est.aglVel = 0;
 
     posEstimator.history.index = 0;
 

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -1000,13 +1000,11 @@ static void publishEstimatedTopic(timeUs_t currentTimeUs)
 
         /* Publish altitude update and set altitude validity */
         if (posEstimator.est.epv < positionEstimationConfig()->max_eph_epv) {
-            const bool aglReliable = (posEstimator.est.aglQual == SURFACE_QUAL_HIGH);
-            updateActualAltitudeAndClimbRate(true, posEstimator.est.pos.V.Z, posEstimator.est.vel.V.Z);
-            updateActualAGLAndClimgRate(true, aglReliable, posEstimator.est.aglAlt, posEstimator.est.aglVel);
+            navigationEstimateStatus_e aglStatus = (posEstimator.est.aglQual == SURFACE_QUAL_LOW) ? EST_USABLE : EST_TRUSTED;
+            updateActualAltitudeAndClimbRate(true, posEstimator.est.pos.V.Z, posEstimator.est.vel.V.Z, posEstimator.est.aglAlt, posEstimator.est.aglVel, aglStatus);
         }
         else {
-            updateActualAltitudeAndClimbRate(false, posEstimator.est.pos.V.Z, 0);
-            updateActualAGLAndClimgRate(false, false, posEstimator.est.aglAlt, 0);
+            updateActualAltitudeAndClimbRate(false, posEstimator.est.pos.V.Z, 0, posEstimator.est.aglAlt, 0, EST_NONE);
         }
 
 #if defined(NAV_BLACKBOX)

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -56,6 +56,12 @@ typedef enum {
     ROC_TO_ALT_NORMAL
 } climbRateToAltitudeControllerMode_e;
 
+typedef enum {
+    EST_NONE = 0,       // No valid sensor present
+    EST_USABLE = 1,     // Estimate is usable but may be inaccurate
+    EST_TRUSTED = 2     // Estimate is usable and based on actual sensor data
+} navigationEstimateStatus_e;
+
 typedef struct navigationFlags_s {
     bool horizontalPositionDataNew;
     bool verticalPositionDataNew;
@@ -65,10 +71,10 @@ typedef struct navigationFlags_s {
     bool horizontalPositionDataConsumed;
     bool verticalPositionDataConsumed;
 
-    bool hasValidAltitudeSensor;        // Indicates that we have a working altitude sensor (got at least one valid reading from it)
-    bool hasValidPositionSensor;        // Indicates that GPS is working (or not)
-    bool hasValidSurfaceSensor;
-    bool hasValidHeadingSensor;         // Indicate valid heading - wither mag or GPS at certain speed on airplane
+    navigationEstimateStatus_e estAltStatus;        // Indicates that we have a working altitude sensor (got at least one valid reading from it)
+    navigationEstimateStatus_e estPosStatue;        // Indicates that GPS is working (or not)
+    navigationEstimateStatus_e estHeadingStatus;    // Indicate valid heading - wither mag or GPS at certain speed on airplane
+    navigationEstimateStatus_e estSurfaceStatus;
 
     bool isAdjustingPosition;
     bool isAdjustingAltitude;
@@ -321,9 +327,9 @@ bool isApproachingLastWaypoint(void);
 float getActiveWaypointSpeed(void);
 
 void updateActualHeading(int32_t newHeading);
-void updateActualHorizontalPositionAndVelocity(bool hasValidSensor, float newX, float newY, float newVelX, float newVelY);
-void updateActualAltitudeAndClimbRate(bool hasValidSensor, float newAltitude, float newVelocity);
-void updateActualSurfaceDistance(bool hasValidSensor, float surfaceDistance, float surfaceVelocity);
+void updateActualHorizontalPositionAndVelocity(bool estimateValid, float newX, float newY, float newVelX, float newVelY);
+void updateActualAltitudeAndClimbRate(bool estimateValid, float newAltitude, float newVelocity);
+void updateActualAGLAndClimgRate(bool estimateValid, bool estimateReliable, float surfaceDistance, float surfaceVelocity);
 
 bool checkForPositionSensorTimeout(void);
 

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -65,7 +65,6 @@ typedef enum {
 typedef struct navigationFlags_s {
     bool horizontalPositionDataNew;
     bool verticalPositionDataNew;
-    bool surfaceDistanceDataNew;
     bool headingDataNew;
 
     bool horizontalPositionDataConsumed;
@@ -328,8 +327,7 @@ float getActiveWaypointSpeed(void);
 
 void updateActualHeading(int32_t newHeading);
 void updateActualHorizontalPositionAndVelocity(bool estimateValid, float newX, float newY, float newVelX, float newVelY);
-void updateActualAltitudeAndClimbRate(bool estimateValid, float newAltitude, float newVelocity);
-void updateActualAGLAndClimgRate(bool estimateValid, bool estimateReliable, float surfaceDistance, float surfaceVelocity);
+void updateActualAltitudeAndClimbRate(bool estimateValid, float newAltitude, float newVelocity, float surfaceDistance, float surfaceVelocity, navigationEstimateStatus_e surfaceStatus);
 
 bool checkForPositionSensorTimeout(void);
 

--- a/src/main/target/SPARKY2/target.h
+++ b/src/main/target/SPARKY2/target.h
@@ -109,7 +109,7 @@
 
 #define USE_I2C
 #define I2C_DEVICE              (I2CDEV_1)
-//#define I2C_DEVICE_EXT          (I2CDEV_2)
+#define I2C_DEVICE_EXT          (I2CDEV_2)
 
 #define USE_ADC
 // PC2 shared with HC-SR04
@@ -124,7 +124,9 @@
 #define LED_STRIP
 #define LED_STRIP_TIMER         TIM5
 
-// #define USE_RANGEFINDER
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_VL53L0X
+#define RANGEFINDER_VL53L0X_INSTANCE    I2C_DEVICE_EXT
 // #define USE_RANGEFINDER_HCSR04
 // #define RANGEFINDER_HCSR04_TRIGGER_PIN       PC2
 // #define RANGEFINDER_HCSR04_ECHO_PIN          PC3


### PR DESCRIPTION
If rangefinder is available - estimate altitude above ground using IMU + baro + rangefinder. 
This PR adds estimation part required for proper terrain-following modes.