### PR TITLE
Add MSPv2 DONT_REPLY flag

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2396,6 +2396,12 @@ mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostPro
     } else {
         ret = mspFcProcessInCommand(cmdMSP, src);
     }
+
+    // Process DONT_REPLY flag
+    if (cmd->flags & MSP_FLAG_DONT_REPLY) {
+        ret = MSP_RESULT_NO_REPLY;
+    }
+
     reply->result = ret;
     return ret;
 }

--- a/src/main/msp/msp.h
+++ b/src/main/msp/msp.h
@@ -44,6 +44,10 @@ typedef struct mspPacket_s {
     int16_t result;
 } mspPacket_t;
 
+typedef enum {
+    MSP_FLAG_DONT_REPLY           = (1 << 0),
+} mspFlags_e;
+
 struct serialPort_s;
 typedef void (*mspPostProcessFnPtr)(struct serialPort_s *port); // msp post process function, used for gracefully handling reboots, etc.
 typedef mspResult_e (*mspProcessCommandFnPtr)(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);


### PR DESCRIPTION
This functionality will allow MSPv2 initiator to decide if it wants a reply or not. I.e. `MSP_REBOOT` and `MSP_SET_RAW_RC` probably don't need a reply.