### PR TITLE
Better GPS accuracy reading for FrSky telemetry

### DIFF
--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -70,8 +70,8 @@ uint16_t frskyGetGPSState(void)
     // ones and tens columns (# of satellites 0 - 99)
     tmpi += constrain(gpsSol.numSat, 0, 99);
     
-    // hundreds column (satellite accuracy HDOP: 0 = worst, 9 = best)
-    tmpi += (9 - constrain(gpsSol.hdop / 1000, 0, 9)) * 100;
+    // hundreds column (satellite accuracy HDOP: 0 = worst [HDOP 6.5], 9 = best [HDOP 2.0])
+    tmpi += (9 - constrain((gpsSol.hdop - 200) / 50, 0, 9)) * 100;
     
     // thousands column (GPS fix status)
     if (STATE(GPS_FIX))

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -71,7 +71,7 @@ uint16_t frskyGetGPSState(void)
     tmpi += constrain(gpsSol.numSat, 0, 99);
     
     // hundreds column (satellite accuracy HDOP: 0 = worst [HDOP 6.5], 9 = best [HDOP 2.0])
-    tmpi += (9 - constrain((gpsSol.hdop - 200) / 50, 0, 9)) * 100;
+    tmpi += (9 - constrain((gpsSol.hdop - 151) / 50, 0, 9)) * 100;
     
     // thousands column (GPS fix status)
     if (STATE(GPS_FIX))


### PR DESCRIPTION
Previously, the GPS accuracy value being sent to FrSky telemetry was basically useless as an HDOP 10 or less was considered the highest accuracy.  Basically, this would cause the GPS accuracy to read either `0`, the worst, or `9` the best.

With this change, the GPS accuracy is more granular.  A value of `9` (the best) is now when the HDOP is 2.0 or less.  Each step down for the accuracy value is an HDOP of 0.5 more.  So an `8` is from 2.0 to 2.5, `7` us from 2.5 to 3.0, etc. with a `0` being an HDOP higher than 6.0.

This change allows for a more useful reporting of the GPS fix accuracy, better informing the pilot of any potential navigation issues.