### PR TITLE
Smart Audio related fixes

### DIFF
--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -626,7 +626,7 @@ static long sacms_SetupTopMenu(const OSD_Entry *from)
 {
     UNUSED(from);
 
-    if (saCmsDeviceStatus) {
+    if (saDevice.version) {
         if (saCmsFselMode == 0)
             cmsx_menuVtxSmartAudio.entries = saCmsMenuChanModeEntries;
         else

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -96,6 +96,3 @@ extern serialPort_t *debugSerialPort;
 #else
 #define dprintf(x)
 #endif // SMARTAUDIO_DPRINTF
-
-int saDacToPowerIndex(int dac);
-bool vtxSmartAudioInit(void);


### PR DESCRIPTION
- Remove duplicate function prototypes in vtx_smartaudio.h 
- Fix SA device menu not working the first time the SA menu was opened

Thanks to AKK (https://www.akktek.com) for providing a sample VTX to test these changes.