### PR TITLE
Add memory usage to linker output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,7 @@ LDFLAGS     = -lm \
               -Wl,-L$(LINKER_DIR) \
               -Wl,--cref \
               -Wl,--no-wchar-size-warning \
+              -Wl,--print-memory-usage \
               -T$(LD_SCRIPT)
 
 ###############################################################################


### PR DESCRIPTION
Some more information about memory areas usage
```
Linking REVO
Memory region         Used Size  Region Size  %age Used
           FLASH:      217880 B       896 KB     23.75%
    FLASH_CONFIG:          0 GB       128 KB      0.00%
             RAM:       38708 B       128 KB     29.53%
             CCM:        7720 B        64 KB     11.78%
     BACKUP_SRAM:          0 GB         4 KB      0.00%
       MEMORY_B1:          0 GB         0 GB     -1.#J%
arm-none-eabi-size ./obj/main/inav_REVO.elf
   text    data     bss     dec     hex filename
 212320    5560   40868  258748   3f2bc ./obj/main/inav_REVO.elf
arm-none-eabi-objcopy -O ihex --set-start 0x8000000 obj/main/inav_REVO.elf obj/inav_2.0.0_REVO.hex
```