### PR TITLE
Fixes to RX/RC mode handling code

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -63,7 +63,7 @@
 
 #define AIRMODE_DEADBAND 25
 #define MIN_RC_TICK_INTERVAL_MS             20
-#define DEFAULT_RC_SWITCH_DISARM_DELAY_MS   150     // Wait at least 150ms before disarming via switch
+#define DEFAULT_RC_SWITCH_DISARM_DELAY_MS   250     // Wait at least 250ms before disarming via switch
 
 stickPositions_e rcStickPositions;
 

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -129,15 +129,24 @@ void updateActivatedModes(void)
             // For AND logic, the specified condition count and valid condition count must be the same.
             // For OR logic, the valid condition count must be greater than zero.
 
-            if (modeActivationOperatorConfig()->modeActivationOperator == MODE_OPERATOR_AND) {
-                // AND the conditions
-                if (activeConditionCountPerMode[modeIndex] == specifiedConditionCountPerMode[modeIndex]) {
-                    bitArraySet(newMask.bits, modeIndex);
+            // Prohibit BOX mode change alltogether if RX link is not stable enough
+            if (rxIsSignalStable() || modeIndex == BOXFAILSAFE) {
+                if (modeActivationOperatorConfig()->modeActivationOperator == MODE_OPERATOR_AND) {
+                    // AND the conditions
+                    if (activeConditionCountPerMode[modeIndex] == specifiedConditionCountPerMode[modeIndex]) {
+                        bitArraySet(newMask.bits, modeIndex);
+                    }
+                }
+                else {
+                    // OR the conditions
+                    if (activeConditionCountPerMode[modeIndex] > 0) {
+                        bitArraySet(newMask.bits, modeIndex);
+                    }
                 }
             }
             else {
-                // OR the conditions
-                if (activeConditionCountPerMode[modeIndex] > 0) {
+                // Retail current mode state
+                if (bitArrayGet(rcModeActivationMask.bits, modeIndex)) {
                     bitArraySet(newMask.bits, modeIndex);
                 }
             }

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -163,6 +163,7 @@ extern rxRuntimeConfig_t rxRuntimeConfig; //!!TODO remove this extern, only need
 void rxInit(void);
 void rxUpdateRSSISource(void);
 bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime);
+bool rxIsSignalStable(void);
 bool rxIsReceivingSignal(void);
 bool rxAreFlightChannelsValid(void);
 void calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs);


### PR DESCRIPTION
Prevent a scenario where unintended in-air disarm or mode switch may happen if failsafe settings on the receiver were incorrect