### PR TITLE
Dynamic serial buffer allocation

### DIFF
--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -99,43 +99,43 @@ static void uartReconfigure(uartPort_t *uartPort)
     USART_Cmd(uartPort->USARTx, ENABLE);
 }
 
-serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_t mode, portOptions_t options)
+serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize)
 {
     uartPort_t *s = NULL;
 
     if (false) {
 #ifdef USE_UART1
     } else if (USARTx == USART1) {
-        s = serialUART1(baudRate, mode, options);
+        s = serialUART1(baudRate, mode, options, rxBufSize, txBufSize);
 
 #endif
 #ifdef USE_UART2
     } else if (USARTx == USART2) {
-        s = serialUART2(baudRate, mode, options);
+        s = serialUART2(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART3
     } else if (USARTx == USART3) {
-        s = serialUART3(baudRate, mode, options);
+        s = serialUART3(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART4
     } else if (USARTx == UART4) {
-        s = serialUART4(baudRate, mode, options);
+        s = serialUART4(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART5
     } else if (USARTx == UART5) {
-        s = serialUART5(baudRate, mode, options);
+        s = serialUART5(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART6
     } else if (USARTx == USART6) {
-        s = serialUART6(baudRate, mode, options);
+        s = serialUART6(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART7
     } else if (USARTx == UART7) {
-        s = serialUART7(baudRate, mode, options);
+        s = serialUART7(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART8
     } else if (USARTx == UART8) {
-        s = serialUART8(baudRate, mode, options);
+        s = serialUART8(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 
     } else {

--- a/src/main/drivers/serial_uart.h
+++ b/src/main/drivers/serial_uart.h
@@ -17,29 +17,6 @@
 
 #pragma once
 
-// Since serial ports can be used for any function these buffer sizes should be equal
-// The two largest things that need to be sent are: 1, MSP responses, 2, UBLOX SVINFO packet.
-
-// Size must be a power of two due to various optimizations which use 'and' instead of 'mod'
-// Various serial routines return the buffer occupied size as uint8_t which would need to be extended in order to
-// increase size further.
-#define UART1_RX_BUFFER_SIZE    256
-#define UART1_TX_BUFFER_SIZE    256
-#define UART2_RX_BUFFER_SIZE    256
-#define UART2_TX_BUFFER_SIZE    256
-#define UART3_RX_BUFFER_SIZE    256
-#define UART3_TX_BUFFER_SIZE    256
-#define UART4_RX_BUFFER_SIZE    256
-#define UART4_TX_BUFFER_SIZE    256
-#define UART5_RX_BUFFER_SIZE    256
-#define UART5_TX_BUFFER_SIZE    256
-#define UART6_RX_BUFFER_SIZE    256
-#define UART6_TX_BUFFER_SIZE    256
-#define UART7_RX_BUFFER_SIZE    256
-#define UART7_TX_BUFFER_SIZE    256
-#define UART8_RX_BUFFER_SIZE    256
-#define UART8_TX_BUFFER_SIZE    256
-
 typedef enum {
     UARTDEV_1 = 0,
     UARTDEV_2 = 1,
@@ -83,7 +60,7 @@ typedef struct {
     USART_TypeDef *USARTx;
 } uartPort_t;
 
-serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_t mode, portOptions_t options);
+serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize);
 
 // serialPort API
 void uartWrite(serialPort_t *instance, uint8_t ch);

--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -177,42 +177,42 @@ static void uartReconfigure(uartPort_t *uartPort)
     return;
 }
 
-serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr callback, void *rxCallbackData, uint32_t baudRate, portMode_t mode, portOptions_t options)
+serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr callback, void *rxCallbackData, uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize)
 {
     uartPort_t *s = NULL;
 
     if (false) {
 #ifdef USE_UART1
     } else if (USARTx == USART1) {
-        s = serialUART1(baudRate, mode, options);
+        s = serialUART1(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART2
     } else if (USARTx == USART2) {
-        s = serialUART2(baudRate, mode, options);
+        s = serialUART2(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART3
     } else if (USARTx == USART3) {
-        s = serialUART3(baudRate, mode, options);
+        s = serialUART3(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART4
     } else if (USARTx == UART4) {
-        s = serialUART4(baudRate, mode, options);
+        s = serialUART4(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART5
     } else if (USARTx == UART5) {
-        s = serialUART5(baudRate, mode, options);
+        s = serialUART5(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART6
     } else if (USARTx == USART6) {
-        s = serialUART6(baudRate, mode, options);
+        s = serialUART6(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART7
     } else if (USARTx == UART7) {
-        s = serialUART7(baudRate, mode, options);
+        s = serialUART7(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
 #ifdef USE_UART8
     } else if (USARTx == UART8) {
-        s = serialUART8(baudRate, mode, options);
+        s = serialUART8(baudRate, mode, options, rxBufSize, txBufSize);
 #endif
     } else {
         return (serialPort_t *)s;

--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -23,12 +23,12 @@ extern const struct serialPortVTable uartVTable[];
 
 void uartStartTxDMA(uartPort_t *s);
 
-uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t options);
-uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t options);
-uartPort_t *serialUART3(uint32_t baudRate, portMode_t mode, portOptions_t options);
-uartPort_t *serialUART4(uint32_t baudRate, portMode_t mode, portOptions_t options);
-uartPort_t *serialUART5(uint32_t baudRate, portMode_t mode, portOptions_t options);
-uartPort_t *serialUART6(uint32_t baudRate, portMode_t mode, portOptions_t options);
-uartPort_t *serialUART7(uint32_t baudRate, portMode_t mode, portOptions_t options);
-uartPort_t *serialUART8(uint32_t baudRate, portMode_t mode, portOptions_t options);
+uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize);
+uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize);
+uartPort_t *serialUART3(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize);
+uartPort_t *serialUART4(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize);
+uartPort_t *serialUART5(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize);
+uartPort_t *serialUART6(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize);
+uartPort_t *serialUART7(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize);
+uartPort_t *serialUART8(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize);
 

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -28,6 +28,7 @@
 
 #include <platform.h>
 
+#include "common/memory.h"
 #include "drivers/time.h"
 #include "drivers/io.h"
 #include "drivers/nvic.h"
@@ -139,21 +140,23 @@ void serialUARTInit(IO_t tx, IO_t rx, portMode_t mode, portOptions_t options, ui
 }
 
 #ifdef USE_UART1
-uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t options)
+uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize)
 {
     uartPort_t *s;
-    static volatile uint8_t rx1Buffer[UART1_RX_BUFFER_SIZE];
-    static volatile uint8_t tx1Buffer[UART1_TX_BUFFER_SIZE];
 
     s = &uartPort1;
     s->port.vTable = uartVTable;
 
     s->port.baudRate = baudRate;
 
-    s->port.rxBuffer = rx1Buffer;
-    s->port.txBuffer = tx1Buffer;
-    s->port.rxBufferSize = UART1_RX_BUFFER_SIZE;
-    s->port.txBufferSize = UART1_TX_BUFFER_SIZE;
+    s->port.rxBuffer = memAllocate(rxBufSize, OWNER_SERIAL);
+    s->port.txBuffer = memAllocate(txBufSize, OWNER_SERIAL);
+    s->port.rxBufferSize = rxBufSize;
+    s->port.txBufferSize = txBufSize;
+
+    if (s->port.rxBuffer == NULL || s->port.txBuffer == NULL) {
+        return NULL;
+    }
 
 #ifdef USE_UART1_RX_DMA
     s->rxDMAChannel = DMA1_Channel5;
@@ -187,21 +190,23 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
 #endif
 
 #ifdef USE_UART2
-uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t options)
+uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize)
 {
     uartPort_t *s;
-    static volatile uint8_t rx2Buffer[UART2_RX_BUFFER_SIZE];
-    static volatile uint8_t tx2Buffer[UART2_TX_BUFFER_SIZE];
 
     s = &uartPort2;
     s->port.vTable = uartVTable;
 
     s->port.baudRate = baudRate;
 
-    s->port.rxBufferSize = UART2_RX_BUFFER_SIZE;
-    s->port.txBufferSize = UART2_TX_BUFFER_SIZE;
-    s->port.rxBuffer = rx2Buffer;
-    s->port.txBuffer = tx2Buffer;
+    s->port.rxBuffer = memAllocate(rxBufSize, OWNER_SERIAL);
+    s->port.txBuffer = memAllocate(txBufSize, OWNER_SERIAL);
+    s->port.rxBufferSize = rxBufSize;
+    s->port.txBufferSize = txBufSize;
+
+    if (s->port.rxBuffer == NULL || s->port.txBuffer == NULL) {
+        return NULL;
+    }
 
     s->USARTx = USART2;
 
@@ -242,21 +247,23 @@ uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t option
 #endif
 
 #ifdef USE_UART3
-uartPort_t *serialUART3(uint32_t baudRate, portMode_t mode, portOptions_t options)
+uartPort_t *serialUART3(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize)
 {
     uartPort_t *s;
-    static volatile uint8_t rx3Buffer[UART3_RX_BUFFER_SIZE];
-    static volatile uint8_t tx3Buffer[UART3_TX_BUFFER_SIZE];
 
     s = &uartPort3;
     s->port.vTable = uartVTable;
 
     s->port.baudRate = baudRate;
 
-    s->port.rxBufferSize = UART3_RX_BUFFER_SIZE;
-    s->port.txBufferSize = UART3_TX_BUFFER_SIZE;
-    s->port.rxBuffer = rx3Buffer;
-    s->port.txBuffer = tx3Buffer;
+    s->port.rxBuffer = memAllocate(rxBufSize, OWNER_SERIAL);
+    s->port.txBuffer = memAllocate(txBufSize, OWNER_SERIAL);
+    s->port.rxBufferSize = rxBufSize;
+    s->port.txBufferSize = txBufSize;
+
+    if (s->port.rxBuffer == NULL || s->port.txBuffer == NULL) {
+        return NULL;
+    }
 
     s->USARTx = USART3;
 
@@ -297,28 +304,31 @@ uartPort_t *serialUART3(uint32_t baudRate, portMode_t mode, portOptions_t option
 #endif
 
 #ifdef USE_UART4
-uartPort_t *serialUART4(uint32_t baudRate, portMode_t mode, portOptions_t options)
+uartPort_t *serialUART4(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize)
 {
     uartPort_t *s;
-    static volatile uint8_t rx4Buffer[UART4_RX_BUFFER_SIZE];
-    static volatile uint8_t tx4Buffer[UART4_TX_BUFFER_SIZE];
-    NVIC_InitTypeDef NVIC_InitStructure;
 
     s = &uartPort4;
     s->port.vTable = uartVTable;
 
     s->port.baudRate = baudRate;
 
-    s->port.rxBufferSize = UART4_RX_BUFFER_SIZE;
-    s->port.txBufferSize = UART4_TX_BUFFER_SIZE;
-    s->port.rxBuffer = rx4Buffer;
-    s->port.txBuffer = tx4Buffer;
+    s->port.rxBuffer = memAllocate(rxBufSize, OWNER_SERIAL);
+    s->port.txBuffer = memAllocate(txBufSize, OWNER_SERIAL);
+    s->port.rxBufferSize = rxBufSize;
+    s->port.txBufferSize = txBufSize;
+
+    if (s->port.rxBuffer == NULL || s->port.txBuffer == NULL) {
+        return NULL;
+    }
 
     s->USARTx = UART4;
 
     RCC_ClockCmd(RCC_APB1(UART4), ENABLE);
 
     serialUARTInit(IOGetByTag(IO_TAG(UART4_TX_PIN)), IOGetByTag(IO_TAG(UART4_RX_PIN)), mode, options, GPIO_AF_5, 4);
+
+    NVIC_InitTypeDef NVIC_InitStructure;
 
     NVIC_InitStructure.NVIC_IRQChannel = UART4_IRQn;
     NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_SERIALUART4);
@@ -331,28 +341,31 @@ uartPort_t *serialUART4(uint32_t baudRate, portMode_t mode, portOptions_t option
 #endif
 
 #ifdef USE_UART5
-uartPort_t *serialUART5(uint32_t baudRate, portMode_t mode, portOptions_t options)
+uartPort_t *serialUART5(uint32_t baudRate, portMode_t mode, portOptions_t options, uint32_t rxBufSize, uint32_t txBufSize)
 {
     uartPort_t *s;
-    static volatile uint8_t rx5Buffer[UART5_RX_BUFFER_SIZE];
-    static volatile uint8_t tx5Buffer[UART5_TX_BUFFER_SIZE];
-    NVIC_InitTypeDef NVIC_InitStructure;
 
     s = &uartPort5;
     s->port.vTable = uartVTable;
 
     s->port.baudRate = baudRate;
 
-    s->port.rxBufferSize = UART5_RX_BUFFER_SIZE;
-    s->port.txBufferSize = UART5_TX_BUFFER_SIZE;
-    s->port.rxBuffer = rx5Buffer;
-    s->port.txBuffer = tx5Buffer;
+    s->port.rxBuffer = memAllocate(rxBufSize, OWNER_SERIAL);
+    s->port.txBuffer = memAllocate(txBufSize, OWNER_SERIAL);
+    s->port.rxBufferSize = rxBufSize;
+    s->port.txBufferSize = txBufSize;
+
+    if (s->port.rxBuffer == NULL || s->port.txBuffer == NULL) {
+        return NULL;
+    }
 
     s->USARTx = UART5;
 
     RCC_ClockCmd(RCC_APB1(UART5), ENABLE);
 
     serialUARTInit(IOGetByTag(IO_TAG(UART5_TX_PIN)), IOGetByTag(IO_TAG(UART5_RX_PIN)), mode, options, GPIO_AF_5, 5);
+
+    NVIC_InitTypeDef NVIC_InitStructure;
 
     NVIC_InitStructure.NVIC_IRQChannel = UART5_IRQn;
     NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_SERIALUART5);

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#define DYNAMIC_HEAP_SIZE   3072
+
 #define I2C1_OVERCLOCK false
 #define I2C2_OVERCLOCK false
 #define USE_I2C_PULLUP          // Enable built-in pullups on all boards in case external ones are too week


### PR DESCRIPTION
Serial buffers are allocated at run-time based on functions configured for UART.
Dependent on https://github.com/iNavFlight/inav/pull/3120