### PR TITLE
Change current sensor offset voltage unit to 0.1mV

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -526,8 +526,8 @@ groups:
         max: 10000
       - name: current_meter_offset
         field: current.offset
-        min: -3300
-        max: 3300
+        min: -32768
+        max: 32767
       - name: current_meter_type
         field: current.type
         table: current_sensor

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -144,7 +144,7 @@ uint16_t batteryAdcToVoltage(uint16_t src)
 
 int32_t currentSensorToCentiamps(uint16_t src)
 {
-    int32_t microvolts = ((uint32_t)src * ADCVREF * 100) / 0xFFF * 10 - (int32_t)batteryMetersConfig()->current.offset * 1000;
+    int32_t microvolts = ((uint32_t)src * ADCVREF * 100) / 0xFFF * 10 - (int32_t)batteryMetersConfig()->current.offset * 100;
     return microvolts / batteryMetersConfig()->current.scale; // current in 0.01A steps
 }
 


### PR DESCRIPTION
Makes the current sensor offset calibration more precise and the offset unit match the scale unit.

Matching configurator update: https://github.com/iNavFlight/inav-configurator/pull/397