### PR TITLE
SBUS max frame transmission time increased to 6ms.

### DIFF
--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -41,13 +41,17 @@
  * FrSky X8R
  * time between frames: 6ms.
  * time to send frame: 3ms.
-*
+ *
  * Futaba R6208SB/R6303SB
  * time between frames: 11ms.
  * time to send frame: 3ms.
+ *
+ * eLeReS
+ * frame starts every: 14ms
+ * time to send frame: 3-6ms (sent with soft-serial, possible gaps between bytes)
  */
 
-#define SBUS_TIME_NEEDED_PER_FRAME 3000
+#define SBUS_TIME_NEEDED_PER_FRAME 6000
 
 #ifndef CJMCU
 //#define DEBUG_SBUS_PACKETS


### PR DESCRIPTION
This is to allow reception of eLeReS RX SBUS signal, where
single frame is typically transmitted within 3-6 ms, not
exactly 3ms like on Futaba.