### PR TITLE
Change battery cell max default and VBATT_CELL_FULL_MAX_DIFF

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -45,7 +45,7 @@
 
 #define ADCVREF 3300                 // in mV (3300 = 3.3V)
 
-#define VBATT_CELL_FULL_MAX_DIFF 7   // Max difference with cell max voltage for the battery to be considered full (10mV steps)
+#define VBATT_CELL_FULL_MAX_DIFF 14  // Max difference with cell max voltage for the battery to be considered full (10mV steps)
 #define VBATT_PRESENT_THRESHOLD 100  // Minimum voltage to consider battery present
 #define VBATT_STABLE_DELAY 40        // Delay after connecting battery to begin monitoring
 #define VBATT_HYSTERESIS 10          // Batt Hysteresis of +/-100mV for changing battery state
@@ -79,7 +79,7 @@ PG_RESET_TEMPLATE(batteryConfig_t, batteryConfig,
 
     .voltage = {
         .scale = VBAT_SCALE_DEFAULT,
-        .cellMax = 430,
+        .cellMax = 424,
         .cellMin = 330,
         .cellWarning = 350
     },


### PR DESCRIPTION
@digitalentity I thought again about the max cell voltage. When you asked me to restore the old value I didn't think about the full battery detection. The issue with 4.3V/cell is that it defeats it. Few people probably use 1S batteries and for 3S batteries 4.3V/cell means an accepted maximum drift of 300mV that's a lot. So
1. I still think the default max cell voltage can be lowered and that 4.24V/cell would be enough. That would mean a 120mV maximum drift for a 3S battery before it is wrongly detected as 4S.
2. The max difference with max cell voltage to consider the battery full should be raised to 140mV instead of the current 70mV. Meaning a 3S battery would be considered full above 12.3V