### PR TITLE
FW: consider throttle at minimum (tpaFactor = 2.0) during launch

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -43,6 +43,7 @@
 #include "io/gps.h"
 
 #include "navigation/navigation.h"
+#include "navigation/navigation_fw_launch.h"
 
 #include "rx/rx.h"
 
@@ -271,7 +272,12 @@ static float calculateFixedWingTPAFactor(void)
     // tpa_rate is amount of curve TPA applied to PIDs
     // tpa_breakpoint for fixed wing is cruise throttle value (value at which PIDs were tuned)
     if (currentControlRateProfile->throttle.dynPID != 0 && currentControlRateProfile->throttle.pa_breakpoint > motorConfig()->minthrottle) {
-        if (rcCommand[THROTTLE] > motorConfig()->minthrottle) {
+#ifdef USE_NAV
+        if (((!isNavLaunchEnabled()) || isFixedWingLaunchFinishedOrAborted()) && (rcCommand[THROTTLE] > motorConfig()->minthrottle))
+#else
+        if (rcCommand[THROTTLE] > motorConfig()->minthrottle)
+#endif
+        {
             // Calculate TPA according to throttle
             tpaFactor = 0.5f + ((float)(currentControlRateProfile->throttle.pa_breakpoint - motorConfig()->minthrottle) / (rcCommand[THROTTLE] - motorConfig()->minthrottle) / 2.0f);
 

--- a/src/main/navigation/navigation_fw_launch.h
+++ b/src/main/navigation/navigation_fw_launch.h
@@ -1,0 +1,6 @@
+
+#pragma once
+
+#ifdef USE_NAV
+bool isFixedWingLaunchFinishedOrAborted(void);
+#endif


### PR DESCRIPTION
Since air speed low when launching a FW model the calculated tpaFactor should reflect that: 2.0 tpaFactor if tpa configured (1.0 otherwise) until launch is finished.

What do you think ?