### PR TITLE
Bulk gyro/acc reads, temperature sensor framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -653,6 +653,7 @@ COMMON_SRC = \
             scheduler/scheduler.c \
             sensors/acceleration.c \
             sensors/battery.c \
+            sensors/temperature.c \
             sensors/boardalignment.c \
             sensors/compass.c \
             sensors/diagnostics.c \

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -29,8 +29,7 @@
 #include "common/maths.h"
 #include "common/utils.h"
 
-#include "drivers/bus_i2c.h"
-#include "drivers/bus_spi.h"
+#include "drivers/bus.h"
 #include "drivers/exti.h"
 #include "drivers/io.h"
 #include "drivers/exti.h"
@@ -42,6 +41,9 @@
 #include "drivers/sensor.h"
 #include "drivers/accgyro/accgyro.h"
 #include "drivers/accgyro/accgyro_mpu.h"
+
+// Check busDevice scratchpad memory size
+STATIC_ASSERT(sizeof(mpuContextData_t) < BUS_SCRATCHPAD_MEMORY_SIZE, busDevice_scratchpad_memory_too_small);
 
 /*
  * Gyro interrupt service routine
@@ -103,39 +105,62 @@ bool mpuGyroRead(gyroDev_t *gyro)
     return true;
 }
 
-bool mpuAccRead(accDev_t *acc)
-{
-    uint8_t data[6];
-
-    const bool ack = busReadBuf(acc->busDev, MPU_RA_ACCEL_XOUT_H, data, 6);
-    if (!ack) {
-        return false;
-    }
-
-    acc->ADCRaw[X] = (int16_t)((data[0] << 8) | data[1]);
-    acc->ADCRaw[Y] = (int16_t)((data[2] << 8) | data[3]);
-    acc->ADCRaw[Z] = (int16_t)((data[4] << 8) | data[5]);
-
-    return true;
-}
-
 bool mpuCheckDataReady(gyroDev_t* gyro)
 {
     bool ret;
     if (gyro->dataReady) {
         ret = true;
-        gyro->dataReady= false;
+        gyro->dataReady = false;
     } else {
         ret = false;
     }
     return ret;
 }
 
-/*
-void mpuGyroSetIsrUpdate(gyroDev_t *gyro, sensorGyroUpdateFuncPtr updateFn)
+static bool mpuUpdateSensorContext(busDevice_t * busDev, mpuContextData_t * ctx)
 {
-    ATOMIC_BLOCK(NVIC_PRIO_MPU_INT_EXTI) {
-        gyro->updateFn = updateFn;
-    }
+    ctx->lastReadStatus = busReadBuf(busDev, MPU_RA_ACCEL_XOUT_H, ctx->accRaw, 6 + 2 + 6);
+    return ctx->lastReadStatus;
 }
-*/
+
+bool mpuGyroReadScratchpad(gyroDev_t *gyro)
+{
+    busDevice_t * busDev = gyro->busDev;
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(busDev);
+
+    if (mpuUpdateSensorContext(busDev, ctx)) {
+        gyro->gyroADCRaw[X] = (int16_t)((ctx->gyroRaw[0] << 8) | ctx->gyroRaw[1]);
+        gyro->gyroADCRaw[Y] = (int16_t)((ctx->gyroRaw[2] << 8) | ctx->gyroRaw[3]);
+        gyro->gyroADCRaw[Z] = (int16_t)((ctx->gyroRaw[4] << 8) | ctx->gyroRaw[5]);
+
+        return true;
+    }
+
+    return false;
+}
+
+bool mpuAccReadScratchpad(accDev_t *acc)
+{
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(acc->busDev);
+
+    if (ctx->lastReadStatus) {
+        acc->ADCRaw[Y] = (int16_t)((ctx->accRaw[2] << 8) | ctx->accRaw[3]);
+        acc->ADCRaw[X] = (int16_t)((ctx->accRaw[0] << 8) | ctx->accRaw[1]);
+        acc->ADCRaw[Z] = (int16_t)((ctx->accRaw[4] << 8) | ctx->accRaw[5]);
+        return true;
+    }
+
+    return false;
+}
+
+bool mpuTemperatureReadScratchpad(gyroDev_t *gyro, int16_t * data)
+{
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(gyro->busDev);
+
+    if (ctx->lastReadStatus) {
+        *data = (int16_t)((ctx->tempRaw[2] << 8) | ctx->tempRaw[3]);
+        return true;
+    }
+
+    return false;
+}

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -144,8 +144,8 @@ bool mpuAccReadScratchpad(accDev_t *acc)
     mpuContextData_t * ctx = busDeviceGetScratchpadMemory(acc->busDev);
 
     if (ctx->lastReadStatus) {
-        acc->ADCRaw[Y] = (int16_t)((ctx->accRaw[2] << 8) | ctx->accRaw[3]);
         acc->ADCRaw[X] = (int16_t)((ctx->accRaw[0] << 8) | ctx->accRaw[1]);
+        acc->ADCRaw[Y] = (int16_t)((ctx->accRaw[2] << 8) | ctx->accRaw[3]);
         acc->ADCRaw[Z] = (int16_t)((ctx->accRaw[4] << 8) | ctx->accRaw[5]);
         return true;
     }
@@ -158,7 +158,8 @@ bool mpuTemperatureReadScratchpad(gyroDev_t *gyro, int16_t * data)
     mpuContextData_t * ctx = busDeviceGetScratchpadMemory(gyro->busDev);
 
     if (ctx->lastReadStatus) {
-        *data = (int16_t)((ctx->tempRaw[2] << 8) | ctx->tempRaw[3]);
+        // Convert to degC*10: degC = raw / 340 + 36.53
+        *data = (int16_t)((ctx->tempRaw[0] << 8) | ctx->tempRaw[1]) / 34 + 365;
         return true;
     }
 

--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -134,6 +134,15 @@ typedef struct mpuConfiguration_s {
     uint8_t gyroReadXRegister; // Y and Z must registers follow this, 2 words each
 } mpuConfiguration_t;
 
+typedef struct __attribute__ ((__packed__)) mpuContextData_s {
+    uint16_t    chipMagicNumber;
+    uint8_t     lastReadStatus;
+    uint8_t     __padding;
+    uint8_t     accRaw[6];  // MPU_RA_ACCEL_XOUT_H
+    uint8_t     tempRaw[2]; // MPU_RA_TEMP_OUT_H
+    uint8_t     gyroRaw[6]; // MPU_RA_GYRO_XOUT_H
+} mpuContextData_t;
+
 enum gyro_fsr_e {
     INV_FSR_250DPS = 0,
     INV_FSR_500DPS,
@@ -163,11 +172,12 @@ enum accel_fsr_e {
 };
 
 struct gyroDev_s;
+struct accDev_s;
 void mpuIntExtiInit(struct gyroDev_s *gyro);
 
-struct accDev_s;
-bool mpuAccRead(struct accDev_s *acc);
 bool mpuGyroRead(struct gyroDev_s *gyro);
-void mpuDetect(struct gyroDev_s *gyro);
+bool mpuGyroReadScratchpad(struct gyroDev_s *gyro);
+bool mpuAccReadScratchpad(struct accDev_s *acc);
+bool mpuTemperatureReadScratchpad(struct gyroDev_s *gyro, int16_t * data);
+
 bool mpuCheckDataReady(struct gyroDev_s *gyro);
-void mpuGyroSetIsrUpdate(struct gyroDev_s *gyro, sensorGyroUpdateFuncPtr updateFn);

--- a/src/main/drivers/accgyro/accgyro_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6000.c
@@ -142,12 +142,13 @@ bool mpu6000AccDetect(accDev_t *acc)
         return false;
     }
 
-    if (busDeviceReadScratchpad(acc->busDev) != 0xFFFF6000) {
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(acc->busDev);
+    if (ctx->chipMagicNumber != 0x6860) {
         return false;
     }
 
     acc->initFn = mpu6000AccInit;
-    acc->readFn = mpuAccRead;
+    acc->readFn = mpuAccReadScratchpad;
 
     return true;
 }
@@ -207,11 +208,14 @@ bool mpu6000GyroDetect(gyroDev_t *gyro)
         return false;
     }
 
-    busDeviceWriteScratchpad(gyro->busDev, 0xFFFF6000);    // Magic number for ACC detection to indicate that we have detected MPU6000 gyro
+    // Magic number for ACC detection to indicate that we have detected MPU6000 gyro
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(gyro->busDev);
+    ctx->chipMagicNumber = 0x6860;
 
     gyro->initFn = mpu6000AccAndGyroInit;
-    gyro->readFn = mpuGyroRead;
+    gyro->readFn = mpuGyroReadScratchpad;
     gyro->intStatusFn = mpuCheckDataReady;
+    gyro->temperatureFn = mpuTemperatureReadScratchpad;
     gyro->scale = 1.0f / 16.4f;     // 16.4 dps/lsb scalefactor
 
     return true;

--- a/src/main/drivers/accgyro/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6500.c
@@ -55,12 +55,13 @@ bool mpu6500AccDetect(accDev_t *acc)
         return false;
     }
 
-    if (busDeviceReadScratchpad(acc->busDev) != 0xFFFF6500) {
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(acc->busDev);
+    if (ctx->chipMagicNumber != 0x6860) {
         return false;
     }
 
     acc->initFn = mpu6500AccInit;
-    acc->readFn = mpuAccRead;
+    acc->readFn = mpuAccReadScratchpad;
 
     return true;
 }
@@ -157,11 +158,14 @@ bool mpu6500GyroDetect(gyroDev_t *gyro)
         return false;
     }
 
-    busDeviceWriteScratchpad(gyro->busDev, 0xFFFF6500);    // Magic number for ACC detection to indicate that we have detected MPU6000 gyro
+    // Magic number for ACC detection to indicate that we have detected MPU6000 gyro
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(gyro->busDev);
+    ctx->chipMagicNumber = 0x6500;
 
     gyro->initFn = mpu6500AccAndGyroInit;
-    gyro->readFn = mpuGyroRead;
+    gyro->readFn = mpuGyroReadScratchpad;
     gyro->intStatusFn = mpuCheckDataReady;
+    gyro->temperatureFn = mpuTemperatureReadScratchpad;
     gyro->scale = 1.0f / 16.4f;     // 16.4 dps/lsb scalefactor
 
     return true;

--- a/src/main/drivers/accgyro/accgyro_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_mpu9250.c
@@ -55,12 +55,13 @@ bool mpu9250AccDetect(accDev_t *acc)
         return false;
     }
 
-    if (busDeviceReadScratchpad(acc->busDev) != 0xFFFF9250) {
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(acc->busDev);
+    if (ctx->chipMagicNumber != 0x9250) {
         return false;
     }
 
     acc->initFn = mpu9250AccInit;
-    acc->readFn = mpuAccRead;
+    acc->readFn = mpuAccReadScratchpad;
 
     return true;
 }
@@ -154,11 +155,14 @@ bool mpu9250GyroDetect(gyroDev_t *gyro)
         return false;
     }
 
-    busDeviceWriteScratchpad(gyro->busDev, 0xFFFF9250);    // Magic number for ACC detection to indicate that we have detected MPU6000 gyro
+    // Magic number for ACC detection to indicate that we have detected MPU6000 gyro
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(gyro->busDev);
+    ctx->chipMagicNumber = 0x9250;
 
     gyro->initFn = mpu9250AccAndGyroInit;
-    gyro->readFn = mpuGyroRead;
+    gyro->readFn = mpuGyroReadScratchpad;
     gyro->intStatusFn = mpuCheckDataReady;
+    gyro->temperatureFn = mpuTemperatureReadScratchpad;
     gyro->scale = 1.0f / 16.4f;     // 16.4 dps/lsb scalefactor
 
     return true;

--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -196,12 +196,17 @@ void busSetSpeed(const busDevice_t * dev, busSpeed_e speed)
 
 uint32_t busDeviceReadScratchpad(const busDevice_t * dev)
 {
-    return dev->scratchpad;
+    return dev->scratchpad[0];
 }
 
 void busDeviceWriteScratchpad(busDevice_t * dev, uint32_t value)
 {
-    dev->scratchpad = value;
+    dev->scratchpad[0] = value;
+}
+
+void * busDeviceGetScratchpadMemory(const busDevice_t * dev)
+{
+    return dev->scratchpad;
 }
 
 bool busTransfer(const busDevice_t * dev, uint8_t * rxBuf, const uint8_t * txBuf, int length)

--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -206,7 +206,7 @@ void busDeviceWriteScratchpad(busDevice_t * dev, uint32_t value)
 
 void * busDeviceGetScratchpadMemory(const busDevice_t * dev)
 {
-    return dev->scratchpad;
+    return (void *)dev->scratchpad;
 }
 
 bool busTransfer(const busDevice_t * dev, uint8_t * rxBuf, const uint8_t * txBuf, int length)

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -45,6 +45,8 @@
 #define BUS_I2C4            I2CDEV_4
 #define BUS_I2C_EMULATED    I2CINVALID
 
+#define BUS_SCRATCHPAD_MEMORY_SIZE      (20)
+
 typedef enum {
     BUS_SPEED_INITIALIZATION = 0,
     BUS_SPEED_SLOW           = 1,
@@ -159,8 +161,9 @@ typedef struct busDevice_s {
 #endif
     } busdev;
     IO_t irqPin;                    // Device IRQ pin. Bus system will only assign IO_t object to this var. Initialization is up to device driver
-    uint32_t scratchpad;            // Memory where device driver can store persistent data. Zeroed out when initializing the device for the first time
-                                    // Useful when once device is shared between several sensors (like MPU/ICM acc-gyro sensors)
+    uint32_t scratchpad[BUS_SCRATCHPAD_MEMORY_SIZE / sizeof(uint32_t)];     // Memory where device driver can store persistent data. Zeroed out when initializing the device 
+                                                                            // for the first time. Useful when once device is shared between several sensors 
+                                                                            // (like MPU/ICM acc-gyro sensors)
 } busDevice_t;
 
 #ifdef __APPLE__
@@ -254,6 +257,7 @@ void busDeviceDeInit(busDevice_t * dev);
 
 uint32_t busDeviceReadScratchpad(const busDevice_t * dev);
 void busDeviceWriteScratchpad(busDevice_t * dev, uint32_t value);
+void * busDeviceGetScratchpadMemory(const busDevice_t * dev);
 
 void busSetSpeed(const busDevice_t * dev, busSpeed_e speed);
 

--- a/src/main/drivers/compass/compass_mpu9250.c
+++ b/src/main/drivers/compass/compass_mpu9250.c
@@ -291,7 +291,8 @@ bool mpu9250CompassDetect(magDev_t * mag)
     }
 
     // Check if Gyro driver initialized the chip
-    if (busDeviceReadScratchpad(mag->busDev) != 0xFFFF9250) {
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(acc->busDev);
+    if (ctx->chipMagicNumber != 0x9250) {
         return false;
     }
 

--- a/src/main/drivers/compass/compass_mpu9250.c
+++ b/src/main/drivers/compass/compass_mpu9250.c
@@ -291,7 +291,7 @@ bool mpu9250CompassDetect(magDev_t * mag)
     }
 
     // Check if Gyro driver initialized the chip
-    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(acc->busDev);
+    mpuContextData_t * ctx = busDeviceGetScratchpadMemory(mag->busDev);
     if (ctx->chipMagicNumber != 0x9250) {
         return false;
     }

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -68,6 +68,7 @@
 
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"
+#include "sensors/temperature.h"
 #include "sensors/barometer.h"
 #include "sensors/battery.h"
 #include "sensors/compass.h"
@@ -109,6 +110,12 @@ void taskUpdateBattery(timeUs_t currentTimeUs)
         powerMeterUpdate(BatMonitoringTimeSinceLastServiced);
 #endif
     batMonitoringLastServiced = currentTimeUs;
+}
+
+void taskUpdateTemperature(timeUs_t currentTimeUs)
+{
+    UNUSED(currentTimeUs);
+    temperatureUpdate();
 }
 
 #ifdef USE_GPS
@@ -307,6 +314,7 @@ void fcTasksInit(void)
     setTaskEnabled(TASK_LIGHTS, true);
 #endif
     setTaskEnabled(TASK_BATTERY, feature(FEATURE_VBAT) || feature(FEATURE_CURRENT_METER));
+    setTaskEnabled(TASK_TEMPERATURE, true);
     setTaskEnabled(TASK_RX, true);
 #ifdef USE_GPS
     setTaskEnabled(TASK_GPS, feature(FEATURE_GPS));
@@ -450,6 +458,13 @@ cfTask_t cfTasks[TASK_COUNT] = {
         .taskFunc = taskUpdateBattery,
         .desiredPeriod = TASK_PERIOD_HZ(50),      // 50 Hz
         .staticPriority = TASK_PRIORITY_MEDIUM,
+    },
+
+    [TASK_TEMPERATURE] = {
+        .taskName = "TEMPERATURE",
+        .taskFunc = taskUpdateTemperature,
+        .desiredPeriod = TASK_PERIOD_HZ(10),      // 10 Hz
+        .staticPriority = TASK_PRIORITY_LOW,
     },
 
     [TASK_RX] = {

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -463,7 +463,7 @@ cfTask_t cfTasks[TASK_COUNT] = {
     [TASK_TEMPERATURE] = {
         .taskName = "TEMPERATURE",
         .taskFunc = taskUpdateTemperature,
-        .desiredPeriod = TASK_PERIOD_HZ(10),      // 10 Hz
+        .desiredPeriod = TASK_PERIOD_HZ(1),       // 1 Hz
         .staticPriority = TASK_PRIORITY_LOW,
     },
 

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -62,6 +62,7 @@ typedef enum {
     TASK_RX,
     TASK_SERIAL,
     TASK_BATTERY,
+    TASK_TEMPERATURE,
 #ifdef BEEPER
     TASK_BEEPER,
 #endif

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -440,11 +440,14 @@ void gyroUpdate(timeDelta_t gyroUpdateDeltaUs)
 #endif
 }
 
-void gyroReadTemperature(void)
+bool gyroReadTemperature(void)
 {
+    // Read gyro sensor temperature. temperatureFn returns temperature in [degC * 10]
     if (gyroDev0.temperatureFn) {
-        gyroDev0.temperatureFn(&gyroDev0, &gyroTemperature0);
+        return gyroDev0.temperatureFn(&gyroDev0, &gyroTemperature0);
     }
+
+    return false;
 }
 
 int16_t gyroGetTemperature(void)

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -66,7 +66,7 @@ void gyroGetMeasuredRotationRate(t_fp_vector *imuMeasuredRotationBF);
 void gyroUpdate(timeDelta_t gyroUpdateDeltaUs);
 void gyroSetCalibrationCycles(uint16_t calibrationCyclesRequired);
 bool gyroIsCalibrationComplete(void);
-void gyroReadTemperature(void);
+bool gyroReadTemperature(void);
 int16_t gyroGetTemperature(void);
 int16_t gyroRateDps(int axis);
 bool gyroSyncCheckUpdate(void);

--- a/src/main/sensors/temperature.c
+++ b/src/main/sensors/temperature.c
@@ -31,12 +31,12 @@
 static bool     tempSensorValid[TEMP_COUNT];
 static int16_t  tempSensorValue[TEMP_COUNT];
 
-bool isTemperatureSensorValid(tempSensor_t sensor)
+bool isTemperatureSensorValid(tempSensor_e sensor)
 {
     return tempSensorValid[sensor];
 }
 
-int16_t getTemperature(tempSensor_t sensor)
+int16_t getTemperature(tempSensor_e sensor)
 {
     return tempSensorValue[sensor];
 }

--- a/src/main/sensors/temperature.c
+++ b/src/main/sensors/temperature.c
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "stdbool.h"
+#include "stdint.h"
+
+#include "platform.h"
+
+#include "common/maths.h"
+
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+
+#include "sensors/temperature.h"
+#include "sensors/gyro.h"
+
+static bool     tempSensorValid[TEMP_COUNT];
+static int16_t  tempSensorValue[TEMP_COUNT];
+
+bool isTemperatureSensorValid(tempSensor_t sensor)
+{
+    return tempSensorValid[sensor];
+}
+
+int16_t getTemperature(tempSensor_t sensor)
+{
+    return tempSensorValue[sensor];
+}
+
+void temperatureUpdate(void)
+{
+    // TEMP_GYRO: Update gyro temperature
+    if (gyroReadTemperature()) {
+        tempSensorValid[TEMP_GYRO] = true;
+        tempSensorValue[TEMP_GYRO] = gyroGetTemperature();
+    }
+}

--- a/src/main/sensors/temperature.h
+++ b/src/main/sensors/temperature.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "config/parameter_group.h"
+
+typedef enum tempSensor_e {
+    TEMP_GYRO = 0,
+    TEMP_COUNT
+} tempSensor_t;
+
+// Temperature is returned in degC*10
+
+bool isTemperatureSensorValid(tempSensor_t sensor);
+int16_t getTemperature(tempSensor_t sensor);
+void temperatureUpdate(void);

--- a/src/main/sensors/temperature.h
+++ b/src/main/sensors/temperature.h
@@ -19,13 +19,13 @@
 
 #include "config/parameter_group.h"
 
-typedef enum tempSensor_e {
+typedef enum {
     TEMP_GYRO = 0,
     TEMP_COUNT
-} tempSensor_t;
+} tempSensor_e;
 
 // Temperature is returned in degC*10
 
-bool isTemperatureSensorValid(tempSensor_t sensor);
-int16_t getTemperature(tempSensor_t sensor);
+bool isTemperatureSensorValid(tempSensor_e sensor);
+int16_t getTemperature(tempSensor_e sensor);
 void temperatureUpdate(void);


### PR DESCRIPTION
This PR changes gyro/acc drivers to read acceleration/temperature/gyro data in one transaction. This should save some bus overhead compared to reading acceleration/gyro separately.

Also introduced framework for temperature sensors. Currently only one sensor - gyroscope/MPU. This temperature readings could be shown in OSD or used in future to compensate for temperature drift of accelerometer.