### PR TITLE
P gains for Heading Hold in CLI

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -314,6 +314,8 @@ Re-apply any new defaults as desired.
 |  nav_fw_pos_xy_p  | 10 | P gain of 2D trajectory PID controller. Play with this to get a straight line between waypoints or a straight RTH |
 |  nav_fw_pos_xy_i  | 5 | I gain of 2D trajectory PID controller. Too high and there will be overshoot in trajectory. Better start tuning with zero |
 |  nav_fw_pos_xy_d  | 8 | D gain of 2D trajectory PID controller. Too high and there will be overshoot in trajectory. Better start tuning with zero |
+|  nav_mc_heading_p  | 60 | P gain of Heading Hold controller (Multirotor) |
+|  nav_fw_heading_p  | 60 | P gain of Heading Hold controller (Fixedwing) |
 |  deadband  | 5 | These are values (in us) by how much RC input can be different before it's considered valid. For transmitters with jitter on outputs, this value can be increased. Defaults are zero, but can be increased up to 10 or so if rc inputs twitch while idle. |
 |  yaw_deadband  | 5 | These are values (in us) by how much RC input can be different before it's considered valid. For transmitters with jitter on outputs, this value can be increased. Defaults are zero, but can be increased up to 10 or so if rc inputs twitch while idle. |
 |  throttle_tilt_comp_str  | 0 | Can be used in ANGLE and HORIZON mode and will automatically boost throttle when banking. Setting is in percentage, 0=disabled. |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -911,6 +911,11 @@ groups:
         condition: USE_NAV
         min: 0
         max: 255
+      - name: nav_mc_heading_p
+        field: bank_mc.pid[PID_HEADING].P
+        condition: USE_NAV
+        min: 0
+        max: 255
       - name: nav_fw_pos_z_p
         field: bank_fw.pid[PID_POS_Z].P
         condition: USE_NAV
@@ -938,6 +943,11 @@ groups:
         max: 255
       - name: nav_fw_pos_xy_d
         field: bank_fw.pid[PID_POS_XY].D
+        condition: USE_NAV
+        min: 0
+        max: 255
+      - name: nav_fw_heading_p
+        field: bank_fw.pid[PID_HEADING].P
         condition: USE_NAV
         min: 0
         max: 255


### PR DESCRIPTION
Looks like those settings were not available in CLI
This fixes #1635 