### PR TITLE
Simplify channel mapping (only map AETR channels)

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1893,25 +1893,26 @@ static void printMap(uint8_t dumpMask, const rxConfig_t *rxConfig, const rxConfi
 static void cliMap(char *cmdline)
 {
     uint32_t len;
-    char out[9];
+    char out[5];
 
     len = strlen(cmdline);
 
-    if (len == 8) {
+    if (len == 4) {
         // uppercase it
-        for (uint32_t i = 0; i < 8; i++)
+        for (uint32_t i = 0; i < 4; i++)
             cmdline[i] = sl_toupper((unsigned char)cmdline[i]);
-        for (uint32_t i = 0; i < 8; i++) {
+        for (uint32_t i = 0; i < 4; i++) {
             if (strchr(rcChannelLetters, cmdline[i]) && !strchr(cmdline + i + 1, cmdline[i]))
                 continue;
             cliShowParseError();
             return;
         }
         parseRcChannels(cmdline);
-    }
+    } else if (len != 0)
+        cliShowParseError();
     cliPrint("Map: ");
     uint32_t i;
-    for (i = 0; i < 8; i++)
+    for (i = 0; i < 4; i++)
         out[rxConfig()->rcmap[i]] = rcChannelLetters[i];
     out[i] = '\0';
     cliPrintLinef("%s", out);

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -67,7 +67,7 @@
 
 //#define DEBUG_RX_SIGNAL_LOSS
 
-const char rcChannelLetters[] = "AERT5678";
+const char rcChannelLetters[] = "AERT";
 
 static uint16_t rssi = 0;                  // range: [0;1023]
 static timeUs_t lastMspRssiUpdateUs = 0;
@@ -118,7 +118,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(rxConfig_t, rxConfig, PG_RX_CONFIG, 3);
 #define RX_MIN_USEX 885
 PG_RESET_TEMPLATE(rxConfig_t, rxConfig,
     .receiverType = DEFAULT_RX_TYPE,
-    .rcmap = {0, 1, 3, 2, 4, 5, 6, 7},      // Default to AETR5678 map
+    .rcmap = {0, 1, 3, 2},      // Default to AETR map
     .halfDuplex = 0,
     .serialrx_provider = SERIALRX_PROVIDER,
     .rx_spi_protocol = RX_SPI_DEFAULT_PROTOCOL,

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -96,7 +96,7 @@ extern const char rcChannelLetters[];
 
 extern int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];       // interval [1000;2000]
 
-#define MAX_MAPPABLE_RX_INPUTS 8
+#define MAX_MAPPABLE_RX_INPUTS 4
 
 #define RSSI_SCALE_MIN 1
 #define RSSI_SCALE_MAX 255

--- a/src/main/target/COLIBRI_RACE/config.c
+++ b/src/main/target/COLIBRI_RACE/config.c
@@ -38,10 +38,6 @@ void targetConfiguration(void)
     rxConfigMutable()->rcmap[1] = 2;
     rxConfigMutable()->rcmap[2] = 3;
     rxConfigMutable()->rcmap[3] = 0;
-    rxConfigMutable()->rcmap[4] = 4;
-    rxConfigMutable()->rcmap[5] = 5;
-    rxConfigMutable()->rcmap[6] = 6;
-    rxConfigMutable()->rcmap[7] = 7;
 
     featureSet(FEATURE_VBAT);
     featureSet(FEATURE_LED_STRIP);


### PR DESCRIPTION
I think it is a good idea following #2774 and #2377. I can't think of any use for swapping channels 5 to 8.

Matching configurator update: https://github.com/iNavFlight/inav-configurator/pull/391