### PR TITLE
Remove posZ constrain to int16 for BB

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1816,7 +1816,7 @@ void updateActualAltitudeAndClimbRate(bool estimateValid, float newAltitude, flo
     }
 
 #if defined(NAV_BLACKBOX)
-    navLatestActualPosition[Z] = constrain(navGetCurrentActualPositionAndVelocity()->pos.z, -32678, 32767);
+    navLatestActualPosition[Z] = navGetCurrentActualPositionAndVelocity()->pos.z;
     navActualVelocity[Z] = constrain(navGetCurrentActualPositionAndVelocity()->vel.z, -32678, 32767);
 #endif
 }


### PR DESCRIPTION
I don't see why navPos[2] is constrained to +-327m in blackbox logs.