### PR TITLE
Revert "SBUS max frame transmission time increased to 6ms."

### DIFF
--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -41,17 +41,13 @@
  * FrSky X8R
  * time between frames: 6ms.
  * time to send frame: 3ms.
- *
+*
  * Futaba R6208SB/R6303SB
  * time between frames: 11ms.
  * time to send frame: 3ms.
- *
- * eLeReS
- * frame starts every: 14ms
- * time to send frame: 3-6ms (sent with soft-serial, possible gaps between bytes)
  */
 
-#define SBUS_TIME_NEEDED_PER_FRAME 6000
+#define SBUS_TIME_NEEDED_PER_FRAME 3000
 
 #ifndef CJMCU
 //#define DEBUG_SBUS_PACKETS


### PR DESCRIPTION
Reverts iNavFlight/inav#2718
Fixes https://github.com/iNavFlight/inav/issues/2827

@fiam @shellixyz @ondrascz can you confirm?