### PR TITLE
Save 6952 bytes of RAM

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -158,8 +158,9 @@ static char menuErrLabel[21 + 1] = "RANDOM DATA";
 static OSD_Entry menuErrEntries[] = {
     { "BROKEN MENU", OME_Label, NULL, NULL, 0 },
     { menuErrLabel, OME_Label, NULL, NULL, 0 },
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu menuErr = {

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -351,9 +351,9 @@ static int cmsDrawMenuEntry(displayPort_t *pDisplay, const OSD_Entry *p, uint8_t
 #ifdef USE_OSD
     case OME_VISIBLE:
         if (IS_PRINTVALUE(p, screenRow) && p->data) {
-            uint16_t *val = (uint16_t *)p->data;
+            uint16_t val = osdConfig()->item_pos[(int)p->data];
 
-            if (VISIBLE(*val)) {
+            if (VISIBLE(val)) {
                 cnt = displayWrite(pDisplay, RIGHT_MENU_COLUMN(pDisplay), row, "YES");
             } else {
                 cnt = displayWrite(pDisplay, RIGHT_MENU_COLUMN(pDisplay), row, "NO ");
@@ -879,7 +879,7 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
 #ifdef USE_OSD
         case OME_VISIBLE:
             if (p->data) {
-                uint16_t *val = (uint16_t *)p->data;
+                uint16_t *val = &osdConfigMutable()->item_pos[(int)p->data];
 
                 if (key == KEY_RIGHT)
                     *val |= VISIBLE_FLAG;

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -75,7 +75,7 @@ static bool cmsx_Blackbox_Enabled(bool *enabled)
     return featureConfigured(FEATURE_BLACKBOX);
 }
 
-static OSD_Entry cmsx_menuBlackboxEntries[] =
+static const OSD_Entry cmsx_menuBlackboxEntries[] =
 {
     OSD_LABEL_ENTRY("-- BLACKBOX --"),
     OSD_BOOL_FUNC_ENTRY("ENABLED", cmsx_Blackbox_Enabled),
@@ -89,7 +89,7 @@ static OSD_Entry cmsx_menuBlackboxEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu cmsx_menuBlackbox = {
+const CMS_Menu cmsx_menuBlackbox = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUBB",
     .GUARD_type = OME_MENU,

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -84,8 +84,8 @@ static OSD_Entry cmsx_menuBlackboxEntries[] =
     { "ERASE FLASH",OME_Funcall, cmsx_EraseFlash, NULL, 0 },
 #endif // USE_FLASHFS
 
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuBlackbox = {

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -77,11 +77,12 @@ static bool cmsx_Blackbox_Enabled(bool *enabled)
 
 static OSD_Entry cmsx_menuBlackboxEntries[] =
 {
-    { "-- BLACKBOX --", OME_Label,      NULL, NULL, 0},
-    { "ENABLED",        OME_BoolFunc,   NULL, cmsx_Blackbox_Enabled, 0 },
+    OSD_LABEL_ENTRY("-- BLACKBOX --"),
+    OSD_BOOL_FUNC_ENTRY("ENABLED", cmsx_Blackbox_Enabled),
     OSD_SETTING_ENTRY("RATE DENOM", SETTING_BLACKBOX_RATE_DENOM),
+
 #ifdef USE_FLASHFS
-    { "ERASE FLASH",OME_Funcall, cmsx_EraseFlash, NULL, 0 },
+    OSD_FUNC_CALL_ENTRY("ERASE FLASH", cmsx_EraseFlash),
 #endif // USE_FLASHFS
 
     OSD_BACK_ENTRY,

--- a/src/main/cms/cms_menu_blackbox.h
+++ b/src/main/cms/cms_menu_blackbox.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-extern CMS_Menu cmsx_menuBlackbox;
+extern const CMS_Menu cmsx_menuBlackbox;

--- a/src/main/cms/cms_menu_builtin.c
+++ b/src/main/cms/cms_menu_builtin.c
@@ -74,11 +74,12 @@ static long cmsx_InfoInit(void)
 }
 
 static OSD_Entry menuInfoEntries[] = {
-    { "--- INFO ---", OME_Label, NULL, NULL, 0 },
-    { "FWID", OME_String, NULL, INAV_IDENTIFIER, 0 },
-    { "FWVER", OME_String, NULL, FC_VERSION_STRING, 0 },
-    { "GITREV", OME_String, NULL, infoGitRev, 0 },
-    { "TARGET", OME_String, NULL, infoTargetName, 0 },
+    OSD_LABEL_ENTRY("--- INFO ---"),
+    OSD_STRING_ENTRY("FWID", INAV_IDENTIFIER),
+    OSD_STRING_ENTRY("FWVER", FC_VERSION_STRING),
+    OSD_STRING_ENTRY("GITREV", infoGitRev),
+    OSD_STRING_ENTRY("TARGET", infoTargetName),
+
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
 };
@@ -98,25 +99,26 @@ static CMS_Menu menuInfo = {
 
 static OSD_Entry menuFeaturesEntries[] =
 {
-    {"--- FEATURES ---", OME_Label, NULL, NULL, 0},
-    {"BLACKBOX", OME_Submenu, cmsMenuChange, &cmsx_menuBlackbox, 0},
+    OSD_LABEL_ENTRY("--- FEATURES ---"),
+    OSD_SUBMENU_ENTRY("BLACKBOX", &cmsx_menuBlackbox),
 #if defined(USE_NAV)
-    {"NAVIGATION", OME_Submenu, cmsMenuChange, &cmsx_menuNavigation, 0},
+    OSD_SUBMENU_ENTRY("NAVIGATION", &cmsx_menuNavigation),
 #endif
 #if defined(VTX) || defined(USE_RTC6705)
-    {"VTX", OME_Submenu, cmsMenuChange, &cmsx_menuVtx, 0},
+    OSD_SUBMENU_ENTRY("VTX", &cmsx_menuVtx),
 #endif // VTX || USE_RTC6705
 #if defined(VTX_CONTROL)
 #if defined(VTX_SMARTAUDIO)
-    {"VTX SA", OME_Submenu, cmsMenuChange, &cmsx_menuVtxSmartAudio, 0},
+    OSD_SUBMENU_ENTRY("VTX SA", &cmsx_menuVtxSmartAudio),
 #endif
 #if defined(VTX_TRAMP)
-    {"VTX TR", OME_Submenu, cmsMenuChange, &cmsx_menuVtxTramp, 0},
+    OSD_SUBMENU_ENTRY("VTX TR", &cmsx_menuVtxTramp),
 #endif
 #endif // VTX_CONTROL
 #ifdef USE_LED_STRIP
-    {"LED STRIP", OME_Submenu, cmsMenuChange, &cmsx_menuLedstrip, 0},
+    OSD_SUBMENU_ENTRY("LED STRIP", &cmsx_menuLedstrip),
 #endif // LED_STRIP
+
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
 };
@@ -136,23 +138,24 @@ static CMS_Menu menuFeatures = {
 
 static OSD_Entry menuMainEntries[] =
 {
-    {"-- MAIN --",  OME_Label, NULL, NULL, 0},
+    OSD_LABEL_ENTRY("-- MAIN --"),
 
-    {"PID TUNING",  OME_Submenu,  cmsMenuChange, &cmsx_menuImu, 0},
-    {"FEATURES",    OME_Submenu,  cmsMenuChange, &menuFeatures, 0},
+    OSD_SUBMENU_ENTRY("PID TUNING", &cmsx_menuImu),
+    OSD_SUBMENU_ENTRY("FEATURES", &menuFeatures),
 #ifdef USE_OSD
-    {"SCR LAYOUT",  OME_Submenu,  cmsMenuChange, &cmsx_menuOsdLayout, 0},
-    {"ALARMS",      OME_Submenu,  cmsMenuChange, &cmsx_menuAlarms, 0},
+    OSD_SUBMENU_ENTRY("SCR LAYOUT", &cmsx_menuOsdLayout),
+    OSD_SUBMENU_ENTRY("ALARMS", &cmsx_menuAlarms),
 #endif
-    {"FC&FW INFO",  OME_Submenu,  cmsMenuChange, &menuInfo, 0},
-    {"MISC",        OME_Submenu,  cmsMenuChange, &cmsx_menuMisc, 0},
+    OSD_SUBMENU_ENTRY("FC&FW INFO", &menuInfo),
+    OSD_SUBMENU_ENTRY("MISC", &cmsx_menuMisc),
+
     {"SAVE&REBOOT", OME_OSD_Exit, cmsMenuExit,   (void*)CMS_EXIT_SAVEREBOOT, 0},
     {"EXIT",        OME_OSD_Exit, cmsMenuExit,   (void*)CMS_EXIT, 0},
 #ifdef CMS_MENU_DEBUG
-    {"ERR SAMPLE",  OME_Submenu,  cmsMenuChange, &menuInfoEntries[0], 0},
+    OSD_SUBMENU_ENTRY("ERR SAMPLE", &menuInfoEntries[0]),
 #endif
 
-    {NULL,OME_END, NULL, NULL, 0}
+    OSD_END_ENTRY,
 };
 
 CMS_Menu menuMain = {

--- a/src/main/cms/cms_menu_builtin.c
+++ b/src/main/cms/cms_menu_builtin.c
@@ -79,8 +79,8 @@ static OSD_Entry menuInfoEntries[] = {
     { "FWVER", OME_String, NULL, FC_VERSION_STRING, 0 },
     { "GITREV", OME_String, NULL, infoGitRev, 0 },
     { "TARGET", OME_String, NULL, infoTargetName, 0 },
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu menuInfo = {
@@ -117,8 +117,8 @@ static OSD_Entry menuFeaturesEntries[] =
 #ifdef USE_LED_STRIP
     {"LED STRIP", OME_Submenu, cmsMenuChange, &cmsx_menuLedstrip, 0},
 #endif // LED_STRIP
-    {"BACK", OME_Back, NULL, NULL, 0},
-    {NULL, OME_END, NULL, NULL, 0}
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu menuFeatures = {

--- a/src/main/cms/cms_menu_builtin.c
+++ b/src/main/cms/cms_menu_builtin.c
@@ -73,7 +73,7 @@ static long cmsx_InfoInit(void)
     return 0;
 }
 
-static OSD_Entry menuInfoEntries[] = {
+static const OSD_Entry menuInfoEntries[] = {
     OSD_LABEL_ENTRY("--- INFO ---"),
     OSD_STRING_ENTRY("FWID", INAV_IDENTIFIER),
     OSD_STRING_ENTRY("FWVER", FC_VERSION_STRING),
@@ -84,7 +84,7 @@ static OSD_Entry menuInfoEntries[] = {
     OSD_END_ENTRY,
 };
 
-static CMS_Menu menuInfo = {
+static const CMS_Menu menuInfo = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUINFO",
     .GUARD_type = OME_MENU,
@@ -97,7 +97,7 @@ static CMS_Menu menuInfo = {
 
 // Features
 
-static OSD_Entry menuFeaturesEntries[] =
+static const OSD_Entry menuFeaturesEntries[] =
 {
     OSD_LABEL_ENTRY("--- FEATURES ---"),
     OSD_SUBMENU_ENTRY("BLACKBOX", &cmsx_menuBlackbox),
@@ -123,7 +123,7 @@ static OSD_Entry menuFeaturesEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu menuFeatures = {
+static const CMS_Menu menuFeatures = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUFEATURES",
     .GUARD_type = OME_MENU,
@@ -136,7 +136,7 @@ static CMS_Menu menuFeatures = {
 
 // Main
 
-static OSD_Entry menuMainEntries[] =
+static const OSD_Entry menuMainEntries[] =
 {
     OSD_LABEL_ENTRY("-- MAIN --"),
 
@@ -158,7 +158,7 @@ static OSD_Entry menuMainEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu menuMain = {
+const CMS_Menu menuMain = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUMAIN",
     .GUARD_type = OME_MENU,

--- a/src/main/cms/cms_menu_builtin.h
+++ b/src/main/cms/cms_menu_builtin.h
@@ -19,4 +19,4 @@
 
 #include "cms/cms_types.h"
 
-extern CMS_Menu menuMain;
+extern const CMS_Menu menuMain;

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -133,17 +133,17 @@ static const OSD_Entry cmsx_menuPidEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- PID --", profileIndexString),
 
-    OSD_UINT8_ENTRY("ROLL  P", (&(OSD_UINT8_t){ &cmsx_pidRoll[0],  0, 200, 1 })),
-    OSD_UINT8_ENTRY("ROLL I", (&(OSD_UINT8_t){ &cmsx_pidRoll[1],  0, 200, 1 })),
-    OSD_UINT8_ENTRY("ROLL D", (&(OSD_UINT8_t){ &cmsx_pidRoll[2],  0, 200, 1 })),
+    OSD_UINT8_ENTRY("ROLL P", (&(const OSD_UINT8_t){ &cmsx_pidRoll[0],  0, 200, 1 })),
+    OSD_UINT8_ENTRY("ROLL I", (&(const OSD_UINT8_t){ &cmsx_pidRoll[1],  0, 200, 1 })),
+    OSD_UINT8_ENTRY("ROLL D", (&(const OSD_UINT8_t){ &cmsx_pidRoll[2],  0, 200, 1 })),
 
-    OSD_UINT8_ENTRY("PITCH P", (&(OSD_UINT8_t){ &cmsx_pidPitch[0], 0, 200, 1 })),
-    OSD_UINT8_ENTRY("PITCH I", (&(OSD_UINT8_t){ &cmsx_pidPitch[1], 0, 200, 1 })),
-    OSD_UINT8_ENTRY("PITCH D", (&(OSD_UINT8_t){ &cmsx_pidPitch[2], 0, 200, 1 })),
+    OSD_UINT8_ENTRY("PITCH P", (&(const OSD_UINT8_t){ &cmsx_pidPitch[0], 0, 200, 1 })),
+    OSD_UINT8_ENTRY("PITCH I", (&(const OSD_UINT8_t){ &cmsx_pidPitch[1], 0, 200, 1 })),
+    OSD_UINT8_ENTRY("PITCH D", (&(const OSD_UINT8_t){ &cmsx_pidPitch[2], 0, 200, 1 })),
 
-    OSD_UINT8_ENTRY("YAW   P", (&(OSD_UINT8_t){ &cmsx_pidYaw[0],   0, 200, 1 })),
-    OSD_UINT8_ENTRY("YAW   I", (&(OSD_UINT8_t){ &cmsx_pidYaw[1],   0, 200, 1 })),
-    OSD_UINT8_ENTRY("YAW   D", (&(OSD_UINT8_t){ &cmsx_pidYaw[2],   0, 200, 1 })),
+    OSD_UINT8_ENTRY("YAW   P", (&(const OSD_UINT8_t){ &cmsx_pidYaw[0],   0, 200, 1 })),
+    OSD_UINT8_ENTRY("YAW   I", (&(const OSD_UINT8_t){ &cmsx_pidYaw[1],   0, 200, 1 })),
+    OSD_UINT8_ENTRY("YAW   D", (&(const OSD_UINT8_t){ &cmsx_pidYaw[2],   0, 200, 1 })),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -190,14 +190,14 @@ static const OSD_Entry cmsx_menuPidAltMagEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- ALT&MAG --", profileIndexString),
 
-    OSD_UINT8_ENTRY("ALT P", (&(OSD_UINT8_t){ &cmsx_pidPosZ[0], 0, 255, 1 })),
-    OSD_UINT8_ENTRY("ALT I", (&(OSD_UINT8_t){ &cmsx_pidPosZ[1], 0, 255, 1 })),
-    OSD_UINT8_ENTRY("ALT D", (&(OSD_UINT8_t){ &cmsx_pidPosZ[2], 0, 255, 1 })),
-    OSD_UINT8_ENTRY("VEL P", (&(OSD_UINT8_t){ &cmsx_pidVelZ[0], 0, 255, 1 })),
-    OSD_UINT8_ENTRY("VEL I", (&(OSD_UINT8_t){ &cmsx_pidVelZ[1], 0, 255, 1 })),
-    OSD_UINT8_ENTRY("VEL D", (&(OSD_UINT8_t){ &cmsx_pidVelZ[2], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("ALT P", (&(const OSD_UINT8_t){ &cmsx_pidPosZ[0], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("ALT I", (&(const OSD_UINT8_t){ &cmsx_pidPosZ[1], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("ALT D", (&(const OSD_UINT8_t){ &cmsx_pidPosZ[2], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("VEL P", (&(const OSD_UINT8_t){ &cmsx_pidVelZ[0], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("VEL I", (&(const OSD_UINT8_t){ &cmsx_pidVelZ[1], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("VEL D", (&(const OSD_UINT8_t){ &cmsx_pidVelZ[2], 0, 255, 1 })),
 
-    OSD_UINT8_ENTRY("MAG P", (&(OSD_UINT8_t){ &cmsx_pidHead[0], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("MAG P", (&(const OSD_UINT8_t){ &cmsx_pidHead[0], 0, 255, 1 })),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -241,11 +241,11 @@ static const OSD_Entry cmsx_menuPidGpsnavEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- GPSNAV --", profileIndexString),
 
-    OSD_UINT8_ENTRY("POS  P", (&(OSD_UINT8_t){ &cmsx_pidPosXY[0],  0, 255, 1 })),
-    OSD_UINT8_ENTRY("POS  I", (&(OSD_UINT8_t){ &cmsx_pidPosXY[1],  0, 255, 1 })),
-    OSD_UINT8_ENTRY("POSR P", (&(OSD_UINT8_t){ &cmsx_pidVelXY[0], 0, 255, 1 })),
-    OSD_UINT8_ENTRY("POSR I", (&(OSD_UINT8_t){ &cmsx_pidVelXY[1], 0, 255, 1 })),
-    OSD_UINT8_ENTRY("POSR D", (&(OSD_UINT8_t){ &cmsx_pidVelXY[2], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("POS  P", (&(const OSD_UINT8_t){ &cmsx_pidPosXY[0],  0, 255, 1 })),
+    OSD_UINT8_ENTRY("POS  I", (&(const OSD_UINT8_t){ &cmsx_pidPosXY[1],  0, 255, 1 })),
+    OSD_UINT8_ENTRY("POSR P", (&(const OSD_UINT8_t){ &cmsx_pidVelXY[0], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("POSR I", (&(const OSD_UINT8_t){ &cmsx_pidVelXY[1], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("POSR D", (&(const OSD_UINT8_t){ &cmsx_pidVelXY[2], 0, 255, 1 })),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -446,14 +446,14 @@ static const OSD_Entry cmsx_menuImuEntries[] =
     OSD_LABEL_ENTRY("-- PID TUNING --"),
 
     // Profile dependent
-    OSD_UINT8_CALLBACK_ENTRY("PID PROF", cmsx_profileIndexOnChange, (&(OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_PROFILE_COUNT, 1})),
+    OSD_UINT8_CALLBACK_ENTRY("PID PROF", cmsx_profileIndexOnChange, (&(const OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_PROFILE_COUNT, 1})),
     OSD_SUBMENU_ENTRY("PID", &cmsx_menuPid),
     OSD_SUBMENU_ENTRY("PID ALTMAG", &cmsx_menuPidAltMag),
     OSD_SUBMENU_ENTRY("PID GPSNAV", &cmsx_menuPidGpsnav),
     OSD_SUBMENU_ENTRY("FILT PP", &cmsx_menuFilterPerProfile),
 
     // Rate profile dependent
-    OSD_UINT8_CALLBACK_ENTRY("RATE PROF", cmsx_profileIndexOnChange, (&(OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_CONTROL_RATE_PROFILE_COUNT, 1})),
+    OSD_UINT8_CALLBACK_ENTRY("RATE PROF", cmsx_profileIndexOnChange, (&(const OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_CONTROL_RATE_PROFILE_COUNT, 1})),
     OSD_SUBMENU_ENTRY("RATE", &cmsx_menuRateProfile),
     OSD_SUBMENU_ENTRY("MANU RATE", &cmsx_menuManualRateProfile),
 

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -129,7 +129,7 @@ static long cmsx_PidWriteback(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuPidEntries[] =
+static const OSD_Entry cmsx_menuPidEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- PID --", profileIndexString),
 
@@ -149,7 +149,7 @@ static OSD_Entry cmsx_menuPidEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu cmsx_menuPid = {
+static const CMS_Menu cmsx_menuPid = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XPID",
     .GUARD_type = OME_MENU,
@@ -186,7 +186,7 @@ static long cmsx_menuPidAltMag_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuPidAltMagEntries[] =
+static const OSD_Entry cmsx_menuPidAltMagEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- ALT&MAG --", profileIndexString),
 
@@ -203,7 +203,7 @@ static OSD_Entry cmsx_menuPidAltMagEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu cmsx_menuPidAltMag = {
+static const CMS_Menu cmsx_menuPidAltMag = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XALTMAG",
     .GUARD_type = OME_MENU,
@@ -237,7 +237,7 @@ static long cmsx_menuPidGpsnav_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuPidGpsnavEntries[] =
+static const OSD_Entry cmsx_menuPidGpsnavEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- GPSNAV --", profileIndexString),
 
@@ -251,7 +251,7 @@ static OSD_Entry cmsx_menuPidGpsnavEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu cmsx_menuPidGpsnav = {
+static const CMS_Menu cmsx_menuPidGpsnav = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XGPSNAV",
     .GUARD_type = OME_MENU,
@@ -265,7 +265,7 @@ static CMS_Menu cmsx_menuPidGpsnav = {
 //
 // MANUAL Rate & Expo
 //
-static OSD_Entry cmsx_menuManualRateProfileEntries[] =
+static const OSD_Entry cmsx_menuManualRateProfileEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- MANUAL RATE --", profileIndexString),
 
@@ -280,7 +280,7 @@ static OSD_Entry cmsx_menuManualRateProfileEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu cmsx_menuManualRateProfile = {
+static const CMS_Menu cmsx_menuManualRateProfile = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUMANURATE",
     .GUARD_type = OME_MENU,
@@ -294,7 +294,7 @@ static CMS_Menu cmsx_menuManualRateProfile = {
 //
 // Rate & Expo
 //
-static OSD_Entry cmsx_menuRateProfileEntries[] =
+static const OSD_Entry cmsx_menuRateProfileEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- RATE --", profileIndexString),
 
@@ -320,7 +320,7 @@ static OSD_Entry cmsx_menuRateProfileEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu cmsx_menuRateProfile = {
+static const CMS_Menu cmsx_menuRateProfile = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENURATE",
     .GUARD_type = OME_MENU,
@@ -366,7 +366,7 @@ static long cmsx_profileOtherOnExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuProfileOtherEntries[] = {
+static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "-- OTHER PP --", OME_Label, NULL, profileIndexString, 0 },
 
     { "D SETPT WT",  OME_FLOAT, NULL, &(OSD_FLOAT_t){ &cmsx_dtermSetpointWeight, 0, 255, 1, 10 }, 0 },
@@ -379,7 +379,7 @@ static OSD_Entry cmsx_menuProfileOtherEntries[] = {
     OSD_END_ENTRY,
 };
 
-static CMS_Menu cmsx_menuProfileOther = {
+static const CMS_Menu cmsx_menuProfileOther = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XPROFOTHER",
     .GUARD_type = OME_MENU,
@@ -394,7 +394,7 @@ static CMS_Menu cmsx_menuProfileOther = {
 //
 // Per profile filters
 //
-static OSD_Entry cmsx_menuFilterPerProfileEntries[] =
+static const OSD_Entry cmsx_menuFilterPerProfileEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- FILTER PP  --", profileIndexString),
 
@@ -407,7 +407,7 @@ static OSD_Entry cmsx_menuFilterPerProfileEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu cmsx_menuFilterPerProfile = {
+static const CMS_Menu cmsx_menuFilterPerProfile = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XFLTPP",
     .GUARD_type = OME_MENU,
@@ -418,7 +418,7 @@ static CMS_Menu cmsx_menuFilterPerProfile = {
     .entries = cmsx_menuFilterPerProfileEntries,
 };
 
-static OSD_Entry cmsx_menuGyroEntries[] =
+static const OSD_Entry cmsx_menuGyroEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- GYRO GLB --", profileIndexString),
 
@@ -430,7 +430,7 @@ static OSD_Entry cmsx_menuGyroEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu cmsx_menuGyro = {
+static const CMS_Menu cmsx_menuGyro = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XGYROGLB",
     .GUARD_type = OME_MENU,
@@ -441,7 +441,7 @@ static CMS_Menu cmsx_menuGyro = {
     .entries = cmsx_menuGyroEntries,
 };
 
-static OSD_Entry cmsx_menuImuEntries[] =
+static const OSD_Entry cmsx_menuImuEntries[] =
 {
     OSD_LABEL_ENTRY("-- PID TUNING --"),
 
@@ -470,7 +470,7 @@ static OSD_Entry cmsx_menuImuEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu cmsx_menuImu = {
+const CMS_Menu cmsx_menuImu = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XIMU",
     .GUARD_type = OME_MENU,

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -131,19 +131,19 @@ static long cmsx_PidWriteback(const OSD_Entry *self)
 
 static OSD_Entry cmsx_menuPidEntries[] =
 {
-    { "-- PID --", OME_Label, NULL, profileIndexString, 0},
+    OSD_LABEL_DATA_ENTRY("-- PID --", profileIndexString),
 
-    { "ROLL  P", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidRoll[0],  0, 200, 1 }, 0 },
-    { "ROLL  I", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidRoll[1],  0, 200, 1 }, 0 },
-    { "ROLL  D", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidRoll[2],  0, 200, 1 }, 0 },
+    OSD_UINT8_ENTRY("ROLL  P", (&(OSD_UINT8_t){ &cmsx_pidRoll[0],  0, 200, 1 })),
+    OSD_UINT8_ENTRY("ROLL I", (&(OSD_UINT8_t){ &cmsx_pidRoll[1],  0, 200, 1 })),
+    OSD_UINT8_ENTRY("ROLL D", (&(OSD_UINT8_t){ &cmsx_pidRoll[2],  0, 200, 1 })),
 
-    { "PITCH P", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidPitch[0], 0, 200, 1 }, 0 },
-    { "PITCH I", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidPitch[1], 0, 200, 1 }, 0 },
-    { "PITCH D", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidPitch[2], 0, 200, 1 }, 0 },
+    OSD_UINT8_ENTRY("PITCH P", (&(OSD_UINT8_t){ &cmsx_pidPitch[0], 0, 200, 1 })),
+    OSD_UINT8_ENTRY("PITCH I", (&(OSD_UINT8_t){ &cmsx_pidPitch[1], 0, 200, 1 })),
+    OSD_UINT8_ENTRY("PITCH D", (&(OSD_UINT8_t){ &cmsx_pidPitch[2], 0, 200, 1 })),
 
-    { "YAW   P", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidYaw[0],   0, 200, 1 }, 0 },
-    { "YAW   I", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidYaw[1],   0, 200, 1 }, 0 },
-    { "YAW   D", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidYaw[2],   0, 200, 1 }, 0 },
+    OSD_UINT8_ENTRY("YAW   P", (&(OSD_UINT8_t){ &cmsx_pidYaw[0],   0, 200, 1 })),
+    OSD_UINT8_ENTRY("YAW   I", (&(OSD_UINT8_t){ &cmsx_pidYaw[1],   0, 200, 1 })),
+    OSD_UINT8_ENTRY("YAW   D", (&(OSD_UINT8_t){ &cmsx_pidYaw[2],   0, 200, 1 })),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -186,16 +186,18 @@ static long cmsx_menuPidAltMag_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuPidAltMagEntries[] = {
-    { "-- ALT&MAG --", OME_Label, NULL, profileIndexString, 0},
+static OSD_Entry cmsx_menuPidAltMagEntries[] =
+{
+    OSD_LABEL_DATA_ENTRY("-- ALT&MAG --", profileIndexString),
 
-    { "ALT P", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidPosZ[0], 0, 255, 1 }, 0 },
-    { "ALT I", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidPosZ[1], 0, 255, 1 }, 0 },
-    { "ALT D", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidPosZ[2], 0, 255, 1 }, 0 },
-    { "VEL P", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidVelZ[0], 0, 255, 1 }, 0 },
-    { "VEL I", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidVelZ[1], 0, 255, 1 }, 0 },
-    { "VEL D", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidVelZ[2], 0, 255, 1 }, 0 },
-    { "MAG P", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidHead[0], 0, 255, 1 }, 0 },
+    OSD_UINT8_ENTRY("ALT P", (&(OSD_UINT8_t){ &cmsx_pidPosZ[0], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("ALT I", (&(OSD_UINT8_t){ &cmsx_pidPosZ[1], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("ALT D", (&(OSD_UINT8_t){ &cmsx_pidPosZ[2], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("VEL P", (&(OSD_UINT8_t){ &cmsx_pidVelZ[0], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("VEL I", (&(OSD_UINT8_t){ &cmsx_pidVelZ[1], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("VEL D", (&(OSD_UINT8_t){ &cmsx_pidVelZ[2], 0, 255, 1 })),
+
+    OSD_UINT8_ENTRY("MAG P", (&(OSD_UINT8_t){ &cmsx_pidHead[0], 0, 255, 1 })),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -235,14 +237,15 @@ static long cmsx_menuPidGpsnav_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static OSD_Entry cmsx_menuPidGpsnavEntries[] = {
-    { "-- GPSNAV --", OME_Label, NULL, profileIndexString, 0},
+static OSD_Entry cmsx_menuPidGpsnavEntries[] =
+{
+    OSD_LABEL_DATA_ENTRY("-- GPSNAV --", profileIndexString),
 
-    { "POS  P", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidPosXY[0],  0, 255, 1 }, 0 },
-    { "POS  I", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidPosXY[1],  0, 255, 1 }, 0 },
-    { "POSR P", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidVelXY[0], 0, 255, 1 }, 0 },
-    { "POSR I", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidVelXY[1], 0, 255, 1 }, 0 },
-    { "POSR D", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidVelXY[2], 0, 255, 1 }, 0 },
+    OSD_UINT8_ENTRY("POS  P", (&(OSD_UINT8_t){ &cmsx_pidPosXY[0],  0, 255, 1 })),
+    OSD_UINT8_ENTRY("POS  I", (&(OSD_UINT8_t){ &cmsx_pidPosXY[1],  0, 255, 1 })),
+    OSD_UINT8_ENTRY("POSR P", (&(OSD_UINT8_t){ &cmsx_pidVelXY[0], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("POSR I", (&(OSD_UINT8_t){ &cmsx_pidVelXY[1], 0, 255, 1 })),
+    OSD_UINT8_ENTRY("POSR D", (&(OSD_UINT8_t){ &cmsx_pidVelXY[2], 0, 255, 1 })),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -264,7 +267,7 @@ static CMS_Menu cmsx_menuPidGpsnav = {
 //
 static OSD_Entry cmsx_menuManualRateProfileEntries[] =
 {
-    { "-- MANUAL RATE --", OME_Label, NULL, profileIndexString, 0 },
+    OSD_LABEL_DATA_ENTRY("-- MANUAL RATE --", profileIndexString),
 
     OSD_SETTING_ENTRY("MANU ROLL RATE", SETTING_MANUAL_ROLL_RATE),
     OSD_SETTING_ENTRY("MANU PITCH RATE", SETTING_MANUAL_PITCH_RATE),
@@ -293,7 +296,7 @@ static CMS_Menu cmsx_menuManualRateProfile = {
 //
 static OSD_Entry cmsx_menuRateProfileEntries[] =
 {
-    { "-- RATE --", OME_Label, NULL, profileIndexString, 0 },
+    OSD_LABEL_DATA_ENTRY("-- RATE --", profileIndexString),
 
 #if 0
     { "RC RATE",     OME_FLOAT,  NULL, &(OSD_FLOAT_t){ &rateProfile.rcRate8,    0, 255, 1, 10 }, 0 },
@@ -393,7 +396,7 @@ static CMS_Menu cmsx_menuProfileOther = {
 //
 static OSD_Entry cmsx_menuFilterPerProfileEntries[] =
 {
-    { "-- FILTER PP  --", OME_Label, NULL, profileIndexString, 0 },
+    OSD_LABEL_DATA_ENTRY("-- FILTER PP  --", profileIndexString),
 
     OSD_SETTING_ENTRY("DTERM LPF", SETTING_DTERM_LPF_HZ),
     OSD_SETTING_ENTRY("GYRO SLPF", SETTING_GYRO_LPF_HZ),
@@ -417,7 +420,7 @@ static CMS_Menu cmsx_menuFilterPerProfile = {
 
 static OSD_Entry cmsx_menuGyroEntries[] =
 {
-    { "-- GYRO GLB --", OME_Label, NULL, profileIndexString, 0},
+    OSD_LABEL_DATA_ENTRY("-- GYRO GLB --", profileIndexString),
 
     OSD_SETTING_ENTRY("GYRO SYNC", SETTING_GYRO_SYNC),
     OSD_SETTING_ENTRY("GYRO DENOM", SETTING_GYRO_SYNC_DENOM),
@@ -440,22 +443,22 @@ static CMS_Menu cmsx_menuGyro = {
 
 static OSD_Entry cmsx_menuImuEntries[] =
 {
-    { "-- PID TUNING --", OME_Label, NULL, NULL, 0},
+    OSD_LABEL_ENTRY("-- PID TUNING --"),
 
     // Profile dependent
-    {"PID PROF",   OME_UINT8,   cmsx_profileIndexOnChange,     &(OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_PROFILE_COUNT, 1}, 0},
-    {"PID",        OME_Submenu, cmsMenuChange,                 &cmsx_menuPid,                                              0},
-    {"PID ALTMAG", OME_Submenu, cmsMenuChange,                 &cmsx_menuPidAltMag,                                        0},
-    {"PID GPSNAV", OME_Submenu, cmsMenuChange,                 &cmsx_menuPidGpsnav,                                        0},
-    {"FILT PP",   OME_Submenu, cmsMenuChange,                 &cmsx_menuFilterPerProfile,                                  0},
+    OSD_UINT8_CALLBACK_ENTRY("PID PROF", cmsx_profileIndexOnChange, (&(OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_PROFILE_COUNT, 1})),
+    OSD_SUBMENU_ENTRY("PID", &cmsx_menuPid),
+    OSD_SUBMENU_ENTRY("PID ALTMAG", &cmsx_menuPidAltMag),
+    OSD_SUBMENU_ENTRY("PID GPSNAV", &cmsx_menuPidGpsnav),
+    OSD_SUBMENU_ENTRY("FILT PP", &cmsx_menuFilterPerProfile),
 
     // Rate profile dependent
-    {"RATE PROF", OME_UINT8,   cmsx_profileIndexOnChange, &(OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_CONTROL_RATE_PROFILE_COUNT, 1}, 0},
-    {"RATE",      OME_Submenu, cmsMenuChange,                 &cmsx_menuRateProfile,                                       0},
-    {"MANU RATE", OME_Submenu, cmsMenuChange,                 &cmsx_menuManualRateProfile,                                 0},
+    OSD_UINT8_CALLBACK_ENTRY("RATE PROF", cmsx_profileIndexOnChange, (&(OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_CONTROL_RATE_PROFILE_COUNT, 1})),
+    OSD_SUBMENU_ENTRY("RATE", &cmsx_menuRateProfile),
+    OSD_SUBMENU_ENTRY("MANU RATE", &cmsx_menuManualRateProfile),
 
     // Global
-    {"GYRO GLB",  OME_Submenu, cmsMenuChange,                 &cmsx_menuGyro,                                              0},
+    OSD_SUBMENU_ENTRY("GYRO GLB",  &cmsx_menuGyro),
 
 #ifdef NOT_YET
     {"OTHER PP",  OME_Submenu, cmsMenuChange,                 &cmsx_menuProfileOther,                                      0},

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -145,8 +145,8 @@ static OSD_Entry cmsx_menuPidEntries[] =
     { "YAW   I", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidYaw[1],   0, 200, 1 }, 0 },
     { "YAW   D", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidYaw[2],   0, 200, 1 }, 0 },
 
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuPid = {
@@ -197,8 +197,8 @@ static OSD_Entry cmsx_menuPidAltMagEntries[] = {
     { "VEL D", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidVelZ[2], 0, 255, 1 }, 0 },
     { "MAG P", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidHead[0], 0, 255, 1 }, 0 },
 
-    {"BACK", OME_Back, NULL, NULL, 0},
-    {NULL, OME_END, NULL, NULL, 0}
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuPidAltMag = {
@@ -244,8 +244,8 @@ static OSD_Entry cmsx_menuPidGpsnavEntries[] = {
     { "POSR I", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidVelXY[1], 0, 255, 1 }, 0 },
     { "POSR D", OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_pidVelXY[2], 0, 255, 1 }, 0 },
 
-    {"BACK", OME_Back, NULL, NULL, 0},
-    {NULL, OME_END, NULL, NULL, 0}
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuPidGpsnav = {
@@ -273,8 +273,8 @@ static OSD_Entry cmsx_menuManualRateProfileEntries[] =
     OSD_SETTING_ENTRY("MANU RC EXPO", SETTING_MANUAL_RC_EXPO),
     OSD_SETTING_ENTRY("MANU RC YAW EXP", SETTING_MANUAL_RC_YAW_EXPO),
 
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuManualRateProfile = {
@@ -313,8 +313,8 @@ static OSD_Entry cmsx_menuRateProfileEntries[] =
     OSD_SETTING_ENTRY("THRPID ATT", SETTING_TPA_RATE),
     OSD_SETTING_ENTRY_STEP("TPA BRKPT", SETTING_TPA_BREAKPOINT, 10),
 
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuRateProfile = {
@@ -372,8 +372,8 @@ static OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "HORZN STR",   OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_horizonStrength,     0, 200, 1 }    , 0 },
     { "HORZN TRS",   OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_horizonTransition,   0, 200, 1 }    , 0 },
 
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuProfileOther = {
@@ -400,8 +400,8 @@ static OSD_Entry cmsx_menuFilterPerProfileEntries[] =
     OSD_SETTING_ENTRY("YAW P LIM", SETTING_YAW_P_LIMIT),
     OSD_SETTING_ENTRY("YAW LPF", SETTING_YAW_LPF_HZ),
 
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuFilterPerProfile = {
@@ -423,8 +423,8 @@ static OSD_Entry cmsx_menuGyroEntries[] =
     OSD_SETTING_ENTRY("GYRO DENOM", SETTING_GYRO_SYNC_DENOM),
     OSD_SETTING_ENTRY("GYRO LPF", SETTING_GYRO_HARDWARE_LPF),
 
-    {"BACK", OME_Back, NULL, NULL, 0},
-    {NULL, OME_END, NULL, NULL, 0}
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuGyro = {
@@ -463,8 +463,8 @@ static OSD_Entry cmsx_menuImuEntries[] =
     {"FILT GLB",  OME_Submenu, cmsMenuChange,                 &cmsx_menuFilterGlobal,                                      0},
 #endif
 
-    {"BACK", OME_Back, NULL, NULL, 0},
-    {NULL, OME_END, NULL, NULL, 0}
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuImu = {

--- a/src/main/cms/cms_menu_imu.h
+++ b/src/main/cms/cms_menu_imu.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-extern CMS_Menu cmsx_menuImu;
+extern const CMS_Menu cmsx_menuImu;

--- a/src/main/cms/cms_menu_ledstrip.c
+++ b/src/main/cms/cms_menu_ledstrip.c
@@ -56,7 +56,7 @@ static bool cmsx_FeatureLedStrip_Enabled(bool *enabled)
     return featureConfigured(FEATURE_LED_STRIP);
 }
 
-static OSD_Entry cmsx_menuLedstripEntries[] =
+static const OSD_Entry cmsx_menuLedstripEntries[] =
 {
     OSD_LABEL_ENTRY("-- LED STRIP --"),
     OSD_BOOL_FUNC_ENTRY("ENABLED", cmsx_FeatureLedStrip_Enabled),
@@ -65,7 +65,7 @@ static OSD_Entry cmsx_menuLedstripEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu cmsx_menuLedstrip = {
+const CMS_Menu cmsx_menuLedstrip = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENULED",
     .GUARD_type = OME_MENU,

--- a/src/main/cms/cms_menu_ledstrip.c
+++ b/src/main/cms/cms_menu_ledstrip.c
@@ -58,8 +58,8 @@ static bool cmsx_FeatureLedStrip_Enabled(bool *enabled)
 
 static OSD_Entry cmsx_menuLedstripEntries[] =
 {
-    { "-- LED STRIP --", OME_Label, NULL, NULL, 0 },
-    { "ENABLED",         OME_BoolFunc,  NULL, cmsx_FeatureLedStrip_Enabled, 0 },
+    OSD_LABEL_ENTRY("-- LED STRIP --"),
+    OSD_BOOL_FUNC_ENTRY("ENABLED", cmsx_FeatureLedStrip_Enabled),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,

--- a/src/main/cms/cms_menu_ledstrip.c
+++ b/src/main/cms/cms_menu_ledstrip.c
@@ -61,8 +61,8 @@ static OSD_Entry cmsx_menuLedstripEntries[] =
     { "-- LED STRIP --", OME_Label, NULL, NULL, 0 },
     { "ENABLED",         OME_BoolFunc,  NULL, cmsx_FeatureLedStrip_Enabled, 0 },
 
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuLedstrip = {

--- a/src/main/cms/cms_menu_ledstrip.h
+++ b/src/main/cms/cms_menu_ledstrip.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-extern CMS_Menu cmsx_menuLedstrip;
+extern const CMS_Menu cmsx_menuLedstrip;

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -66,8 +66,8 @@ static OSD_Entry cmsx_menuRcEntries[] =
     { "AUX3",  OME_INT16, NULL, &(OSD_INT16_t){ &rcData[AUX3],     1, 2500, 0 }, DYNAMIC },
     { "AUX4",  OME_INT16, NULL, &(OSD_INT16_t){ &rcData[AUX4],     1, 2500, 0 }, DYNAMIC },
 
-    { "BACK",  OME_Back, NULL, NULL, 0},
-    {NULL, OME_END, NULL, NULL, 0}
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuRcPreview = {
@@ -102,8 +102,8 @@ static OSD_Entry menuMiscEntries[]=
 
     { "RC PREV",    OME_Submenu, cmsMenuChange, &cmsx_menuRcPreview, 0},
 
-    { "BACK", OME_Back, NULL, NULL, 0},
-    { NULL, OME_END, NULL, NULL, 0}
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuMisc = {

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -52,7 +52,7 @@ static long cmsx_menuRcConfirmBack(const OSD_Entry *self)
 //
 // RC preview
 //
-static OSD_Entry cmsx_menuRcEntries[] =
+static const OSD_Entry cmsx_menuRcEntries[] =
 {
     OSD_LABEL_ENTRY("-- RC PREV --"),
 
@@ -70,7 +70,7 @@ static OSD_Entry cmsx_menuRcEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu cmsx_menuRcPreview = {
+static const CMS_Menu cmsx_menuRcPreview = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XRCPREV",
     .GUARD_type = OME_MENU,
@@ -81,7 +81,7 @@ CMS_Menu cmsx_menuRcPreview = {
     .entries = cmsx_menuRcEntries
 };
 
-static OSD_Entry menuMiscEntries[]=
+static const OSD_Entry menuMiscEntries[]=
 {
     OSD_LABEL_ENTRY("-- MISC --"),
 
@@ -106,7 +106,7 @@ static OSD_Entry menuMiscEntries[]=
     OSD_END_ENTRY,
 };
 
-CMS_Menu cmsx_menuMisc = {
+const CMS_Menu cmsx_menuMisc = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XMISC",
     .GUARD_type = OME_MENU,

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -54,17 +54,17 @@ static long cmsx_menuRcConfirmBack(const OSD_Entry *self)
 //
 static OSD_Entry cmsx_menuRcEntries[] =
 {
-    { "-- RC PREV --", OME_Label, NULL, NULL, 0},
+    OSD_LABEL_ENTRY("-- RC PREV --"),
 
-    { "ROLL",  OME_INT16, NULL, &(OSD_INT16_t){ &rcData[ROLL],     1, 2500, 0 }, DYNAMIC },
-    { "PITCH", OME_INT16, NULL, &(OSD_INT16_t){ &rcData[PITCH],    1, 2500, 0 }, DYNAMIC },
-    { "THR",   OME_INT16, NULL, &(OSD_INT16_t){ &rcData[THROTTLE], 1, 2500, 0 }, DYNAMIC },
-    { "YAW",   OME_INT16, NULL, &(OSD_INT16_t){ &rcData[YAW],      1, 2500, 0 }, DYNAMIC },
+    OSD_INT16_DYN_ENTRY("ROLL", (&(OSD_INT16_t){ &rcData[ROLL],     1, 2500, 0 })),
+    OSD_INT16_DYN_ENTRY("PITCH", (&(OSD_INT16_t){ &rcData[PITCH],    1, 2500, 0 })),
+    OSD_INT16_DYN_ENTRY("THR", (&(OSD_INT16_t){ &rcData[THROTTLE], 1, 2500, 0 })),
+    OSD_INT16_DYN_ENTRY("YAW", (&(OSD_INT16_t){ &rcData[YAW],      1, 2500, 0 })),
 
-    { "AUX1",  OME_INT16, NULL, &(OSD_INT16_t){ &rcData[AUX1],     1, 2500, 0 }, DYNAMIC },
-    { "AUX2",  OME_INT16, NULL, &(OSD_INT16_t){ &rcData[AUX2],     1, 2500, 0 }, DYNAMIC },
-    { "AUX3",  OME_INT16, NULL, &(OSD_INT16_t){ &rcData[AUX3],     1, 2500, 0 }, DYNAMIC },
-    { "AUX4",  OME_INT16, NULL, &(OSD_INT16_t){ &rcData[AUX4],     1, 2500, 0 }, DYNAMIC },
+    OSD_INT16_DYN_ENTRY("AUX1", (&(OSD_INT16_t){ &rcData[AUX1],     1, 2500, 0 })),
+    OSD_INT16_DYN_ENTRY("AUX2", (&(OSD_INT16_t){ &rcData[AUX2],     1, 2500, 0 })),
+    OSD_INT16_DYN_ENTRY("AUX3", (&(OSD_INT16_t){ &rcData[AUX3],     1, 2500, 0 })),
+    OSD_INT16_DYN_ENTRY("AUX4", (&(OSD_INT16_t){ &rcData[AUX4],     1, 2500, 0 })),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -83,7 +83,7 @@ CMS_Menu cmsx_menuRcPreview = {
 
 static OSD_Entry menuMiscEntries[]=
 {
-    { "-- MISC --", OME_Label, NULL, NULL, 0 },
+    OSD_LABEL_ENTRY("-- MISC --"),
 
     OSD_SETTING_ENTRY("MIN THR", SETTING_MIN_THROTTLE),
 #ifdef USE_ADC
@@ -100,7 +100,7 @@ static OSD_Entry menuMiscEntries[]=
 #endif /* USE_OSD */
 #endif /* USE_ADC */
 
-    { "RC PREV",    OME_Submenu, cmsMenuChange, &cmsx_menuRcPreview, 0},
+    OSD_SUBMENU_ENTRY("RC PREV", &cmsx_menuRcPreview),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -56,15 +56,15 @@ static const OSD_Entry cmsx_menuRcEntries[] =
 {
     OSD_LABEL_ENTRY("-- RC PREV --"),
 
-    OSD_INT16_DYN_ENTRY("ROLL", (&(OSD_INT16_t){ &rcData[ROLL],     1, 2500, 0 })),
-    OSD_INT16_DYN_ENTRY("PITCH", (&(OSD_INT16_t){ &rcData[PITCH],    1, 2500, 0 })),
-    OSD_INT16_DYN_ENTRY("THR", (&(OSD_INT16_t){ &rcData[THROTTLE], 1, 2500, 0 })),
-    OSD_INT16_DYN_ENTRY("YAW", (&(OSD_INT16_t){ &rcData[YAW],      1, 2500, 0 })),
+    OSD_INT16_RO_ENTRY("ROLL", &rcData[ROLL]),
+    OSD_INT16_RO_ENTRY("PITCH", &rcData[PITCH]),
+    OSD_INT16_RO_ENTRY("THR", &rcData[THROTTLE]),
+    OSD_INT16_RO_ENTRY("YAW", &rcData[YAW]),
 
-    OSD_INT16_DYN_ENTRY("AUX1", (&(OSD_INT16_t){ &rcData[AUX1],     1, 2500, 0 })),
-    OSD_INT16_DYN_ENTRY("AUX2", (&(OSD_INT16_t){ &rcData[AUX2],     1, 2500, 0 })),
-    OSD_INT16_DYN_ENTRY("AUX3", (&(OSD_INT16_t){ &rcData[AUX3],     1, 2500, 0 })),
-    OSD_INT16_DYN_ENTRY("AUX4", (&(OSD_INT16_t){ &rcData[AUX4],     1, 2500, 0 })),
+    OSD_INT16_RO_ENTRY("AUX1", &rcData[AUX1]),
+    OSD_INT16_RO_ENTRY("AUX2", &rcData[AUX2]),
+    OSD_INT16_RO_ENTRY("AUX3", &rcData[AUX3]),
+    OSD_INT16_RO_ENTRY("AUX4", &rcData[AUX4]),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,

--- a/src/main/cms/cms_menu_misc.h
+++ b/src/main/cms/cms_menu_misc.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-extern CMS_Menu cmsx_menuMisc;
+extern const CMS_Menu cmsx_menuMisc;

--- a/src/main/cms/cms_menu_navigation.c
+++ b/src/main/cms/cms_menu_navigation.c
@@ -38,7 +38,7 @@
 
 #include "navigation/navigation.h"
 
-static OSD_Entry cmsx_menuNavSettingsEntries[] =
+static const OSD_Entry cmsx_menuNavSettingsEntries[] =
 {
     OSD_LABEL_ENTRY("-- BASIC SETTINGS --"),
 
@@ -55,7 +55,7 @@ static OSD_Entry cmsx_menuNavSettingsEntries[] =
     OSD_END_ENTRY,
  };
 
-static CMS_Menu cmsx_menuNavSettings = {
+static const CMS_Menu cmsx_menuNavSettings = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUNAVSETTINGS",
     .GUARD_type = OME_MENU,
@@ -66,7 +66,7 @@ static CMS_Menu cmsx_menuNavSettings = {
     .entries = cmsx_menuNavSettingsEntries
 };
 
- static OSD_Entry cmsx_menuRTHEntries[] =
+ static const OSD_Entry cmsx_menuRTHEntries[] =
  {
     OSD_LABEL_ENTRY("-- RTH --"),
 
@@ -86,7 +86,7 @@ static CMS_Menu cmsx_menuNavSettings = {
     OSD_END_ENTRY,
  };
 
-static CMS_Menu cmsx_menuRTH = {
+static const CMS_Menu cmsx_menuRTH = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUNAVRTH",
     .GUARD_type = OME_MENU,
@@ -97,7 +97,7 @@ static CMS_Menu cmsx_menuRTH = {
     .entries = cmsx_menuRTHEntries
 };
 
-static OSD_Entry cmsx_menuFixedWingEntries[] =
+static const OSD_Entry cmsx_menuFixedWingEntries[] =
 {
     OSD_LABEL_ENTRY("-- FIXED WING --"),
 
@@ -114,7 +114,7 @@ static OSD_Entry cmsx_menuFixedWingEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu cmsx_menuFixedWing = {
+static const CMS_Menu cmsx_menuFixedWing = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUNAVFW",
     .GUARD_type = OME_MENU,
@@ -125,7 +125,7 @@ static CMS_Menu cmsx_menuFixedWing = {
     .entries = cmsx_menuFixedWingEntries
 };
 
-static OSD_Entry cmsx_menuNavigationEntries[] =
+static const OSD_Entry cmsx_menuNavigationEntries[] =
 {
     OSD_LABEL_ENTRY("-- NAVIGATION --"),
 
@@ -137,7 +137,7 @@ static OSD_Entry cmsx_menuNavigationEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu cmsx_menuNavigation = {
+const CMS_Menu cmsx_menuNavigation = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUNAV",
     .GUARD_type = OME_MENU,

--- a/src/main/cms/cms_menu_navigation.c
+++ b/src/main/cms/cms_menu_navigation.c
@@ -40,7 +40,8 @@
 
 static OSD_Entry cmsx_menuNavSettingsEntries[] =
 {
-    { "-- BASIC SETTINGS --",                     OME_Label, NULL, NULL, 0},
+    OSD_LABEL_ENTRY("-- BASIC SETTINGS --"),
+
     OSD_SETTING_ENTRY("CONTROL MODE", SETTING_NAV_USER_CONTROL_MODE),
     OSD_SETTING_ENTRY("MAX NAV SPEED", SETTING_NAV_AUTO_SPEED),
     OSD_SETTING_ENTRY("MAX CRUISE SPEED", SETTING_NAV_MANUAL_SPEED),
@@ -67,7 +68,8 @@ static CMS_Menu cmsx_menuNavSettings = {
 
  static OSD_Entry cmsx_menuRTHEntries[] =
  {
-    { "-- RTH --",                     OME_Label, NULL, NULL, 0},
+    OSD_LABEL_ENTRY("-- RTH --"),
+
     OSD_SETTING_ENTRY("RTH ALT MODE", SETTING_NAV_RTH_ALT_MODE),
     OSD_SETTING_ENTRY("RTH ALT", SETTING_NAV_RTH_ALTITUDE),
     OSD_SETTING_ENTRY("CLIMB BEFORE RTH", SETTING_NAV_RTH_CLIMB_FIRST),
@@ -97,7 +99,8 @@ static CMS_Menu cmsx_menuRTH = {
 
 static OSD_Entry cmsx_menuFixedWingEntries[] =
 {
-    { "-- FIXED WING --",                     OME_Label, NULL, NULL, 0},
+    OSD_LABEL_ENTRY("-- FIXED WING --"),
+
     OSD_SETTING_ENTRY("CRUISE THROTTLE", SETTING_NAV_FW_CRUISE_THR),
     OSD_SETTING_ENTRY("MIN THROTTLE", SETTING_NAV_FW_MIN_THR),
     OSD_SETTING_ENTRY("MAX THROTTLE", SETTING_NAV_FW_MAX_THR),
@@ -124,10 +127,11 @@ static CMS_Menu cmsx_menuFixedWing = {
 
 static OSD_Entry cmsx_menuNavigationEntries[] =
 {
-    { "-- NAVIGATION --",   OME_Label, NULL, NULL, 0},
-    { "BASIC SETTINGS",     OME_Submenu, cmsMenuChange, &cmsx_menuNavSettings, 0},
-    { "RTH",                OME_Submenu, cmsMenuChange, &cmsx_menuRTH, 0},
-    { "FIXED WING",         OME_Submenu, cmsMenuChange, &cmsx_menuFixedWing, 0},
+    OSD_LABEL_ENTRY("-- NAVIGATION --"),
+
+    OSD_SUBMENU_ENTRY("BASIC SETTINGS", &cmsx_menuNavSettings),
+    OSD_SUBMENU_ENTRY("RTH", &cmsx_menuRTH),
+    OSD_SUBMENU_ENTRY("FIXED WING", &cmsx_menuFixedWing),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,

--- a/src/main/cms/cms_menu_navigation.c
+++ b/src/main/cms/cms_menu_navigation.c
@@ -49,8 +49,9 @@ static OSD_Entry cmsx_menuNavSettingsEntries[] =
     OSD_SETTING_ENTRY("MC MAX BANK ANGLE", SETTING_NAV_MC_BANK_ANGLE),
     OSD_SETTING_ENTRY("MID THR FOR AH", SETTING_NAV_USE_MIDTHR_FOR_ALTHOLD),
     OSD_SETTING_ENTRY("MC HOVER THR", SETTING_NAV_MC_HOVER_THR),
-    { "BACK",                          OME_Back, NULL, NULL, 0 },
-    { NULL,                            OME_END, NULL, NULL, 0 }
+
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
  };
 
 static CMS_Menu cmsx_menuNavSettings = {
@@ -78,8 +79,9 @@ static CMS_Menu cmsx_menuNavSettings = {
     OSD_SETTING_ENTRY("MIN RTH DISTANCE", SETTING_NAV_MIN_RTH_DISTANCE),
     OSD_SETTING_ENTRY("RTH ABORT THRES", SETTING_NAV_RTH_ABORT_THRESHOLD),
     OSD_SETTING_ENTRY("EMERG LANDING SPEED", SETTING_NAV_EMERG_LANDING_SPEED),
-    { "BACK",                          OME_Back, NULL, NULL, 0 },
-    { NULL,                            OME_END, NULL, NULL, 0 }
+
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
  };
 
 static CMS_Menu cmsx_menuRTH = {
@@ -104,8 +106,9 @@ static OSD_Entry cmsx_menuFixedWingEntries[] =
     OSD_SETTING_ENTRY("MAX DIVE ANGLE", SETTING_NAV_FW_DIVE_ANGLE),
     OSD_SETTING_ENTRY("PITCH TO THR RATIO", SETTING_NAV_FW_PITCH2THR),
     OSD_SETTING_ENTRY("LOITER RADIUS", SETTING_NAV_FW_LOITER_RADIUS),
-    { "BACK",                          OME_Back, NULL, NULL, 0 },
-    { NULL,                            OME_END, NULL, NULL, 0 }
+
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuFixedWing = {
@@ -125,8 +128,9 @@ static OSD_Entry cmsx_menuNavigationEntries[] =
     { "BASIC SETTINGS",     OME_Submenu, cmsMenuChange, &cmsx_menuNavSettings, 0},
     { "RTH",                OME_Submenu, cmsMenuChange, &cmsx_menuRTH, 0},
     { "FIXED WING",         OME_Submenu, cmsMenuChange, &cmsx_menuFixedWing, 0},
-    { "BACK",               OME_Back, NULL, NULL, 0 },
-    { NULL,                 OME_END, NULL, NULL, 0 }
+
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuNavigation = {

--- a/src/main/cms/cms_menu_navigation.h
+++ b/src/main/cms/cms_menu_navigation.h
@@ -26,4 +26,4 @@
 
  #pragma once
 
-extern CMS_Menu cmsx_menuNavigation;
+extern const CMS_Menu cmsx_menuNavigation;

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -56,23 +56,8 @@ const CMS_Menu cmsx_menuAlarms = {
     .entries = cmsx_menuAlarmsEntries,
 };
 
-static uint16_t osdConfig_item_pos[OSD_ITEM_COUNT];
 
-static long menuOsdActiveElemsOnEnter(void)
-{
-    memcpy(&osdConfig_item_pos[0], &osdConfig()->item_pos[0], sizeof(uint16_t) * OSD_ITEM_COUNT);
-    return 0;
-}
-
-static long menuOsdActiveElemsOnExit(const OSD_Entry *self)
-{
-    UNUSED(self);
-
-    memcpy(&osdConfigMutable()->item_pos[0], &osdConfig_item_pos[0], sizeof(uint16_t) * OSD_ITEM_COUNT);
-    return 0;
-}
-
-#define OSD_OSD_ELEMENT_ENTRY(name, osd_id) {name, OME_VISIBLE, NULL, &osdConfig_item_pos[osd_id], 0}
+#define OSD_OSD_ELEMENT_ENTRY(name, osd_item_id) {name, OME_VISIBLE, NULL, (void *)osd_item_id, 0}
 
 static const OSD_Entry menuOsdActiveElemsEntries[] =
 {
@@ -117,8 +102,8 @@ const CMS_Menu menuOsdActiveElems = {
     .GUARD_text = "MENUOSDACT",
     .GUARD_type = OME_MENU,
 #endif
-    .onEnter = menuOsdActiveElemsOnEnter,
-    .onExit = menuOsdActiveElemsOnExit,
+    .onEnter = NULL,
+    .onExit = NULL,
     .onGlobalExit = NULL,
     .entries = menuOsdActiveElemsEntries
 };

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -35,7 +35,7 @@
 
 OSD_Entry cmsx_menuAlarmsEntries[] =
 {
-    {"--- ALARMS ---", OME_Label, NULL, NULL, 0},
+    OSD_LABEL_ENTRY("--- ALARMS ---"),
 
     OSD_SETTING_ENTRY_STEP("RSSI", SETTING_OSD_RSSI_ALARM, 5),
     OSD_SETTING_ENTRY("FLY TIME", SETTING_OSD_TIME_ALARM),
@@ -72,38 +72,41 @@ static long menuOsdActiveElemsOnExit(const OSD_Entry *self)
     return 0;
 }
 
+#define OSD_OSD_ELEMENT_ENTRY(name, osd_id) {name, OME_VISIBLE, NULL, &osdConfig_item_pos[osd_id], 0}
+
 OSD_Entry menuOsdActiveElemsEntries[] =
 {
-    {"--- ACTIV ELEM ---", OME_Label, NULL, NULL, 0},
-    {"RSSI", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_VALUE], 0},
-    {"MAIN BATTERY", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_VOLTAGE], 0},
-    {"HORIZON", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ARTIFICIAL_HORIZON], 0},
-    {"HORIZON SIDEBARS", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HORIZON_SIDEBARS], 0},
-    {"UPTIME", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ONTIME], 0},
-    {"FLY TIME", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_FLYTIME], 0},
-    {"FLY MODE", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_FLYMODE], 0},
-    {"NAME", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRAFT_NAME], 0},
-    {"THROTTLE", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_THROTTLE_POS], 0},
+    OSD_LABEL_ENTRY("--- ACTIV ELEM ---"),
+
+    OSD_OSD_ELEMENT_ENTRY("RSSI", OSD_RSSI_VALUE),
+    OSD_OSD_ELEMENT_ENTRY("MAIN BATTERY", OSD_MAIN_BATT_VOLTAGE),
+    OSD_OSD_ELEMENT_ENTRY("HORIZON", OSD_ARTIFICIAL_HORIZON),
+    OSD_OSD_ELEMENT_ENTRY("HORIZON SIDEBARS", OSD_HORIZON_SIDEBARS),
+    OSD_OSD_ELEMENT_ENTRY("UPTIME", OSD_ONTIME),
+    OSD_OSD_ELEMENT_ENTRY("FLY TIME", OSD_FLYTIME),
+    OSD_OSD_ELEMENT_ENTRY("FLY MODE", OSD_FLYMODE),
+    OSD_OSD_ELEMENT_ENTRY("NAME", OSD_CRAFT_NAME),
+    OSD_OSD_ELEMENT_ENTRY("THROTTLE", OSD_THROTTLE_POS),
 #ifdef VTX
-    {"VTX CHAN", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_VTX_CHANNEL]},
+    OSD_OSD_ELEMENT_ENTRY("VTX CHAN", OSD_VTX_CHANNEL),
 #endif // VTX
-    {"CURRENT (A)", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CURRENT_DRAW], 0},
-    {"USED MAH", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAH_DRAWN], 0},
+    OSD_OSD_ELEMENT_ENTRY("CURRENT (A)", OSD_CURRENT_DRAW),
+    OSD_OSD_ELEMENT_ENTRY("USED MAH", OSD_MAH_DRAWN),
 #ifdef USE_GPS
-    {"HOME DIR.", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HOME_DIR], 0},
-    {"HOME DIST.", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HOME_DIST], 0},
-    {"GPS SPEED", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_GPS_SPEED], 0},
-    {"GPS SATS.", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_GPS_SATS], 0},
-    {"GPS LAT", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_GPS_LAT], 0},
-    {"GPS LON.", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_GPS_LON], 0},
-    {"HEADING", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_HEADING], 0},
+    OSD_OSD_ELEMENT_ENTRY("HOME DIR.", OSD_HOME_DIR),
+    OSD_OSD_ELEMENT_ENTRY("HOME DIST.", OSD_HOME_DIST),
+    OSD_OSD_ELEMENT_ENTRY("GPS SPEED", OSD_GPS_SPEED),
+    OSD_OSD_ELEMENT_ENTRY("GPS SATS.", OSD_GPS_SATS),
+    OSD_OSD_ELEMENT_ENTRY("GPS LAT", OSD_GPS_LAT),
+    OSD_OSD_ELEMENT_ENTRY("GPS LON.", OSD_GPS_LON),
+    OSD_OSD_ELEMENT_ENTRY("HEADING", OSD_HEADING),
 #endif // GPS
 #if defined(USE_BARO) || defined(USE_GPS)
-    {"VARIO", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_VARIO], 0},
-    {"VARIO NUM", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_VARIO_NUM], 0},
+    OSD_OSD_ELEMENT_ENTRY("VARIO", OSD_VARIO),
+    OSD_OSD_ELEMENT_ENTRY("VARIO NUM", OSD_VARIO_NUM),
 #endif // defined
-    {"ALTITUDE", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ALTITUDE], 0},
-    {"AIR SPEED", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_AIR_SPEED], 0},
+    OSD_OSD_ELEMENT_ENTRY("ALTITUDE", OSD_ALTITUDE),
+    OSD_OSD_ELEMENT_ENTRY("AIR SPEED", OSD_AIR_SPEED),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -122,8 +125,8 @@ CMS_Menu menuOsdActiveElems = {
 
 OSD_Entry cmsx_menuOsdLayoutEntries[] =
 {
-    {"---SCREEN LAYOUT---", OME_Label, NULL, NULL, 0},
-    {"ACTIVE ELEM", OME_Submenu, cmsMenuChange, &menuOsdActiveElems, 0},
+    OSD_LABEL_ENTRY("---SCREEN LAYOUT---"),
+    OSD_SUBMENU_ENTRY("ACTIVE ELEM", &menuOsdActiveElems),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -33,7 +33,7 @@
 
 #include "io/osd.h"
 
-OSD_Entry cmsx_menuAlarmsEntries[] =
+static const OSD_Entry cmsx_menuAlarmsEntries[] =
 {
     OSD_LABEL_ENTRY("--- ALARMS ---"),
 
@@ -45,7 +45,7 @@ OSD_Entry cmsx_menuAlarmsEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu cmsx_menuAlarms = {
+const CMS_Menu cmsx_menuAlarms = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUALARMS",
     .GUARD_type = OME_MENU,
@@ -74,7 +74,7 @@ static long menuOsdActiveElemsOnExit(const OSD_Entry *self)
 
 #define OSD_OSD_ELEMENT_ENTRY(name, osd_id) {name, OME_VISIBLE, NULL, &osdConfig_item_pos[osd_id], 0}
 
-OSD_Entry menuOsdActiveElemsEntries[] =
+static const OSD_Entry menuOsdActiveElemsEntries[] =
 {
     OSD_LABEL_ENTRY("--- ACTIV ELEM ---"),
 
@@ -112,7 +112,7 @@ OSD_Entry menuOsdActiveElemsEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu menuOsdActiveElems = {
+const CMS_Menu menuOsdActiveElems = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUOSDACT",
     .GUARD_type = OME_MENU,
@@ -123,7 +123,7 @@ CMS_Menu menuOsdActiveElems = {
     .entries = menuOsdActiveElemsEntries
 };
 
-OSD_Entry cmsx_menuOsdLayoutEntries[] =
+static const OSD_Entry cmsx_menuOsdLayoutEntries[] =
 {
     OSD_LABEL_ENTRY("---SCREEN LAYOUT---"),
     OSD_SUBMENU_ENTRY("ACTIVE ELEM", &menuOsdActiveElems),
@@ -132,7 +132,7 @@ OSD_Entry cmsx_menuOsdLayoutEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu cmsx_menuOsdLayout = {
+const CMS_Menu cmsx_menuOsdLayout = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENULAYOUT",
     .GUARD_type = OME_MENU,

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -41,8 +41,8 @@ OSD_Entry cmsx_menuAlarmsEntries[] =
     OSD_SETTING_ENTRY("FLY TIME", SETTING_OSD_TIME_ALARM),
     OSD_SETTING_ENTRY("MAX ALT", SETTING_OSD_ALT_ALARM),
 
-    {"BACK", OME_Back, NULL, NULL, 0},
-    {NULL, OME_END, NULL, NULL, 0}
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuAlarms = {
@@ -104,8 +104,9 @@ OSD_Entry menuOsdActiveElemsEntries[] =
 #endif // defined
     {"ALTITUDE", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_ALTITUDE], 0},
     {"AIR SPEED", OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_AIR_SPEED], 0},
-    {"BACK", OME_Back, NULL, NULL, 0},
-    {NULL, OME_END, NULL, NULL, 0}
+
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu menuOsdActiveElems = {
@@ -123,8 +124,9 @@ OSD_Entry cmsx_menuOsdLayoutEntries[] =
 {
     {"---SCREEN LAYOUT---", OME_Label, NULL, NULL, 0},
     {"ACTIVE ELEM", OME_Submenu, cmsMenuChange, &menuOsdActiveElems, 0},
-    {"BACK", OME_Back, NULL, NULL, 0},
-    {NULL, OME_END, NULL, NULL, 0}
+
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuOsdLayout = {

--- a/src/main/cms/cms_menu_osd.h
+++ b/src/main/cms/cms_menu_osd.h
@@ -17,5 +17,5 @@
 
 #pragma once
 
-extern CMS_Menu cmsx_menuAlarms;
-extern CMS_Menu cmsx_menuOsdLayout;
+extern const CMS_Menu cmsx_menuAlarms;
+extern const CMS_Menu cmsx_menuOsdLayout;

--- a/src/main/cms/cms_menu_vtx.c
+++ b/src/main/cms/cms_menu_vtx.c
@@ -64,8 +64,8 @@ static const char * const vtxBandNames[] = {
     "RACEBAND",
 };
 
-static OSD_TAB_t entryVtxBand = {&cmsx_vtxBand,4,&vtxBandNames[0]};
-static OSD_UINT8_t entryVtxChannel =  {&cmsx_vtxChannel, 1, 8, 1};
+static const OSD_TAB_t entryVtxBand = {&cmsx_vtxBand,4,&vtxBandNames[0]};
+static const OSD_UINT8_t entryVtxChannel =  {&cmsx_vtxChannel, 1, 8, 1};
 
 static void cmsx_Vtx_ConfigRead(void)
 {
@@ -110,8 +110,8 @@ static long cmsx_Vtx_onExit(const OSD_Entry *self)
 }
 
 #ifdef VTX
-static OSD_UINT8_t entryVtxMode =  {&masterConfig.vtx_mode, 0, 2, 1};
-static OSD_UINT16_t entryVtxMhz =  {&masterConfig.vtx_mhz, 5600, 5950, 1};
+static const OSD_UINT8_t entryVtxMode =  {&masterConfig.vtx_mode, 0, 2, 1};
+static const OSD_UINT16_t entryVtxMhz =  {&masterConfig.vtx_mhz, 5600, 5950, 1};
 #endif // VTX
 
 static const OSD_Entry cmsx_menuVtxEntries[] =

--- a/src/main/cms/cms_menu_vtx.c
+++ b/src/main/cms/cms_menu_vtx.c
@@ -116,16 +116,16 @@ static OSD_UINT16_t entryVtxMhz =  {&masterConfig.vtx_mhz, 5600, 5950, 1};
 
 static OSD_Entry cmsx_menuVtxEntries[] =
 {
-    {"--- VTX ---", OME_Label, NULL, NULL, 0},
-    {"ENABLED", OME_Bool, NULL, &cmsx_featureVtx, 0},
+    OSD_LABEL_ENTRY("--- VTX ---"),
+    OSD_BOOL_ENTRY("ENABLED", &cmsx_featureVtx),
 #ifdef VTX
-    {"VTX MODE", OME_UINT8, NULL, &entryVtxMode, 0},
-    {"VTX MHZ", OME_UINT16, NULL, &entryVtxMhz, 0},
+    OSD_UINT8_ENTRY("VTX MODE", &entryVtxMode),
+    OSD_UINT16_ENTRY("VTX MHZ", &entryVtxMhz),
 #endif // VTX
-    {"BAND", OME_TAB, NULL, &entryVtxBand, 0},
-    {"CHANNEL", OME_UINT8, NULL, &entryVtxChannel, 0},
+    OSD_TAB_ENTRY("BAND", &entryVtxBand),
+    OSD_UINT8_ENTRY("CHANNEL", &entryVtxChannel),
 #ifdef USE_RTC6705
-    {"LOW POWER", OME_Bool, NULL, &masterConfig.vtx_power, 0},
+    OSD_BOOL_ENTRY("LOW POWER", &masterConfig.vtx_power),
 #endif // USE_RTC6705
 
     OSD_BACK_ENTRY,

--- a/src/main/cms/cms_menu_vtx.c
+++ b/src/main/cms/cms_menu_vtx.c
@@ -114,7 +114,7 @@ static OSD_UINT8_t entryVtxMode =  {&masterConfig.vtx_mode, 0, 2, 1};
 static OSD_UINT16_t entryVtxMhz =  {&masterConfig.vtx_mhz, 5600, 5950, 1};
 #endif // VTX
 
-static OSD_Entry cmsx_menuVtxEntries[] =
+static const OSD_Entry cmsx_menuVtxEntries[] =
 {
     OSD_LABEL_ENTRY("--- VTX ---"),
     OSD_BOOL_ENTRY("ENABLED", &cmsx_featureVtx),
@@ -132,7 +132,7 @@ static OSD_Entry cmsx_menuVtxEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu cmsx_menuVtx = {
+const CMS_Menu cmsx_menuVtx = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUVTX",
     .GUARD_type = OME_MENU,

--- a/src/main/cms/cms_menu_vtx.c
+++ b/src/main/cms/cms_menu_vtx.c
@@ -127,8 +127,9 @@ static OSD_Entry cmsx_menuVtxEntries[] =
 #ifdef USE_RTC6705
     {"LOW POWER", OME_Bool, NULL, &masterConfig.vtx_power, 0},
 #endif // USE_RTC6705
-    {"BACK", OME_Back, NULL, NULL, 0},
-    {NULL, OME_END, NULL, NULL, 0}
+
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuVtx = {

--- a/src/main/cms/cms_menu_vtx.h
+++ b/src/main/cms/cms_menu_vtx.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-extern CMS_Menu cmsx_menuVtx;
+extern const CMS_Menu cmsx_menuVtx;

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -304,19 +304,19 @@ static const char * const saCmsDeviceStatusNames[] = {
     "ONL V2",
 };
 
-static OSD_TAB_t saCmsEntOnline = { &saCmsDeviceStatus, 2, saCmsDeviceStatusNames };
+static const OSD_TAB_t saCmsEntOnline = { &saCmsDeviceStatus, 2, saCmsDeviceStatusNames };
 
 static const OSD_Entry saCmsMenuStatsEntries[] = {
     OSD_LABEL_ENTRY("- SA STATS -"),
 
     OSD_TAB_DYN_ENTRY("STATUS", &saCmsEntOnline),
-    OSD_UINT16_DYN_ENTRY("BAUDRATE", (&(OSD_UINT16_t){ &sa_smartbaud, 0, 0, 0 })),
-    OSD_UINT16_DYN_ENTRY("SENT", (&(OSD_UINT16_t){ &saStat.pktsent, 0, 0, 0 })),
-    OSD_UINT16_DYN_ENTRY("RCVD", (&(OSD_UINT16_t){ &saStat.pktrcvd, 0, 0, 0 })),
-    OSD_UINT16_DYN_ENTRY("BADPRE", (&(OSD_UINT16_t){ &saStat.badpre, 0, 0, 0 })),
-    OSD_UINT16_DYN_ENTRY("BADLEN", (&(OSD_UINT16_t){ &saStat.badlen, 0, 0, 0 })),
-    OSD_UINT16_DYN_ENTRY("CRCERR", (&(OSD_UINT16_t){ &saStat.crc, 0, 0, 0 })),
-    OSD_UINT16_DYN_ENTRY("OOOERR", (&(OSD_UINT16_t){ &saStat.ooopresp, 0, 0, 0 })),
+    OSD_UINT16_RO_ENTRY("BAUDRATE", &sa_smartbaud),
+    OSD_UINT16_RO_ENTRY("SENT", &saStat.pktsent),
+    OSD_UINT16_RO_ENTRY("RCVD", &saStat.pktrcvd),
+    OSD_UINT16_RO_ENTRY("BADPRE", &saStat.badpre),
+    OSD_UINT16_RO_ENTRY("BADLEN", &saStat.badlen),
+    OSD_UINT16_RO_ENTRY("CRCERR", &saStat.crc),
+    OSD_UINT16_RO_ENTRY("OOOERR", &saStat.ooopresp),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -333,9 +333,9 @@ static const CMS_Menu saCmsMenuStats = {
     .entries = saCmsMenuStatsEntries
 };
 
-static OSD_TAB_t saCmsEntBand = { &saCmsBand, 5, vtx58BandNames };
+static const OSD_TAB_t saCmsEntBand = { &saCmsBand, 5, vtx58BandNames };
 
-static OSD_TAB_t saCmsEntChan = { &saCmsChan, 8, vtx58ChannelNames };
+static const OSD_TAB_t saCmsEntChan = { &saCmsChan, 8, vtx58ChannelNames };
 
 static const char * const saCmsPowerNames[] = {
     "---",
@@ -345,9 +345,7 @@ static const char * const saCmsPowerNames[] = {
     "800",
 };
 
-static OSD_TAB_t saCmsEntPower = { &saCmsPower, 4, saCmsPowerNames};
-
-static OSD_UINT16_t saCmsEntFreqRef = { &saCmsFreqRef, 5600, 5900, 0 };
+static const OSD_TAB_t saCmsEntPower = { &saCmsPower, 4, saCmsPowerNames};
 
 static const char * const saCmsOpmodelNames[] = {
     "----",
@@ -365,7 +363,7 @@ static const char * const saCmsPitFModeNames[] = {
     "POR"
 };
 
-static OSD_TAB_t saCmsEntPitFMode = { &saCmsPitFMode, 1, saCmsPitFModeNames };
+static const OSD_TAB_t saCmsEntPitFMode = { &saCmsPitFMode, 1, saCmsPitFModeNames };
 
 static long sacms_SetupTopMenu(void); // Forward
 
@@ -480,7 +478,7 @@ static const OSD_Entry saCmsMenuPORFreqEntries[] =
 {
     OSD_LABEL_ENTRY("- POR FREQ -"),
 
-    OSD_UINT16_DYN_ENTRY("CUR FREQ", (&(OSD_UINT16_t){ &saCmsORFreq, 5000, 5900, 0 })),
+    OSD_UINT16_RO_ENTRY("CUR FREQ", &saCmsORFreq),
     OSD_UINT16_ENTRY("NEW FREQ", (&(OSD_UINT16_t){ &saCmsORFreqNew, 5000, 5900, 1 })),
     OSD_FUNC_CALL_ENTRY("SET", saCmsSetPORFreq),
 
@@ -504,7 +502,7 @@ static const OSD_Entry saCmsMenuUserFreqEntries[] =
 {
     OSD_LABEL_ENTRY("- USER FREQ -"),
 
-    OSD_UINT16_DYN_ENTRY("CUR FREQ", (&(OSD_UINT16_t){ &saCmsUserFreq, 5000, 5900, 0 })),
+    OSD_UINT16_RO_ENTRY("CUR FREQ", &saCmsUserFreq),
     OSD_UINT16_ENTRY("NEW FREQ", (&(OSD_UINT16_t){ &saCmsUserFreqNew, 5000, 5900, 1 })),
     OSD_FUNC_CALL_ENTRY("SET", saCmsConfigUserFreq),
 
@@ -524,7 +522,7 @@ static const CMS_Menu saCmsMenuUserFreq =
     .entries = saCmsMenuUserFreqEntries,
 };
 
-static OSD_TAB_t saCmsEntFselMode = { &saCmsFselMode, 1, saCmsFselModeNames };
+static const OSD_TAB_t saCmsEntFselMode = { &saCmsFselMode, 1, saCmsFselModeNames };
 
 static const OSD_Entry saCmsMenuConfigEntries[] =
 {
@@ -592,7 +590,7 @@ static const OSD_Entry saCmsMenuChanModeEntries[] =
     OSD_LABEL_FUNC_DYN_ENTRY("", saCmsDrawStatusString),
     OSD_TAB_CALLBACK_ENTRY("BAND", saCmsConfigBandByGvar, &saCmsEntBand),
     OSD_TAB_CALLBACK_ENTRY("CHAN", saCmsConfigChanByGvar, &saCmsEntChan),
-    OSD_UINT16_DYN_ENTRY("(FREQ)", &saCmsEntFreqRef),
+    OSD_UINT16_RO_ENTRY("(FREQ)", &saCmsFreqRef),
     OSD_TAB_CALLBACK_ENTRY("POWER", saCmsConfigPowerByGvar, &saCmsEntPower),
     OSD_SUBMENU_ENTRY("SET",  &saCmsMenuCommence),
     OSD_SUBMENU_ENTRY("CONFIG", &saCmsMenuConfig),

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -306,7 +306,7 @@ static const char * const saCmsDeviceStatusNames[] = {
 
 static OSD_TAB_t saCmsEntOnline = { &saCmsDeviceStatus, 2, saCmsDeviceStatusNames };
 
-static OSD_Entry saCmsMenuStatsEntries[] = {
+static const OSD_Entry saCmsMenuStatsEntries[] = {
     OSD_LABEL_ENTRY("- SA STATS -"),
 
     OSD_TAB_DYN_ENTRY("STATUS", &saCmsEntOnline),
@@ -322,7 +322,7 @@ static OSD_Entry saCmsMenuStatsEntries[] = {
     OSD_END_ENTRY,
 };
 
-static CMS_Menu saCmsMenuStats = {
+static const CMS_Menu saCmsMenuStats = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XSAST",
     .GUARD_type = OME_MENU,
@@ -476,7 +476,7 @@ static long saCmsConfigUserFreq(displayPort_t *pDisp, const void *self)
     return MENU_CHAIN_BACK;
 }
 
-static OSD_Entry saCmsMenuPORFreqEntries[] =
+static const OSD_Entry saCmsMenuPORFreqEntries[] =
 {
     OSD_LABEL_ENTRY("- POR FREQ -"),
 
@@ -488,7 +488,7 @@ static OSD_Entry saCmsMenuPORFreqEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu saCmsMenuPORFreq =
+static const CMS_Menu saCmsMenuPORFreq =
 {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XSAPOR",
@@ -500,7 +500,7 @@ static CMS_Menu saCmsMenuPORFreq =
     .entries = saCmsMenuPORFreqEntries,
 };
 
-static OSD_Entry saCmsMenuUserFreqEntries[] =
+static const OSD_Entry saCmsMenuUserFreqEntries[] =
 {
     OSD_LABEL_ENTRY("- USER FREQ -"),
 
@@ -512,7 +512,7 @@ static OSD_Entry saCmsMenuUserFreqEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu saCmsMenuUserFreq =
+static const CMS_Menu saCmsMenuUserFreq =
 {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XSAUFQ",
@@ -526,21 +526,21 @@ static CMS_Menu saCmsMenuUserFreq =
 
 static OSD_TAB_t saCmsEntFselMode = { &saCmsFselMode, 1, saCmsFselModeNames };
 
-static OSD_Entry saCmsMenuConfigEntries[] =
+static const OSD_Entry saCmsMenuConfigEntries[] =
 {
     OSD_LABEL_ENTRY("- SA CONFIG -"),
 
     { "OP MODEL",  OME_TAB,     saCmsConfigOpmodelByGvar,              &(OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, DYNAMIC },
     { "FSEL MODE", OME_TAB,     saCmsConfigFreqModeByGvar,             &saCmsEntFselMode,                                   DYNAMIC },
     OSD_TAB_CALLBACK_ENTRY("PIT FMODE", saCmsConfigPitFModeByGvar, &saCmsEntPitFMode),
-    { "POR FREQ",  OME_Submenu, (CMSEntryFuncPtr)saCmsORFreqGetString, &saCmsMenuPORFreq,                                   OPTSTRING },
+    { "POR FREQ",  OME_Submenu, (CMSEntryFuncPtr)saCmsORFreqGetString, (void *)&saCmsMenuPORFreq,                                   OPTSTRING },
     OSD_SUBMENU_ENTRY("STATX", &saCmsMenuStats),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
 };
 
-static CMS_Menu saCmsMenuConfig = {
+static const CMS_Menu saCmsMenuConfig = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XSACFG",
     .GUARD_type = OME_MENU,
@@ -551,7 +551,7 @@ static CMS_Menu saCmsMenuConfig = {
     .entries = saCmsMenuConfigEntries
 };
 
-static OSD_Entry saCmsMenuCommenceEntries[] =
+static const OSD_Entry saCmsMenuCommenceEntries[] =
 {
     OSD_LABEL_ENTRY("CONFIRM"),
     OSD_FUNC_CALL_ENTRY("YES", saCmsCommence),
@@ -560,7 +560,7 @@ static OSD_Entry saCmsMenuCommenceEntries[] =
     OSD_END_ENTRY,
 };
 
-static CMS_Menu saCmsMenuCommence = {
+static const CMS_Menu saCmsMenuCommence = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XVTXCOM",
     .GUARD_type = OME_MENU,
@@ -571,7 +571,7 @@ static CMS_Menu saCmsMenuCommence = {
     .entries = saCmsMenuCommenceEntries,
 };
 
-static OSD_Entry saCmsMenuFreqModeEntries[] =
+static const OSD_Entry saCmsMenuFreqModeEntries[] =
 {
     OSD_LABEL_ENTRY("- SMARTAUDIO -"),
 
@@ -585,7 +585,7 @@ static OSD_Entry saCmsMenuFreqModeEntries[] =
     OSD_END_ENTRY,
 };
 
-static OSD_Entry saCmsMenuChanModeEntries[] =
+static const OSD_Entry saCmsMenuChanModeEntries[] =
 {
     OSD_LABEL_ENTRY("- SMARTAUDIO -"),
 
@@ -601,7 +601,7 @@ static OSD_Entry saCmsMenuChanModeEntries[] =
     OSD_END_ENTRY,
 };
 
-static OSD_Entry saCmsMenuOfflineEntries[] =
+static const OSD_Entry saCmsMenuOfflineEntries[] =
 {
     OSD_LABEL_ENTRY("- VTX SMARTAUDIO -"),
 

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -307,15 +307,16 @@ static const char * const saCmsDeviceStatusNames[] = {
 static OSD_TAB_t saCmsEntOnline = { &saCmsDeviceStatus, 2, saCmsDeviceStatusNames };
 
 static OSD_Entry saCmsMenuStatsEntries[] = {
-    { "- SA STATS -", OME_Label, NULL, NULL, 0 },
-    { "STATUS",   OME_TAB,    NULL, &saCmsEntOnline,                              DYNAMIC },
-    { "BAUDRATE", OME_UINT16, NULL, &(OSD_UINT16_t){ &sa_smartbaud, 0, 0, 0 },    DYNAMIC },
-    { "SENT",     OME_UINT16, NULL, &(OSD_UINT16_t){ &saStat.pktsent, 0, 0, 0 },  DYNAMIC },
-    { "RCVD",     OME_UINT16, NULL, &(OSD_UINT16_t){ &saStat.pktrcvd, 0, 0, 0 },  DYNAMIC },
-    { "BADPRE",   OME_UINT16, NULL, &(OSD_UINT16_t){ &saStat.badpre, 0, 0, 0 },   DYNAMIC },
-    { "BADLEN",   OME_UINT16, NULL, &(OSD_UINT16_t){ &saStat.badlen, 0, 0, 0 },   DYNAMIC },
-    { "CRCERR",   OME_UINT16, NULL, &(OSD_UINT16_t){ &saStat.crc, 0, 0, 0 },      DYNAMIC },
-    { "OOOERR",   OME_UINT16, NULL, &(OSD_UINT16_t){ &saStat.ooopresp, 0, 0, 0 }, DYNAMIC },
+    OSD_LABEL_ENTRY("- SA STATS -"),
+
+    OSD_TAB_DYN_ENTRY("STATUS", &saCmsEntOnline),
+    OSD_UINT16_DYN_ENTRY("BAUDRATE", (&(OSD_UINT16_t){ &sa_smartbaud, 0, 0, 0 })),
+    OSD_UINT16_DYN_ENTRY("SENT", (&(OSD_UINT16_t){ &saStat.pktsent, 0, 0, 0 })),
+    OSD_UINT16_DYN_ENTRY("RCVD", (&(OSD_UINT16_t){ &saStat.pktrcvd, 0, 0, 0 })),
+    OSD_UINT16_DYN_ENTRY("BADPRE", (&(OSD_UINT16_t){ &saStat.badpre, 0, 0, 0 })),
+    OSD_UINT16_DYN_ENTRY("BADLEN", (&(OSD_UINT16_t){ &saStat.badlen, 0, 0, 0 })),
+    OSD_UINT16_DYN_ENTRY("CRCERR", (&(OSD_UINT16_t){ &saStat.crc, 0, 0, 0 })),
+    OSD_UINT16_DYN_ENTRY("OOOERR", (&(OSD_UINT16_t){ &saStat.ooopresp, 0, 0, 0 })),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -475,12 +476,13 @@ static long saCmsConfigUserFreq(displayPort_t *pDisp, const void *self)
     return MENU_CHAIN_BACK;
 }
 
-static OSD_Entry saCmsMenuPORFreqEntries[] = {
-    { "- POR FREQ -", OME_Label,   NULL,             NULL,                                                 0 },
+static OSD_Entry saCmsMenuPORFreqEntries[] =
+{
+    OSD_LABEL_ENTRY("- POR FREQ -"),
 
-    { "CUR FREQ",     OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsORFreq, 5000, 5900, 0 },       DYNAMIC },
-    { "NEW FREQ",     OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsORFreqNew, 5000, 5900, 1 },    0 },
-    { "SET",          OME_Funcall, saCmsSetPORFreq,  NULL,                                                 0 },
+    OSD_UINT16_DYN_ENTRY("CUR FREQ", (&(OSD_UINT16_t){ &saCmsORFreq, 5000, 5900, 0 })),
+    OSD_UINT16_ENTRY("NEW FREQ", (&(OSD_UINT16_t){ &saCmsORFreqNew, 5000, 5900, 1 })),
+    OSD_FUNC_CALL_ENTRY("SET", saCmsSetPORFreq),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -498,12 +500,13 @@ static CMS_Menu saCmsMenuPORFreq =
     .entries = saCmsMenuPORFreqEntries,
 };
 
-static OSD_Entry saCmsMenuUserFreqEntries[] = {
-    { "- USER FREQ -", OME_Label,   NULL,             NULL,                                                0 },
+static OSD_Entry saCmsMenuUserFreqEntries[] =
+{
+    OSD_LABEL_ENTRY("- USER FREQ -"),
 
-    { "CUR FREQ",      OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreq, 5000, 5900, 0 },    DYNAMIC },
-    { "NEW FREQ",      OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreqNew, 5000, 5900, 1 }, 0 },
-    { "SET",           OME_Funcall, saCmsConfigUserFreq, NULL,                                                0 },
+    OSD_UINT16_DYN_ENTRY("CUR FREQ", (&(OSD_UINT16_t){ &saCmsUserFreq, 5000, 5900, 0 })),
+    OSD_UINT16_ENTRY("NEW FREQ", (&(OSD_UINT16_t){ &saCmsUserFreqNew, 5000, 5900, 1 })),
+    OSD_FUNC_CALL_ENTRY("SET", saCmsConfigUserFreq),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -523,14 +526,15 @@ static CMS_Menu saCmsMenuUserFreq =
 
 static OSD_TAB_t saCmsEntFselMode = { &saCmsFselMode, 1, saCmsFselModeNames };
 
-static OSD_Entry saCmsMenuConfigEntries[] = {
-    { "- SA CONFIG -", OME_Label, NULL, NULL, 0 },
+static OSD_Entry saCmsMenuConfigEntries[] =
+{
+    OSD_LABEL_ENTRY("- SA CONFIG -"),
 
     { "OP MODEL",  OME_TAB,     saCmsConfigOpmodelByGvar,              &(OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, DYNAMIC },
     { "FSEL MODE", OME_TAB,     saCmsConfigFreqModeByGvar,             &saCmsEntFselMode,                                   DYNAMIC },
-    { "PIT FMODE", OME_TAB,     saCmsConfigPitFModeByGvar,             &saCmsEntPitFMode,                                   0 },
+    OSD_TAB_CALLBACK_ENTRY("PIT FMODE", saCmsConfigPitFModeByGvar, &saCmsEntPitFMode),
     { "POR FREQ",  OME_Submenu, (CMSEntryFuncPtr)saCmsORFreqGetString, &saCmsMenuPORFreq,                                   OPTSTRING },
-    { "STATX",     OME_Submenu, cmsMenuChange,                         &saCmsMenuStats,                                     0 },
+    OSD_SUBMENU_ENTRY("STATX", &saCmsMenuStats),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -547,10 +551,10 @@ static CMS_Menu saCmsMenuConfig = {
     .entries = saCmsMenuConfigEntries
 };
 
-static OSD_Entry saCmsMenuCommenceEntries[] = {
-    { "CONFIRM", OME_Label,   NULL,          NULL, 0 },
-
-    { "YES",     OME_Funcall, saCmsCommence, NULL, 0 },
+static OSD_Entry saCmsMenuCommenceEntries[] =
+{
+    OSD_LABEL_ENTRY("CONFIRM"),
+    OSD_FUNC_CALL_ENTRY("YES", saCmsCommence),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -567,14 +571,15 @@ static CMS_Menu saCmsMenuCommence = {
     .entries = saCmsMenuCommenceEntries,
 };
 
-static OSD_Entry saCmsMenuFreqModeEntries[] = {
-    { "- SMARTAUDIO -", OME_Label, NULL, NULL, 0 },
+static OSD_Entry saCmsMenuFreqModeEntries[] =
+{
+    OSD_LABEL_ENTRY("- SMARTAUDIO -"),
 
-    { "",       OME_LabelFunc,  NULL,                                     saCmsDrawStatusString,  DYNAMIC },
-    { "FREQ",   OME_Submenu,    (CMSEntryFuncPtr)saCmsUserFreqGetString,  &saCmsMenuUserFreq, OPTSTRING },
-    { "POWER",  OME_TAB,        saCmsConfigPowerByGvar,                   &saCmsEntPower,     0 },
-    { "SET",    OME_Submenu,    cmsMenuChange,                            &saCmsMenuCommence, 0 },
-    { "CONFIG", OME_Submenu,    cmsMenuChange,                            &saCmsMenuConfig,   0 },
+    OSD_LABEL_FUNC_DYN_ENTRY("", saCmsDrawStatusString),
+    { "FREQ",   OME_Submenu, (CMSEntryFuncPtr)saCmsUserFreqGetString,  &saCmsMenuUserFreq, OPTSTRING },
+    OSD_TAB_CALLBACK_ENTRY("POWER", saCmsConfigPowerByGvar, &saCmsEntPower),
+    OSD_SUBMENU_ENTRY("SET", &saCmsMenuCommence),
+    OSD_SUBMENU_ENTRY("CONFIG", &saCmsMenuConfig),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -582,15 +587,15 @@ static OSD_Entry saCmsMenuFreqModeEntries[] = {
 
 static OSD_Entry saCmsMenuChanModeEntries[] =
 {
-    { "- SMARTAUDIO -", OME_Label, NULL, NULL, 0 },
+    OSD_LABEL_ENTRY("- SMARTAUDIO -"),
 
-    { "",       OME_LabelFunc,   NULL,                  saCmsDrawStatusString,  DYNAMIC },
-    { "BAND",   OME_TAB,        saCmsConfigBandByGvar,  &saCmsEntBand,      0 },
-    { "CHAN",   OME_TAB,        saCmsConfigChanByGvar,  &saCmsEntChan,      0 },
-    { "(FREQ)", OME_UINT16,     NULL,                   &saCmsEntFreqRef,   DYNAMIC },
-    { "POWER",  OME_TAB,        saCmsConfigPowerByGvar, &saCmsEntPower,     0 },
-    { "SET",    OME_Submenu,    cmsMenuChange,          &saCmsMenuCommence, 0 },
-    { "CONFIG", OME_Submenu,    cmsMenuChange,          &saCmsMenuConfig,   0 },
+    OSD_LABEL_FUNC_DYN_ENTRY("", saCmsDrawStatusString),
+    OSD_TAB_CALLBACK_ENTRY("BAND", saCmsConfigBandByGvar, &saCmsEntBand),
+    OSD_TAB_CALLBACK_ENTRY("CHAN", saCmsConfigChanByGvar, &saCmsEntChan),
+    OSD_UINT16_DYN_ENTRY("(FREQ)", &saCmsEntFreqRef),
+    OSD_TAB_CALLBACK_ENTRY("POWER", saCmsConfigPowerByGvar, &saCmsEntPower),
+    OSD_SUBMENU_ENTRY("SET",  &saCmsMenuCommence),
+    OSD_SUBMENU_ENTRY("CONFIG", &saCmsMenuConfig),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -598,10 +603,10 @@ static OSD_Entry saCmsMenuChanModeEntries[] =
 
 static OSD_Entry saCmsMenuOfflineEntries[] =
 {
-    { "- VTX SMARTAUDIO -", OME_Label, NULL, NULL, 0 },
+    OSD_LABEL_ENTRY("- VTX SMARTAUDIO -"),
 
-    { "",      OME_LabelFunc,   NULL,          saCmsDrawStatusString, DYNAMIC },
-    { "STATX", OME_Submenu,     cmsMenuChange, &saCmsMenuStats,   0 },
+    OSD_LABEL_FUNC_DYN_ENTRY("", saCmsDrawStatusString),
+    OSD_SUBMENU_ENTRY("STATX", &saCmsMenuStats),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -316,8 +316,9 @@ static OSD_Entry saCmsMenuStatsEntries[] = {
     { "BADLEN",   OME_UINT16, NULL, &(OSD_UINT16_t){ &saStat.badlen, 0, 0, 0 },   DYNAMIC },
     { "CRCERR",   OME_UINT16, NULL, &(OSD_UINT16_t){ &saStat.crc, 0, 0, 0 },      DYNAMIC },
     { "OOOERR",   OME_UINT16, NULL, &(OSD_UINT16_t){ &saStat.ooopresp, 0, 0, 0 }, DYNAMIC },
-    { "BACK",     OME_Back,   NULL, NULL, 0 },
-    { NULL,       OME_END,    NULL, NULL, 0 }
+
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu saCmsMenuStats = {
@@ -481,8 +482,8 @@ static OSD_Entry saCmsMenuPORFreqEntries[] = {
     { "NEW FREQ",     OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsORFreqNew, 5000, 5900, 1 },    0 },
     { "SET",          OME_Funcall, saCmsSetPORFreq,  NULL,                                                 0 },
 
-    { "BACK",         OME_Back,    NULL,             NULL,                                                 0 },
-    { NULL,           OME_END,     NULL,             NULL,                                                 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu saCmsMenuPORFreq =
@@ -504,8 +505,8 @@ static OSD_Entry saCmsMenuUserFreqEntries[] = {
     { "NEW FREQ",      OME_UINT16,  NULL,             &(OSD_UINT16_t){ &saCmsUserFreqNew, 5000, 5900, 1 }, 0 },
     { "SET",           OME_Funcall, saCmsConfigUserFreq, NULL,                                                0 },
 
-    { "BACK",          OME_Back,    NULL,             NULL,                                                0 },
-    { NULL,            OME_END,     NULL,             NULL,                                                0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu saCmsMenuUserFreq =
@@ -531,8 +532,8 @@ static OSD_Entry saCmsMenuConfigEntries[] = {
     { "POR FREQ",  OME_Submenu, (CMSEntryFuncPtr)saCmsORFreqGetString, &saCmsMenuPORFreq,                                   OPTSTRING },
     { "STATX",     OME_Submenu, cmsMenuChange,                         &saCmsMenuStats,                                     0 },
 
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu saCmsMenuConfig = {
@@ -551,8 +552,8 @@ static OSD_Entry saCmsMenuCommenceEntries[] = {
 
     { "YES",     OME_Funcall, saCmsCommence, NULL, 0 },
 
-    { "BACK",    OME_Back, NULL, NULL, 0 },
-    { NULL,      OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu saCmsMenuCommence = {
@@ -575,8 +576,8 @@ static OSD_Entry saCmsMenuFreqModeEntries[] = {
     { "SET",    OME_Submenu,    cmsMenuChange,                            &saCmsMenuCommence, 0 },
     { "CONFIG", OME_Submenu,    cmsMenuChange,                            &saCmsMenuConfig,   0 },
 
-    { "BACK", OME_Back, NULL, NULL, 0 },
-    { NULL, OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static OSD_Entry saCmsMenuChanModeEntries[] =
@@ -591,8 +592,8 @@ static OSD_Entry saCmsMenuChanModeEntries[] =
     { "SET",    OME_Submenu,    cmsMenuChange,          &saCmsMenuCommence, 0 },
     { "CONFIG", OME_Submenu,    cmsMenuChange,          &saCmsMenuConfig,   0 },
 
-    { "BACK",   OME_Back, NULL, NULL, 0 },
-    { NULL,     OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static OSD_Entry saCmsMenuOfflineEntries[] =
@@ -602,8 +603,8 @@ static OSD_Entry saCmsMenuOfflineEntries[] =
     { "",      OME_LabelFunc,   NULL,          saCmsDrawStatusString, DYNAMIC },
     { "STATX", OME_Submenu,     cmsMenuChange, &saCmsMenuStats,   0 },
 
-    { "BACK",  OME_Back, NULL, NULL, 0 },
-    { NULL,    OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuVtxSmartAudio; // Forward

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -479,7 +479,7 @@ static const OSD_Entry saCmsMenuPORFreqEntries[] =
     OSD_LABEL_ENTRY("- POR FREQ -"),
 
     OSD_UINT16_RO_ENTRY("CUR FREQ", &saCmsORFreq),
-    OSD_UINT16_ENTRY("NEW FREQ", (&(OSD_UINT16_t){ &saCmsORFreqNew, 5000, 5900, 1 })),
+    OSD_UINT16_ENTRY("NEW FREQ", (&(const OSD_UINT16_t){ &saCmsORFreqNew, 5000, 5900, 1 })),
     OSD_FUNC_CALL_ENTRY("SET", saCmsSetPORFreq),
 
     OSD_BACK_ENTRY,
@@ -503,7 +503,7 @@ static const OSD_Entry saCmsMenuUserFreqEntries[] =
     OSD_LABEL_ENTRY("- USER FREQ -"),
 
     OSD_UINT16_RO_ENTRY("CUR FREQ", &saCmsUserFreq),
-    OSD_UINT16_ENTRY("NEW FREQ", (&(OSD_UINT16_t){ &saCmsUserFreqNew, 5000, 5900, 1 })),
+    OSD_UINT16_ENTRY("NEW FREQ", (&(const OSD_UINT16_t){ &saCmsUserFreqNew, 5000, 5900, 1 })),
     OSD_FUNC_CALL_ENTRY("SET", saCmsConfigUserFreq),
 
     OSD_BACK_ENTRY,
@@ -528,7 +528,7 @@ static const OSD_Entry saCmsMenuConfigEntries[] =
 {
     OSD_LABEL_ENTRY("- SA CONFIG -"),
 
-    { "OP MODEL",  OME_TAB,     saCmsConfigOpmodelByGvar,              &(OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, DYNAMIC },
+    { "OP MODEL",  OME_TAB,     saCmsConfigOpmodelByGvar,              &(const OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, DYNAMIC },
     { "FSEL MODE", OME_TAB,     saCmsConfigFreqModeByGvar,             &saCmsEntFselMode,                                   DYNAMIC },
     OSD_TAB_CALLBACK_ENTRY("PIT FMODE", saCmsConfigPitFModeByGvar, &saCmsEntPitFMode),
     { "POR FREQ",  OME_Submenu, (CMSEntryFuncPtr)saCmsORFreqGetString, (void *)&saCmsMenuPORFreq,                                   OPTSTRING },

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -78,15 +78,13 @@ uint8_t trampCmsBand = 1;
 uint8_t trampCmsChan = 1;
 uint16_t trampCmsFreqRef;
 
-OSD_TAB_t trampCmsEntBand = { &trampCmsBand, 5, vtx58BandNames };
+static const OSD_TAB_t trampCmsEntBand = { &trampCmsBand, 5, vtx58BandNames };
 
-OSD_TAB_t trampCmsEntChan = { &trampCmsChan, 8, vtx58ChannelNames };
-
-static OSD_UINT16_t trampCmsEntFreqRef = { &trampCmsFreqRef, 5600, 5900, 0 };
+static const OSD_TAB_t trampCmsEntChan = { &trampCmsChan, 8, vtx58ChannelNames };
 
 static uint8_t trampCmsPower = 1;
 
-OSD_TAB_t trampCmsEntPower = { &trampCmsPower, 5, trampPowerNames };
+static const OSD_TAB_t trampCmsEntPower = { &trampCmsPower, 5, trampPowerNames };
 
 static void trampCmsUpdateFreqRef(void)
 {
@@ -134,13 +132,11 @@ static long trampCmsConfigPower(displayPort_t *pDisp, const void *self)
     return 0;
 }
 
-static OSD_INT16_t trampCmsEntTemp = { &trampData.temperature, -100, 300, 0 };
-
 static const char * const trampCmsPitModeNames[] = {
     "---", "OFF", "ON "
 };
 
-static OSD_TAB_t trampCmsEntPitMode = { &trampCmsPitMode, 2, trampCmsPitModeNames };
+static const OSD_TAB_t trampCmsEntPitMode = { &trampCmsPitMode, 2, trampCmsPitModeNames };
 
 static long trampCmsSetPitMode(displayPort_t *pDisp, const void *self)
 {
@@ -223,9 +219,9 @@ static const OSD_Entry trampMenuEntries[] =
     OSD_TAB_CALLBACK_ENTRY("PIT", trampCmsSetPitMode, &trampCmsEntPitMode),
     OSD_TAB_CALLBACK_ENTRY("BAND", trampCmsConfigBand, &trampCmsEntBand),
     OSD_TAB_CALLBACK_ENTRY("CHAN", trampCmsConfigChan, &trampCmsEntChan),
-    OSD_UINT16_DYN_ENTRY("(FREQ)", &trampCmsEntFreqRef),
+    OSD_UINT16_RO_ENTRY("(FREQ)", &trampCmsFreqRef),
     OSD_TAB_CALLBACK_ENTRY("POWER", trampCmsConfigPower, &trampCmsEntPower),
-    OSD_INT16_DYN_ENTRY("T(C)", &trampCmsEntTemp),
+    OSD_INT16_RO_ENTRY("T(C)", &trampData.temperature),
     OSD_SUBMENU_ENTRY("SET", &trampCmsMenuCommence),
 
     OSD_BACK_ENTRY,

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -197,8 +197,8 @@ static long trampCmsOnEnter(void)
 }
 
 static OSD_Entry trampCmsMenuCommenceEntries[] = {
-    { "CONFIRM", OME_Label,   NULL,          NULL, 0 },
-    { "YES",     OME_Funcall, trampCmsCommence, NULL, 0 },
+    OSD_LABEL_ENTRY("CONFIRM"),
+    OSD_FUNC_CALL_ENTRY("YES", trampCmsCommence),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
@@ -217,16 +217,16 @@ static CMS_Menu trampCmsMenuCommence = {
 
 static OSD_Entry trampMenuEntries[] =
 {
-    { "- TRAMP -", OME_Label, NULL, NULL, 0 },
+    OSD_LABEL_ENTRY("- TRAMP -"),
 
-    { "",       OME_LabelFunc,  NULL,                   trampCmsDrawStatusString,  DYNAMIC },
-    { "PIT",    OME_TAB,        trampCmsSetPitMode,     &trampCmsEntPitMode,   0 },
-    { "BAND",   OME_TAB,        trampCmsConfigBand,     &trampCmsEntBand,      0 },
-    { "CHAN",   OME_TAB,        trampCmsConfigChan,     &trampCmsEntChan,      0 },
-    { "(FREQ)", OME_UINT16,     NULL,                   &trampCmsEntFreqRef,   DYNAMIC },
-    { "POWER",  OME_TAB,        trampCmsConfigPower,    &trampCmsEntPower,     0 },
-    { "T(C)",   OME_INT16,      NULL,                   &trampCmsEntTemp,      DYNAMIC },
-    { "SET",    OME_Submenu,    cmsMenuChange,          &trampCmsMenuCommence, 0 },
+    OSD_LABEL_FUNC_DYN_ENTRY("", trampCmsDrawStatusString),
+    OSD_TAB_CALLBACK_ENTRY("PIT", trampCmsSetPitMode, &trampCmsEntPitMode),
+    OSD_TAB_CALLBACK_ENTRY("BAND", trampCmsConfigBand, &trampCmsEntBand),
+    OSD_TAB_CALLBACK_ENTRY("CHAN", trampCmsConfigChan, &trampCmsEntChan),
+    OSD_UINT16_DYN_ENTRY("(FREQ)", &trampCmsEntFreqRef),
+    OSD_TAB_CALLBACK_ENTRY("POWER", trampCmsConfigPower, &trampCmsEntPower),
+    OSD_INT16_DYN_ENTRY("T(C)", &trampCmsEntTemp),
+    OSD_SUBMENU_ENTRY("SET", &trampCmsMenuCommence),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -196,7 +196,7 @@ static long trampCmsOnEnter(void)
     return 0;
 }
 
-static OSD_Entry trampCmsMenuCommenceEntries[] = {
+static const OSD_Entry trampCmsMenuCommenceEntries[] = {
     OSD_LABEL_ENTRY("CONFIRM"),
     OSD_FUNC_CALL_ENTRY("YES", trampCmsCommence),
 
@@ -204,7 +204,7 @@ static OSD_Entry trampCmsMenuCommenceEntries[] = {
     OSD_END_ENTRY,
 };
 
-static CMS_Menu trampCmsMenuCommence = {
+static const CMS_Menu trampCmsMenuCommence = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XVTXTRC",
     .GUARD_type = OME_MENU,
@@ -215,7 +215,7 @@ static CMS_Menu trampCmsMenuCommence = {
     .entries = trampCmsMenuCommenceEntries,
 };
 
-static OSD_Entry trampMenuEntries[] =
+static const OSD_Entry trampMenuEntries[] =
 {
     OSD_LABEL_ENTRY("- TRAMP -"),
 
@@ -232,7 +232,7 @@ static OSD_Entry trampMenuEntries[] =
     OSD_END_ENTRY,
 };
 
-CMS_Menu cmsx_menuVtxTramp = {
+const CMS_Menu cmsx_menuVtxTramp = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "XVTXTR",
     .GUARD_type = OME_MENU,

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -199,8 +199,9 @@ static long trampCmsOnEnter(void)
 static OSD_Entry trampCmsMenuCommenceEntries[] = {
     { "CONFIRM", OME_Label,   NULL,          NULL, 0 },
     { "YES",     OME_Funcall, trampCmsCommence, NULL, 0 },
-    { "BACK",    OME_Back, NULL, NULL, 0 },
-    { NULL,      OME_END, NULL, NULL, 0 }
+
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 static CMS_Menu trampCmsMenuCommence = {
@@ -227,8 +228,8 @@ static OSD_Entry trampMenuEntries[] =
     { "T(C)",   OME_INT16,      NULL,                   &trampCmsEntTemp,      DYNAMIC },
     { "SET",    OME_Submenu,    cmsMenuChange,          &trampCmsMenuCommence, 0 },
 
-    { "BACK",   OME_Back, NULL, NULL, 0 },
-    { NULL,     OME_END, NULL, NULL, 0 }
+    OSD_BACK_ENTRY,
+    OSD_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuVtxTramp = {

--- a/src/main/cms/cms_menu_vtx_tramp.h
+++ b/src/main/cms/cms_menu_vtx_tramp.h
@@ -19,4 +19,5 @@
 
 #include "cms/cms.h"
 #include "cms/cms_types.h"
-extern CMS_Menu cmsx_menuVtxTramp;
+
+extern const CMS_Menu cmsx_menuVtxTramp;

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -75,8 +75,26 @@ typedef struct
 #define DYNAMIC        (1 << 2)  // Value should be updated dynamically
 #define OPTSTRING      (1 << 3)  // (Temporary) Flag for OME_Submenu, indicating func should be called to get a string to display.
 
-#define OSD_BACK_ENTRY  ((OSD_Entry){ "BACK", OME_Back, NULL, NULL, 0 })
-#define OSD_END_ENTRY   ((OSD_Entry){ NULL, OME_END, NULL, NULL, 0 })
+#define OSD_LABEL_ENTRY(label)                  ((OSD_Entry){ label, OME_Label, NULL, NULL, 0 })
+#define OSD_LABEL_DATA_ENTRY(label, data)       ((OSD_Entry){ label, OME_Label, NULL, data, 0 })
+#define OSD_LABEL_DATA_DYN_ENTRY(label, data)   ((OSD_Entry){ label, OME_Label, NULL, data, DYNAMIC })
+#define OSD_LABEL_FUNC_DYN_ENTRY(label, fn)     ((OSD_Entry){ label, OME_LabelFunc, NULL, fn, DYNAMIC })
+#define OSD_BACK_ENTRY                          ((OSD_Entry){ "BACK", OME_Back, NULL, NULL, 0 })
+#define OSD_SUBMENU_ENTRY(label, menu)          ((OSD_Entry){ label, OME_Submenu, cmsMenuChange, menu, 0 })
+#define OSD_FUNC_CALL_ENTRY(label, fn)          ((OSD_Entry){ label, OME_Funcall, fn, NULL, 0 })
+#define OSD_BOOL_ENTRY(label, val)              ((OSD_Entry){ label, OME_Bool, NULL, val, 0 })
+#define OSD_BOOL_FUNC_ENTRY(label, fn)          ((OSD_Entry){ label, OME_BoolFunc, NULL, fn, 0 })
+#define OSD_UINT8_ENTRY(label, val)             ((OSD_Entry){ label, OME_UINT8, NULL, val, 0 })
+#define OSD_UINT8_CALLBACK_ENTRY(label, cb, val)((OSD_Entry){ label, OME_UINT8, cb, val, 0 })
+#define OSD_UINT16_ENTRY(label, val)            ((OSD_Entry){ label, OME_UINT16, NULL, val, 0 })
+#define OSD_UINT16_DYN_ENTRY(label, val)        ((OSD_Entry){ label, OME_UINT16, NULL, val, DYNAMIC })
+#define OSD_INT16_DYN_ENTRY(label, val)         ((OSD_Entry){ label, OME_INT16, NULL, val, DYNAMIC })
+#define OSD_STRING_ENTRY(label, str)            ((OSD_Entry){ label, OME_String, NULL, str, 0 })
+#define OSD_TAB_ENTRY(label, val)               ((OSD_Entry){ label, OME_TAB, NULL, val, 0 })
+#define OSD_TAB_DYN_ENTRY(label, val)           ((OSD_Entry){ label, OME_TAB, NULL, val, DYNAMIC })
+#define OSD_TAB_CALLBACK_ENTRY(label, cb, val)  ((OSD_Entry){ label, OME_TAB, cb, val, 0 })
+
+#define OSD_END_ENTRY                           ((OSD_Entry){ NULL, OME_END, NULL, NULL, 0 })
 
 // Data type for OME_Setting. Uses upper 4 bits
 // of flags, leaving 16 data types.

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -80,7 +80,11 @@ typedef struct
 #define OSD_LABEL_DATA_DYN_ENTRY(label, data)   ((OSD_Entry){ label, OME_Label, NULL, data, DYNAMIC })
 #define OSD_LABEL_FUNC_DYN_ENTRY(label, fn)     ((OSD_Entry){ label, OME_LabelFunc, NULL, fn, DYNAMIC })
 #define OSD_BACK_ENTRY                          ((OSD_Entry){ "BACK", OME_Back, NULL, NULL, 0 })
-#define OSD_SUBMENU_ENTRY(label, menu)          ((OSD_Entry){ label, OME_Submenu, cmsMenuChange, menu, 0 })
+// Cast menus to (void *), since they should be declared as const to
+// be able to save them in FLASH. Of course, this means that changing
+// a entry->data pointer for a menu declared as const will result in
+// UB.
+#define OSD_SUBMENU_ENTRY(label, menu)          ((OSD_Entry){ label, OME_Submenu, cmsMenuChange, (void *)menu, 0 })
 #define OSD_FUNC_CALL_ENTRY(label, fn)          ((OSD_Entry){ label, OME_Funcall, fn, NULL, 0 })
 #define OSD_BOOL_ENTRY(label, val)              ((OSD_Entry){ label, OME_Bool, NULL, val, 0 })
 #define OSD_BOOL_FUNC_ENTRY(label, fn)          ((OSD_Entry){ label, OME_BoolFunc, NULL, fn, 0 })
@@ -106,16 +110,6 @@ typedef enum {
 // Use a function and data type to make sure switches are exhaustive
 static inline CMSDataType_e CMS_DATA_TYPE(const OSD_Entry *entry) { return entry->flags & 0xF0; }
 
-#define IS_PRINTVALUE(p) ((p)->flags & PRINT_VALUE)
-#define SET_PRINTVALUE(p) { (p)->flags |= PRINT_VALUE; }
-#define CLR_PRINTVALUE(p) { (p)->flags &= ~PRINT_VALUE; }
-
-#define IS_PRINTLABEL(p) ((p)->flags & PRINT_LABEL)
-#define SET_PRINTLABEL(p) { (p)->flags |= PRINT_LABEL; }
-#define CLR_PRINTLABEL(p) { (p)->flags &= ~PRINT_LABEL; }
-
-#define IS_DYNAMIC(p) ((p)->flags & DYNAMIC)
-
 typedef long (*CMSMenuFuncPtr)(void);
 
 // Special return value(s) for function chaining by CMSMenuFuncPtr
@@ -140,7 +134,7 @@ typedef struct
     const CMSMenuFuncPtr onEnter;
     const CMSMenuOnExitPtr onExit;
     const CMSMenuFuncPtr onGlobalExit;
-    OSD_Entry *entries;
+    const OSD_Entry *entries;
 } CMS_Menu;
 
 typedef struct

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -65,7 +65,7 @@ typedef struct
     const char * const text;
     const OSD_MenuElement type;
     const CMSEntryFuncPtr func;
-    void *data;
+    const void * const data;
     uint8_t flags;
 } OSD_Entry;
 
@@ -74,17 +74,14 @@ typedef struct
 #define PRINT_LABEL    (1 << 1)  // Text label should be printed
 #define DYNAMIC        (1 << 2)  // Value should be updated dynamically
 #define OPTSTRING      (1 << 3)  // (Temporary) Flag for OME_Submenu, indicating func should be called to get a string to display.
+#define READONLY       (1 << 4)  // Indicates that the value is read-only and p->data points directly to it - applies to [U]INT(8|16)
 
 #define OSD_LABEL_ENTRY(label)                  ((OSD_Entry){ label, OME_Label, NULL, NULL, 0 })
 #define OSD_LABEL_DATA_ENTRY(label, data)       ((OSD_Entry){ label, OME_Label, NULL, data, 0 })
 #define OSD_LABEL_DATA_DYN_ENTRY(label, data)   ((OSD_Entry){ label, OME_Label, NULL, data, DYNAMIC })
 #define OSD_LABEL_FUNC_DYN_ENTRY(label, fn)     ((OSD_Entry){ label, OME_LabelFunc, NULL, fn, DYNAMIC })
 #define OSD_BACK_ENTRY                          ((OSD_Entry){ "BACK", OME_Back, NULL, NULL, 0 })
-// Cast menus to (void *), since they should be declared as const to
-// be able to save them in FLASH. Of course, this means that changing
-// a entry->data pointer for a menu declared as const will result in
-// UB.
-#define OSD_SUBMENU_ENTRY(label, menu)          ((OSD_Entry){ label, OME_Submenu, cmsMenuChange, (void *)menu, 0 })
+#define OSD_SUBMENU_ENTRY(label, menu)          ((OSD_Entry){ label, OME_Submenu, cmsMenuChange, menu, 0 })
 #define OSD_FUNC_CALL_ENTRY(label, fn)          ((OSD_Entry){ label, OME_Funcall, fn, NULL, 0 })
 #define OSD_BOOL_ENTRY(label, val)              ((OSD_Entry){ label, OME_Bool, NULL, val, 0 })
 #define OSD_BOOL_FUNC_ENTRY(label, fn)          ((OSD_Entry){ label, OME_BoolFunc, NULL, fn, 0 })
@@ -92,7 +89,9 @@ typedef struct
 #define OSD_UINT8_CALLBACK_ENTRY(label, cb, val)((OSD_Entry){ label, OME_UINT8, cb, val, 0 })
 #define OSD_UINT16_ENTRY(label, val)            ((OSD_Entry){ label, OME_UINT16, NULL, val, 0 })
 #define OSD_UINT16_DYN_ENTRY(label, val)        ((OSD_Entry){ label, OME_UINT16, NULL, val, DYNAMIC })
+#define OSD_UINT16_RO_ENTRY(label, val)         ((OSD_Entry){ label, OME_UINT16, NULL, val, DYNAMIC | READONLY })
 #define OSD_INT16_DYN_ENTRY(label, val)         ((OSD_Entry){ label, OME_INT16, NULL, val, DYNAMIC })
+#define OSD_INT16_RO_ENTRY(label, val)          ((OSD_Entry){ label, OME_INT16, NULL, val, DYNAMIC | READONLY })
 #define OSD_STRING_ENTRY(label, str)            ((OSD_Entry){ label, OME_String, NULL, str, 0 })
 #define OSD_TAB_ENTRY(label, val)               ((OSD_Entry){ label, OME_TAB, NULL, val, 0 })
 #define OSD_TAB_DYN_ENTRY(label, val)           ((OSD_Entry){ label, OME_TAB, NULL, val, DYNAMIC })

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -182,7 +182,7 @@ typedef struct OSD_SETTING_s {
     const uint8_t step;
 } __attribute__((packed)) OSD_SETTING_t;
 
-#define OSD_SETTING_ENTRY_STEP_TYPE(name, setting, step, type)  { name, OME_Setting, NULL, &(OSD_SETTING_t){ setting, step }, type }
+#define OSD_SETTING_ENTRY_STEP_TYPE(name, setting, step, type)  { name, OME_Setting, NULL, &(const OSD_SETTING_t){ setting, step }, type }
 #define OSD_SETTING_ENTRY_TYPE(name, setting, type)             OSD_SETTING_ENTRY_STEP_TYPE(name, setting, 0, type)
 #define OSD_SETTING_ENTRY_STEP(name, setting, step)             OSD_SETTING_ENTRY_STEP_TYPE(name, setting, step, 0)
 #define OSD_SETTING_ENTRY(name, setting)                        OSD_SETTING_ENTRY_STEP(name, setting, 0)

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -75,6 +75,9 @@ typedef struct
 #define DYNAMIC        (1 << 2)  // Value should be updated dynamically
 #define OPTSTRING      (1 << 3)  // (Temporary) Flag for OME_Submenu, indicating func should be called to get a string to display.
 
+#define OSD_BACK_ENTRY  ((OSD_Entry){ "BACK", OME_Back, NULL, NULL, 0 })
+#define OSD_END_ENTRY   ((OSD_Entry){ NULL, OME_END, NULL, NULL, 0 })
+
 // Data type for OME_Setting. Uses upper 4 bits
 // of flags, leaving 16 data types.
 #define CMS_DATA_TYPE_OFFSET (4)


### PR DESCRIPTION
Make CMS use a separate static array for keeping track of the items that need redrawing rather than modifying each OSD_Entry_t item. This lets us move all items and most menus to flash (the SA menu uses dynamic entries, so it needs to stay in ram). Note that text increases by 6728 bytes due to these changes, but even F3 still has ~31K free.

Also, a bunch of macros have been added to CMS to make both the code cleaner and changes like this one easier. Please, try to use them in the future when adding new menus.

Before:

```
Linking OMNIBUS
arm-none-eabi-size ./obj/main/inav_OMNIBUS.elf
   text	   data	    bss	    dec	    hex	filename
 218430	  10136	  37900	 266466	  410e2	./obj/main/inav_OMNIBUS.elf
```

After:

```
arm-none-eabi-size ./obj/main/inav_OMNIBUS.elf
   text	   data	    bss	    dec	    hex	filename
 225158	   3224	  37860	 266242	  41002	./obj/main/inav_OMNIBUS.elf
```