### PR TITLE
remove unneeded rxConfig from sbusChannelsInit and fix up callers

### DIFF
--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -359,7 +359,7 @@ bool fportRxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     static uint16_t sbusChannelData[SBUS_MAX_CHANNEL];
     rxRuntimeConfig->channelData = sbusChannelData;
-    sbusChannelsInit(rxConfig, rxRuntimeConfig);
+    sbusChannelsInit(rxRuntimeConfig);
 
     rxRuntimeConfig->channelCount = SBUS_MAX_CHANNEL;
     rxRuntimeConfig->rxRefreshRate = 11000;

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -193,7 +193,7 @@ bool sbusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 
     rxRuntimeConfig->channelData = sbusChannelData;
     rxRuntimeConfig->frameData = &sbusFrameData;
-    sbusChannelsInit(rxConfig, rxRuntimeConfig);
+    sbusChannelsInit(rxRuntimeConfig);
 
     rxRuntimeConfig->channelCount = SBUS_MAX_CHANNEL;
     rxRuntimeConfig->rxRefreshRate = 11000;

--- a/src/main/rx/sbus_channels.c
+++ b/src/main/rx/sbus_channels.c
@@ -84,7 +84,7 @@ static uint16_t sbusChannelsReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, 
     return (5 * rxRuntimeConfig->channelData[chan] / 8) + 880;
 }
 
-void sbusChannelsInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+void sbusChannelsInit(rxRuntimeConfig_t *rxRuntimeConfig)
 {
     rxRuntimeConfig->rcReadRawFn = sbusChannelsReadRawRC;
     for (int b = 0; b < SBUS_MAX_CHANNEL; b++) {

--- a/src/main/rx/sbus_channels.h
+++ b/src/main/rx/sbus_channels.h
@@ -49,4 +49,4 @@ typedef struct sbusChannels_s {
 
 uint8_t sbusChannelsDecode(rxRuntimeConfig_t *rxRuntimeConfig, const sbusChannels_t *channels);
 
-void sbusChannelsInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
+void sbusChannelsInit(rxRuntimeConfig_t *rxRuntimeConfig);


### PR DESCRIPTION
janitorial cleanup following #3314. Fixes 'unused parameter' compilation warnings.