### PR TITLE
Add Watt symbol to OSD

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -184,7 +184,7 @@
 #define SYM_AMP   0x9A
 #define SYM_MAH   0x07
 #define SYM_WH    0xAB
-#define SYM_WATT  0x57
+#define SYM_WATT  0xAE
 
 // Efficiency
 #define SYM_MAH_KM_0    157

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1310,8 +1310,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_POWER:
         {
-            // TODO: SYM_WATTS?
-            buff[0] = 'W';
+            buff[0] = SYM_WATT;
             osdFormatCentiNumber(buff + 1, getPower(), 0, 2, 0, 3);
             break;
         }


### PR DESCRIPTION
Changed Watt in OSD from 'W' letter to dedicated symbol.
Fonts were changed here: https://github.com/iNavFlight/inav-configurator/pull/416