### PR TITLE
Fix OSD summary screen not displayed after long flight

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -140,7 +140,7 @@ typedef struct osd_sidebar_s {
     uint8_t idle;
 } osd_sidebar_t;
 
-uint32_t resumeRefreshAt = 0;
+timeUs_t resumeRefreshAt = 0;
 #define REFRESH_1S    (1000*1000)
 
 static bool fullRedraw = false;


### PR DESCRIPTION
Possible fix for #2973 and #2638 

Issue might be that  the `resumeRefreshAt` variable controlling the OSD refresh / arming screen display time / summary display time is only 32 bits and 2^32/1000000/60 ~= 71 minutes.