### PR TITLE
Improve video system selection

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -262,7 +262,7 @@ void max7456ReInit(void)
 
 
 //here we init only CS and try to init MAX for first time
-void max7456Init(const vcdProfile_t *pVcdProfile)
+void max7456Init(const videoSystem_e videoSystem)
 {
     max7456dev = busDeviceInit(BUSTYPE_SPI, DEVHW_MAX7456, 0, OWNER_OSD);
 
@@ -275,7 +275,7 @@ void max7456Init(const vcdProfile_t *pVcdProfile)
     // force soft reset on Max7456
     busWrite(max7456dev, MAX7456ADD_VM0, MAX7456_RESET);
 
-    videoSignalCfg = pVcdProfile->video_system;
+    videoSignalCfg = videoSystem;
 
     // Set screenbuffer to all blanks
     for (uint_fast16_t ii = 0; ii < ARRAYLEN(screenBuffer); ii++) {

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include "drivers/vcd.h"
 
 #ifndef WHITEBRIGHTNESS
   #define WHITEBRIGHTNESS 0x01
@@ -43,7 +44,7 @@ enum VIDEO_TYPES { AUTO = 0, PAL, NTSC };
 extern uint16_t maxScreenSize;
 
 struct vcdProfile_s;
-void    max7456Init(const struct vcdProfile_s *vcdProfile);
+void    max7456Init(const videoSystem_e videoSystem);
 void    max7456DrawScreenPartial(void);
 void    max7456WriteNvm(uint8_t char_address, const uint8_t *font_data);
 uint8_t max7456GetRowsCount(void);

--- a/src/main/drivers/vcd.h
+++ b/src/main/drivers/vcd.h
@@ -19,12 +19,8 @@
 
 // Video Character Display parameters
 
-typedef struct vcdProfile_s {
-    uint8_t video_system;
-} vcdProfile_t;
-
-enum VIDEO_SYSTEMS {
+typedef enum {
     VIDEO_SYSTEM_AUTO = 0,
     VIDEO_SYSTEM_PAL,
     VIDEO_SYSTEM_NTSC
-};
+} videoSystem_e;

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -557,9 +557,7 @@ void init(void)
     if (feature(FEATURE_OSD)) {
 #if defined(USE_MAX7456)
         // If there is a max7456 chip for the OSD then use it
-        static vcdProfile_t vcdProfile;
-        vcdProfile.video_system = osdConfig()->video_system;
-        osdDisplayPort = max7456DisplayPortInit(&vcdProfile);
+        osdDisplayPort = max7456DisplayPortInit(osdConfig()->video_system);
 #elif defined(USE_OSD_OVER_MSP_DISPLAYPORT) // OSD over MSP; not supported (yet)
         osdDisplayPort = displayPortMspInit();
 #endif

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -59,6 +59,9 @@ tables:
   - name: osd_stats_energy_unit
     values: ["MAH", "WH"]
     enum: osd_stats_energy_unit_e
+  - name: osd_video_system
+    values: ["AUTO", "PAL", "NTSC"]
+    enum: videoSystem_e
   - name: frsky_unit
     values: ["METRIC", "IMPERIAL"]
     enum: frskyUnit_e
@@ -1482,13 +1485,13 @@ groups:
 
   - name: PG_OSD_CONFIG
     type: osdConfig_t
-    headers: ["io/osd.h"]
+    headers: ["io/osd.h", "drivers/vcd.h"]
     condition: USE_OSD
     members:
       - name: osd_video_system
+        table: osd_video_system
         field: video_system
-        min: 0
-        max: 2
+        type: uint8_t
       - name: osd_row_shiftdown
         field: row_shiftdown
         min: 0

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -158,10 +158,10 @@ static const displayPortVTable_t max7456VTable = {
     .supportedTextAttributes = supportedTextAttributes,
 };
 
-displayPort_t *max7456DisplayPortInit(const vcdProfile_t *vcdProfile)
+displayPort_t *max7456DisplayPortInit(const videoSystem_e videoSystem)
 {
     displayInit(&max7456DisplayPort, &max7456VTable);
-    max7456Init(vcdProfile);
+    max7456Init(videoSystem);
     resync(&max7456DisplayPort);
     return &max7456DisplayPort;
 }

--- a/src/main/io/displayport_max7456.h
+++ b/src/main/io/displayport_max7456.h
@@ -19,5 +19,6 @@
 
 #include "config/parameter_group.h"
 #include "drivers/display.h"
+#include "drivers/vcd.h"
 
-displayPort_t *max7456DisplayPortInit(const struct vcdProfile_s *vcdProfile);
+displayPort_t *max7456DisplayPortInit(const videoSystem_e videoSystem);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2102,7 +2102,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->dist_alarm = 1000;
     osdConfig->neg_alt_alarm = 5;
 
-    osdConfig->video_system = 0;
+    osdConfig->video_system = VIDEO_SYSTEM_AUTO;
 
     osdConfig->ahi_reverse_roll = 0;
     osdConfig->crosshairs_style = OSD_CROSSHAIRS_STYLE_DEFAULT;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -20,6 +20,8 @@
 #include "common/time.h"
 #include "config/parameter_group.h"
 
+#include "drivers/vcd.h"
+
 #ifndef OSD_ALTERNATE_LAYOUT_COUNT
 #define OSD_ALTERNATE_LAYOUT_COUNT 3
 #endif
@@ -124,7 +126,7 @@ typedef struct osdConfig_s {
     uint16_t dist_alarm; // home distance in m
     uint16_t neg_alt_alarm; // abs(negative altitude) in m
 
-    uint8_t video_system;
+    videoSystem_e video_system;
     uint8_t row_shiftdown;
 
     // Preferences


### PR DESCRIPTION
Possible values for the `video_system` setting are now `AUTO`, `PAL` or `NTSC` (instead of 0, 1 or 2)