### PR TITLE
NAV_LAUNCH: add min time before leaving

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1205,6 +1205,10 @@ groups:
         field: fw.launch_motor_spinup_time
         min: 0
         max: 1000
+      - name: nav_fw_launch_min_time
+        field: fw.launch_min_time
+        min: 0
+        max: 60000
       - name: nav_fw_launch_timeout
         field: fw.launch_timeout
         max: 60000

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -139,6 +139,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .launch_idle_throttle = 1000,          // Motor idle or MOTOR_STOP
         .launch_motor_timer = 500,             // ms
         .launch_motor_spinup_time = 100,       // ms, time to gredually increase throttle from idle to launch
+        .launch_min_time = 0,                  // ms, min time in launch mode
         .launch_timeout = 5000,                // ms, timeout for launch procedure
         .launch_climb_angle = 18,              // 18 degrees
         .launch_max_angle = 45                 // 45 deg

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -155,6 +155,7 @@ typedef struct navConfig_s {
         uint16_t launch_throttle;            // Launch throttle
         uint16_t launch_motor_timer;         // Time to wait before setting launch_throttle (ms)
         uint16_t launch_motor_spinup_time;   // Time to speed-up motors from idle to launch_throttle (ESC desync prevention)
+	uint16_t launch_min_time;	     // Minimum time in launch mode to prevent possible bump of the sticks from leaving launch mode early
         uint16_t launch_timeout;             // Launch timeout to disable launch mode and swith to normal flight (ms)
         uint8_t  launch_climb_angle;         // Target climb angle for launch (deg)
         uint8_t  launch_max_angle;           // Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg]

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -155,7 +155,7 @@ typedef struct navConfig_s {
         uint16_t launch_throttle;            // Launch throttle
         uint16_t launch_motor_timer;         // Time to wait before setting launch_throttle (ms)
         uint16_t launch_motor_spinup_time;   // Time to speed-up motors from idle to launch_throttle (ESC desync prevention)
-	uint16_t launch_min_time;	     // Minimum time in launch mode to prevent possible bump of the sticks from leaving launch mode early
+        uint16_t launch_min_time;	     // Minimum time in launch mode to prevent possible bump of the sticks from leaving launch mode early
         uint16_t launch_timeout;             // Launch timeout to disable launch mode and swith to normal flight (ms)
         uint8_t  launch_climb_angle;         // Target climb angle for launch (deg)
         uint8_t  launch_max_angle;           // Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg]

--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -149,7 +149,7 @@ void applyFixedWingLaunchController(timeUs_t currentTimeUs)
             const float timeElapsedSinceLaunchMs = US2MS(currentTimeUs - launchState.launchStartedTime);
 
             // If user moves the stick - finish the launch
-            if ((ABS(rcCommand[ROLL]) > rcControlsConfig()->pos_hold_deadband) || (ABS(rcCommand[PITCH]) > rcControlsConfig()->pos_hold_deadband)) {
+            if ((timeElapsedSinceLaunchMs > navConfig()->fw.launch_min_time) && ((ABS(rcCommand[ROLL]) > rcControlsConfig()->pos_hold_deadband) || (ABS(rcCommand[PITCH]) > rcControlsConfig()->pos_hold_deadband))) {
                 launchState.launchFinished = true;
             }
 


### PR DESCRIPTION
When I'm launching my big wings I often do a over head launch using two hands. Before this patch I was laying my remote control down on the ground so that I could not accidentally bump the roll/pitch stick making the wing leave launch mode prematurely. This patch adds a delay after launch during which launch mode can't be interrupted by the roll/pitch stick. If the aircraft is going to crash or has crashed during the delay the user can still disarm or put the throttle to 0 to stop the motor(s).

This adds the new setting `nav_fw_launch_min_time` representing the described delay in milliseconds set by default to 0.