### PR TITLE
WIP/RFQ: Option to average ADC samples

### DIFF
--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -45,3 +45,7 @@ void adcInit(drv_adc_config_t *init);
 uint16_t adcGetChannel(uint8_t channel);
 bool adcIsFunctionAssigned(uint8_t function);
 int adcGetFunctionChannelAllocation(uint8_t function);
+
+#if !defined(USE_ADC_AVERAGING)
+#define ADC_AVERAGE_N_SAMPLES 1
+#endif

--- a/src/main/drivers/adc_impl.h
+++ b/src/main/drivers/adc_impl.h
@@ -78,7 +78,7 @@ typedef struct adc_config_s {
 
 extern const adcTagMap_t adcTagMap[ADC_TAG_MAP_COUNT];
 extern adc_config_t adcConfig[ADC_CHN_COUNT];
-extern volatile uint16_t adcValues[ADCDEV_COUNT][ADC_CHN_COUNT];
+extern volatile uint16_t adcValues[ADCDEV_COUNT][ADC_CHN_COUNT * ADC_AVERAGE_N_SAMPLES];
 
 void adcHardwareInit(drv_adc_config_t *init);
 ADCDevice adcDeviceByInstance(ADC_TypeDef *instance);

--- a/src/main/drivers/adc_stm32f4xx.c
+++ b/src/main/drivers/adc_stm32f4xx.c
@@ -99,9 +99,9 @@ static void adcInstanceInit(ADCDevice adcDevice)
     DMA_InitStructure.DMA_Channel = adc->channel;
     DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)adcValues[adcDevice];
     DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralToMemory;
-    DMA_InitStructure.DMA_BufferSize = adc->usedChannelCount;
+    DMA_InitStructure.DMA_BufferSize = adc->usedChannelCount * ADC_AVERAGE_N_SAMPLES;
     DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
-    DMA_InitStructure.DMA_MemoryInc = adc->usedChannelCount > 1 ? DMA_MemoryInc_Enable : DMA_MemoryInc_Disable;
+    DMA_InitStructure.DMA_MemoryInc = ((adc->usedChannelCount > 1) || (ADC_AVERAGE_N_SAMPLES > 1)) ? DMA_MemoryInc_Enable : DMA_MemoryInc_Disable;
     DMA_InitStructure.DMA_PeripheralDataSize = DMA_PeripheralDataSize_HalfWord;
     DMA_InitStructure.DMA_MemoryDataSize = DMA_MemoryDataSize_HalfWord;
     DMA_InitStructure.DMA_Mode = DMA_Mode_Circular;


### PR DESCRIPTION
I have a current sensor that gave very noisy reading when used with an airplane ESC. After some testing, I found that the current drawn by the ESC is very irregular, i.e., every 125us it draws a lot of current when the FETs are switching (8kHz switching frequency). This is reflected in the current sensor output.

The battery task currently updates at 50Hz, so it can randomly sample the current sensor output at a peak or valley, which leads to the fluctuating readings.

I see 2 possible ways to fix this:

1) Add a hardware low-pass filter to the current sensor output. Which isn't ideal, as it requires hardware changes

2) Average ADC samples over a longer time interval. This is implemented here.

On a typical F4 target with an APB2 clock of 84MHz, the ADC is running at 10.5MHz and a sample is obtained every 503 clock cycles (488 + 15). So for a single channel, the actual sampling rate is 20.9kHz, for 2 channels it is 10.4kHz and for 3 it is 7kHz. 

With the previous implementation, we just use the last obtained ADC sample. So if we have 2 channels and e.g. update the battery status at 50Hz, there are over 200 samples obtained between each update that we don't use. 

This PR adds the option to use a longer circular buffer that is filled by the DMA and averaged when the ADC is being read. 

Other than using a bit more memory and averaging the samples when the ADC output is read, this doesn't add much additional processing (the DMA controller does most of the work "for free").

For the current sensor I have, this completely solves the problem when a 20 sample average is used. I tested this on the BrainFPV RADIX FC, which currently isn't a part of iNAV but it probably makes sense to use this on other F4 and F7 targets as well. 


