### PR TITLE
change year base for RTC time_t to correct leap processing

### DIFF
--- a/src/main/common/time.c
+++ b/src/main/common/time.c
@@ -32,7 +32,11 @@
 
 #include "drivers/time.h"
 
-#define UNIX_REFERENCE_YEAR 1970
+// For the "modulo 4" arithmetic to work, we need a leap base year
+#define REFERENCE_YEAR 2000
+// Offset (seconds) from the UNIX epoch (1970-01-01) to 2000-01-01
+#define EPOCH_2000_OFFSET 946684800
+
 #define MILLIS_PER_SECOND 1000
 
 // rtcTime_t when the system was started.
@@ -61,14 +65,14 @@ static rtcTime_t dateTimeToRtcTime(dateTime_t *dt)
     unsigned int hour = dt->hours;      // 0-23
     unsigned int day = dt->day - 1;     // 0-30
     unsigned int month = dt->month - 1; // 0-11
-    unsigned int year = dt->year - UNIX_REFERENCE_YEAR; // 0-99
-    int32_t unixTime = (((year / 4 * (365 * 4 + 1) + days[year % 4][month] + day) * 24 + hour) * 60 + minute) * 60 + second;
+    unsigned int year = dt->year - REFERENCE_YEAR; // 0-99
+    int32_t unixTime = (((year / 4 * (365 * 4 + 1) + days[year % 4][month] + day) * 24 + hour) * 60 + minute) * 60 + second + EPOCH_2000_OFFSET;
     return rtcTimeMake(unixTime, dt->millis);
 }
 
 static void rtcTimeToDateTime(dateTime_t *dt, rtcTime_t t)
 {
-    int32_t unixTime = t / MILLIS_PER_SECOND;
+    int32_t unixTime = t / MILLIS_PER_SECOND - EPOCH_2000_OFFSET;
     dt->seconds = unixTime % 60;
     unixTime /= 60;
     dt->minutes = unixTime % 60;
@@ -93,7 +97,7 @@ static void rtcTimeToDateTime(dateTime_t *dt, rtcTime_t t)
         }
     }
 
-    dt->year = years + year + UNIX_REFERENCE_YEAR;
+    dt->year = years + year + REFERENCE_YEAR;
     dt->month = month + 1;
     dt->day = unixTime - days[year][month] + 1;
     dt->millis = t % MILLIS_PER_SECOND;
@@ -112,7 +116,7 @@ static void rtcGetDefaultDateTime(dateTime_t *dateTime)
 
 static bool rtcIsDateTimeValid(dateTime_t *dateTime)
 {
-    return (dateTime->year >= UNIX_REFERENCE_YEAR) &&
+    return (dateTime->year >= REFERENCE_YEAR) &&
            (dateTime->month >= 1 && dateTime->month <= 12) &&
            (dateTime->day >= 1 && dateTime->day <= 31) &&
            (dateTime->hours <= 23) &&


### PR DESCRIPTION
Modify the base year for RTC time_t calculation in order for the"modulo 4" calculations to work correctly for leap years. The base is 2000 (a leap year) and an offset added / subtracted to get back to the UNIX epoch.

Fixes #3302 (for issue for detail)

mwp log (day is now correct):
```
2018-06-01T08:12:40+0100 RTC local 2018-06-01T08:12:40.769, fc 2018-06-01T08:12:45.520
```
BB log, file system time and log remain correct
```
H Log start datetime:2018-06-01T07:20:02.762+00:00
``` 
