### PR TITLE
Sparky2: Use correct ADC pin mapping

### DIFF
--- a/src/main/target/SPARKY2/target.h
+++ b/src/main/target/SPARKY2/target.h
@@ -111,7 +111,7 @@
 
 #define USE_ADC
 #define ADC_CHANNEL_1_PIN               PC2
-#define ADC_CHANNEL_2_PIN               PC1
+#define ADC_CHANNEL_2_PIN               PC3
 #define VBAT_ADC_CHANNEL                ADC_CHN_2
 #define CURRENT_METER_ADC_CHANNEL       ADC_CHN_1
 


### PR DESCRIPTION
In Sparky2, CONN5 is connected to PC2 (ADC Current), PC3 (ADC Voltage) and PA4 (DAC Out). This PR corrects the pin map so that voltage can be measured.