### PR TITLE
Fix current BB logging and improve battery code

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1139,7 +1139,7 @@ void blackboxStart(void)
     blackboxHistory[1] = &blackboxHistoryRing[1];
     blackboxHistory[2] = &blackboxHistoryRing[2];
 
-    vbatReference = getBatteryVoltageLatestADC();
+    vbatReference = getBatteryRawVoltage();
 
     //No need to clear the content of blackboxHistoryRing since our first frame will be an intra which overwrites it
 
@@ -1301,8 +1301,8 @@ static void loadMainState(timeUs_t currentTimeUs)
         blackboxCurrent->motor[i] = motor[i];
     }
 
-    blackboxCurrent->vbatLatest = getBatteryVoltageLatestADC();
-    blackboxCurrent->amperageLatest = getAmperageLatestADC();
+    blackboxCurrent->vbatLatest = getBatteryRawVoltage();
+    blackboxCurrent->amperageLatest = getAmperage();
 
 #ifdef USE_BARO
     blackboxCurrent->BaroAlt = baro.BaroAlt;

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -125,7 +125,6 @@ bool isPowerSupplyImpedanceValid(void);
 uint16_t getBatteryVoltage(void);
 uint16_t getBatteryRawVoltage(void);
 uint16_t getBatterySagCompensatedVoltage(void);
-uint16_t getBatteryVoltageLatestADC(void);
 uint16_t getBatteryWarningVoltage(void);
 uint8_t getBatteryCellCount(void);
 uint16_t getBatteryRawAverageCellVoltage(void);
@@ -136,7 +135,6 @@ uint16_t getPowerSupplyImpedance(void);
 
 bool isAmperageConfigured(void);
 int16_t getAmperage(void);
-int16_t getAmperageLatestADC(void);
 int32_t getPower(void);
 int32_t getMAhDrawn(void);
 int32_t getMWhDrawn(void);


### PR DESCRIPTION
Current sensor offset was not taken into account in BB log so if `current_sensor_offset` was different from 0 logged current was always wrong.