### PR TITLE
Fix buidling with FLASH_SIZE > 128 and without USE_ADC

### DIFF
--- a/src/main/drivers/pitotmeter_adc.c
+++ b/src/main/drivers/pitotmeter_adc.c
@@ -28,7 +28,7 @@
 #include "pitotmeter_adc.h"
 #include "adc.h"
 
-#if defined(USE_PITOT_ADC)
+#if defined(USE_ADC) && defined(USE_PITOT_ADC)
 
 /*
  * NXP MPXV7002DP differential pressure sensor

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -496,7 +496,7 @@ void init(void)
         adc_params.adcFunctionChannel[ADC_CURRENT] =  adcChannelConfig()->adcFunctionChannel[ADC_CURRENT];
     }
 
-#if defined(USE_PITOT) && defined(USE_PITOT_ADC)
+#if defined(USE_PITOT) && defined(USE_ADC) && defined(USE_PITOT_ADC)
     if (pitotmeterConfig()->pitot_hardware == PITOT_ADC || pitotmeterConfig()->pitot_hardware == PITOT_AUTODETECT) {
         adc_params.adcFunctionChannel[ADC_AIRSPEED] = adcChannelConfig()->adcFunctionChannel[ADC_AIRSPEED];
     }

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -88,7 +88,7 @@ bool pitotDetect(pitotDev_t *dev, uint8_t pitotHardwareToUse)
             FALLTHROUGH;
 
         case PITOT_ADC:
-#if defined(USE_PITOT_ADC)
+#if defined(USE_ADC) && defined(USE_PITOT_ADC)
             if (adcPitotDetect(dev)) {
                 pitotHardware = PITOT_ADC;
                 break;


### PR DESCRIPTION
When FLASH_SIZE > 128 USE_PITOT_ADC is defined in target/common.h.