### PR TITLE
Fix blackbox current logging

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -307,13 +307,12 @@ void currentMeterUpdate(int32_t timeDelta)
 {
     static pt1Filter_t amperageFilterState;
     static int64_t mAhdrawnRaw = 0;
-    uint16_t amperageSample;
 
     switch (batteryConfig()->current.type) {
         case CURRENT_SENSOR_ADC:
-            amperageSample = adcGetChannel(ADC_CURRENT);
-            amperageSample = pt1FilterApply4(&amperageFilterState, amperageSample, AMPERAGE_LPF_FREQ, timeDelta * 1e-6f);
-            amperage = currentSensorToCentiamps(amperageSample);
+            amperageLatestADC = adcGetChannel(ADC_CURRENT);
+            amperageLatestADC = pt1FilterApply4(&amperageFilterState, amperageLatestADC, AMPERAGE_LPF_FREQ, timeDelta * 1e-6f);
+            amperage = currentSensorToCentiamps(amperageLatestADC);
             break;
         case CURRENT_SENSOR_VIRTUAL:
             amperage = batteryConfig()->current.offset;


### PR DESCRIPTION
Logged current is always 0 in 1.9.0 (my fault). Fixes #2922 