### PR TITLE
Remove trailing ';' from box definitions

### DIFF
--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -35,41 +35,43 @@
 
 #include "telemetry/telemetry.h"
 
-// FIXME remove ;'s
+#define BOX_SUFFIX ';'
+#define BOX_SUFFIX_LEN 1
+
 static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
-    { BOXARM, "ARM;", 0 },
-    { BOXANGLE, "ANGLE;", 1 },
-    { BOXHORIZON, "HORIZON;", 2 },
-    { BOXNAVALTHOLD, "NAV ALTHOLD;", 3 },   // old BARO
-    { BOXHEADINGHOLD, "HEADING HOLD;", 5 },
-    { BOXHEADFREE, "HEADFREE;", 6 },
-    { BOXHEADADJ, "HEADADJ;", 7 },
-    { BOXCAMSTAB, "CAMSTAB;", 8 },
-    { BOXNAVRTH, "NAV RTH;", 10 },         // old GPS HOME
-    { BOXNAVPOSHOLD, "NAV POSHOLD;", 11 },     // old GPS HOLD
-    { BOXMANUAL, "MANUAL;", 12 },
-    { BOXBEEPERON, "BEEPER;", 13 },
-    { BOXLEDLOW, "LEDLOW;", 15 },
-    { BOXLIGHTS, "LIGHTS;", 16 },
-    { BOXOSD, "OSD SW;", 19 },
-    { BOXTELEMETRY, "TELEMETRY;", 20 },
-    { BOXAUTOTUNE, "AUTO TUNE;", 21 },
-    { BOXBLACKBOX, "BLACKBOX;", 26 },
-    { BOXFAILSAFE, "FAILSAFE;", 27 },
-    { BOXNAVWP, "NAV WP;", 28 },
-    { BOXAIRMODE, "AIR MODE;", 29 },
-    { BOXHOMERESET, "HOME RESET;", 30 },
-    { BOXGCSNAV, "GCS NAV;", 31 },
-    //{ BOXHEADINGLOCK, "HEADING LOCK;", 32 },
-    { BOXSURFACE, "SURFACE;", 33 },
-    { BOXFLAPERON, "FLAPERON;", 34 },
-    { BOXTURNASSIST, "TURN ASSIST;", 35 },
-    { BOXNAVLAUNCH, "NAV LAUNCH;", 36 },
-    { BOXAUTOTRIM, "SERVO AUTOTRIM;", 37 },
-    { BOXKILLSWITCH, "KILLSWITCH;", 38 },
-    { BOXCAMERA1, "CAMERA CONTROL 1;", 39 },
-    { BOXCAMERA2, "CAMERA CONTROL 2;", 40 },
-    { BOXCAMERA3, "CAMERA CONTROL 3;", 41 },
+    { BOXARM, "ARM", 0 },
+    { BOXANGLE, "ANGLE", 1 },
+    { BOXHORIZON, "HORIZON", 2 },
+    { BOXNAVALTHOLD, "NAV ALTHOLD", 3 },   // old BARO
+    { BOXHEADINGHOLD, "HEADING HOLD", 5 },
+    { BOXHEADFREE, "HEADFREE", 6 },
+    { BOXHEADADJ, "HEADADJ", 7 },
+    { BOXCAMSTAB, "CAMSTAB", 8 },
+    { BOXNAVRTH, "NAV RTH", 10 },         // old GPS HOME
+    { BOXNAVPOSHOLD, "NAV POSHOLD", 11 },     // old GPS HOLD
+    { BOXMANUAL, "MANUAL", 12 },
+    { BOXBEEPERON, "BEEPER", 13 },
+    { BOXLEDLOW, "LEDLOW", 15 },
+    { BOXLIGHTS, "LIGHTS", 16 },
+    { BOXOSD, "OSD SW", 19 },
+    { BOXTELEMETRY, "TELEMETRY", 20 },
+    { BOXAUTOTUNE, "AUTO TUNE", 21 },
+    { BOXBLACKBOX, "BLACKBOX", 26 },
+    { BOXFAILSAFE, "FAILSAFE", 27 },
+    { BOXNAVWP, "NAV WP", 28 },
+    { BOXAIRMODE, "AIR MODE", 29 },
+    { BOXHOMERESET, "HOME RESET", 30 },
+    { BOXGCSNAV, "GCS NAV", 31 },
+    //{ BOXHEADINGLOCK, "HEADING LOCK", 32 },
+    { BOXSURFACE, "SURFACE", 33 },
+    { BOXFLAPERON, "FLAPERON", 34 },
+    { BOXTURNASSIST, "TURN ASSIST", 35 },
+    { BOXNAVLAUNCH, "NAV LAUNCH", 36 },
+    { BOXAUTOTRIM, "SERVO AUTOTRIM", 37 },
+    { BOXKILLSWITCH, "KILLSWITCH", 38 },
+    { BOXCAMERA1, "CAMERA CONTROL 1", 39 },
+    { BOXCAMERA2, "CAMERA CONTROL 2", 40 },
+    { BOXCAMERA3, "CAMERA CONTROL 3", 41 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -107,7 +109,7 @@ bool serializeBoxNamesReply(sbuf_t *dst)
     for (int i = 0; i < activeBoxIdCount; i++) {
         const box_t *box = findBoxByActiveBoxId(activeBoxIds[i]);
         if (box) {
-            replyLengthTotal += strlen(box->boxName);
+            replyLengthTotal += strlen(box->boxName) + BOX_SUFFIX_LEN;
         }
     }
 
@@ -122,6 +124,7 @@ bool serializeBoxNamesReply(sbuf_t *dst)
         if (box) {
             const int len = strlen(box->boxName);
             sbufWriteData(dst, box->boxName, len);
+            sbufWriteU8(dst, BOX_SUFFIX);
         }
     }
 


### PR DESCRIPTION
Instead, write it after each box name in serializeBoxNamesReply()

Saves 80 bytes of FLASH on F3