### PR TITLE
Add new target DALRCF405

### DIFF
--- a/src/main/target/DALRCF405/target.c
+++ b/src/main/target/DALRCF405/target.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    { TIM12, IO_TAG(PB15),    TIM_Channel_2, 0, IOCFG_AF_PP_PD, GPIO_AF_TIM10, TIM_USE_PPM },
+
+    { TIM3, IO_TAG(PB0),    TIM_Channel_3, 1,  IOCFG_AF_PP_PD, GPIO_AF_TIM3, TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_MOTOR },
+    { TIM8, IO_TAG(PC6),    TIM_Channel_1, 1,  IOCFG_AF_PP_PD, GPIO_AF_TIM8, TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO },
+    { TIM1, IO_TAG(PA10),    TIM_Channel_3, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM1, TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO },
+    { TIM1, IO_TAG(PA8),    TIM_Channel_1, 1,  IOCFG_AF_PP_PD, GPIO_AF_TIM1, TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO },
+
+    { TIM8, IO_TAG(PC8),    TIM_Channel_3, 1,  IOCFG_AF_PP_PD, GPIO_AF_TIM8, TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO },
+    { TIM3, IO_TAG(PB1),    TIM_Channel_4, 1,  IOCFG_AF_PP_PD, GPIO_AF_TIM3, TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO },
+    { TIM3, IO_TAG(PC7),    TIM_Channel_2, 1,  IOCFG_AF_PP_PD, GPIO_AF_TIM3, TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO },
+    { TIM8, IO_TAG(PC9),    TIM_Channel_4, 1,  IOCFG_AF_PP_PD, GPIO_AF_TIM8, TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO },
+    { TIM4, IO_TAG(PB6),    TIM_Channel_1, 1,  IOCFG_AF_PP_PD, GPIO_AF_TIM4, TIM_USE_LED },
+    { TIM2, IO_TAG(PA5),    TIM_Channel_1, 1,  IOCFG_AF_PP_PD, GPIO_AF_TIM2, TIM_USE_PWM },
+};
+
+
+

--- a/src/main/target/DALRCF405/target.h
+++ b/src/main/target/DALRCF405/target.h
@@ -1,0 +1,162 @@
+/*
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "DLF4"
+#define USBD_PRODUCT_STRING  "DALRCF405"
+
+#define LED0                PC14
+
+#define BEEPER              PC13
+#define BEEPER_INVERTED
+
+// *************** Gyro & ACC **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_SCK_PIN            PB3
+#define SPI1_MISO_PIN   	PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_EXTI
+#define GYRO_INT_EXTI            PC4
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define USE_GYRO
+#define USE_ACC
+
+#define MPU6500_CS_PIN          PA4
+#define MPU6500_SPI_BUS         BUS_SPI1
+#define USE_GYRO_MPU6500
+#define GYRO_MPU6500_ALIGN      CW90_DEG
+#define USE_ACC_MPU6500
+#define ACC_MPU6500_ALIGN       CW90_DEG
+
+#define MPU6000_CS_PIN          PA4
+#define MPU6000_SPI_BUS         BUS_SPI1
+#define USE_GYRO_MPU6000
+#define GYRO_MPU6000_ALIGN      CW90_DEG
+#define USE_ACC_MPU6000
+#define ACC_MPU6000_ALIGN       CW90_DEG
+
+
+//FLASH
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PC3
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN           PB12
+#define M25P16_SPI_BUS          BUS_SPI2
+
+//OSD
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11 
+#define SPI3_MOSI_PIN           PB5
+
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI3
+#define MAX7456_CS_PIN          PA15
+
+//I2C
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+#define DEFAULT_I2C_BUS         BUS_I2C1
+
+#define USE_BARO
+#define BARO_I2C_BUS            DEFAULT_I2C_BUS
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_BMP085
+
+#define USE_MAG
+#define MAG_I2C_BUS             DEFAULT_I2C_BUS
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define USE_MAG_IST8310
+#define USE_MAG_MAG3110
+
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_HCSR04_I2C
+#define RANGEFINDER_I2C_BUS     DEFAULT_I2C_BUS
+
+#define USE_PITOT_MS4525
+#define PITOT_I2C_BUS           DEFAULT_I2C_BUS 
+
+//USART
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PB7
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART5
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN            PC12
+
+#define SERIAL_PORT_COUNT       5
+
+//LED_STRIP
+#define USE_LED_STRIP
+#define WS2811_PIN                      PB6
+#define WS2811_DMA_STREAM               DMA1_Stream0
+#define WS2811_DMA_CHANNEL              DMA_Channel_2
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST0_HANDLER
+//ADC
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM         DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC2
+#define ADC_CHANNEL_2_PIN           PC1
+#define ADC_CHANNEL_3_PIN           PA0
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_3 
+
+#define DEFAULT_FEATURES        (FEATURE_VBAT | FEATURE_OSD) 
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         0xffff
+
+//TIMER
+#define USABLE_TIMER_CHANNEL_COUNT 11
+#define MAX_PWM_OUTPUT_PORTS       10
+#define USED_TIMERS             (TIM_N(1)|TIM_N(2)|TIM_N(3)|TIM_N(4)|TIM_N(8)|TIM_N(12))
+
+
+

--- a/src/main/target/DALRCF405/target.mk
+++ b/src/main/target/DALRCF405/target.mk
@@ -1,0 +1,21 @@
+F405_TARGETS   += $(TARGET)
+FEATURES       += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_mpu6500.c \
+            drivers/accgyro/accgyro_mpu6000.c \
+            drivers/barometer/barometer_bmp085.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_ms56xx.c \
+            drivers/compass/compass_ak8963.c \
+            drivers/compass/compass_ak8975.c \
+            drivers/compass/compass_hmc5883l.c \
+            drivers/compass/compass_qmc5883l.c \
+            drivers/compass/compass_ist8310.c \
+            drivers/compass/compass_mag3110.c \
+            drivers/pitotmeter_ms4525.c \
+            drivers/pitotmeter_adc.c \
+            drivers/light_ws2811strip.c \
+            drivers/light_ws2811strip_stdperiph.c \
+            drivers/max7456.c
+			


### PR DESCRIPTION
Add new target DALRCF405.
The code has been compiled and tested.
The DALRCF405 described here:
http://www.dalrcmodel.com/DALRC/plus/view.php?aid=184

This board use the STM32F405RGT6 microcontroller and have the following features:

* 1024K bytes of flash memory,192K bytes RAM,168 MHz CPU/210 DMIPS

* The 16M byte SPI flash for data logging

* USB VCP and boot select button on board(for DFU)

* Stable voltage regulation,9V/2A DCDC BEC for VTX/camera etc.And could select 5v/9v with pad

* Serial LED interface(LED_STRIP)

* VBAT/CURR/RSSI sensors input

* Suppose IRC Tramp/smart audio/FPV Camera Control/FPORT/telemetry

* Supports SBus, Spektrum1024/2048, PPM. No external inverters required (built-in).

* Supports I2C device extend(baro/compass/OLED etc)

* Supports GPS