### PR TITLE
Send GPS related sensors via S.Port even without a fix

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -325,6 +325,15 @@ static void smartPortSendMspResponse(uint8_t *data) {
 }
 #endif
 
+static bool smartPortShouldSendGPSData(void)
+{
+    // We send GPS data if the GPS is configured and we have a fix
+    // or the craft has never been armed yet. This way if GPS stops working
+    // while in flight, the user will easily notice because the sensor will stop
+    // updating.
+    return feature(FEATURE_GPS) && (STATE(GPS_FIX) || !ARMING_FLAG(WAS_EVER_ARMED));
+}
+
 void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clearToSend, const uint32_t *requestTimeout)
 {
     if (payload) {
@@ -475,10 +484,9 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
                     break;
                 }
             case FSSP_DATAID_T2         :
-                if (sensors(SENSOR_GPS)) {
-#ifdef USE_GPS
+                if (smartPortShouldSendGPSData()) {
                     uint32_t tmpi = 0;
-
+#ifdef USE_GPS
                     // ones and tens columns (# of satellites 0 - 99)
                     tmpi += constrain(gpsSol.numSat, 0, 99);
 
@@ -496,14 +504,11 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
                     smartPortSendPackage(id, tmpi);
                     *clearToSend = false;
 #endif
-                } else if (feature(FEATURE_GPS)) {
-                    smartPortSendPackage(id, 0);
-                    *clearToSend = false;
                 }
                 break;
 #ifdef USE_GPS
             case FSSP_DATAID_SPEED      :
-                if (sensors(SENSOR_GPS) && STATE(GPS_FIX)) {
+                if (smartPortShouldSendGPSData()) {
                     //convert to knots: 1cm/s = 0.0194384449 knots
                     //Speed should be sent in knots/1000 (GPS speed is in cm/s)
                     uint32_t tmpui = gpsSol.groundSpeed * 1944 / 100;
@@ -512,7 +517,7 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
                 }
                 break;
             case FSSP_DATAID_LATLONG    :
-                if (sensors(SENSOR_GPS) && STATE(GPS_FIX)) {
+                if (smartPortShouldSendGPSData()) {
                     uint32_t tmpui = 0;
                     // the same ID is sent twice, one for longitude, one for latitude
                     // the MSB of the sent uint32_t helps FrSky keep track
@@ -532,13 +537,13 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
                 }
                 break;
             case FSSP_DATAID_HOME_DIST  :
-                if (sensors(SENSOR_GPS) && STATE(GPS_FIX)) {
+                if (smartPortShouldSendGPSData()) {
                     smartPortSendPackage(id, GPS_distanceToHome);
                      *clearToSend = false;
                 }
                 break;
             case FSSP_DATAID_GPS_ALT    :
-                if (sensors(SENSOR_GPS) && STATE(GPS_FIX)) {
+                if (smartPortShouldSendGPSData()) {
                     smartPortSendPackage(id, gpsSol.llh.alt); // cm
                     *clearToSend = false;
                 }


### PR DESCRIPTION
Check for feature(FEATURE_GPS) rather than for a GPS fix. This lets
users perform the sensor discovery step without having a GPS fix.

To still allow users to notice if the GPS has stopped working, we
check that either the craft has never been armed or we do have a GPS
fix. This way the sensor is available on startup, but if it stops
working mid-flight the user will get a "sensor lost" alarm.