### PR TITLE
Add feature(FEATURE_CURRENT_METER) condition to battery percent calculation

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -346,7 +346,7 @@ uint8_t calculateBatteryPercentage(void)
     if (batteryState == BATTERY_NOT_PRESENT)
         return 0;
 
-    if (batteryFullWhenPluggedIn && (batteryConfig()->capacity.value > 0) && (batteryConfig()->capacity.critical > 0)) {
+    if (batteryFullWhenPluggedIn && feature(FEATURE_CURRENT_METER) && (batteryConfig()->capacity.value > 0) && (batteryConfig()->capacity.critical > 0)) {
         uint32_t capacityDiffBetweenFullAndEmpty = batteryConfig()->capacity.value - batteryConfig()->capacity.critical;
         return constrain(batteryRemainingCapacity * 100 / capacityDiffBetweenFullAndEmpty, 0, 100);
     } else


### PR DESCRIPTION
Add the feature(FEATURE_CURRENT_METER) condition to `calculateBatteryPercentage()` because it does not use the batteryUseCapacityThresholds boolean.