### PR TITLE
FW LAUNCH: Apply surface deflection proportional to THR

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -191,6 +191,7 @@ Re-apply any new defaults as desired.
 |  nav_fw_launch_timeout  | 5000 | Maximum time for launch sequence to be executed. After this time LAUNCH mode will be turned off and regular flight mode will take over (ms) |
 |  nav_fw_launch_max_altitude  | 0 | Altitude at which LAUNCH mode will be turned off and regular flight mode will take over. [cm] |
 |  nav_fw_launch_climb_angle  | 18 | Climb angle for launch sequence (degrees), is also restrained by global max_angle_inclination_pit |
+|  nav_fw_launch_climb_angle_awaits_motor  | ON | Wether the climb angle awaits for the motor to start spinning (ON) or it's applied immediately when launch mode is activated (OFF, old behavior) |
 |  nav_fw_launch_min_time | 0 | Allow launch mode to execute at least this time (ms) and ignore stick movements [0-60000]. |
 |  nav_fw_launch_max_altitude | 0 | Altitude (centimeters) at which LAUNCH mode will be turned off and regular flight mode will take over [0-60000]. |
 |  nav_fw_land_dive_angle  | 2 | Dive angle that airplane will use during final landing phase. During dive phase, motor is stopped or IDLE and roll control is locked to 0 degrees |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1300,6 +1300,9 @@ groups:
         field: fw.launch_climb_angle
         min: 5
         max: 45
+      - name: nav_fw_launch_climb_angle_awaits_motor
+        field: fw.launch_climb_angle_awaits_motor
+        type: bool
 
   - name: PG_TELEMETRY_CONFIG
     type: telemetryConfig_t

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -132,18 +132,19 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .land_dive_angle = 2,   // 2 degrees dive by default
 
         // Fixed wing launch
-        .launch_velocity_thresh = 300,         // 3 m/s
-        .launch_accel_thresh = 1.9f * 981,     // cm/s/s (1.9*G)
-        .launch_time_thresh = 40,              // 40ms
+        .launch_velocity_thresh = 300,          // 3 m/s
+        .launch_accel_thresh = 1.9f * 981,      // cm/s/s (1.9*G)
+        .launch_time_thresh = 40,               // 40ms
         .launch_throttle = 1700,
-        .launch_idle_throttle = 1000,          // Motor idle or MOTOR_STOP
-        .launch_motor_timer = 500,             // ms
-        .launch_motor_spinup_time = 100,       // ms, time to gredually increase throttle from idle to launch
-        .launch_min_time = 0,                  // ms, min time in launch mode
-        .launch_timeout = 5000,                // ms, timeout for launch procedure
-        .launch_max_altitude = 0,              // cm, altitude where to consider launch ended
-        .launch_climb_angle = 18,              // 18 degrees
-        .launch_max_angle = 45                 // 45 deg
+        .launch_idle_throttle = 1000,           // Motor idle or MOTOR_STOP
+        .launch_motor_timer = 500,              // ms
+        .launch_motor_spinup_time = 100,        // ms, time to gredually increase throttle from idle to launch
+        .launch_min_time = 0,                   // ms, min time in launch mode
+        .launch_timeout = 5000,                 // ms, timeout for launch procedure
+        .launch_max_altitude = 0,               // cm, altitude where to consider launch ended
+        .launch_climb_angle = 18,               // 18 degrees
+        .launch_max_angle = 45,                 // 45 deg
+        .launch_climb_angle_awaits_motor = true,
     }
 );
 

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -144,7 +144,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .launch_max_altitude = 0,               // cm, altitude where to consider launch ended
         .launch_climb_angle = 18,               // 18 degrees
         .launch_max_angle = 45,                 // 45 deg
-        .launch_climb_angle_awaits_motor = true,
+        .launch_climb_angle_awaits_motor = false,
     }
 );
 

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -163,6 +163,7 @@ typedef struct navConfig_s {
         uint16_t launch_max_altitude;        // cm, altitude where to consider launch ended
         uint8_t  launch_climb_angle;         // Target climb angle for launch (deg)
         uint8_t  launch_max_angle;           // Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg]
+        uint8_t  launch_climb_angle_awaits_motor; // Wether the climb angle is applied slowly (true) or from the start (false)
     } fw;
 } navConfig_t;
 


### PR DESCRIPTION
To avoid stalling the plane, start with a pitch angle of zero until
the launch is detected. Then, use a climb angle proportional to
the applied THR between the idle launch THR and the full launch THR.

References #2885