### PR TITLE
 Add SOFTSERIAL support on TX6 for OMNIBUSF4V3 target

### DIFF
--- a/docs/Board - Omnibus F4.md
+++ b/docs/Board - Omnibus F4.md
@@ -147,7 +147,7 @@ Please note that this is *not* the motor PWM5/PWM6 pins, but small surface mount
 
 ### Omnibus F4 v3/v4/v5 SoftwareSerial Connections
 
-The SOFTSERIAL1 is an uni-directional (TX-only) port mapped to UART6-TX pin.
+The SOFTSERIAL1 is an uni-directional port mapped to UART6-TX pin.
 When enabled, the UART6 is still available as hardware port but it's then RX-only port (good for e.g. receiving S.BUS input). TX instead is controlled in software (can be used for e.g. transmitting one-way telemetry).
 
 

--- a/docs/Board - Omnibus F4.md
+++ b/docs/Board - Omnibus F4.md
@@ -38,7 +38,7 @@
 * PPM and UART6 can be used together when S.BUS jumper is removed (close to PPM/SBUS connector)
 * Uses target **OMNIBUSF4V3**
 
-### Omnibus F4 v4
+### Omnibus F4 v4/v5
 
 * Switching voltage regulator - solves problem of overheating BEC
 * SD Card slot instead of flash memory
@@ -143,9 +143,13 @@ Please note that this is *not* the motor PWM5/PWM6 pins, but small surface mount
 | CH5   | RX                    |
 | CH6   | TX                    |
 
-## SoftwareSerial
-
 ![Omnibus F4 Pro SmartPort using SoftwareSerial](assets/images/omnibusf4pro_ss.png)
+
+### Omnibus F4 v3/v4/v5 SoftwareSerial Connections
+
+The SOFTSERIAL1 is an uni-directional (TX-only) port mapped to UART6-TX pin.
+When enabled, the UART6 is still available as hardware port but it's then RX-only port (good for e.g. receiving S.BUS input). TX instead is controlled in software (can be used for e.g. transmitting one-way telemetry).
+
 
 # Wiring diagrams for Omnibus F4 Pro
 

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -137,7 +137,11 @@
 #define UART6_TX_PIN            PC6
 
 #if defined(OMNIBUSF4V3)
-#define SERIAL_PORT_COUNT       4 //VCP, USART1, USART3, USART6
+#define USE_SOFTSERIAL1
+#define SOFTSERIAL_1_RX_PIN     NONE
+#define SOFTSERIAL_1_TX_PIN     PC6 //shared with UART6_TX
+
+#define SERIAL_PORT_COUNT       5 //VCP, USART1, USART3, USART6, SOFTSERIAL1
 #else
 #define USE_SOFTSERIAL1
 #define SOFTSERIAL_1_RX_PIN     PC8

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -138,7 +138,7 @@
 
 #if defined(OMNIBUSF4V3)
 #define USE_SOFTSERIAL1
-#define SOFTSERIAL_1_RX_PIN     NONE
+#define SOFTSERIAL_1_RX_PIN     PC6 //shared with UART6_TX
 #define SOFTSERIAL_1_TX_PIN     PC6 //shared with UART6_TX
 
 #define SERIAL_PORT_COUNT       5 //VCP, USART1, USART3, USART6, SOFTSERIAL1


### PR DESCRIPTION
Based on https://github.com/iNavFlight/inav/pull/3033
Verified by using S.BUS on RX6 and LTM telemetry on TX6 (SOFTSERIAL1).
When the SOFTSERIAL1 is not assigned any function in the Ports tab, UART6 works normally, as a bi-directional HW port.