### PR TITLE
NAV_LAUNCH extra safety

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2322,9 +2322,13 @@ static navigationFSMEvent_t selectNavEventFromBoxModeInput(void)
                 }
             }
             else {
-                // If we were in LAUNCH mode - force switch to IDLE
+                // If we were in LAUNCH mode - force switch to IDLE only if the throttle is low
                 if (FLIGHT_MODE(NAV_LAUNCH_MODE)) {
-                    return NAV_FSM_EVENT_SWITCH_TO_IDLE;
+                    throttleStatus_e throttleStatus = calculateThrottleStatus();
+                    if (throttleStatus != THROTTLE_LOW) 
+                        return NAV_FSM_EVENT_NONE;
+                    else 
+                        return NAV_FSM_EVENT_SWITCH_TO_IDLE;
                 }
             }
         }


### PR DESCRIPTION
Currently if an user enables the launch mode via a switch, rise the throttle before launch and inadvertently disable the launch mode switch the motor will immediately start spinning. This is not safe.

After this PR launch mode will remain active even if the user toggles the switch until throttle is not lowered.
