### PR TITLE
Add MPU6000 support to FIREWORKSV2 target

### DIFF
--- a/src/main/target/FIREWORKSV2/target.h
+++ b/src/main/target/FIREWORKSV2/target.h
@@ -54,6 +54,14 @@
 #define GYRO_MPU6500_ALIGN      CW180_DEG
 #define ACC_MPU6500_ALIGN       CW180_DEG
 
+// OmnibusF4 Nano v6 has a MPU6000
+#define USE_GYRO_MPU6000
+#define USE_ACC_MPU6000
+#define MPU6000_CS_PIN          PD2
+#define MPU6000_SPI_BUS         BUS_SPI3
+#define GYRO_MPU6000_ALIGN      CW180_DEG
+#define ACC_MPU6000_ALIGN       CW180_DEG
+
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
 #define USE_MAG_HMC5883


### PR DESCRIPTION
Should make Omnibus F4 Nano V6 supported by FIREWORKSV2 target