### PR TITLE
Make the OSD home arrow closer to the actual home direction

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1128,10 +1128,14 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_HOME_DIR:
         {
-            int16_t h = osdGetHeadingAngle(GPS_directionToHome - DECIDEGREES_TO_DEGREES(osdGetHeading()));
-            h = h * 2 / 45;
-
-            buff[0] = SYM_ARROW_UP + h;
+            // There are 16 orientations for the home direction arrow.
+            // so we use 22.5deg per image, where the 1st image is used
+            // for [349, 11], the 2nd for [12, 33], etc...
+            int homeDirection = GPS_directionToHome - DECIDEGREES_TO_DEGREES(osdGetHeading());
+            // Add 11 to the angle, so first character maps to [349, 11]
+            int homeArrowDir = osdGetHeadingAngle(homeDirection + 11);
+            unsigned arrowOffset = homeArrowDir * 2 / 45;
+            buff[0] = SYM_ARROW_UP + arrowOffset;
             buff[1] = 0;
             break;
         }


### PR DESCRIPTION
We were using the first image (up) for [0deg, 22deg] which made
some directions like [350deg, 360deg) feel pretty unnatural because
the craft was almost pointing home but the arrow pointed a bit to
the left. Maximum error between actual direction and the arrow was
22deg.

With this change, the up image is used for [349deg, 11deg], 2nd
image covers [12deg, 33deg], etc... which makes the error between
the actual direction and the arrow smaller. This also cuts the
maximum error between the arrow and the actual direction to ~12deg.