### PR TITLE
Make FPort stop one sensor cycle every 3

### DIFF
--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -48,6 +48,7 @@
 #define FPORT_MIN_TELEMETRY_RESPONSE_DELAY_US 500
 #define FPORT_MAX_TELEMETRY_AGE_MS 500
 
+#define FPORT_TELEMETRY_MAX_CONSECUTIVE_SENSORS 2 // Needed to avoid lost sensors on FPort, see #3198
 
 #define FPORT_FRAME_MARKER 0x7E
 
@@ -340,7 +341,17 @@ static bool fportProcessFrame(const rxRuntimeConfig_t *rxRuntimeConfig)
     if (clearToSend) {
         DEBUG_SET(DEBUG_FPORT, DEBUG_FPORT_TELEMETRY_DELAY, currentTimeUs - lastTelemetryFrameReceivedUs);
 
-        processSmartPortTelemetry(mspPayload, &clearToSend, NULL);
+        uint8_t *consecutiveSensorCount = rxRuntimeConfig->frameData;
+        if (*consecutiveSensorCount >= FPORT_TELEMETRY_MAX_CONSECUTIVE_SENSORS && !smartPortPayloadContainsMSP(mspPayload)) {
+            // Stop one cycle to avoid saturating the buffer in the RX, since the
+            // downstream bandwidth doesn't allow sensor sensors on every cycle.
+            // We allow MSP frames to run over the resting period, expecting that
+            // the caller won't flood us with requests.
+            *consecutiveSensorCount = 0;
+        } else {
+            (*consecutiveSensorCount)++;
+            processSmartPortTelemetry(mspPayload, &clearToSend, NULL);
+        }
 
         if (clearToSend) {
             smartPortWriteFrameFport(&emptySmartPortFrame);
@@ -358,7 +369,9 @@ static bool fportProcessFrame(const rxRuntimeConfig_t *rxRuntimeConfig)
 bool fportRxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     static uint16_t sbusChannelData[SBUS_MAX_CHANNEL];
+    static uint8_t consecutiveSensorCount = 0;
     rxRuntimeConfig->channelData = sbusChannelData;
+    rxRuntimeConfig->frameData = &consecutiveSensorCount;
     sbusChannelsInit(rxRuntimeConfig);
 
     rxRuntimeConfig->channelCount = SBUS_MAX_CHANNEL;

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -233,7 +233,7 @@ void smartPortSendByte(uint8_t c, uint16_t *checksum, serialPort_t *port)
 
 bool smartPortPayloadContainsMSP(const smartPortPayload_t *payload)
 {
-    return payload->frameId == FSSP_MSPC_FRAME_SMARTPORT || payload->frameId == FSSP_MSPC_FRAME_FPORT;
+    return payload && (payload->frameId == FSSP_MSPC_FRAME_SMARTPORT || payload->frameId == FSSP_MSPC_FRAME_FPORT);
 }
 
 void smartPortWriteFrameSerial(const smartPortPayload_t *payload, serialPort_t *port, uint16_t checksum)

--- a/src/main/telemetry/smartport.h
+++ b/src/main/telemetry/smartport.h
@@ -55,3 +55,4 @@ smartPortPayload_t *smartPortDataReceive(uint16_t c, bool *clearToSend, smartPor
 struct serialPort_s;
 void smartPortWriteFrameSerial(const smartPortPayload_t *payload, struct serialPort_s *port, uint16_t checksum);
 void smartPortSendByte(uint8_t c, uint16_t *checksum, struct serialPort_s *port);
+bool smartPortPayloadContainsMSP(const smartPortPayload_t *payload);


### PR DESCRIPTION
Sending 3 cycles and then pausing once still produces some sensor
lost warnings after 10-15 mins, but reducing it to 2 sensors/1 pause
seems to get rid of the problem. Since this reduces the effective data
rate by 33%, changes have been removed from the SmartPort driver and
moved to affect just FPort. This way, S.Port doesn't have suffer any
update rate reductions.

Fixes #3198 (hopefully for real this time)