### PR TITLE
Disable RC adjustments while in FAILSAFE mode

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -488,7 +488,7 @@ void processRx(timeUs_t currentTimeUs)
 
     updateActivatedModes();
 
-    if (!cliMode) {
+    if ((!cliMode) && (!FLIGHT_MODE(FAILSAFE_MODE))) {
         updateAdjustmentStates();
         processRcAdjustments(CONST_CAST(controlRateConfig_t*, currentControlRateProfile));
     }


### PR DESCRIPTION
I think it can be dangerous not to disable RC adjustments when in failsafe. If the adjustment channel keep its value during failsafe the adjusted value before failsafe can keep being adjusted and result in unexpected behavior.