### PR TITLE
Make telemetry_inversion default ON for all MCUs

### DIFF
--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -51,14 +51,8 @@
 
 PG_REGISTER_WITH_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 0);
 
-#if defined(STM32F303xC)
-#define TELEMETRY_DEFAULT_INVERSION 1
-#else
-#define TELEMETRY_DEFAULT_INVERSION 0
-#endif
-
 PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
-    .telemetry_inversion = TELEMETRY_DEFAULT_INVERSION,
+    .telemetry_inversion = 1,
     .telemetry_switch = 0,
     .gpsNoFixLatitude = 0,
     .gpsNoFixLongitude = 0,


### PR DESCRIPTION
As discussed with @DzikuVx. Default at least for F3/F7 MCUs should be ON but it shouldn't be an issue to use ON as default for other MCUs as well.