### PR TITLE
Move build-stamp and generated files to obj/main/$(TARGET)

### DIFF
--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -4,10 +4,11 @@
 #include "common/string_light.h"
 #include "common/utils.h"
 
-#include "fc/settings_generated.h"
+#include "settings_generated.h"
+
 #include "fc/settings.h"
 
-#include "fc/settings_generated.c"
+#include "settings_generated.c"
 
 void setting_get_name(const setting_t *val, char *buf)
 {

--- a/src/main/fc/settings.h
+++ b/src/main/fc/settings.h
@@ -6,7 +6,7 @@
 
 #include "config/parameter_group.h"
 
-#include "fc/settings_generated.h"
+#include "settings_generated.h"
 
 typedef struct lookupTableEntry_s {
     const char * const *values;

--- a/src/utils/build_stamp.rb
+++ b/src/utils/build_stamp.rb
@@ -65,7 +65,9 @@ class Stamper
         output = File.join(@stamp_dir, "stamp")
         stdout, stderr = @compiler.run(input, output, ["-dM", "-E"])
         File.delete(input)
-        File.delete(output)
+        if File.file?(output)
+            File.delete(output)
+        end
         return Digest::SHA1.hexdigest(stdout)
     end
 end

--- a/src/utils/compiler.rb
+++ b/src/utils/compiler.rb
@@ -80,7 +80,10 @@ class Compiler
         if args
             all_args.push(*args)
         end
-        all_args << "-o" << output << input
+        if output
+            all_args << "-o" << output
+        end
+        all_args << input
         stdout, stderr, compile_status = Open3.capture3(join_args(all_args))
 	raise "Compiler error:\n#{all_args.join(' ')}\n#{stderr}" if not options[:noerror] and not compile_status.success?
         return stdout, stderr

--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -260,10 +260,10 @@ end
 OFF_ON_TABLE = Hash["name" => "off_on", "values" => ["OFF", "ON"]]
 
 class Generator
-    def initialize(src_root, settings_file)
+    def initialize(src_root, settings_file, output_dir)
         @src_root = src_root
         @settings_file = settings_file
-        @output_dir = File.dirname(settings_file)
+        @output_dir = output_dir || File.dirname(settings_file)
 
         @compiler = Compiler.new
 
@@ -416,7 +416,7 @@ class Generator
         }
         add_header.call("platform.h")
         add_header.call("config/parameter_group_ids.h")
-        add_header.call("settings.h")
+        add_header.call("fc/settings.h")
 
         foreach_enabled_group do |group|
             (group["headers"] || []).each do |h|
@@ -623,10 +623,12 @@ class Generator
         # Use a temporary dir reachable by relative path
         # since g++ in cygwin fails to open files
         # with absolute paths
-        tmp = File.join("obj", "tmp")
+        tmp = File.join(@output_dir, "tmp")
         FileUtils.mkdir_p(tmp) unless File.directory?(tmp)
         value = yield(tmp)
-        FileUtils.remove_dir(tmp)
+        if File.directory?(tmp)
+            FileUtils.remove_dir(tmp)
+        end
         value
     end
 
@@ -882,17 +884,20 @@ if __FILE__ == $0
         exit(1)
     end
 
-    gen = Generator.new(src_root, settings_file)
 
     opts = GetoptLong.new(
+        [ "--output-dir", "-o", GetoptLong::REQUIRED_ARGUMENT ],
         [ "--help", "-h", GetoptLong::NO_ARGUMENT ],
         [ "--json", "-j", GetoptLong::REQUIRED_ARGUMENT ],
     )
 
     jsonFile = nil
+    output_dir = nil
 
     opts.each do |opt, arg|
         case opt
+        when "--output-dir"
+            output_dir = arg
         when "--help"
             usage()
             exit(0)
@@ -900,6 +905,8 @@ if __FILE__ == $0
             jsonFile = arg
         end
     end
+
+    gen = Generator.new(src_root, settings_file, output_dir)
 
     if jsonFile
         gen.write_json(jsonFile)


### PR DESCRIPTION
This allows target level parallel builds, since now there are no
shared files between targets.

Fixes #3261