### PR TITLE
Fix vertical alignment of ARMED screen on NTSC

### DIFF
--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -83,6 +83,10 @@ void displayClearScreen(displayPort_t *instance)
 
 void displayDrawScreen(displayPort_t *instance)
 {
+    if (instance->rows == 0 || instance->cols == 0) {
+        // Display not fully initialized yet
+        displayResync(instance);
+    }
     instance->vTable->drawScreen(instance);
 }
 

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -171,6 +171,7 @@ static BITARRAY_DECLARE(screenIsDirty, VIDEO_BUFFER_CHARS_PAL);
 #define MAX_CHARS2UPDATE        10
 #define BYTES_PER_CHAR2UPDATE   8 // [3-4] spi regs + values for them
 
+static bool     firstInit = true;
 static uint8_t  videoSignalCfg   = 0;
 static uint8_t  videoSignalReg   = VIDEO_MODE_PAL | OSD_ENABLE; //PAL by default
 static bool  max7456Lock        = false;
@@ -186,8 +187,13 @@ static int max7456PrepareBuffer(uint8_t * buf, int bufPtr, uint8_t add, uint8_t 
 
 uint8_t max7456GetRowsCount(void)
 {
-    if (videoSignalReg & VIDEO_MODE_PAL)
+    if (firstInit) {
+        // Not initialized yet
+        return 0;
+    }
+    if (videoSignalReg & VIDEO_MODE_PAL) {
         return VIDEO_LINES_PAL;
+    }
 
     return VIDEO_LINES_NTSC;
 }
@@ -201,7 +207,6 @@ void max7456ReInit(void)
     int bufPtr;
     uint8_t maxScreenRows;
     uint8_t srdata = 0;
-    static bool firstInit = true;
 
     // Check if device is available
     if (max7456dev == NULL) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1906,7 +1906,8 @@ static void osdShowArmed(void)
     char buf[MAX(32, FORMATTED_DATE_TIME_BUFSIZE)];
     char *date;
     char *time;
-    uint8_t y = 7;
+    // We need 6 visible rows
+    uint8_t y = MIN((osdDisplayPort->rows / 2) - 1, osdDisplayPort->rows - 6 - 1);
 
     displayClearScreen(osdDisplayPort);
     displayWrite(osdDisplayPort, 12, y, "ARMED");


### PR DESCRIPTION
Make sure we have enough vertical space to draw all information.

Fixed also a race condition which in some cases initialized the display size incorrectly.

Fixes #3147