### PR TITLE
Fix tz_automatic_dst settings table

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1553,6 +1553,7 @@ groups:
         max: 1440
       - name: tz_automatic_dst
         type: uint8_t
+        table: tz_automatic_dst
 
   - name: PG_DISPLAY_CONFIG
     type: displayConfig_t


### PR DESCRIPTION
#3072 was incomplete, the settings table was not linked to the setting itself.

I got distracted while refactoring, I'm sorry. Thanks to @MRC3742 for the heads up.