### PR TITLE
Fix compiler bug, MSP2_INAV_ANALOG and convert amperage from int32_t to int16_t

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -541,16 +541,16 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         break;
 
     case MSP2_INAV_ANALOG:
+        // Bit 1: battery full, Bit 2: use capacity threshold, Bit 3-4: battery state, Bit 5-8: battery cell count
+        sbufWriteU8(dst, batteryWasFullWhenPluggedIn() | (batteryUsesCapacityThresholds() << 1) | (getBatteryState() << 2) | (getBatteryCellCount() << 4));
         sbufWriteU16(dst, getBatteryVoltage());
-        sbufWriteU8(dst, getBatteryCellCount());
-        sbufWriteU8(dst, calculateBatteryPercentage());
-        sbufWriteU16(dst, constrain(getPower(), 0, 0x7FFFFFFF));           // power draw
-        sbufWriteU16(dst, (uint16_t)constrain(getMAhDrawn(), 0, 0xFFFF)); // milliamp hours drawn from battery
-        sbufWriteU16(dst, (uint16_t)constrain(getMWhDrawn(), 0, 0xFFFF)); // milliWatt hours drawn from battery
-        sbufWriteU16(dst, getRSSI());
-        sbufWriteU16(dst, (int16_t)constrain(getAmperage(), -0x8000, 0x7FFF)); // send amperage in 0.01 A steps, range is -320A to 320A
-        sbufWriteU8(dst, batteryWasFullWhenPluggedIn() | (batteryUsesCapacityThresholds() << 1) | (getBatteryState() << 2));
+        sbufWriteU16(dst, getAmperage()); // send amperage in 0.01 A steps
+        sbufWriteU32(dst, getPower());    // power draw
+        sbufWriteU32(dst, getMAhDrawn()); // milliamp hours drawn from battery
+        sbufWriteU32(dst, getMWhDrawn()); // milliWatt hours drawn from battery
         sbufWriteU32(dst, getBatteryRemainingCapacity());
+        sbufWriteU8(dst, calculateBatteryPercentage());
+        sbufWriteU16(dst, getRSSI());
         break;
 
     case MSP_ARMING_CONFIG:

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -461,7 +461,10 @@ void currentMeterUpdate(timeUs_t timeDelta)
             break;
     }
 
-    mAhdrawnRaw += (int32_t)amperage * timeDelta / 1000;
+    // Work around int64 math compiler bug, don't change it unless the bug has been fixed !
+    // should be: mAhdrawnRaw += (int64_t)amperage * timeDelta / 1000;
+    mAhdrawnRaw += (int64_t)((int32_t)amperage * timeDelta) / 1000;
+
     mAhDrawn = mAhdrawnRaw / (3600 * 100);
 }
 
@@ -470,7 +473,11 @@ void powerMeterUpdate(timeUs_t timeDelta)
     static int64_t mWhDrawnRaw = 0;
     power = (int32_t)amperage * vbat / 100; // power unit is cW (0.01W resolution)
     int32_t heatLossesCompensatedPower_mW = (int32_t)amperage * vbat / 10 + sq((int64_t)amperage) * powerSupplyImpedance / 10000;
-    mWhDrawnRaw += (int64_t)heatLossesCompensatedPower_mW * timeDelta / 10000;
+
+    // Work around int64 math compiler bug, don't change it unless the bug has been fixed !
+    // should be: mWhDrawnRaw += (int64_t)heatLossesCompensatedPower_mW * timeDelta / 10000;
+    mWhDrawnRaw += (int64_t)((int64_t)heatLossesCompensatedPower_mW * timeDelta) / 10000;
+
     mWhDrawn = mWhDrawnRaw / (3600 * 100);
 }
 

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -135,8 +135,8 @@ uint32_t getBatteryRemainingCapacity(void);
 uint16_t getPowerSupplyImpedance(void);
 
 bool isAmperageConfigured(void);
-int32_t getAmperage(void);
-int32_t getAmperageLatestADC(void);
+int16_t getAmperage(void);
+int16_t getAmperageLatestADC(void);
 int32_t getPower(void);
 int32_t getMAhDrawn(void);
 int32_t getMWhDrawn(void);


### PR DESCRIPTION
- Work around compiler bug in int64 math causing issues with mAh and mWh calculations when amperage is negative
- Fix MSP2_INAV_ANALOG to return possible negative values of `power`, `mAhDrawn` and `mWhDrawn`
- int16_t should be enough for amperage (+-325A)

Matching configurator update: https://github.com/iNavFlight/inav-configurator/pull/500