### PR TITLE
Allow disarming while FS is awaiting for stick input

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -186,7 +186,7 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
             // Disarming via ARM BOX
             // Don't disarm via switch if failsafe is active or receiver doesn't receive data - we can't trust receiver
             // and can't afford to risk disarming in the air
-            if (ARMING_FLAG(ARMED) && !IS_RC_MODE_ACTIVE(BOXFAILSAFE) && rxIsReceivingSignal() && !failsafeIsActive()) {
+            if (ARMING_FLAG(ARMED) && rxIsReceivingSignal() && !failsafeIsPreventingDisarm()) {
                 const timeMs_t disarmDelay = currentTimeMs - rcDisarmTimeMs;
                 if (disarmDelay > armingConfig()->switchDisarmDelayMs) {
                     if (armingConfig()->disarm_kill_switch || (throttleStatus == THROTTLE_LOW)) {

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -156,6 +156,7 @@ void failsafeUpdateState(void);
 failsafePhase_e failsafePhase(void);
 bool failsafeIsMonitoring(void);
 bool failsafeIsActive(void);
+bool failsafeIsPreventingDisarm(void);
 bool failsafeIsReceivingRxData(void);
 void failsafeOnRxSuspend(void);
 void failsafeOnRxResume(void);


### PR DESCRIPTION
If the RC link has been properly established again and all it's
missing to exit FS is the user moving the sticks, we allow flipping
the ARM switch disarm even without stick input.