### PR TITLE
Increase FLASH_CONFIG in F3 to 6K

### DIFF
--- a/src/main/target/link/stm32_flash_f303_256k.ld
+++ b/src/main/target/link/stm32_flash_f303_256k.ld
@@ -16,8 +16,8 @@ _Min_Stack_Size = 0x1800;
 /* Specify the memory areas. */
 MEMORY
 {
-    FLASH (rx)        : ORIGIN = 0x08000000, LENGTH = 252K
-    FLASH_CONFIG (r)  : ORIGIN = 0x0803F000, LENGTH = 4K
+    FLASH (rx)        : ORIGIN = 0x08000000, LENGTH = 250K
+    FLASH_CONFIG (r)  : ORIGIN = 0x0803E800, LENGTH = 6K
 
     RAM (xrw)         : ORIGIN = 0x20000000, LENGTH = 40K
     CCM (xrw)         : ORIGIN = 0x10000000, LENGTH = 8K


### PR DESCRIPTION
Config no longer fits in 4K. This means that we also have 2K less
of FLASH available for code.