### PR TITLE
Remove /src/main/fc/settings_generated.{h, c} from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,4 @@ docs/Manual.pdf
 README.pdf
 
 # build generated files
-/src/main/fc/settings_generated.h
-/src/main/fc/settings_generated.c
 /settings.json


### PR DESCRIPTION
The generated files are now in obj/, so there's no need to ignore
the ones in the old location. Also, having the old generated files
in place can make the compiler use the old outdated files if someone
built the firmware before, so it's better to make them easily noticeable
via git status.