### PR TITLE
set switch_disarm_delay / .switchDisarmDelayMs default to 250ms 

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -63,7 +63,7 @@
 
 #define AIRMODE_DEADBAND 25
 #define MIN_RC_TICK_INTERVAL_MS             20
-#define DEFAULT_RC_SWITCH_DISARM_DELAY_MS   150     // Wait at least 150ms before disarming via switch
+#define DEFAULT_RC_SWITCH_DISARM_DELAY_MS   250     // Wait at least 250ms before disarming via switch
 
 stickPositions_e rcStickPositions;
 
@@ -352,4 +352,3 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
 int32_t getRcStickDeflection(int32_t axis) {
     return MIN(ABS(rcData[axis] - PWM_RANGE_MIDDLE), 500);
 }
-


### PR DESCRIPTION
As discussed with @digitalentity et al on Slack. This safe guards the "final" SBUS disarm case.

Note that Cli.md needs to be updated for this (any maybe other new variables). This will be done in a subsequent PR.