### PR TITLE
Ignore OSD time alarm when it's set to zero

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -424,7 +424,7 @@ static inline void osdFormatFlyTime(char *buff, textAttributes_t *attr)
 {
     uint32_t seconds = flyTime / 1000000;
     osdFormatTime(buff, seconds, SYM_FLY_M, SYM_FLY_H);
-    if (attr) {
+    if (attr && osdConfig()->time_alarm > 0) {
        if (seconds / 60 >= osdConfig()->time_alarm && ARMING_FLAG(ARMED)) {
             TEXT_ATTRIBUTES_ADD_BLINK(*attr);
         }


### PR DESCRIPTION
This way users can easily disable the alarm without having to set
it to a big number.

Fixes #1536