### PR TITLE
Make FS mode take priority over any other modes in osd.c

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -991,13 +991,13 @@ static bool osdDrawSingleElement(uint8_t item)
                 p = "AIR ";
             }
 
-            if (FLIGHT_MODE(MANUAL_MODE))
-                p = "MANU";
-            else if (FLIGHT_MODE(FAILSAFE_MODE)) {
+            if (FLIGHT_MODE(FAILSAFE_MODE)) {
                 p = "!FS!";
-            } else if (FLIGHT_MODE(NAV_RTH_MODE))
+            } else if (FLIGHT_MODE(MANUAL_MODE)) {
+                p = "MANU";
+            } else if (FLIGHT_MODE(NAV_RTH_MODE)) {
                 p = "RTH ";
-            else if (FLIGHT_MODE(NAV_POSHOLD_MODE)) {
+            } else if (FLIGHT_MODE(NAV_POSHOLD_MODE)) {
                 if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
                     // 3D HOLD
                     p = "HOLD";


### PR DESCRIPTION
Otherwise MANUAL mode would be shown if the FC went into FS mode
while MANUAL was active. Also, added missing braces around the
checks.

Thanks to @giacomo892 for spotting it.