### PR TITLE
Fix broken boxes initialization in #2751

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -261,8 +261,9 @@ void init(void)
     serialInit(feature(FEATURE_SOFTSERIAL), SERIAL_PORT_NONE);
 #endif
 
-    // Initialize MSP here so the DEBUG_TRACE can share a port with MSP
-    mspFcInit();
+    // Initialize MSP serial ports here so DEBUG_TRACE can share a port with MSP.
+    // XXX: Don't call mspFcInit() yet, since it initializes the boxes and needs
+    // to run after the sensors have been detected.
     mspSerialInit();
 
 #if defined(USE_DEBUG_TRACE)
@@ -559,6 +560,10 @@ void init(void)
 #endif
 
     imuInit();
+
+    // Sensors have now been detected, mspFcInit() can now be called
+    // to set the boxes up
+     mspFcInit();
 
 #ifdef USE_CLI
     cliInit(serialConfig());


### PR DESCRIPTION
mspFcInit() can't be called until the HW has been initialized, since
it performs some checks to decide which boxes to enable. We can
still call mspSerialInit() early in the boot process, so trace-over-MSP
works anyway.

Kudos to @stronnag for noticing the problem so fast!