### PR TITLE
RC filtering logic fix

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -523,9 +523,9 @@ void calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs)
 
         // Update rcData channel value
         if (rxRuntimeConfig.requireFiltering) {
-            rcData[channel] = sample;
-        } else {
             rcData[channel] = applyChannelFiltering(channel, sample);
+        } else {
+            rcData[channel] = sample;
         }
     }
 


### PR DESCRIPTION
RC was filtered on all protocols beside if PWM was choosen. It should be the exact opposite.

Thanks to @fiam helping me to spot this.