### PR TITLE
Lighten OMNIBUS (F3) target

### DIFF
--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -51,11 +51,6 @@
 #define BMP280_SPI_BUS          BUS_SPI1
 #define BMP280_CS_PIN           PA13
 
-#define BARO_I2C_BUS             BUS_I2C1
-#define USE_BARO_BMP085 // External
-#define USE_BARO_BMP180 // External
-#define USE_BARO_MS5611 // External
-
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
 #define USE_MAG_HMC5883
@@ -63,13 +58,6 @@
 #define USE_MAG_IST8310
 #define USE_MAG_IST8308
 #define USE_MAG_MAG3110
-
-#define USE_RANGEFINDER
-#define USE_RANGEFINDER_HCSR04
-#define RANGEFINDER_HCSR04_ECHO_PIN          PB2  // Has 1K series resistor
-#define RANGEFINDER_HCSR04_TRIGGER_PIN       PB4  // FT
-#define USE_RANGEFINDER_HCSR04_I2C
-#define RANGEFINDER_I2C_BUS                  BUS_I2C1
 
 #define USB_CABLE_DETECTION
 #define USB_DETECT_PIN          PB5


### PR DESCRIPTION
The OMNIBUS target (F3) is close to flash saturation.

Remove things probably nobody uses: external I2C baro (already has a baro on board) and HCSR04 rangefinder

Before (b665c48) :
Memory region         Used Size  Region Size  %age Used
           FLASH:      255408 B       252 KB     98.98%
    FLASH_CONFIG:          0 GB         4 KB      0.00%
             RAM:       36744 B        40 KB     89.71%
             CCM:        7804 B         8 KB     95.26%
       MEMORY_B1:          0 GB         0 GB      -nan%

After:
Memory region         Used Size  Region Size  %age Used
           FLASH:      251352 B       252 KB     97.41%
    FLASH_CONFIG:          0 GB         4 KB      0.00%
             RAM:       36352 B        40 KB     88.75%
             CCM:        7800 B         8 KB     95.21%
       MEMORY_B1:          0 GB         0 GB      -nan%