### PR TITLE
Remove FSSP_DATAID_A3 from the smartport sensor array

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -113,7 +113,7 @@ const uint16_t frSkyDataIdTable[] = {
     FSSP_DATAID_HOME_DIST ,
     FSSP_DATAID_GPS_ALT   ,
     FSSP_DATAID_ASPD      ,
-    FSSP_DATAID_A3        ,
+    // FSSP_DATAID_A3        ,
     FSSP_DATAID_A4        ,
     0
 };


### PR DESCRIPTION
Since we don't send any data for A3, the only thing it does here
is more or less waste a telemetry cycle (not 100% wasted since
it can be used for MSP when there's a MSP-over-telemetry request
in flight, but mostly).

Thanks to @teckel12 for pointing it out.