### PR TITLE
fixed broken PWM_SERVO_DRIVER

### DIFF
--- a/src/main/drivers/io_pca9685.c
+++ b/src/main/drivers/io_pca9685.c
@@ -13,7 +13,6 @@
 #include "drivers/bus.h"
 #include "drivers/bus_i2c.h"
 
-#define PCA9685_ADDR 0x40
 #define PCA9685_MODE1 0x00
 #define PCA9685_PRESCALE 0xFE
 

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -204,4 +204,13 @@
     BUSDEV_REGISTER_I2C(busdev_ug2864,      DEVHW_UG2864,       UG2864_I2C_BUS,     0x3C,               NONE,           DEVFLAGS_NONE);
 #endif
 
+#if defined(USE_PMW_SERVO_DRIVER)
+    #if defined(USE_PWM_DRIVER_PCA9685)
+        #if !defined(PCA9685_I2C_BUS)
+            #define PCA9685_I2C_BUS BUS_I2C1
+        #endif
+        BUSDEV_REGISTER_I2C(busdev_pca9685,      DEVHW_PCA9685,       PCA9685_I2C_BUS,     0x40,               NONE,           DEVFLAGS_NONE);
+    #endif
+#endif
+
 #endif  // USE_TARGET_HARDWARE_DESCRIPTORS


### PR DESCRIPTION
Feature PWM_SERVO_DRIVER seems to be broken since 1.9.0. Problem was missing initialization of busDevice for PCA9685 PWM driver(which is only one supported at the time). Alternative I2C bus for PWM driver can be selected in target by defining PCA9685_I2C_BUS. I also removed I2C address from io_pca9685.c since it was not used there.