### PR TITLE
Turn assistant cleanups

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -532,7 +532,6 @@ void processRx(timeUs_t currentTimeUs)
         DISABLE_FLIGHT_MODE(FLAPERON);
     }
 
-#ifdef USE_FLM_TURN_ASSIST
     /* Turn assistant mode */
     if (IS_RC_MODE_ACTIVE(BOXTURNASSIST)) {
         if (!FLIGHT_MODE(TURN_ASSISTANT)) {
@@ -541,7 +540,6 @@ void processRx(timeUs_t currentTimeUs)
     } else {
         DISABLE_FLIGHT_MODE(TURN_ASSISTANT);
     }
-#endif
 
     if (sensors(SENSOR_ACC)) {
         if (IS_RC_MODE_ACTIVE(BOXHEADINGHOLD)) {

--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -156,10 +156,7 @@ void initActiveBoxIds(void)
     if (sensors(SENSOR_ACC)) {
         activeBoxIds[activeBoxIdCount++] = BOXANGLE;
         activeBoxIds[activeBoxIdCount++] = BOXHORIZON;
-
-#ifdef USE_FLM_TURN_ASSIST
         activeBoxIds[activeBoxIdCount++] = BOXTURNASSIST;
-#endif
     }
 
     if (!feature(FEATURE_AIRMODE)) {
@@ -290,9 +287,7 @@ void packBoxModeFlags(boxBitmask_t * mspBoxModeFlags)
 #ifdef USE_FLM_FLAPERON
     CHECK_ACTIVE_BOX(IS_ENABLED(FLIGHT_MODE(FLAPERON)),             BOXFLAPERON);
 #endif
-#ifdef USE_FLM_TURN_ASSIST
     CHECK_ACTIVE_BOX(IS_ENABLED(FLIGHT_MODE(TURN_ASSISTANT)),       BOXTURNASSIST);
-#endif
     CHECK_ACTIVE_BOX(IS_ENABLED(FLIGHT_MODE(NAV_LAUNCH_MODE)),      BOXNAVLAUNCH);
     CHECK_ACTIVE_BOX(IS_ENABLED(FLIGHT_MODE(AUTO_TUNE)),            BOXAUTOTUNE);
     CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXAUTOTRIM)),    BOXAUTOTRIM);

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -78,9 +78,7 @@ typedef enum {
     NAV_WP_MODE     = (1 << 11),
     UNUSED_MODE2    = (1 << 12),
     FLAPERON        = (1 << 13),
-#ifdef USE_FLM_TURN_ASSIST
     TURN_ASSISTANT  = (1 << 14),
-#endif
 } flightModeFlags_e;
 
 extern uint32_t flightModeFlags;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -664,7 +664,6 @@ float pidHeadingHold(void)
     return headingHoldRate;
 }
 
-#ifdef USE_FLM_TURN_ASSIST
 /*
  * TURN ASSISTANT mode is an assisted mode to do a Yaw rotation on a ground plane, allowing one-stick turn in RATE more
  * and keeping ROLL and PITCH attitude though the turn.
@@ -726,7 +725,6 @@ static void pidTurnAssistant(pidState_t *pidState)
         pidState[YAW].rateTarget = constrainf(targetRates.z, -currentControlRateProfile->stabilized.rates[YAW] * 10.0f, currentControlRateProfile->stabilized.rates[YAW] * 10.0f);
     }
 }
-#endif
 
 void pidController(void)
 {
@@ -760,11 +758,9 @@ void pidController(void)
         pidLevel(&pidState[FD_PITCH], FD_PITCH, horizonRateMagnitude);
     }
 
-#ifdef USE_FLM_TURN_ASSIST
     if (FLIGHT_MODE(TURN_ASSISTANT) || navigationRequiresTurnAssistance()) {
         pidTurnAssistant(pidState);
     }
-#endif
 
     // Apply setpoint rate of change limits
     for (int axis = 0; axis < 3; axis++) {

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -40,7 +40,6 @@
 #define USE_GPS
 #define USE_GPS_PROTO_UBLOX
 #define USE_NAV
-#define USE_FLM_TURN_ASSIST     // This is mandatory for fixed-wing navigation
 #define USE_TELEMETRY
 #define USE_TELEMETRY_LTM
 #define USE_TELEMETRY_FRSKY


### PR DESCRIPTION
Just some cleanup. Since turn assistant is compulsory for FW navigation I don't see the point of keeping the #define flag.