### PR TITLE
Increase initialization retry loop timeout to 2s for HMC5883 compass.

### DIFF
--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -241,7 +241,7 @@ static bool hmc5883lInit(magDev_t * mag)
     return bret;
 }
 
-#define DETECTION_MAX_RETRY_COUNT   5
+#define DETECTION_MAX_RETRY_COUNT   200
 static bool deviceDetect(magDev_t * mag)
 {
     for (int retryCount = 0; retryCount < DETECTION_MAX_RETRY_COUNT; retryCount++) {


### PR DESCRIPTION
This change fixes #727 for me.
In a cold condition my MAG seems to need up to ~1s before it could be detected and initialized. The patch changes the max wait time to 2s. Note that not the amount of iterations is important, but the time (the 10ms delay already in the loop is essential).
I think it should have no negative effects and could me merged.