### PR TITLE
Fix incorrect USB Device Class for F7 VCP descriptor

### DIFF
--- a/src/main/vcp_hal/usbd_conf.h
+++ b/src/main/vcp_hal/usbd_conf.h
@@ -51,14 +51,16 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f7xx_hal.h"
+#if (USBD_DEBUG_LEVEL > 0)
 #include <stdio.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
 /* Common Config */
-#define USBD_MAX_NUM_INTERFACES               1
+#define USBD_MAX_NUM_INTERFACES               0
 #define USBD_MAX_NUM_CONFIGURATION            1
 #define USBD_MAX_STR_DESC_SIZ                 0x100
 #define USBD_SUPPORT_USER_STRING              0

--- a/src/main/vcp_hal/usbd_desc.c
+++ b/src/main/vcp_hal/usbd_desc.c
@@ -98,7 +98,7 @@ __ALIGN_BEGIN uint8_t USBD_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END = {
   USB_DESC_TYPE_DEVICE,       /* bDescriptorType */
   0x00,                       /* bcdUSB */
   0x02,
-  0x00,                       /* bDeviceClass */
+  0x02,                       /* bDeviceClass */
   0x00,                       /* bDeviceSubClass */
   0x00,                       /* bDeviceProtocol */
   USB_MAX_EP0_SIZE,           /* bMaxPacketSize */
@@ -303,4 +303,3 @@ static void IntToUnicode (uint32_t value , uint8_t *pbuf , uint8_t len)
   }
 }
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-


### PR DESCRIPTION
Fixes issue with VCP on Win10 reported multiple times on https://github.com/iNavFlight/inav/pull/2611