### PR TITLE
Add support for string settings, make "name" a setting rather an a CLI command

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -146,6 +146,7 @@ Re-apply any new defaults as desired.
 |  inav_w_acc_bias  | 0.010 | Weight for accelerometer drift estimation |
 |  inav_max_eph_epv  | 1000.000 | Maximum uncertainty value until estimated position is considered valid and is used for navigation [cm] |
 |  inav_baro_epv  | 100.000 | Uncertainty value for barometric sensor [cm] |
+|  name  | Empty string | Craft name |
 |  nav_disarm_on_landing  | OFF | If set to ON, iNav disarms the FC after landing |
 |  nav_use_midthr_for_althold  | OFF | If set to OFF, the FC remembers your throttle stick position when enabling ALTHOLD and treats it as a neutral midpoint for holding altitude |
 |  nav_extra_arming_safety  | ON | If set to ON drone won't arm if no GPS fix and any navigation mode like RTH or POSHOLD is configured |

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -430,7 +430,7 @@ static int cmsDrawMenuEntry(displayPort_t *pDisplay, const OSD_Entry *p, uint8_t
             const OSD_SETTING_t *ptr = p->data;
             const setting_t *var = &settingsTable[ptr->val];
             int32_t value;
-            const void *valuePointer = setting_get_value_pointer(var);
+            const void *valuePointer = settingGetValuePointer(var);
             switch (SETTING_TYPE(var)) {
                 case VAR_UINT8:
                     value = *(uint8_t *)valuePointer;
@@ -1006,13 +1006,13 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
             if (p->data) {
                 const OSD_SETTING_t *ptr = p->data;
                 const setting_t *var = &settingsTable[ptr->val];
-                setting_min_t min = setting_get_min(var);
-                setting_max_t max = setting_get_max(var);
+                setting_min_t min = settingGetMin(var);
+                setting_max_t max = settingGetMax(var);
                 float step = ptr->step ?: 1;
                 if (key != KEY_RIGHT) {
                     step = -step;
                 }
-                const void *valuePointer = setting_get_value_pointer(var);
+                const void *valuePointer = settingGetValuePointer(var);
                 switch (SETTING_TYPE(var)) {
                     case VAR_UINT8:
                         {

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -453,6 +453,9 @@ static int cmsDrawMenuEntry(displayPort_t *pDisplay, const OSD_Entry *p, uint8_t
                     // a data type yet.
                     ftoa(*(float *)valuePointer, buff);
                     break;
+                case VAR_STRING:
+                    strncpy(buff, valuePointer, sizeof(buff));
+                    break;
             }
             if (buff[0] == '\0') {
                 const char *suffix = NULL;
@@ -1056,6 +1059,8 @@ STATIC_UNIT_TESTED uint16_t cmsHandleKey(displayPort_t *pDisplay, uint8_t key)
                             *(float *)valuePointer = val;
                             break;
                         }
+                        break;
+                    case VAR_STRING:
                         break;
                 }
                 SET_PRINTVALUE(p, currentCtx.cursorRow);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2578,7 +2578,7 @@ static const setting_t *mspReadSettingName(sbuf_t *src)
             return NULL;
         }
     }
-    return setting_find(name);
+    return settingFind(name);
 }
 
 static bool mspSettingCommand(sbuf_t *dst, sbuf_t *src)
@@ -2588,8 +2588,8 @@ static bool mspSettingCommand(sbuf_t *dst, sbuf_t *src)
         return false;
     }
 
-    const void *ptr = setting_get_value_pointer(setting);
-    size_t size = setting_get_value_size(setting);
+    const void *ptr = settingGetValuePointer(setting);
+    size_t size = settingGetValueSize(setting);
     sbufWriteDataSafe(dst, ptr, size);
     return true;
 }
@@ -2603,10 +2603,10 @@ static bool mspSetSettingCommand(sbuf_t *dst, sbuf_t *src)
         return false;
     }
 
-    setting_min_t min = setting_get_min(setting);
-    setting_max_t max = setting_get_max(setting);
+    setting_min_t min = settingGetMin(setting);
+    setting_max_t max = settingGetMax(setting);
 
-    void *ptr = setting_get_value_pointer(setting);
+    void *ptr = settingGetValuePointer(setting);
     switch (SETTING_TYPE(setting)) {
         case VAR_UINT8:
             {

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2680,6 +2680,11 @@ static bool mspSetSettingCommand(sbuf_t *dst, sbuf_t *src)
                 *((float*)ptr) = val;
             }
             break;
+        case VAR_STRING:
+            {
+                settingSetString(setting, (const char*)sbufPtr(src), sbufBytesRemaining(src));
+            }
+            break;
     }
 
     return true;

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -92,6 +92,8 @@ size_t settingGetValueSize(const setting_t *val)
 			FALLTHROUGH;
 		case VAR_FLOAT:
 			return 4;
+		case VAR_STRING:
+			return settingGetMax(val);
 	}
 	return 0; // Unreachable
 }
@@ -150,4 +152,31 @@ setting_max_t settingGetMax(const setting_t *val)
 		return settingLookupTables[val->config.lookup.tableIndex].valueCount - 1;
 	}
 	return settingMinMaxTable[SETTING_INDEXES_GET_MAX(val)];
+}
+
+const char * settingGetString(const setting_t *val)
+{
+	if (SETTING_TYPE(val) == VAR_STRING) {
+		return settingGetValuePointer(val);
+	}
+	return NULL;
+}
+
+void settingSetString(const setting_t *val, const char *s, size_t size)
+{
+	if (SETTING_TYPE(val) == VAR_STRING) {
+		char *p = settingGetValuePointer(val);
+		size_t copySize = MIN(size, settingGetMax(val));
+		memcpy(p, s, copySize);
+		p[copySize] = '\0';
+	}
+}
+
+setting_max_t settingGetStringMaxLength(const setting_t *val)
+{
+	if (SETTING_TYPE(val) == VAR_STRING) {
+		// Max string length is stored as its max
+		return settingGetMax(val);
+	}
+	return 0;
 }

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -10,7 +10,7 @@
 
 #include "settings_generated.c"
 
-void setting_get_name(const setting_t *val, char *buf)
+void settingGetName(const setting_t *val, char *buf)
 {
 	uint8_t bpos = 0;
 	uint16_t n = 0;
@@ -52,24 +52,24 @@ void setting_get_name(const setting_t *val, char *buf)
 	buf[bpos] = '\0';
 }
 
-bool setting_name_contains(const setting_t *val, char *buf, const char *cmdline)
+bool settingNameContains(const setting_t *val, char *buf, const char *cmdline)
 {
-	setting_get_name(val, buf);
+	settingGetName(val, buf);
 	return strstr(buf, cmdline) != NULL;
 }
 
-bool setting_name_exact_match(const setting_t *val, char *buf, const char *cmdline, uint8_t var_name_length)
+bool settingNameIsExactMatch(const setting_t *val, char *buf, const char *cmdline, uint8_t var_name_length)
 {
-	setting_get_name(val, buf);
+	settingGetName(val, buf);
 	return sl_strncasecmp(cmdline, buf, strlen(buf)) == 0 && var_name_length == strlen(buf);
 }
 
-const setting_t *setting_find(const char *name)
+const setting_t *settingFind(const char *name)
 {
 	char buf[SETTING_MAX_NAME_LENGTH];
 	for (int ii = 0; ii < SETTINGS_TABLE_COUNT; ii++) {
 		const setting_t *setting = &settingsTable[ii];
-		setting_get_name(setting, buf);
+		settingGetName(setting, buf);
 		if (strcmp(buf, name) == 0) {
 			return setting;
 		}
@@ -77,7 +77,7 @@ const setting_t *setting_find(const char *name)
 	return NULL;
 }
 
-size_t setting_get_value_size(const setting_t *val)
+size_t settingGetValueSize(const setting_t *val)
 {
 	switch (SETTING_TYPE(val)) {
 		case VAR_UINT8:
@@ -96,7 +96,7 @@ size_t setting_get_value_size(const setting_t *val)
 	return 0; // Unreachable
 }
 
-pgn_t setting_get_pgn(const setting_t *val)
+pgn_t settingGetPgn(const setting_t *val)
 {
 	uint16_t pos = val - (const setting_t *)settingsTable;
 	uint16_t acc = 0;
@@ -124,19 +124,19 @@ static uint16_t getValueOffset(const setting_t *value)
     return 0;
 }
 
-void *setting_get_value_pointer(const setting_t *val)
+void *settingGetValuePointer(const setting_t *val)
 {
-    const pgRegistry_t *pg = pgFind(setting_get_pgn(val));
+    const pgRegistry_t *pg = pgFind(settingGetPgn(val));
     return pg->address + getValueOffset(val);
 }
 
-const void * setting_get_copy_value_pointer(const setting_t *val)
+const void * settingGetCopyValuePointer(const setting_t *val)
 {
-    const pgRegistry_t *pg = pgFind(setting_get_pgn(val));
+    const pgRegistry_t *pg = pgFind(settingGetPgn(val));
     return pg->copy + getValueOffset(val);
 }
 
-setting_min_t setting_get_min(const setting_t *val)
+setting_min_t settingGetMin(const setting_t *val)
 {
 	if (SETTING_MODE(val) == MODE_LOOKUP) {
 		return 0;
@@ -144,7 +144,7 @@ setting_min_t setting_get_min(const setting_t *val)
 	return settingMinMaxTable[SETTING_INDEXES_GET_MIN(val)];
 }
 
-setting_max_t setting_get_max(const setting_t *val)
+setting_max_t settingGetMax(const setting_t *val)
 {
 	if (SETTING_MODE(val) == MODE_LOOKUP) {
 		return settingLookupTables[val->config.lookup.tableIndex].valueCount - 1;

--- a/src/main/fc/settings.h
+++ b/src/main/fc/settings.h
@@ -27,6 +27,7 @@ typedef enum {
     VAR_INT16 = (3 << SETTING_TYPE_OFFSET),
     VAR_UINT32 = (4 << SETTING_TYPE_OFFSET),
     VAR_FLOAT = (5 << SETTING_TYPE_OFFSET), // 0x05
+    VAR_STRING = (6 << SETTING_TYPE_OFFSET) // 0x06
 } setting_type_e;
 
 typedef enum {
@@ -99,3 +100,13 @@ setting_min_t settingGetMin(const setting_t *val);
 // depends on the target and build options, but will always be an unsigned
 // integer (e.g. uintxx_t,)
 setting_max_t settingGetMax(const setting_t *val);
+// Returns the setting value as a const char * iff the setting is of type
+// VAR_STRING. Otherwise it returns NULL.
+const char * settingGetString(const setting_t *val);
+// Sets the value for the given string setting. Size indicates the number of
+// bytes in the string without the '\0' terminator (i.e. its strlen()).
+// If the setting is not of type VAR_STRING, this function does nothing.
+void settingSetString(const setting_t *val, const char *s, size_t size);
+// Returns the max string length (without counting the '\0' terminator)
+// for setting of type VAR_STRING. Otherwise it returns 0.
+setting_max_t settingGetStringMaxLength(const setting_t *val);

--- a/src/main/fc/settings.h
+++ b/src/main/fc/settings.h
@@ -74,28 +74,28 @@ static inline setting_type_e SETTING_TYPE(const setting_t *s) { return s->type &
 static inline setting_section_e SETTING_SECTION(const setting_t *s) { return s->type & SETTING_SECTION_MASK; }
 static inline setting_mode_e SETTING_MODE(const setting_t *s) { return s->type & SETTING_MODE_MASK; }
 
-void setting_get_name(const setting_t *val, char *buf);
-bool setting_name_contains(const setting_t *val, char *buf, const char *cmdline);
-bool setting_name_exact_match(const setting_t *val, char *buf, const char *cmdline, uint8_t var_name_length);
+void settingGetName(const setting_t *val, char *buf);
+bool settingNameContains(const setting_t *val, char *buf, const char *cmdline);
+bool settingNameIsExactMatch(const setting_t *val, char *buf, const char *cmdline, uint8_t var_name_length);
 // Returns a setting_t with the exact name (case sensitive), or
 // NULL if no setting with that name exists.
-const setting_t *setting_find(const char *name);
+const setting_t *settingFind(const char *name);
 // Returns the size in bytes of the setting value.
-size_t setting_get_value_size(const setting_t *val);
-pgn_t setting_get_pgn(const setting_t *val);
+size_t settingGetValueSize(const setting_t *val);
+pgn_t settingGetPgn(const setting_t *val);
 // Returns a pointer to the actual value stored by
 // the setting_t. The returned value might be modified.
-void * setting_get_value_pointer(const setting_t *val);
+void * settingGetValuePointer(const setting_t *val);
 // Returns a pointer to the backed up copy of the value. Note that
 // this will contain random garbage unless a copy of the parameter
 // group for the value has been manually performed. Currently, this
 // is only used by cli.c during config dumps.
-const void * setting_get_copy_value_pointer(const setting_t *val);
+const void * settingGetCopyValuePointer(const setting_t *val);
 // Returns the minimum valid value for the given setting_t. setting_min_t
 // depends on the target and build options, but will always be a signed
 // integer (e.g. intxx_t,)
-setting_min_t setting_get_min(const setting_t *val);
+setting_min_t settingGetMin(const setting_t *val);
 // Returns the maximum valid value for the given setting_t. setting_max_t
 // depends on the target and build options, but will always be an unsigned
 // integer (e.g. uintxx_t,)
-setting_max_t setting_get_max(const setting_t *val);
+setting_max_t settingGetMax(const setting_t *val);

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1589,6 +1589,7 @@ groups:
       - name: input_filtering_mode
         field: pwmRxInputFilteringMode
         type: bool
+      - name: name
 
   - name: PG_MODE_ACTIVATION_OPERATOR_CONFIG
     type: modeActivationOperatorConfig_t

--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -532,6 +532,8 @@ class Generator
             return "VAR_UINT32"
         when "float"
             return "VAR_FLOAT"
+        when "string"
+            return "VAR_STRING"
         else
             raise "unknown variable type #{typ.inspect}"
         end
@@ -764,6 +766,10 @@ class Generator
                 typ = "uint32_t"
             when "float"
                 typ = "float"
+            when /^char \[(\d+)\]/
+                # Substract 1 to show the maximum string size without the null terminator
+                member["max"] = $1.to_i - 1;
+                typ = "string"
             else
                 raise "Unknown type #{m[1]} when resolving type for setting #{member["name"]}"
             end


### PR DESCRIPTION
- Rename settings related functions from snake_case to camelCase
- Teach settings how to handle strings, make craft name a setting