### PR TITLE
make isAmperageConfigured respect FEATURE_CURRENT_METER and not just current_meter_type

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -275,7 +275,7 @@ uint32_t getBatteryRemainingCapacity(void)
 
 bool isAmperageConfigured(void)
 {
-    return batteryConfig()->current.type != CURRENT_SENSOR_NONE;
+    return feature(FEATURE_CURRENT_METER) && batteryConfig()->current.type != CURRENT_SENSOR_NONE;
 }
 
 int32_t getAmperage(void)


### PR DESCRIPTION
Simple change, but was making my mind explode.  Basically, if you'd turn off the current sensor in the configurator it would still send 0 Amps of current telemetry.  This happened because `isAmperageConfigured()` wasn't respecting the current sensor feature.  It was only looking at the `current_meter_type` CLI value if it wasn't set to NONE.

With this change _**BOTH**_ current sensor needs to be turned on in the configurator _**AND**_ the `current_meter_type` CLI value can't be set to NONE.  The only place `isAmperageConfigured()` is used is with FrSky telemetry, so this change won't effect other systems.