### PR TITLE
gcc 8 support

### DIFF
--- a/src/main/build/atomic.h
+++ b/src/main/build/atomic.h
@@ -91,7 +91,7 @@ static inline uint8_t __basepriSetRetVal(uint8_t prio)
 // ideally this would only protect memory passed as parameter (any type should work), but gcc is currently creating almost full barrier
 // this macro can be used only ONCE PER LINE, but multiple uses per block are fine
 
-#if (__GNUC__ > 7)
+#if (__GNUC__ > 8)
 #warning "Please verify that ATOMIC_BARRIER works as intended"
 // increment version number is BARRIER works
 // TODO - use flag to disable ATOMIC_BARRIER and use full barrier instead

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -309,7 +309,7 @@ static int cmsDrawMenuEntry(displayPort_t *pDisplay, const OSD_Entry *p, uint8_t
             if ((p->type == OME_Submenu) && p->func && (p->flags & OPTSTRING)) {
 
                 // Special case of sub menu entry with optional value display.
-                char *str = ((CMSMenuOptFuncPtr)p->menufunc)();
+                char *str = p->menufunc();
                 cnt = displayWrite(pDisplay, colPos, row, str);
                 colPos += strlen(str);
             }

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -309,14 +309,7 @@ static int cmsDrawMenuEntry(displayPort_t *pDisplay, const OSD_Entry *p, uint8_t
             if ((p->type == OME_Submenu) && p->func && (p->flags & OPTSTRING)) {
 
                 // Special case of sub menu entry with optional value display.
-#pragma GCC diagnostic push
-#if (__GNUC__ > 7)
-                    // This is safe on 32bit platforms, suppress warning.
-#pragma GCC diagnostic ignored "-Wcast-function-type"
-#endif
-                char *str = ((CMSMenuOptFuncPtr)p->func)();
-#pragma GCC diagnostic pop
-
+                char *str = ((CMSMenuOptFuncPtr)p->menufunc)();
                 cnt = displayWrite(pDisplay, colPos, row, str);
                 colPos += strlen(str);
             }

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -309,8 +309,14 @@ static int cmsDrawMenuEntry(displayPort_t *pDisplay, const OSD_Entry *p, uint8_t
             if ((p->type == OME_Submenu) && p->func && (p->flags & OPTSTRING)) {
 
                 // Special case of sub menu entry with optional value display.
-
+#pragma GCC diagnostic push
+#if (__GNUC__ > 7)
+                    // This is safe on 32bit platforms, suppress warning.
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
                 char *str = ((CMSMenuOptFuncPtr)p->func)();
+#pragma GCC diagnostic pop
+
                 cnt = displayWrite(pDisplay, colPos, row, str);
                 colPos += strlen(str);
             }

--- a/src/main/cms/cms_menu_builtin.c
+++ b/src/main/cms/cms_menu_builtin.c
@@ -153,8 +153,8 @@ static const OSD_Entry menuMainEntries[] =
     OSD_SUBMENU_ENTRY("FC&FW INFO", &menuInfo),
     OSD_SUBMENU_ENTRY("MISC", &cmsx_menuMisc),
 
-    {"SAVE&REBOOT", OME_OSD_Exit, cmsMenuExit,   (void*)CMS_EXIT_SAVEREBOOT, 0},
-    {"EXIT",        OME_OSD_Exit, cmsMenuExit,   (void*)CMS_EXIT, 0},
+    {"SAVE&REBOOT", OME_OSD_Exit, {.func = cmsMenuExit}, (void*)CMS_EXIT_SAVEREBOOT, 0},
+    {"EXIT",        OME_OSD_Exit, {.func = cmsMenuExit}, (void*)CMS_EXIT, 0},
 #ifdef CMS_MENU_DEBUG
     OSD_SUBMENU_ENTRY("ERR SAMPLE", &menuInfoEntries[0]),
 #endif

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -36,7 +36,6 @@
 #include "io/osd.h"
 
 #define OSD_ITEM_ENTRY(label, item_id)      ((OSD_Entry){ label, OME_Submenu, {.itemId  = item_id}, &cmsx_menuOsdElementActions, 0 })
-#define OSD_ITEM_GET_ID(entry)              (entry->itemId)
 
 static int osdCurrentLayout = -1;
 static int osdCurrentItem = -1;
@@ -126,7 +125,7 @@ static CMS_Menu cmsx_menuOsdElementActions = {
 
 static long osdElemActionsOnEnter(const OSD_Entry *from)
 {
-    osdCurrentItem = OSD_ITEM_GET_ID(from);
+    osdCurrentItem = from->itemId;
     uint16_t pos = osdConfig()->item_pos[osdCurrentLayout][osdCurrentItem];
     osdCurrentElementColumn = OSD_X(pos);
     osdCurrentElementRow = OSD_Y(pos);

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -35,8 +35,8 @@
 
 #include "io/osd.h"
 
-#define OSD_ITEM_ENTRY(label, item_id)      ((OSD_Entry){ label, OME_Submenu, (void *)item_id, &cmsx_menuOsdElementActions, 0 })
-#define OSD_ITEM_GET_ID(entry)              ((int)entry->func)
+#define OSD_ITEM_ENTRY(label, item_id)      ((OSD_Entry){ label, OME_Submenu, {.itemId  = item_id}, &cmsx_menuOsdElementActions, 0 })
+#define OSD_ITEM_GET_ID(entry)              (entry->itemId)
 
 static int osdCurrentLayout = -1;
 static int osdCurrentItem = -1;

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -528,6 +528,11 @@ static const CMS_Menu saCmsMenuUserFreq =
 
 static const OSD_TAB_t saCmsEntFselMode = { &saCmsFselMode, 1, saCmsFselModeNames };
 
+#pragma GCC diagnostic push
+#if (__GNUC__ > 7)
+    // This is safe on 32bit platforms, suppress warning for saCmsUserFreqGetString
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 static const OSD_Entry saCmsMenuConfigEntries[] =
 {
     OSD_LABEL_ENTRY("- SA CONFIG -"),
@@ -541,6 +546,7 @@ static const OSD_Entry saCmsMenuConfigEntries[] =
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
 };
+#pragma GCC diagnostic pop
 
 static const CMS_Menu saCmsMenuConfig = {
 #ifdef CMS_MENU_DEBUG
@@ -573,6 +579,11 @@ static const CMS_Menu saCmsMenuCommence = {
     .entries = saCmsMenuCommenceEntries,
 };
 
+#pragma GCC diagnostic push
+#if (__GNUC__ > 7)
+    // This is safe on 32bit platforms, suppress warning for saCmsUserFreqGetString
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 static const OSD_Entry saCmsMenuFreqModeEntries[] =
 {
     OSD_LABEL_ENTRY("- SMARTAUDIO -"),
@@ -586,6 +597,7 @@ static const OSD_Entry saCmsMenuFreqModeEntries[] =
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
 };
+#pragma GCC diagnostic pop
 
 static const OSD_Entry saCmsMenuChanModeEntries[] =
 {

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -528,25 +528,19 @@ static const CMS_Menu saCmsMenuUserFreq =
 
 static const OSD_TAB_t saCmsEntFselMode = { &saCmsFselMode, 1, saCmsFselModeNames };
 
-#pragma GCC diagnostic push
-#if (__GNUC__ > 7)
-    // This is safe on 32bit platforms, suppress warning for saCmsORFreqGetString
-#pragma GCC diagnostic ignored "-Wcast-function-type"
-#endif
 static const OSD_Entry saCmsMenuConfigEntries[] =
 {
     OSD_LABEL_ENTRY("- SA CONFIG -"),
 
-    { "OP MODEL",  OME_TAB,     saCmsConfigOpmodelByGvar,              &(const OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, DYNAMIC },
-    { "FSEL MODE", OME_TAB,     saCmsConfigFreqModeByGvar,             &saCmsEntFselMode,                                   DYNAMIC },
+    { "OP MODEL",  OME_TAB,  {.func = saCmsConfigOpmodelByGvar}, &(const OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, DYNAMIC },
+    { "FSEL MODE", OME_TAB,  {.func = saCmsConfigFreqModeByGvar}, &saCmsEntFselMode, DYNAMIC },
     OSD_TAB_CALLBACK_ENTRY("PIT FMODE", saCmsConfigPitFModeByGvar, &saCmsEntPitFMode),
-    { "POR FREQ",  OME_Submenu, (CMSEntryFuncPtr)saCmsORFreqGetString, (void *)&saCmsMenuPORFreq,                                   OPTSTRING },
+    { "POR FREQ",  OME_Submenu, {.menufunc = saCmsORFreqGetString}, (void *)&saCmsMenuPORFreq, OPTSTRING },
     OSD_SUBMENU_ENTRY("STATX", &saCmsMenuStats),
 
     OSD_BACK_ENTRY,
     OSD_END_ENTRY,
 };
-#pragma GCC diagnostic pop
 
 static const CMS_Menu saCmsMenuConfig = {
 #ifdef CMS_MENU_DEBUG
@@ -589,7 +583,7 @@ static const OSD_Entry saCmsMenuFreqModeEntries[] =
     OSD_LABEL_ENTRY("- SMARTAUDIO -"),
 
     OSD_LABEL_FUNC_DYN_ENTRY("", saCmsDrawStatusString),
-    { "FREQ",   OME_Submenu, (CMSEntryFuncPtr)saCmsUserFreqGetString,  &saCmsMenuUserFreq, OPTSTRING },
+    { "FREQ",   OME_Submenu, {.menufunc = saCmsUserFreqGetString},  &saCmsMenuUserFreq, OPTSTRING },
     OSD_TAB_CALLBACK_ENTRY("POWER", saCmsConfigPowerByGvar, &saCmsEntPower),
     OSD_SUBMENU_ENTRY("SET", &saCmsMenuCommence),
     OSD_SUBMENU_ENTRY("CONFIG", &saCmsMenuConfig),

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -530,7 +530,7 @@ static const OSD_TAB_t saCmsEntFselMode = { &saCmsFselMode, 1, saCmsFselModeName
 
 #pragma GCC diagnostic push
 #if (__GNUC__ > 7)
-    // This is safe on 32bit platforms, suppress warning for saCmsUserFreqGetString
+    // This is safe on 32bit platforms, suppress warning for saCmsORFreqGetString
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 static const OSD_Entry saCmsMenuConfigEntries[] =

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -56,12 +56,19 @@ typedef enum
 } OSD_MenuElement;
 
 typedef long (*CMSEntryFuncPtr)(displayPort_t *displayPort, const void *ptr);
+// This is a function used in the func member if the type is OME_Submenu.
+typedef char * (*CMSMenuOptFuncPtr)(void);
 
 typedef struct
 {
     const char * const text;
     const OSD_MenuElement type;
-    const CMSEntryFuncPtr func;
+    union
+    {
+        const CMSEntryFuncPtr func;
+        const CMSMenuOptFuncPtr menufunc;
+        int itemId;
+    };
     const void * const data;
     uint8_t flags;
 } OSD_Entry;
@@ -73,29 +80,29 @@ typedef struct
 #define OPTSTRING      (1 << 3)  // (Temporary) Flag for OME_Submenu, indicating func should be called to get a string to display.
 #define READONLY       (1 << 4)  // Indicates that the value is read-only and p->data points directly to it - applies to [U]INT(8|16)
 
-#define OSD_LABEL_ENTRY(label)                  ((OSD_Entry){ label, OME_Label, NULL, NULL, 0 })
-#define OSD_LABEL_DATA_ENTRY(label, data)       ((OSD_Entry){ label, OME_Label, NULL, data, 0 })
-#define OSD_LABEL_DATA_DYN_ENTRY(label, data)   ((OSD_Entry){ label, OME_Label, NULL, data, DYNAMIC })
-#define OSD_LABEL_FUNC_DYN_ENTRY(label, fn)     ((OSD_Entry){ label, OME_LabelFunc, NULL, fn, DYNAMIC })
-#define OSD_BACK_ENTRY                          ((OSD_Entry){ "BACK", OME_Back, NULL, NULL, 0 })
-#define OSD_SUBMENU_ENTRY(label, menu)          ((OSD_Entry){ label, OME_Submenu, NULL, menu, 0 })
-#define OSD_FUNC_CALL_ENTRY(label, fn)          ((OSD_Entry){ label, OME_Funcall, fn, NULL, 0 })
-#define OSD_BOOL_ENTRY(label, val)              ((OSD_Entry){ label, OME_Bool, NULL, val, 0 })
-#define OSD_BOOL_CALLBACK_ENTRY(label, cb, val) ((OSD_Entry){ label, OME_Bool, cb, val, 0 })
-#define OSD_BOOL_FUNC_ENTRY(label, fn)          ((OSD_Entry){ label, OME_BoolFunc, NULL, fn, 0 })
-#define OSD_UINT8_ENTRY(label, val)             ((OSD_Entry){ label, OME_UINT8, NULL, val, 0 })
-#define OSD_UINT8_CALLBACK_ENTRY(label, cb, val)((OSD_Entry){ label, OME_UINT8, cb, val, 0 })
-#define OSD_UINT16_ENTRY(label, val)            ((OSD_Entry){ label, OME_UINT16, NULL, val, 0 })
-#define OSD_UINT16_DYN_ENTRY(label, val)        ((OSD_Entry){ label, OME_UINT16, NULL, val, DYNAMIC })
-#define OSD_UINT16_RO_ENTRY(label, val)         ((OSD_Entry){ label, OME_UINT16, NULL, val, DYNAMIC | READONLY })
-#define OSD_INT16_DYN_ENTRY(label, val)         ((OSD_Entry){ label, OME_INT16, NULL, val, DYNAMIC })
-#define OSD_INT16_RO_ENTRY(label, val)          ((OSD_Entry){ label, OME_INT16, NULL, val, DYNAMIC | READONLY })
-#define OSD_STRING_ENTRY(label, str)            ((OSD_Entry){ label, OME_String, NULL, str, 0 })
-#define OSD_TAB_ENTRY(label, val)               ((OSD_Entry){ label, OME_TAB, NULL, val, 0 })
-#define OSD_TAB_DYN_ENTRY(label, val)           ((OSD_Entry){ label, OME_TAB, NULL, val, DYNAMIC })
-#define OSD_TAB_CALLBACK_ENTRY(label, cb, val)  ((OSD_Entry){ label, OME_TAB, cb, val, 0 })
+#define OSD_LABEL_ENTRY(label)                  ((OSD_Entry){ label, OME_Label, {.func = NULL}, NULL, 0 })
+#define OSD_LABEL_DATA_ENTRY(label, data)       ((OSD_Entry){ label, OME_Label, {.func = NULL}, data, 0 })
+#define OSD_LABEL_DATA_DYN_ENTRY(label, data)   ((OSD_Entry){ label, OME_Label, {.func = NULL}, data, DYNAMIC })
+#define OSD_LABEL_FUNC_DYN_ENTRY(label, fn)     ((OSD_Entry){ label, OME_LabelFunc, {.func = NULL}, fn, DYNAMIC })
+#define OSD_BACK_ENTRY                          ((OSD_Entry){ "BACK", OME_Back, {.func = NULL}, NULL, 0 })
+#define OSD_SUBMENU_ENTRY(label, menu)          ((OSD_Entry){ label, OME_Submenu, {.func = NULL}, menu, 0 })
+#define OSD_FUNC_CALL_ENTRY(label, fn)          ((OSD_Entry){ label, OME_Funcall, {.func = fn}, NULL, 0 })
+#define OSD_BOOL_ENTRY(label, val)              ((OSD_Entry){ label, OME_Bool, {.func = NULL}, val, 0 })
+#define OSD_BOOL_CALLBACK_ENTRY(label, cb, val) ((OSD_Entry){ label, OME_Bool, {.func = cb}, val, 0 })
+#define OSD_BOOL_FUNC_ENTRY(label, fn)          ((OSD_Entry){ label, OME_BoolFunc, {.func = NULL}, fn, 0 })
+#define OSD_UINT8_ENTRY(label, val)             ((OSD_Entry){ label, OME_UINT8, {.func = NULL}, val, 0 })
+#define OSD_UINT8_CALLBACK_ENTRY(label, cb, val)((OSD_Entry){ label, OME_UINT8, {.func = cb}, val, 0 })
+#define OSD_UINT16_ENTRY(label, val)            ((OSD_Entry){ label, OME_UINT16, {.func = NULL}, val, 0 })
+#define OSD_UINT16_DYN_ENTRY(label, val)        ((OSD_Entry){ label, OME_UINT16, {.func = NULL}, val, DYNAMIC })
+#define OSD_UINT16_RO_ENTRY(label, val)         ((OSD_Entry){ label, OME_UINT16, {.func = NULL}, val, DYNAMIC | READONLY })
+#define OSD_INT16_DYN_ENTRY(label, val)         ((OSD_Entry){ label, OME_INT16, {.func = NULL}, val, DYNAMIC })
+#define OSD_INT16_RO_ENTRY(label, val)          ((OSD_Entry){ label, OME_INT16, {.func = NULL}, val, DYNAMIC | READONLY })
+#define OSD_STRING_ENTRY(label, str)            ((OSD_Entry){ label, OME_String, {.func = NULL}, str, 0 })
+#define OSD_TAB_ENTRY(label, val)               ((OSD_Entry){ label, OME_TAB, {.func = NULL}, val, 0 })
+#define OSD_TAB_DYN_ENTRY(label, val)           ((OSD_Entry){ label, OME_TAB, {.func = NULL}, val, DYNAMIC })
+#define OSD_TAB_CALLBACK_ENTRY(label, cb, val)  ((OSD_Entry){ label, OME_TAB, {.func = cb}, val, 0 })
 
-#define OSD_END_ENTRY                           ((OSD_Entry){ NULL, OME_END, NULL, NULL, 0 })
+#define OSD_END_ENTRY                           ((OSD_Entry){ NULL, OME_END, {.func = NULL}, NULL, 0 })
 
 // Data type for OME_Setting. Uses upper 4 bits
 // of flags, leaving 16 data types.
@@ -196,7 +203,3 @@ typedef struct
 {
     char *val;
 } OSD_String_t;
-
-// This is a function used in the func member if the type is OME_Submenu.
-
-typedef char * (*CMSMenuOptFuncPtr)(void);

--- a/src/main/config/parameter_group.c
+++ b/src/main/config/parameter_group.c
@@ -55,7 +55,7 @@ static void pgResetInstance(const pgRegistry_t *reg, uint8_t *base)
         memcpy(base, reg->reset.ptr, regSize);
     } else if (reg->reset.fn) {
         // reset function, call it
-        reg->reset.fn(base, regSize);
+        reg->reset.fn(base);
     }
 }
 

--- a/src/main/config/parameter_group.h
+++ b/src/main/config/parameter_group.h
@@ -39,7 +39,7 @@ typedef enum {
 } pgRegistryInternal_e;
 
 // function that resets a single parameter group instance
-typedef void (pgResetFunc)(void * /* base */, int /* size */);
+typedef void (pgResetFunc)(void * /* base */);
 
 typedef struct pgRegistry_s {
     pgn_t pgn;             // The parameter group number, the top 4 bits are reserved for version

--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -750,15 +750,15 @@ class Generator
         stderr.scan(/var_(\d+).*?', which is of non-class type '(.*)'/).each do |m|
             member = members[m[0].to_i]
             case m[1]
-            when "int8_t {aka signed char}"
+            when /^int8_t/ # {aka signed char}"
                 typ = "int8_t"
-            when "uint8_t {aka unsigned char}"
+            when /^uint8_t/ # {aka unsigned char}"
                 typ = "uint8_t"
-            when "int16_t {aka short int}"
+            when /^int16_t/ # {aka short int}"
                 typ = "int16_t"
-            when "uint16_t {aka short unsigned int}"
+            when /^uint16_t/ # {aka short unsigned int}"
                 typ = "uint16_t"
-            when "uint32_t {aka long unsigned int}"
+            when /^uint32_t/ # {aka long unsigned int}"
                 typ = "uint32_t"
             when "float"
                 typ = "float"


### PR DESCRIPTION
Initial  and trivial changes to compile with gcc 8. 

* Compiles and bench tests OK
* Small reduction in code size

**TODO**

Resolve function pointer warnings mainly related to `PG_REGISTER_ARRAY_WITH_RESET_FN` and `PG_REGISTER_WITH_RESET_FN`