### PR TITLE
Override the OSD layout for 10 seconds when configuring an item

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -308,7 +308,7 @@ static long osdElementsOnEnter(const OSD_Entry *from)
     // First entry is the label. Store the current layout
     // and override it on the OSD so previews so this layout.
     osdCurrentLayout = from - cmsx_menuOsdLayoutEntries - 1;
-    osdOverrideLayout(osdCurrentLayout);
+    osdOverrideLayout(osdCurrentLayout, 0);
     return 0;
 }
 
@@ -317,7 +317,7 @@ static long osdElementsOnExit(const OSD_Entry *from)
     UNUSED(from);
 
     // Stop overriding OSD layout
-    osdOverrideLayout(-1);
+    osdOverrideLayout(-1, 0);
     return 0;
 }
 

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2552,7 +2552,16 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             if (!sbufReadU16Safe(&osdConfigMutable()->item_pos[layout][item], src)) {
                 return MSP_RESULT_ERROR;
             }
-            osdStartFullRedraw();
+            // If the layout is not already overriden and it's different
+            // than the layout for the item that was just configured,
+            // override it for 10 seconds.
+            bool overridden;
+            int activeLayout = osdGetActiveLayout(&overridden);
+            if (activeLayout != layout && !overridden) {
+                osdOverrideLayout(layout, 10000);
+            } else {
+                osdStartFullRedraw();
+            }
         }
 
         break;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -135,6 +135,7 @@
 static unsigned currentLayout = 0;
 static int layoutOverride = -1;
 static bool hasExtendedFont = false; // Wether the font supports characters > 256
+static timeMs_t layoutOverrideUntil = 0;
 
 typedef struct statistic_s {
     uint16_t max_speed;
@@ -2902,6 +2903,12 @@ void osdUpdate(timeUs_t currentTimeUs)
     unsigned activeLayout;
     if (layoutOverride >= 0) {
         activeLayout = layoutOverride;
+        // Check for timed override, it will go into effect on
+        // the next OSD iteration
+        if (layoutOverrideUntil > 0 && millis() > layoutOverrideUntil) {
+            layoutOverrideUntil = 0;
+            layoutOverride = -1;
+        }
     } else if (osdConfig()->osd_failsafe_switch_layout && FLIGHT_MODE(FAILSAFE_MODE)) {
         activeLayout = 0;
     } else {
@@ -2957,9 +2964,22 @@ void osdStartFullRedraw(void)
     fullRedraw = true;
 }
 
-void osdOverrideLayout(int layout)
+void osdOverrideLayout(int layout, timeMs_t duration)
 {
     layoutOverride = constrain(layout, -1, ARRAYLEN(osdConfig()->item_pos) - 1);
+    if (layoutOverride >= 0 && duration > 0) {
+        layoutOverrideUntil = millis() + duration;
+    } else {
+        layoutOverrideUntil = 0;
+    }
+}
+
+int osdGetActiveLayout(bool *overridden)
+{
+    if (overridden) {
+        *overridden = layoutOverride >= 0;
+    }
+    return currentLayout;
 }
 
 bool osdItemIsFixed(osd_items_e item)

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -189,6 +189,12 @@ void osdInit(struct displayPort_s *osdDisplayPort);
 void osdUpdate(timeUs_t currentTimeUs);
 void osdStartFullRedraw(void);
 // Sets a fixed OSD layout ignoring the RC input. Set it
-// to -1 to disable the override.
-void osdOverrideLayout(int layout);
+// to -1 to disable the override. If layout is >= 0 and
+// duration is > 0, the override is automatically cleared by
+// the OSD after the given duration. Otherwise, the caller must
+// explicitely remove it.
+void osdOverrideLayout(int layout, timeMs_t duration);
+// Returns the current current layout as well as wether its
+// set by the user configuration (modes, etc..) or by overriding it.
+int osdGetActiveLayout(bool *overridden);
 bool osdItemIsFixed(osd_items_e item);


### PR DESCRIPTION
When configuring the OSD via MSP (e.g. from the configurator), the
layout that was just altered is shown in the OSD for 10 seconds,
regardless of the selected OSD layout via modes.

This allows configuring the layouts when looking at them in the
goggles while the radio is powered off.