### PR TITLE
Fix bug when saving servo params causing the servos not to move as configured

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1668,6 +1668,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             sbufReadU8(src);
             servoParamsMutable(tmp_u8)->forwardFromChannel = sbufReadU8(src);
             servoParamsMutable(tmp_u8)->reversedSources = sbufReadU32(src);
+            servoComputeScalingFactors(tmp_u8);
         }
         break;
 #endif

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -192,6 +192,14 @@ int servoDirection(int servoIndex, int inputSource)
         return 1;
 }
 
+/*
+ * Compute scaling factor for upper and lower servo throw
+ */
+void servoComputeScalingFactors(uint8_t servoIndex) {
+    servoMetadata[servoIndex].scaleMax = (servoParams(servoIndex)->max - servoParams(servoIndex)->middle) / 500.0f;
+    servoMetadata[servoIndex].scaleMin = (servoParams(servoIndex)->middle - servoParams(servoIndex)->min) / 500.0f;
+}
+
 void servosInit(void)
 {
     const mixerMode_e currentMixerMode = mixerConfig()->mixerMode;
@@ -235,13 +243,8 @@ void servosInit(void)
         }
     }
 
-    /*
-     * Compute scaling factor for upper and lower servo throw
-     */
-    for (uint8_t i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
-        servoMetadata[i].scaleMax = (servoParams(i)->max - servoParams(i)->middle) / 500.0f;
-        servoMetadata[i].scaleMin = (servoParams(i)->middle - servoParams(i)->min) / 500.0f;
-    }
+    for (uint8_t i = 0; i < MAX_SUPPORTED_SERVOS; i++)
+        servoComputeScalingFactors(i);
 
 }
 

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -136,4 +136,5 @@ void servoMixerLoadMix(int index);
 bool loadCustomServoMixer(void);
 int servoDirection(int servoIndex, int fromChannel);
 void servoMixer(float dT);
+void servoComputeScalingFactors(uint8_t servoIndex);
 void servosInit(void);


### PR DESCRIPTION
If the servo differential throw scaling was changed it was not applied until next reboot.