### PR TITLE
Made scaling of gyro and acc in updates more consistent

### DIFF
--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -17,15 +17,13 @@
 
 #pragma once
 
+#include "common/axis.h"
 #include "common/maths.h"
 #include "common/time.h"
 #include "config/parameter_group.h"
 
 #define GRAVITY_CMSS    980.665f
 #define GRAVITY_MSS     9.80665f
-
-extern int16_t throttleAngleCorrection;
-extern int16_t smallAngle;
 
 extern t_fp_vector imuMeasuredAccelBF;         // cm/s/s
 extern t_fp_vector imuMeasuredRotationBF;       // rad/s


### PR DESCRIPTION
Scaling to standard units done in `imuUpdateMeasuredRotationRate` and `imuUpdateMeasuredAcceleration` whether or not `ASYNC_GYRO_PROCESSING` is defined.