### PR TITLE
Fix ANTI_WINDUP

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -595,8 +595,8 @@ void processRx(timeUs_t currentTimeUs)
             if (isAirmodeActive() && !failsafeIsActive() && ARMING_FLAG(ARMED)) {
                 rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
 
-                // ANTI_WINDUP at centred stick with MOTOR_STOP is needed on MRs and not needed on FWs
-                if ((rollPitchStatus == CENTERED) || (feature(FEATURE_MOTOR_STOP) && !STATE(FIXED_WING))) {
+                // ANTI_WINDUP at centered stick with MOTOR_STOP is needed on MRs and not needed on FWs
+                if ((!STATE(FIXED_WING)) && (rollPitchStatus == CENTERED) && (feature(FEATURE_MOTOR_STOP))) {
                     ENABLE_STATE(ANTI_WINDUP);
                 }
                 else {


### PR DESCRIPTION
Enable ANTI_WINDUP only for MRs when THR LOW && FEATURE_MOTOR_STOP && ROLL/PITCH CENTER.

Fixes #2834. If right should probably be merged for 1.9.