### PR TITLE
Makefile compatibility with GPG-signed commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ GROUP_3_TARGETS := OMNIBUS AIRBOTF4 BLUEJAYF4 OMNIBUSF4 OMNIBUSF4PRO OMNIBUSF4V3
 GROUP_4_TARGETS := ANYFC ANYFCF7 ANYFCF7_EXTERNAL_BARO ANYFCM7 ALIENFLIGHTNGF7 PIXRACER
 GROUP_OTHER_TARGETS := $(filter-out $(GROUP_1_TARGETS) $(GROUP_2_TARGETS) $(GROUP_3_TARGETS) $(GROUP_4_TARGETS), $(VALID_TARGETS))
 
-REVISION = $(shell git log -1 --format="%h")
+REVISION = $(shell git rev-parse --short HEAD)
 
 FC_VER_MAJOR := $(shell grep " FC_VERSION_MAJOR" src/main/build/version.h | awk '{print $$3}' )
 FC_VER_MINOR := $(shell grep " FC_VERSION_MINOR" src/main/build/version.h | awk '{print $$3}' )


### PR DESCRIPTION
The Makefile currently does not handle signed commits if git's option **log.showsignature** is enabled (extended logging of signature details).

+ Expected output: `Makefile:140: *** $REVISION is [e73748b0].  ....`

+ Actual output: `Makefile:140: *** $REVISION is [gpg: Signature made fri 18 may 2018 14:55:19 CEST gpg:               ... e73748b0].  ....` _(unterminated garbage string)_

This PR fixes this behavior by using git's plumbing commands instead of formatting the log. _Based on research done for stronnag/mwptools#41 and stronnag/mwptools#42._