### PR TITLE
Fix stack overwrite in osdDisplayPIDValues() which could cause a crash

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1040,9 +1040,10 @@ static void osdDisplayBatteryVoltage(uint8_t elemPosX, uint8_t elemPosY, uint16_
     displayWriteWithAttr(osdDisplayPort, elemPosX + 1, elemPosY, buff, elemAttr);
 }
 
-static void osdDisplayPIDValues(uint8_t elemPosX, uint8_t elemPosY, const char *str, const pid8_t *pid, adjustmentFunction_e adjFuncP, adjustmentFunction_e adjFuncI, adjustmentFunction_e adjFuncD) {
+static void osdDisplayPIDValues(uint8_t elemPosX, uint8_t elemPosY, const char *str, const pid8_t *pid, adjustmentFunction_e adjFuncP, adjustmentFunction_e adjFuncI, adjustmentFunction_e adjFuncD)
+{
     textAttributes_t elemAttr;
-    char buff[3];
+    char buff[4];
 
     displayWrite(osdDisplayPort, elemPosX, elemPosY, str);
 


### PR DESCRIPTION
buff was declared as char[3], but 3 digits plus null terminator are
written to it. The variable just before it, might be non-zero in some
cases, causing the string to be not null terminated anymore when it's
passed to displayWriteWithAttr().