### PR TITLE
Increase OSD_EFFICIENCY_WH_PER_KM max displayed value

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1674,7 +1674,7 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_EFFICIENCY_WH_PER_KM:
         {
             // amperage is in centi amps, speed is in cms/s. We want
-            // mah/km. Values over 999 are considered useless and
+            // mWh/km. Values over 999Wh/km are considered useless and
             // displayed as "---""
             static pt1Filter_t eFilterState;
             static timeUs_t efficiencyUpdated = 0;
@@ -1691,7 +1691,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     value = eFilterState.state;
                 }
             }
-            if (value > 0 && value <= 999) {
+            if (value > 0 && value <= 999999) {
                 osdFormatCentiNumber(buff, value / 10, 0, 2, 0, 3);
             } else {
                 buff[0] = buff[1] = buff[2] = '-';


### PR DESCRIPTION
In 1.9.1 the Wh/km indicator can only display up to 1Wh/km. 