### PR TITLE
Add watchdog support for boards with flash bigger than 256

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -52,6 +52,7 @@ COMMON_SRC = \
             drivers/system.c \
             drivers/timer.c \
             drivers/lights_io.c \
+            drivers/watchdog.c \
             fc/cli.c \
             fc/config.c \
             fc/controlrate_profile.c \

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -37,6 +37,7 @@
 #include "config/feature.h"
 
 #include "drivers/time.h"
+#include "drivers/watchdog.h"
 
 #include "fc/config.h"
 #include "fc/settings.h"
@@ -54,6 +55,9 @@ static long cmsx_EraseFlash(displayPort_t *pDisplay, const void *ptr)
 
     flashfsEraseCompletely();
     while (!flashfsIsReady()) {
+#if defined(USE_WATCHDOG)
+        watchdogRestart();
+#endif
         delay(100);
     }
 

--- a/src/main/drivers/watchdog.c
+++ b/src/main/drivers/watchdog.c
@@ -26,8 +26,6 @@
 
 #include "platform.h"
 
-#include "build/debug.h"
-
 #include "drivers/watchdog.h"
 
 #define LSI_FREQ 32000 // 32khz
@@ -80,7 +78,7 @@ void watchdogSetTimeout(uint32_t ms)
     }
 
     uint32_t clk = LSI_FREQ / (0x04 << pr);
-    uint32_t rlr = ms * clk / 1000UL-1;
+    uint32_t rlr = ms * clk / 1000UL - 1;
 
     while (watchdogPrescalerIsBusy());
     // enable write to PR, RLR

--- a/src/main/drivers/watchdog.c
+++ b/src/main/drivers/watchdog.c
@@ -1,0 +1,119 @@
+/*
+ * This file is part of INAV.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ * @author Alberto Garcia Hierro <alberto@garciahierro.com>
+ */
+
+#include "platform.h"
+
+#include "build/debug.h"
+
+#include "drivers/watchdog.h"
+
+#define LSI_FREQ 32000 // 32khz
+#define RLR_BITS 12
+#define RLR_MASK ((1 << RLR_BITS)-1)
+
+#define IWDG_PR_DIV256  (6)
+#define IWDG_PR_DIV128  (5)
+#define IWDG_PR_DIV64   (4)
+#define IWDG_PR_DIV32   (3)
+#define IWDG_PR_DIV16   (2)
+#define IWDG_PR_DIV8    (1)
+#define IWDG_PR_DIV4    (0)
+
+#define IWDG_KR_RESET			0xAAAA
+#define IWDG_KR_UNLOCK			0x5555
+#define IWDG_KR_START			0xCCCC
+
+static bool watchdogPrescalerIsBusy(void)
+{
+    return IWDG->SR & IWDG_SR_PVU;
+}
+
+static bool watchdogReloadIsBusy(void)
+{
+    return IWDG->SR & IWDG_SR_RVU;
+}
+
+void watchdogSetTimeout(uint32_t ms)
+{
+    if (ms <= 0) {
+        ms = 500;
+    }
+
+    uint32_t pr;
+    if (ms > 16384) {
+        pr = IWDG_PR_DIV256;
+    } else if (ms > 8192) {
+        pr = IWDG_PR_DIV128;
+    } else if (ms > 4096) {
+        pr = IWDG_PR_DIV64;
+    } else if (ms > 2048) {
+        pr = IWDG_PR_DIV32;
+    } else if (ms > 1024) {
+        pr = IWDG_PR_DIV16;
+    } else if (ms > 512) {
+        pr = IWDG_PR_DIV8;
+    } else {
+        pr = IWDG_PR_DIV4;
+    }
+
+    uint32_t clk = LSI_FREQ / (0x04 << pr);
+    uint32_t rlr = ms * clk / 1000UL-1;
+
+    while (watchdogPrescalerIsBusy());
+    // enable write to PR, RLR
+    IWDG->KR = IWDG_KR_UNLOCK;
+    // Set prescaler
+    IWDG->PR = pr;
+
+    while (watchdogReloadIsBusy());
+    // Set count
+    IWDG->RLR = rlr & RLR_MASK;
+    // Reset the watchdog
+    IWDG->KR = IWDG_KR_RESET;
+}
+
+void watchdogInit(void)
+{
+    // LSI enable, used by IWDG
+    RCC->CSR |= RCC_CSR_LSION;
+    // wait until LSI is ready
+    while ((RCC->CSR & RCC_CSR_LSIRDY) == 0);
+
+    // Set default timeout
+    watchdogSetTimeout(0);
+    // Start the watchdog
+    IWDG->KR = IWDG_KR_START;
+}
+
+void watchdogRestart(void)
+{
+    IWDG->KR = IWDG_KR_RESET;
+}
+
+bool watchdogBarked(void)
+{
+    return (RCC_GetFlagStatus(RCC_FLAG_IWDGRST) == SET);
+}

--- a/src/main/drivers/watchdog.c
+++ b/src/main/drivers/watchdog.c
@@ -105,7 +105,7 @@ void watchdogInit(void)
     // Start the watchdog
     IWDG->KR = IWDG_KR_START;
     // Set default timeout
-    watchdogSetTimeout(1000);
+    watchdogSetTimeout(0);
 }
 
 void watchdogRestart(void)

--- a/src/main/drivers/watchdog.c
+++ b/src/main/drivers/watchdog.c
@@ -26,6 +26,8 @@
 
 #include "platform.h"
 
+#if defined(USE_WATCHDOG)
+
 #include "drivers/watchdog.h"
 
 #define LSI_FREQ 32000 // 32khz
@@ -115,3 +117,5 @@ bool watchdogBarked(void)
 {
     return (RCC_GetFlagStatus(RCC_FLAG_IWDGRST) == SET);
 }
+
+#endif

--- a/src/main/drivers/watchdog.c
+++ b/src/main/drivers/watchdog.c
@@ -100,10 +100,10 @@ void watchdogInit(void)
     // wait until LSI is ready
     while ((RCC->CSR & RCC_CSR_LSIRDY) == 0);
 
-    // Set default timeout
-    watchdogSetTimeout(0);
     // Start the watchdog
     IWDG->KR = IWDG_KR_START;
+    // Set default timeout
+    watchdogSetTimeout(1000);
 }
 
 void watchdogRestart(void)

--- a/src/main/drivers/watchdog.h
+++ b/src/main/drivers/watchdog.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of INAV.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ * @author Alberto Garcia Hierro <alberto@garciahierro.com>
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+// Initializes the watchdog, typically called during system startup.
+// Note that once enabled, the watchdog can't be disabled.
+void watchdogInit(void);
+
+// Restart the watchdog counter.
+void watchdogRestart(void);
+
+// Returns true iff the system was restarted
+// due to a watchdog reset. This MUST be called
+// before systemInit() (which resets the flags by
+// calling RCC_ClearFlag()). Otherwise it will always
+// return false.
+bool watchdogBarked(void);

--- a/src/main/drivers/watchdog.h
+++ b/src/main/drivers/watchdog.h
@@ -29,7 +29,9 @@
 #include <stdbool.h>
 
 // Initializes the watchdog, typically called during system startup.
-// Note that once enabled, the watchdog can't be disabled.
+// Note that once enabled, the watchdog can't be disabled. This function
+// can be called multiple times and it will always set the watchdog
+// interval to 500ms.
 void watchdogInit(void);
 
 // Restart the watchdog counter.

--- a/src/main/drivers/watchdog.h
+++ b/src/main/drivers/watchdog.h
@@ -37,6 +37,16 @@ void watchdogInit(void);
 // Restart the watchdog counter.
 void watchdogRestart(void);
 
+// Momentarily suspend the watchdog. If the watchdog isn't running
+// (either not initialized or already suspended) this function does
+// nothing. Returns true iff the WD was suspended by this call.
+bool watchdogSuspend(void);
+
+// Resume the watchdog after suspending it via watchdogSuspend().
+// If the watchdog wasn't previously suspended, this function does
+// nothing. Returns true iff the WD was resumed by this call.
+bool watchdogResume(void);
+
 // Returns true iff the system was restarted
 // due to a watchdog reset. This MUST be called
 // before systemInit() (which resets the flags by

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -64,6 +64,7 @@ extern uint8_t __config_end;
 #include "drivers/system.h"
 #include "drivers/time.h"
 #include "drivers/timer.h"
+#include "drivers/watchdog.h"
 
 #include "fc/cli.h"
 #include "fc/config.h"
@@ -1593,6 +1594,9 @@ static void cliFlashErase(char *cmdline)
     flashfsEraseCompletely();
 
     while (!flashfsIsReady()) {
+#if defined(USE_WATCHDOG)
+        watchdogRestart();
+#endif
         delay(100);
     }
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -42,6 +42,7 @@
 #include "drivers/serial.h"
 #include "drivers/timer.h"
 #include "drivers/bus_i2c.h"
+#include "drivers/watchdog.h"
 
 #include "sensors/sensors.h"
 #include "sensors/gyro.h"
@@ -390,6 +391,9 @@ static void activateConfig(void)
 
 void readEEPROM(void)
 {
+#if defined(USE_WATCHDOG)
+    watchdogSuspend();
+#endif
     suspendRxSignal();
 
     // Sanity check, read flash
@@ -404,15 +408,24 @@ void readEEPROM(void)
     activateConfig();
 
     resumeRxSignal();
+#if defined(USE_WATCHDOG)
+    watchdogResume();
+#endif
 }
 
 void writeEEPROM(void)
 {
+#if defined(USE_WATCHDOG)
+    watchdogSuspend();
+#endif
     suspendRxSignal();
 
     writeConfigToEEPROM();
 
     resumeRxSignal();
+#if defined(USE_WATCHDOG)
+    watchdogResume();
+#endif
 }
 
 void resetEEPROM(void)

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -34,6 +34,7 @@
 #include "drivers/light_led.h"
 #include "drivers/serial.h"
 #include "drivers/time.h"
+#include "drivers/watchdog.h"
 
 #include "sensors/sensors.h"
 #include "sensors/diagnostics.h"
@@ -373,6 +374,11 @@ void tryArm(void)
         if (ARMING_FLAG(ARMED)) {
             return;
         }
+        // Start the watchdog now. We don't start it until the aircraft is
+        // armed because once it's enabled we can't disable it and it interferes
+        // with the bootloader, requiring a full power cycle after entering the
+        // bootloader and flashing.
+        watchdogInit();
 
         lastDisarmReason = DISARM_NONE;
 

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -374,11 +374,13 @@ void tryArm(void)
         if (ARMING_FLAG(ARMED)) {
             return;
         }
+#if defined(USE_WATCHDOG)
         // Start the watchdog now. We don't start it until the aircraft is
         // armed because once it's enabled we can't disable it and it interferes
         // with the bootloader, requiring a full power cycle after entering the
         // bootloader and flashing.
         watchdogInit();
+#endif
 
         lastDisarmReason = DISARM_NONE;
 

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -75,6 +75,7 @@
 #include "drivers/io_pca9685.h"
 #include "drivers/vtx_rtc6705.h"
 #include "drivers/vtx_common.h"
+#include "drivers/watchdog.h"
 
 #include "fc/cli.h"
 #include "fc/config.h"
@@ -691,4 +692,6 @@ void init(void)
 
     addBootlogEvent2(BOOT_EVENT_SYSTEM_READY, BOOT_EVENT_FLAGS_NONE);
     systemState |= SYSTEM_STATE_READY;
+
+    watchdogInit();
 }

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -75,7 +75,6 @@
 #include "drivers/io_pca9685.h"
 #include "drivers/vtx_rtc6705.h"
 #include "drivers/vtx_common.h"
-#include "drivers/watchdog.h"
 
 #include "fc/cli.h"
 #include "fc/config.h"
@@ -692,6 +691,4 @@ void init(void)
 
     addBootlogEvent2(BOOT_EVENT_SYSTEM_READY, BOOT_EVENT_FLAGS_NONE);
     systemState |= SYSTEM_STATE_READY;
-
-    watchdogInit();
 }

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -129,8 +129,10 @@ void taskSystem(timeUs_t currentTimeUs)
         totalWaitingTasks = 0;
     }
 
+#if defined(USE_WATCHDOG)
     // Restart watchdog counter
     watchdogRestart();
+#endif
 }
 
 #ifndef SKIP_TASK_STATISTICS

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -31,6 +31,7 @@
 #include "common/utils.h"
 
 #include "drivers/time.h"
+#include "drivers/watchdog.h"
 
 STATIC_FASTRAM cfTask_t *currentTask = NULL;
 
@@ -127,6 +128,9 @@ void taskSystem(timeUs_t currentTimeUs)
         totalWaitingTasksSamples = 0;
         totalWaitingTasks = 0;
     }
+
+    // Restart watchdog counter
+    watchdogRestart();
 }
 
 #ifndef SKIP_TASK_STATISTICS

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -61,6 +61,7 @@
 #define USE_EXTENDED_CMS_MENUS
 #define USE_UAV_INTERCONNECT
 #define USE_RX_UIB
+#define USE_WATCHDOG
 #endif
 
 #if (FLASH_SIZE > 128)


### PR DESCRIPTION
If the firmware blocks up for more than 500ms, the board will reboot. This prevents crashes from leaving the motors running. The following long running operations have been made watchdog aware:

- Reading EEPROM
- Writing EEPROM
- Erasing on board flash