### PR TITLE
Shrink ADXL345 Read Function Buffer Size(8->6)

### DIFF
--- a/src/main/drivers/accgyro/accgyro_adxl345.c
+++ b/src/main/drivers/accgyro/accgyro_adxl345.c
@@ -70,7 +70,7 @@ static void adxl345Init(accDev_t *acc)
 
 static bool adxl345Read(accDev_t *acc)
 {
-    uint8_t buf[8];
+    uint8_t buf[6];
 
     if (!busReadBuf(acc->busDev, ADXL345_DATA_OUT, buf, 6)) {
         return false;


### PR DESCRIPTION
ADXL345 ReadFunction No Longer Reads in Extra 2 Registers(FIFO_CTL, FIFO_STATUS) for FIFO Mode.

(as currently done in Cleanflight to allow multiple data read in a Burst, then average them out)

So shrink buf size from 8 to 6. Since iNAV doesn't need 2 extra buffer.