### PR TITLE
Output more information in MSP_BOARD_INFO

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -304,6 +304,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         break;
 
     case MSP_BOARD_INFO:
+    {
         sbufWriteData(dst, boardIdentifier, BOARD_IDENTIFIER_LENGTH);
 #ifdef USE_HARDWARE_REVISION_DETECTION
         sbufWriteU16(dst, hardwareRevision);
@@ -319,17 +320,22 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
 #else
         sbufWriteU8(dst, 0);
 #endif
-        // 1 = USE_VCP, 0 = no VCP
-        // This way the configurator can find wether a board
-        // uses VCP without relying on a board list.
+        // Board communication capabilities (uint8)
+        // Bit 0: 1 iff the board has VCP
+        // Bit 1: 1 iff the board supports software serial
+        uint8_t commCapabilities = 0;
 #ifdef USE_VCP
-        sbufWriteU8(dst, 1);
-#else
-        sbufWriteU8(dst, 0);
+        commCapabilities |= 1 << 0;
 #endif
+#if defined(USE_SOFTSERIAL1) || defined(USE_SOFTSERIAL2)
+        commCapabilities |= 1 << 1;
+#endif
+        sbufWriteU8(dst, commCapabilities);
+
         sbufWriteU8(dst, strlen(targetName));
         sbufWriteData(dst, targetName, strlen(targetName));
         break;
+    }
 
     case MSP_BUILD_INFO:
         sbufWriteData(dst, buildDate, BUILD_DATE_LENGTH);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -310,6 +310,25 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
 #else
         sbufWriteU16(dst, 0); // No other build targets currently have hardware revision detection.
 #endif
+        // OSD support (for BF compatibility):
+        // 0 = no OSD
+        // 1 = OSD slave (not supported in INAV)
+        // 2 = OSD chip on board
+#if defined(USE_OSD) && defined(USE_MAX7456)
+        sbufWriteU8(dst, 2);
+#else
+        sbufWriteU8(dst, 0);
+#endif
+        // 1 = USE_VCP, 0 = no VCP
+        // This way the configurator can find wether a board
+        // uses VCP without relying on a board list.
+#ifdef USE_VCP
+        sbufWriteU8(dst, 1);
+#else
+        sbufWriteU8(dst, 0);
+#endif
+        sbufWriteU8(dst, strlen(targetName));
+        sbufWriteData(dst, targetName, strlen(targetName));
         break;
 
     case MSP_BUILD_INFO:


### PR DESCRIPTION
- Report wether the board has OSD support
- Report wether the board uses VCP
- Include the full target name in the response

This will eventually let us get rid of `js/boards.js` in the configurator and also makes MSP_BOARD_INFO output the same information as BF.