### PR TITLE
Update navigation_private.h

### DIFF
--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -21,6 +21,7 @@
 
 #if defined(USE_NAV)
 
+#include "common/axis.h"
 #include "common/filter.h"
 #include "fc/runtime_config.h"
 


### PR DESCRIPTION
Add #include "common/axis.h".

This file uses XYZ_AXIS_COUNT but does not include axis.h.  This causes a compile error if you include this file in another module so that you can use functions such as calculateDistanceToDestination() in another module.