### PR TITLE
Gyro SPI bus fix according to OmnibusF4-nano v8 schematics

### DIFF
--- a/src/main/target/FIREWORKSV2/target.h
+++ b/src/main/target/FIREWORKSV2/target.h
@@ -57,8 +57,8 @@
 // OmnibusF4 Nano v6 has a MPU6000
 #define USE_GYRO_MPU6000
 #define USE_ACC_MPU6000
-#define MPU6000_CS_PIN          PD2
-#define MPU6000_SPI_BUS         BUS_SPI3
+#define MPU6000_CS_PIN          PA4
+#define MPU6000_SPI_BUS         BUS_SPI1
 #define GYRO_MPU6000_ALIGN      CW180_DEG
 #define ACC_MPU6000_ALIGN       CW180_DEG
 


### PR DESCRIPTION
Fix according to schematics OmnibusF4-Nano-V8 provided by Airbot.

Firmware file for testing:  [inav_2.0.0_FIREWORKSV2.hex.zip](https://github.com/iNavFlight/inav/files/2130573/inav_2.0.0_FIREWORKSV2.hex.zip)
