### PR TITLE
Fix orientation of the drivers for AK8963, AK8975 and MPU9250 MAGs

### DIFF
--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -139,7 +139,7 @@ static bool ak8963Read(magDev_t * mag)
     }
 
     mag->magADCRaw[X] = -parseMag(buf + 0, magGain[X]);
-    mag->magADCRaw[Y] = -parseMag(buf + 2, magGain[Y]);
+    mag->magADCRaw[Y] = parseMag(buf + 2, magGain[Y]);
     mag->magADCRaw[Z] = -parseMag(buf + 4, magGain[Z]);
 
     return true;

--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -118,7 +118,7 @@ static bool ak8975Read(magDev_t * mag)
     }
 
     mag->magADCRaw[X] = -(int16_t)(buf[1] << 8 | buf[0]) * 4;
-    mag->magADCRaw[Y] = -(int16_t)(buf[3] << 8 | buf[2]) * 4;
+    mag->magADCRaw[Y] = (int16_t)(buf[3] << 8 | buf[2]) * 4;
     mag->magADCRaw[Z] = -(int16_t)(buf[5] << 8 | buf[4]) * 4;
 
     ack = busWrite(mag->busDev, AK8975_MAG_REG_CNTL, 0x01); // start reading again

--- a/src/main/drivers/compass/compass_mpu9250.c
+++ b/src/main/drivers/compass/compass_mpu9250.c
@@ -269,7 +269,7 @@ static bool mpu9250CompassRead(magDev_t * mag)
     }
 
     mag->magADCRaw[X] = -parseMag(buf + 0, magGain[X]);
-    mag->magADCRaw[Y] = -parseMag(buf + 2, magGain[Y]);
+    mag->magADCRaw[Y] = parseMag(buf + 2, magGain[Y]);
     mag->magADCRaw[Z] = -parseMag(buf + 4, magGain[Z]);
 
     memcpy(cachedMagData, &mag->magADCRaw, sizeof(cachedMagData));

--- a/src/main/target/ALIENFLIGHTF3/target.h
+++ b/src/main/target/ALIENFLIGHTF3/target.h
@@ -69,7 +69,7 @@
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
 #define USE_MAG_MPU9250
-#define MAG_MPU9250_ALIGN       CW180_DEG_FLIP
+#define MAG_MPU9250_ALIGN       CW0_DEG
 #define USE_MAG_AK8963
 #define USE_MAG_AK8975
 #define USE_MAG_HMC5883

--- a/src/main/target/ALIENFLIGHTF4/target.h
+++ b/src/main/target/ALIENFLIGHTF4/target.h
@@ -68,7 +68,7 @@
 #define USE_MAG_IST8308
 #define USE_MAG_LIS3MDL
 
-#define MAG_MPU9250_ALIGN       CW180_DEG_FLIP
+#define MAG_MPU9250_ALIGN       CW0_DEG
 
 #define USE_BARO
 #define BARO_I2C_BUS             BUS_I2C1

--- a/src/main/target/ALIENFLIGHTNGF7/target.h
+++ b/src/main/target/ALIENFLIGHTNGF7/target.h
@@ -66,8 +66,8 @@
 #define USE_MAG_IST8308
 #define USE_MAG_LIS3MDL
 
-#define MAG_AK9863_ALIGN        CW180_DEG_FLIP
-#define MAG_MPU9250_ALIGN       CW180_DEG_FLIP
+#define MAG_AK9863_ALIGN        CW0_DEG
+#define MAG_MPU9250_ALIGN       CW0_DEG
 
 #define AK8963_CS_PIN           PC15
 #define AK8963_SPI_BUS          BUS_SPI3

--- a/src/main/target/CLRACINGF4AIR/target.h
+++ b/src/main/target/CLRACINGF4AIR/target.h
@@ -54,6 +54,8 @@
 #define ACC_MPU9250_ALIGN       CW0_DEG
 #define USE_MAG
 #define USE_MAG_MPU9250
+#define MAG_MPU9250_ALIGN       CW90_DEG
+
 // MPU6 interrupts
 #define USE_EXTI
 #define GYRO_INT_EXTI            PC4

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -48,7 +48,7 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
-#define MAG_AK8975_ALIGN        CW180_DEG_FLIP
+#define MAG_AK8975_ALIGN        CW0_DEG
 #define USE_MAG_AK8975
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883

--- a/src/main/target/SPARKY2/target.h
+++ b/src/main/target/SPARKY2/target.h
@@ -47,7 +47,7 @@
 
 #define USE_MAG
 #define USE_MAG_MPU9250
-#define MAG_MPU9250_ALIGN       CW270_DEG
+#define MAG_MPU9250_ALIGN       CW0_DEG
 
 #define MAG_I2C_BUS             BUS_I2C1
 #define USE_MAG_HMC5883

--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -54,7 +54,7 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
-#define MAG_MPU9250_ALIGN       CW90_DEG_FLIP
+#define MAG_MPU9250_ALIGN       CW270_DEG
 #define USE_MAG_MPU9250
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -54,7 +54,7 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
-#define MAG_AK8963_ALIGN       CW270_DEG_FLIP
+#define MAG_AK8963_ALIGN        CW270_DEG
 #define USE_MAG_AK8963
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883


### PR DESCRIPTION
Due to the unsual axis definition of the AKxxxx MAGs (the +Y axis
is 90ºCW from the +X axis when +Z points up), the driver needs to
invert e.g. X and Z, then rotate rather than inverting all of
X, Y and Z like it was doing.

It seems this bug was introduced in 3d024c6f3 back in November,
between 1.8 and 1.9 and some targets were written or updated in the
meantime assuming the driver was correct and thus have incorrect mag
alignments. I've tried to fix them all, but I don't have all these
boards and while ones with the MP9250 are obvious (assumming the
acc/gyro orientation is right, the mag orientation can be derived
from it), some of them have AK8963 or AK8975 which might be
oriented differently than the acc/gyro.

Fixes #3438
Fixes #3434