### PR TITLE
DEBUG_ALWAYS as debug_mode

### DIFF
--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -57,6 +57,7 @@ typedef enum {
     DEBUG_PITOT,
     DEBUG_AGL,
     DEBUG_FLOW_RAW,
+    DEBUG_ALWAYS,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -69,7 +69,7 @@ tables:
   - name: i2c_speed
     values: ["400KHZ", "800KHZ", "100KHZ", "200KHZ"]
   - name: debug_modes
-    values: ["NONE", "GYRO", "NOTCH", "NAV_LANDING", "FW_ALTITUDE", "RFIND", "RFIND_Q", "PITOT", "AGL", "FLOW_RAW"]
+    values: ["NONE", "GYRO", "NOTCH", "NAV_LANDING", "FW_ALTITUDE", "RFIND", "RFIND_Q", "PITOT", "AGL", "FLOW_RAW","ALWAYS"]
   - name: async_mode
     values: ["NONE", "GYRO", "ALL"]
   - name: aux_operator


### PR DESCRIPTION
Allows to set debug_mode to DEBUG_ALWAYS so any dev can place debug[i] in any part of the code and get it logged into the blackbox while testing new features without having to mess with blackbox code to make it logging.
