### PR TITLE
Make the isConnected() function in the serial vtable accept a const arg

### DIFF
--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -86,7 +86,7 @@ struct serialPortVTable {
 
     void (*writeBuf)(serialPort_t *instance, const void *data, int count);
 
-    bool (*isConnected)(serialPort_t *instance);
+    bool (*isConnected)(const serialPort_t *instance);
 
     // Optional functions used to buffer large writes.
     void (*beginWrite)(serialPort_t *instance);

--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -92,7 +92,7 @@ static uint8_t usbVcpRead(serialPort_t *instance)
     }
 }
 
-static bool usbVcpIsConnected(serialPort_t *instance)
+static bool usbVcpIsConnected(const serialPort_t *instance)
 {
     (void)instance;
     return usbIsConnected() && usbIsConfigured();


### PR DESCRIPTION
Fixes warning during build.
Fixes #2786