### PR TITLE
CLI: make status command show battery voltage in V (not in 0.1V unit)

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2328,7 +2328,7 @@ static void cliStatus(char *cmdline)
     rtcGetDateTime(&dt);
     dateTimeFormatLocal(buf, &dt);
     cliPrintLinef("Current Time: %s", buf);
-    cliPrintLinef("Voltage: %d * 0.1V (%dS battery - %s)", vbat, batteryCellCount, getBatteryStateString());
+    cliPrintLinef("Voltage: %d.%dV (%dS battery - %s)", vbat / 10, vbat % 10, batteryCellCount, getBatteryStateString());
     cliPrintf("CPU Clock=%dMHz", (SystemCoreClock / 1000000));
 
 #if (FLASH_SIZE > 64)


### PR DESCRIPTION
```
Entering CLI Mode, type 'exit' to return, or 'help'

# status
System Uptime: 38 seconds
Current Time: 0000-01-01T00:00:00.000+00:00
Voltage: 12.4V (3S battery - OK)
CPU Clock=72MHz, GYRO=MPU6000, ACC=MPU6000, BARO=BMP280
STM32 system clocks:
  SYSCLK = 72 MHz
  HCLK   = 72 MHz
  PCLK1  = 36 MHz
  PCLK2  = 72 MHz
Sensor status: GYRO=OK, ACC=OK, MAG=NONE, BARO=OK, RANGEFINDER=NONE, OPFLOW=NONE, GPS=NONE
SD card: Manufacturer 0x13, 124160kB, 09/2006, v1.0, 'SD128'
Filesystem: Ready
Stack size: 6144, Stack address: 0x10002000
I2C Errors: 0, config size: 3430, max available config: 4096
ADC channel usage:
   BATTERY : configured = ADC 1, used = ADC 1
      RSSI : configured = ADC 3, used = none
   CURRENT : configured = ADC 2, used = ADC 2
  AIRSPEED : configured = none, used = none
System load: 2, cycle time: 2011, PID rate: 497, RX rate: 49, System rate: 9
Arming disabled flags: RX CLI
```