### PR TITLE
Rename left MPU_INT_EXTI to GYRO_INT_EXTI in MATEKF405SE and MATEKF411

### DIFF
--- a/src/main/target/MATEKF405SE/target.h
+++ b/src/main/target/MATEKF405SE/target.h
@@ -38,7 +38,7 @@
 #define MPU6000_SPI_BUS         BUS_SPI1
 
 #define USE_EXTI
-#define MPU_INT_EXTI            PC4
+#define GYRO_INT_EXTI            PC4
 #define USE_MPU_DATA_READY_SIGNAL
 
 #define USE_GYRO

--- a/src/main/target/MATEKF411/target.h
+++ b/src/main/target/MATEKF411/target.h
@@ -39,7 +39,7 @@
 #define MPU6000_SPI_BUS         BUS_SPI1
 
 #define USE_EXTI
-#define MPU_INT_EXTI            PA1
+#define GYRO_INT_EXTI            PA1
 #define USE_MPU_DATA_READY_SIGNAL
 
 #define USE_GYRO


### PR DESCRIPTION
Closes #3404 