### PR TITLE
Add support for BME280 barometer to BMP280 barometer driver

### DIFF
--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -166,7 +166,7 @@ static bool deviceDetect(busDevice_t * busDev)
 
         bool ack = busRead(busDev, BMP280_CHIP_ID_REG, &chipId);
 
-        if (ack && chipId == BMP280_DEFAULT_CHIP_ID) {
+        if (ack && (chipId == BMP280_DEFAULT_CHIP_ID || chipId == BME280_DEFAULT_CHIP_ID)) {
             return true;
         }
     };

--- a/src/main/drivers/barometer/barometer_bmp280.h
+++ b/src/main/drivers/barometer/barometer_bmp280.h
@@ -19,6 +19,7 @@
 
 #define BMP280_I2C_ADDR                      (0x76)
 #define BMP280_DEFAULT_CHIP_ID               (0x58)
+#define BME280_DEFAULT_CHIP_ID               (0x60)
 
 #define BMP280_CHIP_ID_REG                   (0xD0)  /* Chip ID Register */
 #define BMP280_RST_REG                       (0xE0)  /* Softreset Register */


### PR DESCRIPTION
The BME280 is similar to the BMP280. It just has an additional humidity sensor and report with a different chip ID. This is adding support for this chip ID. The additional humidity sensor data is not used.