### PR TITLE
Allow aligning the mag to any rotation

### DIFF
--- a/src/main/drivers/compass/compass.h
+++ b/src/main/drivers/compass/compass.h
@@ -17,13 +17,21 @@
 
 #pragma once
 
+#include "common/vector.h"
+
 #include "drivers/sensor.h"
 
 typedef struct magDev_s {
     busDevice_t * busDev;
     sensorMagInitFuncPtr init;  // initialize function
     sensorMagReadFuncPtr read;  // read 3 axis data function
-    sensor_align_e magAlign;
+    struct {
+        bool useExternal;
+        union {
+            fpMat3_t externalRotation;
+            sensor_align_e onBoard;
+        };
+    } magAlign;
     uint8_t magSensorToUse;
     int16_t magADCRaw[XYZ_AXIS_COUNT];
 } magDev_t;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -264,6 +264,18 @@ groups:
         condition: USE_DUAL_MAG
         min: 0
         max: 1
+      - name: align_mag_roll
+        field: rollDeciDegrees
+        min: -1800
+        max: 3600
+      - name: align_mag_pitch
+        field: pitchDeciDegrees
+        min: -1800
+        max: 3600
+      - name: align_mag_yaw
+        field: yawDeciDegrees
+        min: -1800
+        max: 3600
 
   - name: PG_BAROMETER_CONFIG
     type: barometerConfig_t

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -51,13 +51,16 @@ typedef struct mag_s {
 extern mag_t mag;
 
 typedef struct compassConfig_s {
-    int16_t mag_declination;                // Get your magnetic decliniation from here : http://magnetic-declination.com/
+    int16_t mag_declination;                // Get your magnetic declination from here : http://magnetic-declination.com/
                                             // For example, -6deg 37min, = -637 Japan, format is [sign]dddmm (degreesminutes) default is zero.
-    sensor_align_e mag_align;               // mag alignment
+    sensor_align_e mag_align;               // on-board mag alignment. Ignored if externally aligned via *DeciDegrees.
     uint8_t mag_hardware;                   // Which mag hardware to use on boards with more than one device
     flightDynamicsTrims_t magZero;
     uint8_t mag_to_use;
     uint8_t magCalibrationTimeLimit;        // Time for compass calibration (seconds)
+    int16_t rollDeciDegrees;                // Alignment for external mag on the roll (X) axis (0.1deg)
+    int16_t pitchDeciDegrees;               // Alignment for external mag on the pitch (Y) axis (0.1deg)
+    int16_t yawDeciDegrees;                 // Alignment for external mag on the yaw (Z) axis (0.1deg)
 } compassConfig_t;
 
 PG_DECLARE(compassConfig_t, compassConfig);


### PR DESCRIPTION
Introduce 3 new variables which allow setting the decidegrees
for the mag sensor alignment. When any of these 3 variables
are non-zero, mag is assumed to be mounted off-board and
"align_mag" as well as the board alignment are ignored.

Settings are named align_mag_roll, align_mag_pitch and
align_mag_yaw.

Fixes #86
Fixes #1029