### PR TITLE
Increased OSD armed screen display time

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1868,7 +1868,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
         if (ARMING_FLAG(ARMED)) {
             osdResetStats();
             osdShowArmed(); // reset statistic etc
-            resumeRefreshAt = currentTimeUs + (REFRESH_1S / 2);
+            resumeRefreshAt = currentTimeUs + (3 * REFRESH_1S / 2);
         } else {
             osdShowStats(); // show statistic
             resumeRefreshAt = currentTimeUs + (60 * REFRESH_1S);


### PR DESCRIPTION
Add 1 second to the display time of the OSD armed screen. For the moment is is displayed less than 500ms taking into account the refresh time and it doesn't allow to read what is written.