### PR TITLE
NAV LAUNCH: code tidy and add altitude where leave the launch

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -189,6 +189,7 @@ Re-apply any new defaults as desired.
 |  nav_fw_launch_motor_delay    | 500 | Delay between detected launch and launch sequence start and throttling up (ms) |
 |  nav_fw_launch_spinup_time    | 100 | Time to bring power from min_throttle to nav_fw_launch_thr - to avoid big stress on ESC and large torque from propeller |
 |  nav_fw_launch_timeout  | 5000 | Maximum time for launch sequence to be executed. After this time LAUNCH mode will be turned off and regular flight mode will take over (ms) |
+|  nav_fw_launch_max_altitude  | 0 | Altitude at which LAUNCH mode will be turned off and regular flight mode will take over. [cm] |
 |  nav_fw_launch_climb_angle  | 18 | Climb angle for launch sequence (degrees), is also restrained by global max_angle_inclination_pit |
 |  nav_fw_land_dive_angle  | 2 | Dive angle that airplane will use during final landing phase. During dive phase, motor is stopped or IDLE and roll control is locked to 0 degrees |
 |  serialrx_provider  | SPEK1024 | When feature SERIALRX is enabled, this allows connection to several receivers which output data via digital interface resembling serial. See RX section. |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1281,6 +1281,10 @@ groups:
       - name: nav_fw_launch_timeout
         field: fw.launch_timeout
         max: 60000
+      - name: nav_fw_launch_max_altitude
+        field: fw.launch_max_altitude
+        min: 0
+        max: 60000
       - name: nav_fw_launch_climb_angle
         field: fw.launch_climb_angle
         min: 5

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -141,6 +141,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .launch_motor_spinup_time = 100,       // ms, time to gredually increase throttle from idle to launch
         .launch_min_time = 0,                  // ms, min time in launch mode
         .launch_timeout = 5000,                // ms, timeout for launch procedure
+        .launch_max_altitude = 0,              // cm, altitude where to consider launch ended
         .launch_climb_angle = 18,              // 18 degrees
         .launch_max_angle = 45                 // 45 deg
     }

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -157,6 +157,7 @@ typedef struct navConfig_s {
         uint16_t launch_motor_spinup_time;   // Time to speed-up motors from idle to launch_throttle (ESC desync prevention)
         uint16_t launch_min_time;	     // Minimum time in launch mode to prevent possible bump of the sticks from leaving launch mode early
         uint16_t launch_timeout;             // Launch timeout to disable launch mode and swith to normal flight (ms)
+        uint16_t launch_max_altitude;        // cm, altitude where to consider launch ended
         uint8_t  launch_climb_angle;         // Target climb angle for launch (deg)
         uint8_t  launch_max_angle;           // Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg]
     } fw;


### PR DESCRIPTION
The model will leave launch mode when the target altitude is reached (if  launch timeout doesn't kick before) and switch back to the current flight mode.
Also tidied a bit conditions check 