### PR TITLE
FW: Allow manual throttle increase in auto controlled modes

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1384,6 +1384,9 @@ groups:
         field: fw.cruise_yaw_rate
         min: 0
         max: 60
+      - name: nav_fw_allow_manual_thr_increase
+        field: fw.allow_manual_thr_increase
+        type: bool
 
   - name: PG_TELEMETRY_CONFIG
     type: telemetryConfig_t

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -750,7 +750,7 @@ static void osdCrosshairsBounds(uint8_t *x, uint8_t *y, uint8_t *length)
  * uses the THR value applied by the system rather than the
  * input value received by the sticks.
  **/
-static void osdFormatThrottlePosition(char *buff, bool autoThr)
+static void osdFormatThrottlePosition(char *buff, bool autoThr, textAttributes_t *elemAttr)
 {
     buff[0] = SYM_THR;
     buff[1] = SYM_THR1;
@@ -759,6 +759,8 @@ static void osdFormatThrottlePosition(char *buff, bool autoThr)
         buff[0] = SYM_AUTO_THR0;
         buff[1] = SYM_AUTO_THR1;
         thr = rcCommand[THROTTLE];
+        if (isFixedWingAutoThrottleManuallyIncreased())
+            TEXT_ATTRIBUTES_ADD_BLINK(*elemAttr);
     }
     tfp_sprintf(buff + 2, "%3d", (constrain(thr, PWM_RANGE_MIN, PWM_RANGE_MAX) - PWM_RANGE_MIN) * 100 / (PWM_RANGE_MAX - PWM_RANGE_MIN));
 }
@@ -1344,7 +1346,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_THROTTLE_POS:
     {
-        osdFormatThrottlePosition(buff, false);
+        osdFormatThrottlePosition(buff, false, NULL);
         break;
     }
 
@@ -1736,7 +1738,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_THROTTLE_POS_AUTO_THR:
         {
-            osdFormatThrottlePosition(buff, true);
+            osdFormatThrottlePosition(buff, true, &elemAttr);
             break;
         }
 

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -147,6 +147,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .launch_climb_angle = 18,              // 18 degrees
         .launch_max_angle = 45,                // 45 deg
         .cruise_yaw_rate  = 20,                // 20dps
+        .allow_manual_thr_increase = false
     }
 );
 

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -31,6 +31,8 @@ extern gpsLocation_t        GPS_home;
 extern uint16_t             GPS_distanceToHome;        // distance to home point in meters
 extern int16_t              GPS_directionToHome;       // direction to home point in degrees
 
+extern bool autoThrottleManuallyIncreased;
+
 /* Navigation system updates */
 void onNewGPSData(void);
 
@@ -171,6 +173,7 @@ typedef struct navConfig_s {
         uint8_t  launch_climb_angle;         // Target climb angle for launch (deg)
         uint8_t  launch_max_angle;           // Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg]
         uint8_t  cruise_yaw_rate;            // Max yaw rate (dps) when CRUISE MODE is enabled
+        bool     allow_manual_thr_increase;
     } fw;
 } navConfig_t;
 
@@ -335,6 +338,7 @@ rthState_e getStateOfForcedRTH(void);
 
 /* Getter functions which return data about the state of the navigation system */
 bool navigationIsControllingThrottle(void);
+bool isFixedWingAutoThrottleManuallyIncreased(void);
 bool navigationIsFlyingAutonomousMode(void);
 /* Returns true iff navConfig()->general.flags.rth_allow_landing is NAV_RTH_ALLOW_LANDING_ALWAYS
  * or if it's NAV_RTH_ALLOW_LANDING_FAILSAFE and failsafe mode is active.


### PR DESCRIPTION
Should satisfy #3251 and #1985 at least partially until better air speed functionality.

The idea is to increase the throttle in auto modes by raising the throttle stick above `nav_fw_cruise_thr`. If no increase in throttle is wanted the throttle stick can be left at cruise power for easy transition out of the auto controlled throttle mode. If the throttle is above 95% the motor will be commanded to run at `max_throttle`. The OSD throttle indicator will blink in auto modes when the throttle is manually increased.