### PR TITLE
Add accessors for battery functions

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1027,7 +1027,7 @@ void blackboxStart(void)
     blackboxHistory[1] = &blackboxHistoryRing[1];
     blackboxHistory[2] = &blackboxHistoryRing[2];
 
-    vbatReference = vbatLatestADC;
+    vbatReference = getBatteryVoltageLatestADC();
 
     //No need to clear the content of blackboxHistoryRing since our first frame will be an intra which overwrites it
 
@@ -1158,8 +1158,8 @@ static void loadMainState(timeUs_t currentTimeUs)
         blackboxCurrent->motor[i] = motor[i];
     }
 
-    blackboxCurrent->vbatLatest = vbatLatestADC;
-    blackboxCurrent->amperageLatest = amperageLatestADC;
+    blackboxCurrent->vbatLatest = getBatteryVoltageLatestADC();
+    blackboxCurrent->amperageLatest = getAmperageLatestADC();
 
 #ifdef USE_BARO
     blackboxCurrent->BaroAlt = baro.BaroAlt;

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2330,7 +2330,7 @@ static void cliStatus(char *cmdline)
     rtcGetDateTime(&dt);
     dateTimeFormatLocal(buf, &dt);
     cliPrintLinef("Current Time: %s", buf);
-    cliPrintLinef("Voltage: %d.%dV (%dS battery - %s)", vbat / 100, vbat % 100, batteryCellCount, getBatteryStateString());
+    cliPrintLinef("Voltage: %d.%dV (%dS battery - %s)", getBatteryVoltage() / 100, getBatteryVoltage() % 100, getBatteryCellCount(), getBatteryStateString());
     cliPrintf("CPU Clock=%dMHz", (SystemCoreClock / 1000000));
 
 #if (FLASH_SIZE > 64)

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -536,23 +536,23 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         break;
 
     case MSP_ANALOG:
-        sbufWriteU8(dst, (uint8_t)constrain(vbat / 10, 0, 255));
-        sbufWriteU16(dst, (uint16_t)constrain(mAhDrawn, 0, 0xFFFF)); // milliamp hours drawn from battery
+        sbufWriteU8(dst, (uint8_t)constrain(getBatteryVoltage() / 10, 0, 255));
+        sbufWriteU16(dst, (uint16_t)constrain(getMAhDrawn(), 0, 0xFFFF)); // milliamp hours drawn from battery
         sbufWriteU16(dst, rssi);
-        sbufWriteU16(dst, (int16_t)constrain(amperage, -0x8000, 0x7FFF)); // send amperage in 0.01 A steps, range is -320A to 320A
+        sbufWriteU16(dst, (int16_t)constrain(getAmperage(), -0x8000, 0x7FFF)); // send amperage in 0.01 A steps, range is -320A to 320A
         break;
 
     case MSP2_INAV_ANALOG:
-        sbufWriteU16(dst, vbat);
-        sbufWriteU8(dst, batteryCellCount);
+        sbufWriteU16(dst, getBatteryVoltage());
+        sbufWriteU8(dst, getBatteryCellCount());
         sbufWriteU8(dst, calculateBatteryPercentage());
-        sbufWriteU16(dst, constrain(power, 0, 0x7FFFFFFF));           // power draw
-        sbufWriteU16(dst, (uint16_t)constrain(mAhDrawn, 0, 0xFFFF)); // milliamp hours drawn from battery
-        sbufWriteU16(dst, (uint16_t)constrain(mWhDrawn, 0, 0xFFFF)); // milliWatt hours drawn from battery
+        sbufWriteU16(dst, constrain(getPower(), 0, 0x7FFFFFFF));           // power draw
+        sbufWriteU16(dst, (uint16_t)constrain(getMAhDrawn(), 0, 0xFFFF)); // milliamp hours drawn from battery
+        sbufWriteU16(dst, (uint16_t)constrain(getMWhDrawn(), 0, 0xFFFF)); // milliWatt hours drawn from battery
         sbufWriteU16(dst, rssi);
-        sbufWriteU16(dst, (int16_t)constrain(amperage, -0x8000, 0x7FFF)); // send amperage in 0.01 A steps, range is -320A to 320A
-        sbufWriteU8(dst, batteryFullWhenPluggedIn | (batteryUseCapacityThresholds << 1) | (batteryState << 2));
-        sbufWriteU32(dst, batteryRemainingCapacity);
+        sbufWriteU16(dst, (int16_t)constrain(getAmperage(), -0x8000, 0x7FFF)); // send amperage in 0.01 A steps, range is -320A to 320A
+        sbufWriteU8(dst, batteryWasFullWhenPluggedIn() | (batteryUsesCapacityThresholds() << 1) | (getBatteryState() << 2));
+        sbufWriteU32(dst, getBatteryRemainingCapacity());
         break;
 
     case MSP_ARMING_CONFIG:

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -211,7 +211,7 @@ static const beeperTableEntry_t *currentBeeperEntry = NULL;
  */
 void beeper(beeperMode_e mode)
 {
-    if (mode == BEEPER_SILENCE || ((getBeeperOffMask() & (1 << (BEEPER_USB-1))) && (feature(FEATURE_VBAT) && (batteryCellCount < 2)))) {
+    if (mode == BEEPER_SILENCE || ((getBeeperOffMask() & (1 << (BEEPER_USB-1))) && (feature(FEATURE_VBAT) && (getBatteryCellCount() < 2)))) {
         beeperSilence();
         return;
     }

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -357,7 +357,7 @@ static void showStatusPage(void)
 
     if (feature(FEATURE_VBAT)) {
         i2c_OLED_set_line(rowIndex++);
-        tfp_sprintf(lineBuffer, "V: %d.%1d ", vbat / 100, vbat % 100);
+        tfp_sprintf(lineBuffer, "V: %d.%1d ", getBatteryVoltage() / 100, getBatteryVoltage() % 100);
         padLineBufferToChar(12);
         i2c_OLED_send_string(lineBuffer);
 
@@ -367,7 +367,7 @@ static void showStatusPage(void)
 
     if (feature(FEATURE_CURRENT_METER)) {
         i2c_OLED_set_line(rowIndex++);
-        tfp_sprintf(lineBuffer, "mAh: %d", mAhDrawn);
+        tfp_sprintf(lineBuffer, "mAh: %d", getMAhDrawn());
         padLineBufferToChar(12);
         i2c_OLED_send_string(lineBuffer);
 

--- a/src/main/rx/eleres.c
+++ b/src/main/rx/eleres.c
@@ -258,7 +258,7 @@ static void telemetryRX(void)
     static int32_t presfil;
     static int16_t thempfil;
     uint8_t i, themp=90, wii_flymode=0;
-    uint16_t pres,curr = abs(amperage) / 10;
+    uint16_t pres,curr = abs(getAmperage()) / 10;
     union {
         int32_t val;
         uint8_t b[4];
@@ -294,7 +294,7 @@ static void telemetryRX(void)
         rfTxBuffer[0] = 0x54;
         rfTxBuffer[1] = localRssi;
         rfTxBuffer[2] = quality;
-        rfTxBuffer[3] = vbat / 10;
+        rfTxBuffer[3] = getBatteryVoltage() / 10;
         rfTxBuffer[4] = themp;
         rfTxBuffer[5] = curr & 0xff;
         rfTxBuffer[6] = pres>>8;

--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -521,10 +521,10 @@ void handleJetiExBusTelemetry(void)
         }
 
         if ((jetiExBusRequestFrame[EXBUS_HEADER_DATA_ID] == EXBUS_EX_REQUEST) && (calcCRC16(jetiExBusRequestFrame, jetiExBusRequestFrame[EXBUS_HEADER_MSG_LEN]) == 0)) {
-            jetiExSensors[EX_VOLTAGE].value = vbat / 10;
-            jetiExSensors[EX_CURRENT].value = amperage;
+            jetiExSensors[EX_VOLTAGE].value = getBatteryVoltage() / 10;
+            jetiExSensors[EX_CURRENT].value = getAmperage();
             jetiExSensors[EX_ALTITUDE].value = baro.BaroAlt;
-            jetiExSensors[EX_CAPACITY].value = mAhDrawn;
+            jetiExSensors[EX_CAPACITY].value = getMAhDrawn();
             jetiExSensors[EX_FRAMES_LOST].value = framesLost;
             jetiExSensors[EX_TIME_DIFF].value = timeDiff;
 

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -54,22 +54,22 @@
 
 
 // Battery monitoring stuff
-uint8_t batteryCellCount = 3;       // cell count
-uint16_t batteryFullVoltage;
-uint16_t batteryWarningVoltage;
-uint16_t batteryCriticalVoltage;
-uint32_t batteryRemainingCapacity = 0;
-bool batteryUseCapacityThresholds = false;
-bool batteryFullWhenPluggedIn = false;
+static uint8_t batteryCellCount = 3;       // cell count
+static uint16_t batteryFullVoltage;
+static uint16_t batteryWarningVoltage;
+static uint16_t batteryCriticalVoltage;
+static uint32_t batteryRemainingCapacity = 0;
+static bool batteryUseCapacityThresholds = false;
+static bool batteryFullWhenPluggedIn = false;
 
-uint16_t vbat = 0;                   // battery voltage in 0.1V steps (filtered)
-uint16_t vbatLatestADC = 0;         // most recent unsmoothed raw reading from vbat ADC
-uint16_t amperageLatestADC = 0;     // most recent raw reading from current ADC
+static uint16_t vbat = 0;                   // battery voltage in 0.1V steps (filtered)
+static uint16_t vbatLatestADC = 0;          // most recent unsmoothed raw reading from vbat ADC
+static uint16_t amperageLatestADC = 0;      // most recent raw reading from current ADC
 
-int32_t amperage = 0;               // amperage read by current sensor in centiampere (1/100th A)
-int32_t power = 0;                  // power draw in cW (0.01W resolution)
-int32_t mAhDrawn = 0;               // milliampere hours drawn from the battery since start
-int32_t mWhDrawn = 0;               // energy (milliWatt hours) drawn from the battery since start
+static int32_t amperage = 0;               // amperage read by current sensor in centiampere (1/100th A)
+static int32_t power = 0;                  // power draw in cW (0.01W resolution)
+static int32_t mAhDrawn = 0;               // milliampere hours drawn from the battery since start
+static int32_t mWhDrawn = 0;               // energy (milliWatt hours) drawn from the battery since start
 
 batteryState_e batteryState;
 
@@ -223,6 +223,75 @@ batteryState_e getBatteryState(void)
 {
     return batteryState;
 }
+
+bool batteryWasFullWhenPluggedIn(void)
+{
+    return batteryFullWhenPluggedIn;
+}
+
+bool batteryUsesCapacityThresholds(void)
+{
+    return batteryUseCapacityThresholds;
+}
+
+uint16_t getBatteryVoltage(void)
+{
+    return vbat;
+}
+
+uint16_t getBatteryVoltageLatestADC(void)
+{
+    return vbatLatestADC;
+}
+
+uint16_t getBatteryWarningVoltage(void)
+{
+    return batteryWarningVoltage;
+}
+
+uint8_t getBatteryCellCount(void)
+{
+    return batteryCellCount;
+}
+
+uint16_t getBatteryAverageCellVoltage(void)
+{
+    if (batteryCellCount > 0) {
+        return vbat / batteryCellCount;
+    }
+    return 0;
+}
+
+uint32_t getBatteryRemainingCapacity(void)
+{
+    return batteryRemainingCapacity;
+}
+
+int32_t getAmperage(void)
+{
+    return amperage;
+}
+
+int32_t getAmperageLatestADC(void)
+{
+    return amperageLatestADC;
+}
+
+int32_t getPower(void)
+{
+    return power;
+}
+
+int32_t getMAhDrawn(void)
+{
+    return mAhDrawn;
+}
+
+int32_t getMWhDrawn(void)
+{
+    return mWhDrawn;
+}
+
 
 void currentMeterUpdate(int32_t timeDelta)
 {

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -74,26 +74,25 @@ typedef enum {
     BATTERY_NOT_PRESENT
 } batteryState_e;
 
-extern uint16_t vbat;
-extern uint16_t vbatRaw;
-extern uint16_t vbatLatestADC;
-extern uint8_t batteryCellCount;
-extern uint16_t batteryCriticalVoltage;
-extern uint16_t batteryWarningVoltage;
-extern uint16_t amperageLatestADC;
-extern int32_t amperage;
-extern int32_t power;
-extern int32_t mAhDrawn;
-extern int32_t mWhDrawn;
-extern uint32_t batteryRemainingCapacity;
-extern bool batteryUseCapacityThresholds;
-extern bool batteryFullWhenPluggedIn;
-extern batteryState_e batteryState;
-
 uint16_t batteryAdcToVoltage(uint16_t src);
 batteryState_e getBatteryState(void);
+bool batteryWasFullWhenPluggedIn(void);
+bool batteryUsesCapacityThresholds(void);
 void batteryUpdate(uint32_t vbatTimeDelta);
 void batteryInit(void);
+
+uint16_t getBatteryVoltage(void);
+uint16_t getBatteryVoltageLatestADC(void);
+uint16_t getBatteryWarningVoltage(void);
+uint8_t getBatteryCellCount(void);
+uint16_t getBatteryAverageCellVoltage(void);
+uint32_t getBatteryRemainingCapacity(void);
+
+int32_t getAmperage(void);
+int32_t getAmperageLatestADC(void);
+int32_t getPower(void);
+int32_t getMAhDrawn(void);
+int32_t getMWhDrawn(void);
 
 void currentMeterUpdate(int32_t lastUpdateAt);
 

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -166,12 +166,12 @@ void crsfFrameBatterySensor(sbuf_t *dst)
     // use sbufWrite since CRC does not include frame length
     sbufWriteU8(dst, CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE + CRSF_FRAME_LENGTH_TYPE_CRC);
     crsfSerialize8(dst, CRSF_FRAMETYPE_BATTERY_SENSOR);
-    crsfSerialize16(dst, vbat / 10); // vbat is in units of 0.01V
-    crsfSerialize16(dst, amperage / 10);
+    crsfSerialize16(dst, getBatteryVoltage() / 10); // vbat is in units of 0.01V
+    crsfSerialize16(dst, getAmperage() / 10);
     const uint8_t batteryRemainingPercentage = calculateBatteryPercentage();
-    crsfSerialize8(dst, (mAhDrawn >> 16));
-    crsfSerialize8(dst, (mAhDrawn >> 8));
-    crsfSerialize8(dst, (uint8_t)mAhDrawn);
+    crsfSerialize8(dst, (getMAhDrawn() >> 16));
+    crsfSerialize8(dst, (getMAhDrawn() >> 8));
+    crsfSerialize8(dst, (uint8_t)getMAhDrawn());
     crsfSerialize8(dst, batteryRemainingPercentage);
 }
 

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -365,7 +365,7 @@ static void sendVoltage(void)
      * The actual value sent for cell voltage has resolution of 0.002 volts
      * Since vbat has resolution of 0.01 volts it has to be multiplied by 5
      */
-    cellVoltage = ((uint32_t)vbat * 10) / (batteryCellCount * 2);
+    cellVoltage = ((uint32_t)getBatteryVoltage() * 10) / (getBatteryCellCount() * 2);
 
     // Cell number is at bit 9-12 (only uses vbat, so it can't send individual cell voltages, set cell number to 0)
     payload = 0;
@@ -385,6 +385,7 @@ static void sendVoltage(void)
  */
 static void sendVoltageAmp(void)
 {
+    uint16_t vbat = getBatteryVoltage();
     if (telemetryConfig()->frsky_vfas_precision == FRSKY_VFAS_PRECISION_HIGH) {
         /*
          * Use new ID 0x39 to send voltage directly in 0.1 volts resolution
@@ -395,7 +396,7 @@ static void sendVoltageAmp(void)
         uint16_t voltage = (vbat * 11) / 21;
         uint16_t vfasVoltage;
         if (telemetryConfig()->frsky_vfas_cell_voltage) {
-            vfasVoltage = voltage / batteryCellCount;
+            vfasVoltage = voltage / getBatteryCellCount();
         } else {
             vfasVoltage = voltage;
         }
@@ -409,7 +410,7 @@ static void sendVoltageAmp(void)
 static void sendAmperage(void)
 {
     sendDataHead(ID_CURRENT);
-    serialize16((uint16_t)(amperage / 10));
+    serialize16((uint16_t)(getAmperage() / 10));
 }
 
 static void sendFuelLevel(void)

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -253,7 +253,7 @@ static inline void updateAlarmBatteryStatus(HOTT_EAM_MSG_t *hottEAMMessage)
 
 static inline void hottEAMUpdateBattery(HOTT_EAM_MSG_t *hottEAMMessage)
 {
-    uint8_t vbat_dcv = vbat / 10; // vbat resolution is 10mV convert to 100mv (deciVolt)
+    uint8_t vbat_dcv = getBatteryVoltage() / 10; // vbat resolution is 10mV convert to 100mv (deciVolt)
     hottEAMMessage->main_voltage_L = vbat_dcv & 0xFF;
     hottEAMMessage->main_voltage_H = vbat_dcv >> 8;
     hottEAMMessage->batt1_voltage_L = vbat_dcv & 0xFF;
@@ -264,14 +264,14 @@ static inline void hottEAMUpdateBattery(HOTT_EAM_MSG_t *hottEAMMessage)
 
 static inline void hottEAMUpdateCurrentMeter(HOTT_EAM_MSG_t *hottEAMMessage)
 {
-    const int32_t amp = amperage / 10;
+    const int32_t amp = getAmperage() / 10;
     hottEAMMessage->current_L = amp & 0xFF;
     hottEAMMessage->current_H = amp >> 8;
 }
 
 static inline void hottEAMUpdateBatteryDrawnCapacity(HOTT_EAM_MSG_t *hottEAMMessage)
 {
-    const int32_t mAh = mAhDrawn / 10;
+    const int32_t mAh = getMAhDrawn() / 10;
     hottEAMMessage->batt_cap_L = mAh & 0xFF;
     hottEAMMessage->batt_cap_H = mAh >> 8;
 }

--- a/src/main/telemetry/ibus_shared.c
+++ b/src/main/telemetry/ibus_shared.c
@@ -152,12 +152,12 @@ static uint8_t dispatchMeasurementRequest(ibusAddress_t address) {
     } else if (SENSOR_ADDRESS_TYPE_LOOKUP[address].value == IBUS_MEAS_VALUE_RPM) {
         return sendIbusMeasurement2(address, (uint16_t) (rcCommand[THROTTLE]));
     } else if (SENSOR_ADDRESS_TYPE_LOOKUP[address].value == IBUS_MEAS_VALUE_EXTERNAL_VOLTAGE) { //VBAT
-        return sendIbusMeasurement2(address, vbat);
+        return sendIbusMeasurement2(address, getBatteryVoltage());
     } else if (SENSOR_ADDRESS_TYPE_LOOKUP[address].value == IBUS_MEAS_VALUE_CURRENT) { //CURR in 10*mA, 1 = 10 mA
-        if (feature(FEATURE_CURRENT_METER)) return sendIbusMeasurement2(address, (uint16_t) amperage); //int32_t
+        if (feature(FEATURE_CURRENT_METER)) return sendIbusMeasurement2(address, (uint16_t) getAmperage()); //int32_t
         else return sendIbusMeasurement2(address, 0);
     } else if (SENSOR_ADDRESS_TYPE_LOOKUP[address].value == IBUS_MEAS_VALUE_FUEL) { //capacity in mAh
-        if (feature(FEATURE_CURRENT_METER)) return sendIbusMeasurement2(address, (uint16_t) mAhDrawn); //int32_t
+        if (feature(FEATURE_CURRENT_METER)) return sendIbusMeasurement2(address, (uint16_t) getMAhDrawn()); //int32_t
         else return sendIbusMeasurement2(address, 0);
     } else if (SENSOR_ADDRESS_TYPE_LOOKUP[address].value == IBUS_MEAS_VALUE_CLIMB) {
         return sendIbusMeasurement2(address, (int16_t) (getEstimatedActualVelocity(Z))); //

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -185,8 +185,8 @@ void ltm_sframe(sbuf_t *dst)
     if (failsafeIsActive())
         lt_statemode |= 2;
     sbufWriteU8(dst, 'S');
-    sbufWriteU16(dst, vbat * 10);    //vbat converted to mv
-    sbufWriteU16(dst, (uint16_t)constrain(mAhDrawn, 0, 0xFFFF));    // current mAh (65535 mAh max)
+    sbufWriteU16(dst, getBatteryVoltage() * 10);    //vbat converted to mv
+    sbufWriteU16(dst, (uint16_t)constrain(getMAhDrawn(), 0, 0xFFFF));    // current mAh (65535 mAh max)
     sbufWriteU8(dst, (uint8_t)((rssi * 254) / 1023));        // scaled RSSI (uchar)
 #if defined(USE_PITOT)
     sbufWriteU8(dst, sensors(SENSOR_PITOT) ? pitot.airSpeed / 100.0f : 0);  // in m/s

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -227,9 +227,9 @@ void mavlinkSendSystemStatus(void)
         // load Maximum usage in percent of the mainloop time, (0%: 0, 100%: 1000) should be always below 1000
         0,
         // voltage_battery Battery voltage, in millivolts (1 = 1 millivolt)
-        feature(FEATURE_VBAT) ? vbat * 10 : 0,
+        feature(FEATURE_VBAT) ? getBatteryVoltage() * 10 : 0,
         // current_battery Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current
-        feature(FEATURE_CURRENT_METER) ? amperage : -1,
+        feature(FEATURE_CURRENT_METER) ? getAmperage() : -1,
         // battery_remaining Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot estimate the remaining battery
         feature(FEATURE_VBAT) ? calculateBatteryPercentage() : 100,
         // drop_rate_comm Communication drops in percent, (0%: 0, 100%: 10'000), (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -584,8 +584,9 @@ void handleSmartPortTelemetry(void)
             case FSSP_DATAID_VFAS       :
                 if (feature(FEATURE_VBAT)) {
                     uint16_t vfasVoltage;
+                    uint16_t vbat = getBatteryVoltage();
                     if (telemetryConfig()->frsky_vfas_cell_voltage)
-                        vfasVoltage = vbat / batteryCellCount;
+                        vfasVoltage = vbat / getBatteryCellCount();
                     else
                         vfasVoltage = vbat;
                     smartPortSendPackage(id, vfasVoltage);
@@ -593,7 +594,7 @@ void handleSmartPortTelemetry(void)
                 break;
             case FSSP_DATAID_CURRENT    :
                 if (feature(FEATURE_CURRENT_METER))
-                    smartPortSendPackage(id, amperage / 10); // given in 10mA steps, unknown requested unit
+                    smartPortSendPackage(id, getAmperage() / 10); // given in 10mA steps, unknown requested unit
                 break;
             //case FSSP_DATAID_RPM        :
             case FSSP_DATAID_ALTITUDE   :
@@ -604,7 +605,7 @@ void handleSmartPortTelemetry(void)
                 if (telemetryConfig()->smartportFuelUnit == SMARTPORT_FUEL_UNIT_PERCENT)
                     smartPortSendPackage(id, calculateBatteryPercentage()); // Show remaining battery % if smartport_fuel_percent=ON
                 else if (feature(FEATURE_CURRENT_METER))
-                    smartPortSendPackage(id, (telemetryConfig()->smartportFuelUnit == SMARTPORT_FUEL_UNIT_MAH ? mAhDrawn : mWhDrawn));
+                    smartPortSendPackage(id, (telemetryConfig()->smartportFuelUnit == SMARTPORT_FUEL_UNIT_MAH ? getMAhDrawn() : getMWhDrawn()));
                 break;
             //case FSSP_DATAID_ADC1       :
             //case FSSP_DATAID_ADC2       :
@@ -737,7 +738,7 @@ void handleSmartPortTelemetry(void)
             //case FSSP_DATAID_A3         :
             case FSSP_DATAID_A4         :
                 if (feature(FEATURE_VBAT))
-                    smartPortSendPackage(id, vbat / batteryCellCount );
+                    smartPortSendPackage(id, getBatteryAverageCellVoltage());
                 break;
             default:
                 break;

--- a/src/test/unit/telemetry_hott_unittest.cc
+++ b/src/test/unit/telemetry_hott_unittest.cc
@@ -52,6 +52,10 @@ extern "C" {
 
 
     PG_REGISTER(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 0);
+
+    uint16_t testBatteryVoltage = 0;
+    int32_t testAmperage = 0;
+    int32_t testMAhDrawn = 0;
 }
 
 #include "unittest_macros.h"
@@ -256,6 +260,18 @@ float getEstimatedActualPosition(int) {
 
 float getEstimatedActualVelocity(int) {
     return 0.0f;
+}
+
+uint16_t getBatteryVoltage(void) {
+    return testBatteryVoltage;
+}
+
+int32_t getAmperage(void) {
+    return testAmperage;
+}
+
+int32_t getMAhDrawn(void) {
+    return testMAhDrawn;
 }
 
 }


### PR DESCRIPTION
Implement functions for accessing battery/current state rather
than accessing global variables directly. This will let us reuse
the RX/telemetry code from BF minimizing the required changes.
Thanks to LTO, this only adds a small ~20 byte overhead in flash.