### PR TITLE
Fix warning during compilation of osd.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -890,6 +890,7 @@ CFLAGS      += $(ARCH_FLAGS) \
               $(DEBUG_FLAGS) \
               -std=gnu99 \
               -Wall -Wextra -Wunsafe-loop-optimizations -Wdouble-promotion \
+              -Werror=switch \
               -ffunction-sections \
               -fdata-sections \
               $(DEVICE_FLAGS) \

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -539,7 +539,7 @@ static const char * osdArmingDisabledReasonMessage(void)
             return OSD_MESSAGE_STR("NO RC LINK");
         case ARMING_DISABLED_THROTTLE:
             return OSD_MESSAGE_STR("THROTTLE IS NOT LOW");
-	case ARMING_DISABLED_ROLLPITCH_NOT_CENTERED:
+        case ARMING_DISABLED_ROLLPITCH_NOT_CENTERED:
             return OSD_MESSAGE_STR("ROLLPITCH NOT CENTERED");
         case ARMING_DISABLED_SERVO_AUTOTRIM:
             return OSD_MESSAGE_STR("AUTOTRIM IS ACTIVE");

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -543,6 +543,8 @@ static const char * osdArmingDisabledReasonMessage(void)
             return OSD_MESSAGE_STR("ROLLPITCH NOT CENTERED");
         case ARMING_DISABLED_SERVO_AUTOTRIM:
             return OSD_MESSAGE_STR("AUTOTRIM IS ACTIVE");
+        case ARMING_DISABLED_OOM:
+            return OSD_MESSAGE_STR("NOT ENOUGH MEMORY");
         case ARMING_DISABLED_CLI:
             return OSD_MESSAGE_STR("CLI IS ACTIVE");
             // Cases without message


### PR DESCRIPTION
Add the missing case to the switch. Also, make missing switch cases compile time errors now, so they're easier to notice.