### PR TITLE
Add support for new MATEKF405SE target (F405-WING FC)

### DIFF
--- a/src/main/target/MATEKF405SE/README.md
+++ b/src/main/target/MATEKF405SE/README.md
@@ -1,0 +1,16 @@
+# FLIGHT CONTROLLER MATEK F405-WING
+
+* Designed specifically for fixed wing INAV setups by MATEK
+* http://www.mateksys.com/?portfolio=f405-wing
+
+## HW info
+
+* STM32F405
+* MPU6000
+* OSD
+* BMP280
+* 6x UART
+* 1x Softserial
+* 2x I2C
+* 2x Motors & 7x Servos
+* 4x BEC + current sensor

--- a/src/main/target/MATEKF405SE/config.c
+++ b/src/main/target/MATEKF405SE/config.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <platform.h>
+#include "config/config_master.h"
+#include "config/feature.h"
+#include "flight/mixer.h"
+#include "io/serial.h"
+#include "telemetry/telemetry.h"
+
+// alternative defaults settings for MATEKF405SE targets
+void targetConfiguration(void)
+{
+    motorConfigMutable()->minthrottle = 1050;
+    motorConfigMutable()->maxthrottle = 1950;
+
+    serialConfigMutable()->portConfigs[1].functionMask = FUNCTION_MSP;
+    serialConfigMutable()->portConfigs[1].msp_baudrateIndex = BAUD_57600;
+
+    //featureSet(FEATURE_PWM_OUTPUT_ENABLE); // enable PWM outputs by default
+    //mixerConfigMutable()->mixerMode = MIXER_FLYING_WING; // default mixer to flying wing
+    mixerConfigMutable()->mixerMode = MIXER_AIRPLANE;   // default mixer to Airplane
+
+    serialConfigMutable()->portConfigs[7].functionMask = FUNCTION_TELEMETRY_SMARTPORT;
+    telemetryConfigMutable()->telemetry_inversion = 1;
+}

--- a/src/main/target/MATEKF405SE/target.c
+++ b/src/main/target/MATEKF405SE/target.c
@@ -1,0 +1,39 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    { TIM4, IO_TAG(PB7),    TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM4,  TIM_USE_MC_MOTOR  | TIM_USE_FW_MOTOR },  //S1
+    { TIM4, IO_TAG(PB6),    TIM_Channel_1, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM4,  TIM_USE_MC_MOTOR  | TIM_USE_FW_MOTOR },  //S2
+    { TIM3, IO_TAG(PB0),    TIM_Channel_3, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM3,  TIM_USE_MC_MOTOR  | TIM_USE_FW_SERVO },  //S3
+    { TIM3, IO_TAG(PB1),    TIM_Channel_4, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM3,  TIM_USE_MC_MOTOR  | TIM_USE_FW_SERVO },  //S4
+    { TIM8, IO_TAG(PC8),    TIM_Channel_3, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM8,  TIM_USE_MC_MOTOR  | TIM_USE_FW_SERVO },  //S5
+    { TIM8, IO_TAG(PC9),    TIM_Channel_4, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM8,  TIM_USE_MC_MOTOR  | TIM_USE_FW_SERVO },  //S6
+    { TIM12, IO_TAG(PB14),  TIM_Channel_1, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM12, TIM_USE_MC_SERVO  | TIM_USE_FW_SERVO },  //S7
+    { TIM12, IO_TAG(PB15),  TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM12, TIM_USE_MC_SERVO  | TIM_USE_FW_SERVO },  //S8
+    { TIM1, IO_TAG(PA8),    TIM_Channel_1, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM1,  TIM_USE_MC_CHNFW  | TIM_USE_FW_SERVO },  //S9
+
+    { TIM2, IO_TAG(PA15),   TIM_Channel_1, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM2, TIM_USE_LED },  //2812LED
+    { TIM9, IO_TAG(PA3),    TIM_Channel_2, 0, IOCFG_AF_PP_PD, GPIO_AF_TIM9, TIM_USE_PPM },  //RX2
+
+    { TIM5, IO_TAG(PA2),    TIM_Channel_3, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM5, TIM_USE_PWM },  //TX2  softserial1_Tx
+};

--- a/src/main/target/MATEKF405SE/target.h
+++ b/src/main/target/MATEKF405SE/target.h
@@ -1,0 +1,178 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "MF4S"
+#define USBD_PRODUCT_STRING  "Matek_F405SE"
+#define TARGET_CONFIG
+
+#define LED0                    PA14  //Blue
+#define LED1                    PA13  //Green
+#define BEEPER                  PC15
+#define BEEPER_INVERTED
+
+// *************** SPI1 Gyro & ACC *******************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN   	    PA6
+#define SPI1_MOSI_PIN   	    PA7
+
+#define MPU6000_CS_PIN          PA4
+#define MPU6000_SPI_BUS         BUS_SPI1
+
+#define USE_EXTI
+#define MPU_INT_EXTI            PC4
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define USE_GYRO
+#define USE_GYRO_MPU6000
+#define GYRO_MPU6000_ALIGN      CW270_DEG
+
+#define USE_ACC
+#define USE_ACC_MPU6000
+#define ACC_MPU6000_ALIGN       CW270_DEG
+
+// *************** I2C /Baro/Mag *********************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+
+#define USE_I2C_DEVICE_2
+#define I2C2_SCL                PB10
+#define I2C2_SDA                PB11
+
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_BMP085
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C2
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define USE_MAG_IST8310
+#define USE_MAG_MAG3110
+
+#define USE_PITOT_MS4525
+#define PITOT_I2C_BUS           BUS_I2C2
+
+// *************** SPI2 OSD ***************************
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN   	    PC2
+#define SPI2_MOSI_PIN   	    PC3
+
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_CS_PIN          PB12
+#define MAX7456_SPI_BUS         BUS_SPI2
+
+// *************** SPI3 SD Card  ********************
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN   	    PB4
+#define SPI3_MOSI_PIN   	    PB5
+
+#define USE_SDCARD
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+#define SDCARD_SPI_INSTANCE     SPI3
+#define SDCARD_SPI_CS_PIN       PC14
+
+#define SDCARD_DMA_CHANNEL_TX               	DMA1_Stream7
+#define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG 	DMA_FLAG_TCIF7
+#define SDCARD_DMA_CLK                      	RCC_AHB1Periph_DMA1
+#define SDCARD_DMA_CHANNEL                  	DMA_Channel_0
+
+// *************** UART *****************************
+#define USE_VCP
+#define VBUS_SENSING_PIN        PC13
+#define VBUS_SENSING_ENABLED
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define USE_UART3
+#define UART3_TX_PIN            PC10
+#define UART3_RX_PIN            PC11
+
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1
+
+#define USE_UART5
+#define UART5_TX_PIN            PC12
+#define UART5_RX_PIN            PD2
+
+#define USE_UART6
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+#define USE_SOFTSERIAL1               //Frsky SmartPort on TX2 pad
+#define SOFTSERIAL_1_TX_PIN      PA2 
+#define SOFTSERIAL_1_RX_PIN      PA2
+
+#define SERIAL_PORT_COUNT       8
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+// *************** ADC ***************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC0
+#define ADC_CHANNEL_2_PIN           PC1
+#define ADC_CHANNEL_3_PIN           PC5
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_3
+
+// *************** LED2812 ************************
+#define USE_LED_STRIP
+#define WS2811_PIN                      PA15
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST5_HANDLER
+#define WS2811_DMA_STREAM               DMA1_Stream5
+#define WS2811_DMA_CHANNEL              DMA_Channel_3 
+
+// ***************  OTHERS *************************
+#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_SOFTSERIAL)
+#define CURRENT_METER_SCALE   317
+
+#define USE_SPEKTRUM_BIND
+#define BIND_PIN                PA3 //  RX2
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define USABLE_TIMER_CHANNEL_COUNT 12
+#define MAX_PWM_OUTPUT_PORTS       9
+#define USED_TIMERS             (TIM_N(1)|TIM_N(2)|TIM_N(3)|TIM_N(4)|TIM_N(5)|TIM_N(8)|TIM_N(9)|TIM_N(12))

--- a/src/main/target/MATEKF405SE/target.mk
+++ b/src/main/target/MATEKF405SE/target.mk
@@ -1,0 +1,19 @@
+F405_TARGETS    += $(TARGET)
+FEATURES        += SDCARD VCP ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_mpu6000.c \
+            drivers/barometer/barometer_bmp085.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_ms56xx.c \
+            drivers/compass/compass_ak8963.c \
+            drivers/compass/compass_ak8975.c \
+            drivers/compass/compass_hmc5883l.c \
+            drivers/compass/compass_qmc5883l.c \
+            drivers/compass/compass_ist8310.c \
+            drivers/compass/compass_mag3110.c \
+            drivers/pitotmeter_ms4525.c \
+            drivers/pitotmeter_adc.c \
+            drivers/light_ws2811strip.c \
+            drivers/light_ws2811strip_stdperiph.c \
+            drivers/max7456.c


### PR DESCRIPTION
Nice FC for a fixed wing - 2 motors, 7 servos, 6 UARTs and a dedicated BEC for servos: http://www.mateksys.com/?portfolio=f405-wing
Credit for writing the code goes to @MATEKSYS. It's tested and seems to be working properly.