### PR TITLE
Add support for using GPS heading on multirotors

### DIFF
--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -30,6 +30,8 @@
 #include "fc/fc_msp_box.h"
 #include "fc/runtime_config.h"
 
+#include "flight/imu.h"
+
 #include "sensors/diagnostics.h"
 #include "sensors/sensors.h"
 
@@ -179,7 +181,7 @@ void initActiveBoxIds(void)
         activeBoxIds[activeBoxIdCount++] = BOXSURFACE;
     }
 
-    if ((feature(FEATURE_GPS) && sensors(SENSOR_MAG) && sensors(SENSOR_ACC)) || (STATE(FIXED_WING) && sensors(SENSOR_ACC) && feature(FEATURE_GPS))) {
+    if (feature(FEATURE_GPS) && sensors(SENSOR_ACC) && imuHasHeadingEnabled()) {
         activeBoxIds[activeBoxIdCount++] = BOXNAVPOSHOLD;
         activeBoxIds[activeBoxIdCount++] = BOXNAVRTH;
         activeBoxIds[activeBoxIdCount++] = BOXNAVWP;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -49,6 +49,9 @@ tables:
   - name: gps_dyn_model
     values: ["PEDESTRIAN", "AIR_1G", "AIR_4G"]
     enum: gpsDynModel_e
+  - name: use_gps_heading
+    values: ["AUTO", "ON", "OFF"]
+    enum: gps_heading_e
   - name: reset_altitude
     values: ["NEVER", "FIRST_ARM", "EACH_ARM"]
   - name: nav_user_control_mode
@@ -676,6 +679,8 @@ groups:
       - name: small_angle
         min: 0
         max: 180
+      - name: use_gps_heading
+        table: use_gps_heading
 
   - name: PG_ARMING_CONFIG
     type: armingConfig_t

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -615,7 +615,7 @@ bool isImuReady(void)
 
 bool isImuHeadingValid(void)
 {
-    return (sensors(SENSOR_MAG) && STATE(COMPASS_CALIBRATED)) || (STATE(FIXED_WING) && gpsHeadingInitialized);
+    return (sensors(SENSOR_MAG) && STATE(COMPASS_CALIBRATED)) || (imuHasGPSHeadingEnabled() && gpsHeadingInitialized);
 }
 
 bool imuHasHeadingEnabled(void)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -500,7 +500,7 @@ static void imuCalculateEstimatedAttitude(float dT)
 
                 canUseCOG = true;
                 int16_t COGRotation = RADIANS_TO_DECIDEGREES(atan2_approx(attitude.values.roll, attitude.values.pitch));
-                groundCourse = (gpsSol.groundCourse + COGRotation) % DEGREES_TO_CENTIDEGREES(360);
+                groundCourse = (gpsSol.groundCourse + COGRotation);
             }
         }
         // Only use each COG reading once, to avoid reusing the same GPS

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -640,7 +640,7 @@ void imuUpdateGPSCOG(void)
 {
     // Don't check for numSat. gps.c already checks for
     // gpsConfig()->gpsMinSats before enabling GPS_FIX
-    if (STATE(GPS_FIX) && gpsSol.flags.validVelNE && gpsSol.groundSpeed >= 300) {
+    if (STATE(GPS_FIX) && gpsSol.flags.validVelNE) {
         gpsHasCOG = true;
     }
 }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -628,12 +628,17 @@ bool isImuReady(void)
 
 bool isImuHeadingValid(void)
 {
-    return (sensors(SENSOR_MAG) && STATE(COMPASS_CALIBRATED)) || (imuHasGPSHeadingEnabled() && gpsHeadingInitialized);
+    return imuHasPreciseHeading() || (imuHasGPSHeadingEnabled() && gpsHeadingInitialized);
 }
 
 bool imuHasHeadingEnabled(void)
 {
     return sensors(SENSOR_MAG) || imuHasGPSHeadingEnabled();
+}
+
+bool imuHasPreciseHeading(void)
+{
+    return sensors(SENSOR_MAG) && STATE(COMPASS_CALIBRATED);
 }
 
 void imuUpdateGPSCOG(void)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -472,7 +472,7 @@ static void imuCalculateEstimatedAttitude(float dT)
 
 #if defined(USE_GPS)
     bool canUseCOG = false;
-    uint16_t groundCourse;
+    int16_t groundCourse;
     if (imuHasGPSHeadingEnabled() && sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= 6) {
         if (STATE(FIXED_WING)) {
             // Fixed wing always flies forward, so we require a 3m/s speed and use
@@ -498,7 +498,7 @@ static void imuCalculateEstimatedAttitude(float dT)
                 calculateCosTiltAngle() > maxTiltCos) {
 
                 canUseCOG = true;
-                uint16_t COGRotation = RADIANS_TO_CENTIDEGREES(atan2_approx(attitude.values.roll, attitude.values.pitch));
+                int16_t COGRotation = RADIANS_TO_DECIDEGREES(atan2_approx(attitude.values.roll, attitude.values.pitch));
                 groundCourse = (gpsSol.groundCourse + COGRotation) % DEGREES_TO_CENTIDEGREES(360);
             }
         }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -488,13 +488,15 @@ static void imuCalculateEstimatedAttitude(float dT)
                 // For now, we also require a harcoded speed of 3m/s, but we
                 // should adjust this depending on the maximum speed in modes which do limit
                 // it (e.g. RTH).
-                const uint16_t minAttitudeAngle = DECIDEGREES_TO_DEGREES(10);
-                const uint16_t maxAttitudeAngle = DECIDEGREES_TO_DEGREES(90);
+
+                // Check tilt via calculateCosTiltAngle(). Note that cos() is decreasing in
+                // the (10, 90] interval, so the cos for the minimum tilt is the maximum
+                // value for calculateCosTiltAngle() - same thing applies to maxTiltCos.
+                const float minTiltCos = 0.984807753012208f; // cos(10)
+                const float maxTiltCos = 0; // cos(90)
                 if (gpsSol.groundSpeed >= 300 &&
-                    ABS(attitude.values.pitch) >= minAttitudeAngle &&
-                    ABS(attitude.values.pitch) < maxAttitudeAngle &&
-                    ABS(attitude.values.roll) >= minAttitudeAngle &&
-                    ABS(attitude.values.roll) < maxAttitudeAngle) {
+                    calculateCosTiltAngle() <= minTiltCos &&
+                    calculateCosTiltAngle() > maxTiltCos) {
 
                     canUseCOG = true;
                     uint16_t COGRotation = RADIANS_TO_CENTIDEGREES(atan2_approx(attitude.values.roll, attitude.values.pitch));

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -482,16 +482,16 @@ static void imuCalculateEstimatedAttitude(float dT)
         } else {
             // MR might fly on any direction, but it tends to fly in the direction the
             // head it's tilted to. To compensate for this, we rotate gpsSol.groundCourse
-            // by the tilt direction. Pitch and roll angles must fall in the [10, 90) interval
+            // by the tilt direction. Pitch and roll angles must fall in the [20, 90) interval
             // so the data doesn't get polluted during flips or rolls.
             // For now, we also require a harcoded speed of 3m/s, but we
             // should adjust this depending on the maximum speed in modes which do limit
             // it (e.g. RTH).
 
             // Check tilt via calculateCosTiltAngle(). Note that cos() is decreasing in
-            // the (10, 90] interval, so the cos for the minimum tilt is the maximum
+            // the (20, 90] interval, so the cos for the minimum tilt is the maximum
             // value for calculateCosTiltAngle() - same thing applies to maxTiltCos.
-            const float minTiltCos = 0.984807753012208f; // cos(10)
+            const float minTiltCos = 0.9396926207859084f; // cos(20)
             const float maxTiltCos = 0; // cos(90)
             if (gpsSol.groundSpeed >= 300 &&
                 calculateCosTiltAngle() <= minTiltCos &&

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -485,7 +485,7 @@ static void imuCalculateEstimatedAttitude(float dT)
             // head it's tilted to. To compensate for this, we rotate gpsSol.groundCourse
             // by the tilt direction. Pitch and roll angles must fall in the [20, 90) interval
             // so the data doesn't get polluted during flips or rolls.
-            // For now, we also require a harcoded speed of 3m/s, but we
+            // For now, we also require a harcoded speed of 6m/s, but we
             // should adjust this depending on the maximum speed in modes which do limit
             // it (e.g. RTH).
 
@@ -494,7 +494,7 @@ static void imuCalculateEstimatedAttitude(float dT)
             // value for calculateCosTiltAngle() - same thing applies to maxTiltCos.
             const float minTiltCos = 0.9396926207859084f; // cos(20)
             const float maxTiltCos = 0; // cos(90)
-            if (gpsSol.groundSpeed >= 300 &&
+            if (gpsSol.groundSpeed >= 600 &&
                 calculateCosTiltAngle() <= minTiltCos &&
                 calculateCosTiltAngle() > maxTiltCos) {
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -483,8 +483,8 @@ static void imuCalculateEstimatedAttitude(float dT)
             } else {
                 // MR might fly on any direction, but it tends to fly in the direction the
                 // head it's tilted to. To compensate for this, we rotate gpsSol.groundCourse
-                // by the tilt direction. Pitch and roll angles must fall in the [10, 90) so
-                // the data doesn't get polluted during flips or rolls.
+                // by the tilt direction. Pitch and roll angles must fall in the [10, 90) interval
+                // so the data doesn't get polluted during flips or rolls.
                 // For now, we also require a harcoded speed of 3m/s, but we
                 // should adjust this depending on the maximum speed in modes which do limit
                 // it (e.g. RTH).

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -146,6 +146,7 @@ void imuInit(void)
     // Explicitly initialize FASTRAM statics
     isAccelUpdatedAtLeastOnce = false;
     gpsHeadingInitialized = false;
+    gpsHasCOG = false;
     q0 = 1.0f;
     q1 = 0.0f;
     q2 = 0.0f;

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -70,6 +70,7 @@ float calculateCosTiltAngle(void);
 bool isImuReady(void);
 bool isImuHeadingValid(void);
 bool imuHasHeadingEnabled(void);
+void imuUpdateGPSCOG(void);
 
 void imuTransformVectorBodyToEarth(t_fp_vector * v);
 void imuTransformVectorEarthToBody(t_fp_vector * v);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -70,6 +70,7 @@ float calculateCosTiltAngle(void);
 bool isImuReady(void);
 bool isImuHeadingValid(void);
 bool imuHasHeadingEnabled(void);
+bool imuHasPreciseHeading(void);
 void imuUpdateGPSCOG(void);
 
 void imuTransformVectorBodyToEarth(t_fp_vector * v);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -25,6 +25,12 @@
 extern t_fp_vector imuMeasuredAccelBF;         // cm/s/s
 extern t_fp_vector imuMeasuredRotationBF;       // rad/s
 
+typedef enum {
+    GPS_HEADING_AUTO, // Enabled for FW, disabled for anything else
+    GPS_HEADING_ENABLED, // Always enabled
+    GPS_HEADING_DISABLED, // Always disabled
+} gps_heading_e;
+
 typedef union {
     int16_t raw[XYZ_AXIS_COUNT];
     struct {
@@ -43,6 +49,7 @@ typedef struct imuConfig_s {
     uint16_t dcm_kp_mag;                    // DCM filter proportional gain ( x 10000) for magnetometer and GPS heading
     uint16_t dcm_ki_mag;                    // DCM filter integral gain ( x 10000) for magnetometer and GPS heading
     uint8_t small_angle;
+    uint8_t use_gps_heading;                // from gps_heading_e
 } imuConfig_t;
 
 PG_DECLARE(imuConfig_t, imuConfig);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -69,6 +69,7 @@ void imuUpdateAccelerometer(void);
 float calculateCosTiltAngle(void);
 bool isImuReady(void);
 bool isImuHeadingValid(void);
+bool imuHasHeadingEnabled(void);
 
 void imuTransformVectorBodyToEarth(t_fp_vector * v);
 void imuTransformVectorEarthToBody(t_fp_vector * v);

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -964,7 +964,7 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_HOVER_PRIOR_TO_LAND
     // If position ok OR within valid timeout - continue
     if ((posControl.flags.estPosStatue >= EST_USABLE) || !checkForPositionSensorTimeout()) {
         // Wait until target heading is reached (with 15 deg margin for error)
-        if (STATE(FIXED_WING)) {
+        if (!imuHasPreciseHeading()) {
             resetLandingDetector();
             return NAV_FSM_EVENT_SUCCESS;
         }

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -428,6 +428,7 @@ void onNewGPSData(void)
     else {
         posEstimator.gps.lastUpdateTime = 0;
     }
+    imuUpdateGPSCOG();
 }
 #endif
 


### PR DESCRIPTION
Uses the same logic as FW GPS heading, but applies a correction to
the heading reported by the GPS by using the tilt angle of the MR
head.

Please, be very careful testing this feature for the moment.

This commit introduces the new setting use_gps_heading, with
the following values:

- AUTO (default): Enabled just for FW
- ON: Enabled for all crafts
- OFF: Disabled for all crafts