### PR TITLE
Add FEATURE FW_LAUNCH

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -160,7 +160,8 @@ static const char * const featureNames[] = {
     "", "TELEMETRY", "CURRENT_METER", "3D", "RX_PARALLEL_PWM",
     "RX_MSP", "RSSI_ADC", "LED_STRIP", "DASHBOARD", "",
     "BLACKBOX", "CHANNEL_FORWARDING", "TRANSPONDER", "AIRMODE",
-    "SUPEREXPO", "VTX", "RX_SPI", "", "PWM_SERVO_DRIVER", "PWM_OUTPUT_ENABLE", "OSD", NULL
+    "SUPEREXPO", "VTX", "RX_SPI", "", "PWM_SERVO_DRIVER", "PWM_OUTPUT_ENABLE", "OSD", "FW_LAUNCH", NULL
+
 };
 
 /* Sensor names (used in lookup tables for *_hardware settings and in status command output) */

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -73,6 +73,7 @@ typedef enum {
     FEATURE_PWM_SERVO_DRIVER = 1 << 27,
     FEATURE_PWM_OUTPUT_ENABLE = 1 << 28,
     FEATURE_OSD = 1 << 29,
+    FEATURE_FW_LAUNCH = 1 << 30,
 } features_e;
 
 typedef struct systemConfig_s {

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -188,7 +188,7 @@ static void updateArmingStatus(void)
         }
 
 	/* CHECK: pitch / roll sticks centered when NAV_LAUNCH_MODE enabled */
-	if (IS_RC_MODE_ACTIVE(BOXNAVLAUNCH)) {
+	if (isNavLaunchEnabled()) {
 	  if ((ABS(rcCommand[ROLL]) > rcControlsConfig()->pos_hold_deadband) || (ABS(rcCommand[PITCH]) > rcControlsConfig()->pos_hold_deadband)) {
 	    ENABLE_ARMING_FLAG(ARMING_DISABLED_ROLLPITCH_NOT_CENTERED);
 	  } else {

--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -187,7 +187,9 @@ void initActiveBoxIds(void)
 
     if (STATE(FIXED_WING)) {
         activeBoxIds[activeBoxIdCount++] = BOXMANUAL;
-        activeBoxIds[activeBoxIdCount++] = BOXNAVLAUNCH;
+        if (!feature(FEATURE_FW_LAUNCH)) {
+           activeBoxIds[activeBoxIdCount++] = BOXNAVLAUNCH;
+        }
         activeBoxIds[activeBoxIdCount++] = BOXAUTOTRIM;
 #if defined(AUTOTUNE_FIXED_WING)
         activeBoxIds[activeBoxIdCount++] = BOXAUTOTUNE;

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -23,6 +23,8 @@
 
 #include "io/gps.h"
 
+#include "config/feature.h"
+
 /* GPS Home location data */
 extern gpsLocation_t        GPS_home;
 extern uint16_t             GPS_distanceToHome;        // distance to home point in meters
@@ -314,6 +316,8 @@ bool navigationIsFlyingAutonomousMode(void);
  * or if it's NAV_RTH_ALLOW_LANDING_FAILSAFE and failsafe mode is active.
  */
 bool navigationRTHAllowsLanding(void);
+
+bool isNavLaunchEnabled(void);
 
 /* Compatibility data */
 extern navSystemStatus_t    NAV_Status;


### PR DESCRIPTION
This PR introduces the ability to enable NAV_LAUNCH as a feature.

It will allow to permanently enable Launch Mode without the needing of use a dedicated switch on the radio. The pilot with this feature just need to ARM and launch the plane according to the standard procedures.

- The pilot after having armed can leave Launch Mode by moving the ROLL/PITCH stick if the THROTTLE is LOW so the motor will behave depending if MOTOR_STOP is enabled or not. In this case the pilot can go for a manual launch.
- If the pilot inadvertently disarms the craft midair by placing THROTTLE to LOW, arming again (arming check) and just moving the sticks the Launch Mode will exit and full control will be given back to the pilot.

More cleanup and configurator support will come if you like the idea.