### PR TITLE
Reset disarm reason at moment of arming

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -373,6 +373,8 @@ void tryArm(void)
             return;
         }
 
+        lastDisarmReason = DISARM_NONE;
+
         ENABLE_ARMING_FLAG(ARMED);
         ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
         headFreeModeHold = DECIDEGREES_TO_DEGREES(attitude.values.yaw);


### PR DESCRIPTION
Currently we only update disarm reason if `disarm()` is called correctly, however disarm may happen as an accidental reset of `ARMED` flag but then disarm reason won't be helpful in debugging this.