### PR TITLE
Add SOFTSERIAL support on TX2 for MATEKF405 target

### DIFF
--- a/docs/Board - MatekF405.md
+++ b/docs/Board - MatekF405.md
@@ -79,10 +79,10 @@ I2C requires that the WS2812 led strip is moved to S5, thus WS2812 is not usable
 
 ### Soft Serial
 
-Soft serial is available as an alternative to a hardware UART on RX4/TX4. By default this is NOT inverted. In order to use this feature:
+Soft serial is available as an alternative to a hardware UART on RX4/TX4 and TX2. By default this is NOT inverted. In order to use this feature:
 
 * Enable soft serial
-* Do not assign any function to hardware UART 4
+* Do not assign any function to hardware UART4 or UART2-TX
 * Assign the desired function to the soft-serial port
 * Enable inversion if required `set telemetry_inversion = ON` (e.g. for Frsky telemetry)
 

--- a/src/main/target/MATEKF405/target.h
+++ b/src/main/target/MATEKF405/target.h
@@ -122,7 +122,11 @@
 #define SOFTSERIAL_1_RX_PIN      PA1  //RX4
 #define SOFTSERIAL_1_TX_PIN      PA0  //TX4
 
-#define SERIAL_PORT_COUNT       7
+#define USE_SOFTSERIAL2
+#define SOFTSERIAL_2_RX_PIN      PA2  //TX2
+#define SOFTSERIAL_2_TX_PIN      PA2  //TX2
+
+#define SERIAL_PORT_COUNT       8
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_SBUS


### PR DESCRIPTION
Just to extend #2841 and #2842.

Previous patches changed UART4 to a softserial. With this new Softserial MATEKF405-CTR boards would be able to use sbus at RX2 and smartport at TX2 or similar things.

See that example:

![image](https://user-images.githubusercontent.com/6491516/38631696-c2fb6f5e-3dba-11e8-8be1-299fdff5bd5d.png)

As you can see here I can use 6 UARTS:
- 1 - Bluetooth MSP
- 2 - **RX2 SBus serial receiver**
- 3 - RX3+TX3 Runcam Split
- 4 - RX4+TX4 GPS / Not using softserial 4, but could do.
- 5 - TX5 IRC Tramp
- Softserial 2 - **TX2 Smartport**


Notice that TX2 is not present at all the F405 boards.

![image](https://user-images.githubusercontent.com/6491516/38633958-76bf3d94-3dc1-11e8-8d57-2b7b0b265d36.png)

