### PR TITLE
Rollback to old max cell voltage

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -79,7 +79,7 @@ PG_RESET_TEMPLATE(batteryConfig_t, batteryConfig,
 
     .voltage = {
         .scale = VBAT_SCALE_DEFAULT,
-        .cellMax = 424,
+        .cellMax = 430,
         .cellMin = 330,
         .cellWarning = 350
     },


### PR DESCRIPTION
I was getting way too many wrong cell detection cases when plugging in new battery. 3S detected as 4S, 4S as 5S and alarm going off due to that.

This rollbacks to previous `430` instead of `424`