### PR TITLE
Increase AUTOTRIM length to 2s

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -474,7 +474,7 @@ void processServoTilt(void)
     }
 }
 
-#define SERVO_AUTOTRIM_TIMER_MS     1000
+#define SERVO_AUTOTRIM_TIMER_MS     2000
 
 typedef enum {
     AUTOTRIM_IDLE,


### PR DESCRIPTION
Current servo autotrim duration is 1 second. 

I propose to double the trim time to let the surfaces to be trimmed even better discarding some turbulence from the readings.

The wiki says it is 5 seconds and we need to fix it in any case.

What do you think @shellixyz ? 