### PR TITLE
OMNIBUSF7* Fix incorrect pin defs for UART3

### DIFF
--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -94,8 +94,8 @@
 
 // Assigned to shared output I2C2
 #define USE_UART3
-#define UART3_RX_PIN PB10
-#define UART3_TX_PIN PB11
+#define UART3_RX_PIN PB11
+#define UART3_TX_PIN PB10
 
 #define USE_UART6
 #define UART6_RX_PIN PC7


### PR DESCRIPTION
RX and TX pins are swapped.