### PR TITLE
Automatically pitch down in angle mode when throttle is bellow cruise throttle

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -572,6 +572,10 @@ groups:
         field: appliedMixerPreset
         min: -1
         max: INT16_MAX
+      - name: fw_min_throttle_down_pitch
+        field: fwMinThrottleDownPitchAngle
+        min: 0
+        max: 450
 
   - name: PG_MOTOR_3D_CONFIG
     type: flight3DConfig_t

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -74,7 +74,8 @@ PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .yaw_jump_prevention_limit = 200,
     .platformType = PLATFORM_MULTIROTOR,
     .hasFlaps = false,
-    .appliedMixerPreset = -1 //This flag is not available in CLI and used by Configurator only
+    .appliedMixerPreset = -1, //This flag is not available in CLI and used by Configurator only
+    .fwMinThrottleDownPitchAngle = 0
 );
 
 #ifdef BRUSHED_MOTORS

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -59,6 +59,7 @@ typedef struct mixerConfig_s {
     uint8_t platformType;
     bool hasFlaps;
     int16_t appliedMixerPreset;
+    uint16_t fwMinThrottleDownPitchAngle;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);


### PR DESCRIPTION
Inspired by Arduplane [STAB_PITCH_DOWN](http://ardupilot.org/plane/docs/parameters.html#stab-pitch-down-low-throttle-pitch-down-trim) setting.

The `fw_min_throttle_down_pitch` (decidegrees) controls the amount of down pitch to add in `ANGLE` mode mode when at low throttle. No down trim is added when throttle is above `nav_fw_cruise_thr`. Below `nav_fw_cruise_thr` downtrim is added in proportion to the amount the throttle is below `nav_fw_cruise_thr`. At zero throttle the full down pitch specified in this parameter is added. This parameter is meant to help keep airspeed up when flying in `ANGLE` mode with low throttle, such as when on a landing approach, without relying on an airspeed sensor.

Tested, ready to merge.