### PR TITLE
OSD Altitude Hold message

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1375,6 +1375,9 @@ static bool osdDrawSingleElement(uint8_t item)
                             messages[messageCount++] = navStateMessage;
                         }
                     } else {
+                        if (FLIGHT_MODE(NAV_ALTHOLD_MODE) && !FLIGHT_MODE(ANGLE_MODE)) {
+                          messages[messageCount++] = "NOT ANGLE MODE!";
+                        }
                         if (IS_RC_MODE_ACTIVE(BOXAUTOTRIM)) {
                             messages[messageCount++] = "(AUTOTRIM)";
                         }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1023,10 +1023,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 } else {
                     p = " PH ";
                 }
-            } else if (FLIGHT_MODE(NAV_ALTHOLD_MODE) && navigationRequiresAngleMode()) {
-                // If navigationRequiresAngleMode() returns false when ALTHOLD is active,
-                // it means it can be combined with ANGLE, HORIZON, ACRO, etc...
-                // and its display is handled by OSD_MESSAGES rather than OSD_FLYMODE.
+            } else if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
                 p = " AH ";
             } else if (FLIGHT_MODE(NAV_WP_MODE))
                 p = " WP ";
@@ -1378,13 +1375,6 @@ static bool osdDrawSingleElement(uint8_t item)
                             messages[messageCount++] = navStateMessage;
                         }
                     } else {
-                        if (FLIGHT_MODE(NAV_ALTHOLD_MODE) && !navigationRequiresAngleMode()) {
-                            // ALTHOLD might be enabled alongside ANGLE/HORIZON/ACRO
-                            // when it doesn't require ANGLE mode (required only in FW
-                            // right now). If if requires ANGLE, its display is handled
-                            // by OSD_FLYMODE.
-                            messages[messageCount++] = "(ALTITUDE HOLD)";
-                        }
                         if (IS_RC_MODE_ACTIVE(BOXAUTOTRIM)) {
                             messages[messageCount++] = "(AUTOTRIM)";
                         }


### PR DESCRIPTION
I think there's no point in showing "(altitude hold)" message along with "ANGL" flight mode, when Althold + Angle modes are both activated.

Now it is a bit confusing. For example: when I fly my quad with Althold+Angle, I can see "(altitude hold)" message. When I switch on Position Hold to stop in certain point, the message disappears, even though altitude hold is still active.

Citations from iNav wiki:
> In general you shouldn't mix up ALTHOLD and ACRO/HORIZON: ALTHOLD doesn't account for extreme acro maneuvers.
> ...
> As for multicopters, iNAV is not intended to use ALTHOLD controller in anything but ANGLE mode.

Probably, we should show some warning when Althold is activated, but Angle is not.