### PR TITLE
Make the current calculation more precise

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -108,8 +108,8 @@ uint16_t batteryAdcToVoltage(uint16_t src)
 
 int32_t currentSensorToCentiamps(uint16_t src)
 {
-    int32_t millivolts = ((uint32_t)src * ADCVREF) / 0xFFF - batteryConfig()->current.offset;
-    return millivolts * 1000 / batteryConfig()->current.scale; // current in 0.01A steps
+    int32_t microvolts = ((uint32_t)src * ADCVREF * 1000) / 0xFFF - (int32_t)batteryConfig()->current.offset * 1000;
+    return microvolts / batteryConfig()->current.scale; // current in 0.01A steps
 }
 
 void batteryInit(void)


### PR DESCRIPTION
This is not really needed during flight but it makes calibrating the current sensor more precisely easier (without a big load).