### PR TITLE
remove the yaw inversion in 3D mode when platform is set to ROVER

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -381,8 +381,8 @@ void servoMixer(float dT)
         input[INPUT_STABILIZED_PITCH] = axisPID[PITCH];
         input[INPUT_STABILIZED_YAW] = axisPID[YAW];
 
-        // Reverse yaw servo when inverted in 3D mode
-        if (feature(FEATURE_3D) && (rcData[THROTTLE] < rxConfig()->midrc)) {
+        // Reverse yaw servo when inverted in 3D mode except in ROVER mode
+        if (feature(FEATURE_3D) && (rcData[THROTTLE] < rxConfig()->midrc) && mixerConfig()->platformType != PLATFORM_ROVER) {
             input[INPUT_STABILIZED_YAW] *= -1;
         }
     }

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -381,8 +381,9 @@ void servoMixer(float dT)
         input[INPUT_STABILIZED_PITCH] = axisPID[PITCH];
         input[INPUT_STABILIZED_YAW] = axisPID[YAW];
 
-        // Reverse yaw servo when inverted in 3D mode except in ROVER mode
-        if (feature(FEATURE_3D) && (rcData[THROTTLE] < rxConfig()->midrc) && mixerConfig()->platformType != PLATFORM_ROVER) {
+        // Reverse yaw servo when inverted in 3D mode only for multirotor and tricopter
+        if (feature(FEATURE_3D) && (rcData[THROTTLE] < rxConfig()->midrc) && 
+        (mixerConfig()->platformType == PLATFORM_MULTIROTOR || mixerConfig()->platformType == PLATFORM_TRICOPTER)) {
             input[INPUT_STABILIZED_YAW] *= -1;
         }
     }


### PR DESCRIPTION
Yaw inversion in not wanted when used for steering in ROVER mode.
This simply deactivate this. 
Its a fix to wait until there is a real support for rover, since 3d mode is the only way to use reversable esc.