### PR TITLE
Fix settings script

### DIFF
--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -633,7 +633,7 @@ class Generator
     def compile_test_file(prog)
         buf = StringIO.new
         # cstddef for offsetof()
-        headers = ["target.h", "platform.h", "cstddef"]
+        headers = ["platform.h", "target.h", "cstddef"]
         @data["groups"].each do |group|
             gh = group["headers"]
             if gh


### PR DESCRIPTION
Fixed a bug in `settings.rb` causing it to not account for target.h-level `#undef`s of `USE_*`. Noticed for `ASGARD32F4` target that undefs `USE_PITOT`.