### PR TITLE
Add some padding in rxConfig_t to compensate for size reduction

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -100,6 +100,7 @@ uint32_t rcInvalidPulsPeriod[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 rxRuntimeConfig_t rxRuntimeConfig;
 static uint8_t rcSampleIndex = 0;
 
+// TODO: If you increase the version number, remove _padding_0 from rxConfig_t and this line.
 PG_REGISTER_WITH_RESET_TEMPLATE(rxConfig_t, rxConfig, PG_RX_CONFIG, 3);
 
 #ifndef RX_SPI_DEFAULT_PROTOCOL

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -111,6 +111,7 @@ PG_DECLARE_ARRAY(rxChannelRangeConfig_t, NON_AUX_CHANNEL_COUNT, rxChannelRangeCo
 typedef struct rxConfig_s {
     uint8_t receiverType;                   // RC receiver type (rxReceiverType_e enum)
     uint8_t rcmap[MAX_MAPPABLE_RX_INPUTS];  // mapping of radio channels to internal RPYTA+ order
+    uint8_t _padding_0[4];                  // Added when MAX_MAPPABLE_RX_INPUTS was reduced from 8 to 4. TODO: Delete when PG version needs increasing.
     uint8_t serialrx_provider;              // Type of UART-based receiver (rxSerialReceiverType_e enum). Only used if receiverType is RX_TYPE_SERIAL
     uint8_t serialrx_inverted;              // Flip the default inversion of the protocol - e.g. sbus (Futaba, FrSKY) is inverted if this is false, uninverted if it's true. Support for uninverted OpenLRS (and modified FrSKY) receivers.
     uint8_t halfDuplex;                     // allow rx to operate in half duplex mode on F4, ignored for F1 and F3.


### PR DESCRIPTION
Since MAX_MAPPABLE_RX_INPUTS was reduced from 8 to 4, restoring the
PG when upgrading would corrupt several fields in rxConfig_t. This
introduces 4 bytes of padding just after it as well as a couple of
notes to remind whoever increases the PG number, should also delete
the padding and the TODO. This way users won't have to manually
restore the RX configuration when upgrading.