### PR TITLE
Remove the STM32F4 condition for the serialrx_halfduplex setting

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -352,7 +352,6 @@ groups:
         max: PWM_PULSE_MAX
       - name: serialrx_halfduplex
         field: halfDuplex
-        condition: STM32F4
         type: bool
 
   - name: PG_BLACKBOX_CONFIG


### PR DESCRIPTION
Needed for F.Port support on F3 and F7 MCUs