### PR TITLE
Reduce initial map scale, break early when we're too close to home

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -880,7 +880,7 @@ static void osdDrawMap(int referenceHeading, uint8_t referenceSym, uint8_t cente
 
     switch (osdConfig()->units) {
         case OSD_UNIT_IMPERIAL:
-            scale = 161; // 161m ~= 0.1miles
+            scale = 16; // 16m ~= 0.01miles
             scaleToUnit = 100 / 1609.3440f; // scale to 0.01mi for osdFormatCentiNumber()
             scaleUnitDivisor = 0;
             symUnscaled = SYM_MI;
@@ -890,7 +890,7 @@ static void osdDrawMap(int referenceHeading, uint8_t referenceSym, uint8_t cente
         case OSD_UNIT_UK:
             FALLTHROUGH;
         case OSD_UNIT_METRIC:
-            scale = 100; // 100m as initial scale
+            scale = 10; // 10m as initial scale
             scaleToUnit = 100; // scale to cm for osdFormatCentiNumber()
             scaleUnitDivisor = 1000; // Convert to km when scale gets bigger than 999m
             symUnscaled = SYM_M;
@@ -921,6 +921,13 @@ static void osdDrawMap(int referenceHeading, uint8_t referenceSym, uint8_t cente
             int poiY = midY + roundf(pointsY / charHeight);
             if (poiY < minY || poiY > maxY) {
                 continue;
+            }
+
+            if (poiX == midX && poiY == midY && centerSym != SYM_BLANK) {
+                // We're over the map center symbol, so we would be drawing
+                // over it even if we increased the scale. No reason to run
+                // this loop 50 times.
+                break;
             }
 
             uint8_t c;


### PR DESCRIPTION
Reduce minum map scale to 10m in SI/0.01mi in IMP. This way the radar
can draw symbols even when the craft is very close to home.

Also, when the craft is too close to the map center to be drawn,
break out early to save some time.