### PR TITLE
Add Horizon Sidebars to settings list

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1489,6 +1489,10 @@ groups:
         field: item_pos[OSD_ARTIFICIAL_HORIZON]
         min: 0
         max: OSD_POS_MAX_CLI
+      - name: osd_horizon_sidebars_pos
+        field: item_pos[OSD_HORIZON_SIDEBARS]
+        min: 0
+        max: OSD_POS_MAX_CLI
       - name: osd_current_draw_pos
         field: item_pos[OSD_CURRENT_DRAW]
         min: 0


### PR DESCRIPTION
Currently state of this switch is not reflected in diff/dump reports:
![horizon_sidebar](https://user-images.githubusercontent.com/8948963/38782677-dd8af338-40ff-11e8-9149-57e1a4b61f3e.png)
I have horizon sidebars turned off on my setup, so after restoring settings with "diff" command I need to toggle this switch manually every time.
