### PR TITLE
Simplify HMC5883 dirver

### DIFF
--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -136,9 +136,9 @@ static bool hmc5883lRead(magDev_t * mag)
         return false;
     }
 
-    magDev->magADCRaw[X] = (int16_t)(buf[0] << 8 | buf[1]);
-    magDev->magADCRaw[Z] = (int16_t)(buf[2] << 8 | buf[3]);
-    magDev->magADCRaw[Y] = (int16_t)(buf[4] << 8 | buf[5]);
+    mag->magADCRaw[X] = (int16_t)(buf[0] << 8 | buf[1]);
+    mag->magADCRaw[Z] = (int16_t)(buf[2] << 8 | buf[3]);
+    mag->magADCRaw[Y] = (int16_t)(buf[4] << 8 | buf[5]);
 
     return true;
 }

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -60,7 +60,7 @@
 
 mag_t mag;                   // mag access functions
 
-PG_REGISTER_WITH_RESET_TEMPLATE(compassConfig_t, compassConfig, PG_COMPASS_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(compassConfig_t, compassConfig, PG_COMPASS_CONFIG, 3);
 
 #ifdef USE_MAG
 #define MAG_HARDWARE_DEFAULT    MAG_AUTODETECT


### PR DESCRIPTION
PoC implementation 9b02f455c7bf54c69f232c3b008bdc9f7664e4fa by @andrejpodzimek.

I've done some tests and it looks like `magGain` calculated in HMC5883 driver is between 0.8 and 1.0. Not applying per-axis gains may result in non-linearity of heading. In worst case it may lead to heading error of about 6 degrees which is probably acceptable - compass alignment error is likely to be bigger.

References: https://github.com/iNavFlight/inav/issues/2619#issuecomment-362207651, https://github.com/iNavFlight/inav/issues/2558, https://github.com/iNavFlight/inav/issues/2299