### PR TITLE
Disable RC adjustments when the trigger channel goes out of the range

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -483,9 +483,10 @@ void processRx(timeUs_t currentTimeUs)
 
     updateActivatedModes();
 
-    if ((!cliMode) && (!FLIGHT_MODE(FAILSAFE_MODE))) {
-        updateAdjustmentStates();
-        processRcAdjustments(CONST_CAST(controlRateConfig_t*, currentControlRateProfile));
+    if (!cliMode) {
+        bool canUseRxData = rxIsReceivingSignal() && !FLIGHT_MODE(FAILSAFE_MODE);
+        updateAdjustmentStates(canUseRxData);
+        processRcAdjustments(CONST_CAST(controlRateConfig_t*, currentControlRateProfile), canUseRxData);
     }
 
     bool canUseHorizonMode = true;

--- a/src/main/fc/rc_adjustments.h
+++ b/src/main/fc/rc_adjustments.h
@@ -135,7 +135,7 @@ typedef struct adjustmentState_s {
 PG_DECLARE_ARRAY(adjustmentRange_t, MAX_ADJUSTMENT_RANGE_COUNT, adjustmentRanges);
 
 void resetAdjustmentStates(void);
-void updateAdjustmentStates(void);
+void updateAdjustmentStates(bool canUseRxData);
 struct controlRateConfig_s;
-void processRcAdjustments(struct controlRateConfig_s *controlRateConfig);
+void processRcAdjustments(struct controlRateConfig_s *controlRateConfig, bool canUseRxData);
 bool isAdjustmentFunctionSelected(uint8_t adjustmentFunction);


### PR DESCRIPTION
Previously, users needed to configure another adjustment with "No
function" to clear the active adjustment.

Refactor a bit the failsafe checks to make them use a bit less of
flash. This way this commit only adds 16 bytes of code in F3.