### PR TITLE
add eagle tree pitot exp asi

### DIFF
--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -116,6 +116,7 @@ typedef enum {
     DEVHW_PCA9685,      // PWM output device
     DEVHW_M25P16,       // SPI NOR flash
     DEVHW_UG2864,       // I2C OLED display
+    DEVHW_PITOT_EAGLE_TREE,   // Pitot meter
 } devHardwareType_e;
 
 typedef enum {

--- a/src/main/drivers/pitotmeter_eagle_tree.c
+++ b/src/main/drivers/pitotmeter_eagle_tree.c
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "drivers/bus_i2c.h"
+#include "pitotmeter.h"
+#include "drivers/time.h"
+
+#include "common/utils.h"
+#include "common/maths.h"
+
+// eagle_tree, Standard address 0x4D
+#define EAGLE_TREE_ADDR                 0x4D    //the define itself not currently used, but should be used in common_hardware.c and maybe target.c where 0x4D is used
+
+#define EAGLE_TREE_RAW_VALUE_MAX        4048.0f //Max value we can expect from sensor
+#define EAGLE_TREE_RAW_VALUE_MIN        896.0f  //Min value we can expect from the sensor, anything less than this is negative pressure and useless for our needs
+#define EAGLE_TREE_PA_VALUE_MAX         3920.0f //Max value the sensor can read in Pascals
+#define EAGLE_TREE_PA_VALUE_MIN         0.0f    //Min value the sensor can read in Pascals, anything less than this is negative pressure and useless for our needs
+
+#define STANDARD_DAY_TEMP_KELVIN        288.15f //SEE: https://en.wikipedia.org/wiki/Standard_day
+
+static uint16_t eagleTreeUp;  // static result of pressure measurement
+static uint8_t rxbuf[4];
+
+static inline float pitotEagleTreeRawToPa(uint16_t rawValue) {
+  return (((constrainf((float)rawValue,EAGLE_TREE_RAW_VALUE_MIN,EAGLE_TREE_RAW_VALUE_MAX) - EAGLE_TREE_RAW_VALUE_MIN) * (EAGLE_TREE_PA_VALUE_MAX - EAGLE_TREE_PA_VALUE_MIN)) / (EAGLE_TREE_RAW_VALUE_MAX - EAGLE_TREE_RAW_VALUE_MIN) ) + EAGLE_TREE_PA_VALUE_MIN;
+}
+
+static void eagleTreeStart(pitotDev_t *pitot) {
+    busReadBuf(pitot->busDev, 0x00, rxbuf, 2);
+}
+
+static void eagleTreeRead(pitotDev_t *pitot) {
+    if (busReadBuf(pitot->busDev, 0x00, rxbuf, 2)) {
+        eagleTreeUp = (rxbuf[0] << 8) | (rxbuf[1] << 0);
+    }
+}
+
+static void eagleTreeCalculate(pitotDev_t *pitot, float *pressure, float *temperature) {
+    UNUSED(pitot);
+    if (pressure)
+        *pressure = (float)eagleTreeUp;          // Pa
+    if (temperature)
+        *temperature = STANDARD_DAY_TEMP_KELVIN; // Temperature at standard sea level (288.15 K) SEE: https://en.wikipedia.org/wiki/Standard_day
+}
+
+bool pitotEagleTreeDetect(pitotDev_t *pitot) {
+    pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_PITOT_EAGLE_TREE, 0, OWNER_AIRSPEED);
+
+    if (pitot->busDev == NULL) {
+        return false;
+    }
+
+    bool ack = false;
+
+    // Read twice to fix:
+    // Sending a start-stop condition without any transitions on the SCL line (no clock pulses in between) creates a
+    // communication error for the next communication, even if the next start condition is correct and the clock pulse is applied.
+    // An additional start condition must be sent, which results in restoration of proper communication.
+    ack = busReadBuf(pitot->busDev, 0x00, rxbuf, 2);
+    ack = busReadBuf(pitot->busDev, 0x00, rxbuf, 2);
+    if (!ack) {
+        return false;
+    }
+
+    pitot->delay = 10000;
+    pitot->start = eagleTreeStart;
+    pitot->get = eagleTreeRead;
+    pitot->calculate = eagleTreeCalculate;
+    eagleTreeRead(pitot);
+    return true;
+}

--- a/src/main/drivers/pitotmeter_eagle_tree.h
+++ b/src/main/drivers/pitotmeter_eagle_tree.h
@@ -1,0 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+bool pitotEagleTreeDetect(pitotDev_t *pitot);

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -19,7 +19,7 @@ tables:
     values: ["NONE", "AUTO", "BMP085", "MS5611", "BMP280", "MS5607", "LPS25H", "FAKE"]
     enum: baroSensor_e
   - name: pitot_hardware
-    values: ["NONE", "AUTO", "MS4525", "ADC", "VIRTUAL", "FAKE"]
+    values: ["NONE", "AUTO", "MS4525", "ADC", "VIRTUAL", "PITOT_EAGLE_TREE", "FAKE"]
     enum: pitotSensor_e
   - name: receiver_type
     values: ["NONE", "PWM", "PPM", "SERIAL", "MSP", "SPI", "UIB"]

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -33,6 +33,7 @@
 #include "drivers/logging.h"
 #include "drivers/pitotmeter.h"
 #include "drivers/pitotmeter_ms4525.h"
+#include "drivers/pitotmeter_eagle_tree.h"
 #include "drivers/pitotmeter_adc.h"
 #include "drivers/time.h"
 
@@ -108,6 +109,19 @@ bool pitotDetect(pitotDev_t *dev, uint8_t pitotHardwareToUse)
                 break;
             }
             */
+#endif
+            /* If we are asked for a specific sensor - break out, otherwise - fall through and continue */
+            if (pitotHardwareToUse != PITOT_AUTODETECT) {
+                break;
+            }
+            FALLTHROUGH;
+
+        case PITOT_EAGLE_TREE:
+#ifdef USE_PITOT_EAGLE_TREE
+            if (pitotEagleTreeDetect(dev)) {
+                pitotHardware = PITOT_EAGLE_TREE;
+                break;
+            }
 #endif
             /* If we are asked for a specific sensor - break out, otherwise - fall through and continue */
             if (pitotHardwareToUse != PITOT_AUTODETECT) {

--- a/src/main/sensors/pitotmeter.h
+++ b/src/main/sensors/pitotmeter.h
@@ -27,7 +27,8 @@ typedef enum {
     PITOT_MS4525 = 2,
     PITOT_ADC = 3,
     PITOT_VIRTUAL = 4,
-    PITOT_FAKE = 5,
+    PITOT_EAGLE_TREE = 5,
+    PITOT_FAKE = 6,
 } pitotSensor_e;
 
 #define PITOT_MAX  PITOT_FAKE

--- a/src/main/target/REVO/target.c
+++ b/src/main/target/REVO/target.c
@@ -24,17 +24,19 @@
 #include "drivers/timer.h"
 
 /* GYRO */
-BUSDEV_REGISTER_SPI_TAG(busdev_mpu6000,     DEVHW_MPU6000,      MPU6000_SPI_BUS,    MPU6000_CS_PIN,     MPU6000_EXTI_PIN,       0,  DEVFLAGS_NONE);
+BUSDEV_REGISTER_SPI_TAG(busdev_mpu6000,     DEVHW_MPU6000,          MPU6000_SPI_BUS,    MPU6000_CS_PIN,     MPU6000_EXTI_PIN,       0,  DEVFLAGS_NONE);
 
-BUSDEV_REGISTER_I2C(    busdev_ms5611,      DEVHW_MS5611,       BARO_I2C_BUS,       0x77,               NONE,                       DEVFLAGS_USE_RAW_REGISTERS);
+BUSDEV_REGISTER_I2C(    busdev_ms5611,      DEVHW_MS5611,           BARO_I2C_BUS,       0x77,               NONE,                       DEVFLAGS_USE_RAW_REGISTERS);
 
-BUSDEV_REGISTER_I2C_TAG(busdev_hmc5883_int, DEVHW_HMC5883,      MAG_I2C_BUS_INT,    0x1E,               NONE,                   0,  DEVFLAGS_NONE);
+BUSDEV_REGISTER_I2C(    busdev_eagle_tree,  DEVHW_PITOT_EAGLE_TREE, EAGLE_TREE_I2C_BUS, 0x4D,               NONE,                       DEVFLAGS_USE_RAW_REGISTERS);
 
-BUSDEV_REGISTER_I2C_TAG(busdev_hmc5883,     DEVHW_HMC5883,      MAG_I2C_BUS_EXT,    0x1E,               NONE,                   1,  DEVFLAGS_NONE);
-BUSDEV_REGISTER_I2C_TAG(busdev_qmc5883,     DEVHW_QMC5883,      MAG_I2C_BUS_EXT,    0x0D,               NONE,                   1,  DEVFLAGS_NONE);
-BUSDEV_REGISTER_I2C_TAG(busdev_mag3110,     DEVHW_MAG3110,      MAG_I2C_BUS_EXT,    0x0E,               NONE,                   1,  DEVFLAGS_NONE);
+BUSDEV_REGISTER_I2C_TAG(busdev_hmc5883_int, DEVHW_HMC5883,          MAG_I2C_BUS_INT,    0x1E,               NONE,                   0,  DEVFLAGS_NONE);
 
-BUSDEV_REGISTER_SPI    (busdev_m25p16,      DEVHW_M25P16,       M25P16_SPI_BUS,     M25P16_CS_PIN,      NONE,                       DEVFLAGS_NONE);
+BUSDEV_REGISTER_I2C_TAG(busdev_hmc5883,     DEVHW_HMC5883,          MAG_I2C_BUS_EXT,    0x1E,               NONE,                   1,  DEVFLAGS_NONE);
+BUSDEV_REGISTER_I2C_TAG(busdev_qmc5883,     DEVHW_QMC5883,          MAG_I2C_BUS_EXT,    0x0D,               NONE,                   1,  DEVFLAGS_NONE);
+BUSDEV_REGISTER_I2C_TAG(busdev_mag3110,     DEVHW_MAG3110,          MAG_I2C_BUS_EXT,    0x0E,               NONE,                   1,  DEVFLAGS_NONE);
+
+BUSDEV_REGISTER_SPI    (busdev_m25p16,      DEVHW_M25P16,           M25P16_SPI_BUS,     M25P16_CS_PIN,      NONE,                       DEVFLAGS_NONE);
 
 /* TIMERS */
 const timerHardware_t timerHardware[] = {

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -66,8 +66,11 @@
 #define BARO_I2C_BUS            BUS_I2C1
 #define USE_BARO_MS5611
 
-//#define USE_PITOT_MS4525
-//#define PITOT_I2C_BUS           BUS_I2C2
+#define USE_PITOT_MS4525
+#define USE_PITOT_EAGLE_TREE
+#define PITOT_I2C_BUS           BUS_I2C2
+#define MS4525_I2C_BUS          PITOT_I2C_BUS
+#define EAGLE_TREE_I2C_BUS      PITOT_I2C_BUS
 
 #define USE_OPTICAL_FLOW
 #define USE_OPFLOW_CXOF

--- a/src/main/target/REVO/target.mk
+++ b/src/main/target/REVO/target.mk
@@ -11,6 +11,8 @@ TARGET_SRC = \
             drivers/compass/compass_ist8310.c \
             drivers/compass/compass_ist8308.c \
             drivers/compass/compass_mag3110.c \
+            drivers/pitotmeter_eagle_tree.c \
+            drivers/pitotmeter_ms4525.c \
             drivers/pitotmeter_adc.c \
             drivers/light_ws2811strip.c \
             drivers/light_ws2811strip_stdperiph.c

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -199,6 +199,12 @@
     BUSDEV_REGISTER_I2C(busdev_ms5425,      DEVHW_MS4525,       MS4525_I2C_BUS,     0x28,               NONE,           DEVFLAGS_NONE);
 #endif
 
+#if defined(USE_PITOT_EAGLE_TREE)
+    #if !defined(EAGLE_TREE_I2C_BUS)
+        #define EAGLE_TREE_I2C_BUS PITOT_I2C_BUS
+    #endif
+    BUSDEV_REGISTER_I2C(busdev_EAGLE_TREE,   DEVHW_PITOT_EAGLE_TREE,  EAGLE_TREE_I2C_BUS, 0x4D,         NONE,           DEVFLAGS_USE_RAW_REGISTERS);
+#endif
 
 /** OTHER HARDWARE **/
 


### PR DESCRIPTION
This PR is to add Eagle Tree PITOT-EXP support which is an I2C airspeed sensor. Tested on Revo.