### PR TITLE
Use local times (+TZ when possible) for external interfaces

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1485,7 +1485,7 @@ static char *blackboxGetStartDateTime(char *buf)
     // rtcGetDateTime will fill dt with 0000-01-01T00:00:00
     // when time is not known.
     rtcGetDateTime(&dt);
-    dateTimeFormatUTC(buf, &dt);
+    dateTimeFormatLocal(buf, &dt);
     return buf;
 }
 

--- a/src/main/common/time.c
+++ b/src/main/common/time.c
@@ -58,7 +58,7 @@ PG_RESET_TEMPLATE(timeConfig_t, timeConfig,
     .tz_automatic_dst = TZ_AUTO_DST_OFF,
 );
 
-static rtcTime_t dateTimeToRtcTime(dateTime_t *dt)
+static rtcTime_t dateTimeToRtcTime(const dateTime_t *dt)
 {
     unsigned int second = dt->seconds;  // 0-59
     unsigned int minute = dt->minutes;  // 0-59
@@ -205,7 +205,7 @@ static bool isDST(rtcTime_t t)
 }
 #endif
 
-static void dateTimeWithOffset(dateTime_t *dateTimeOffset, dateTime_t *dateTimeInitial, int16_t *minutes, bool automatic_dst)
+static void dateTimeWithOffset(dateTime_t *dateTimeOffset, const dateTime_t *dateTimeInitial, int16_t *minutes, bool automatic_dst)
 {
     rtcTime_t initialTime = dateTimeToRtcTime(dateTimeInitial);
     rtcTime_t offsetTime = rtcTimeMake(rtcTimeGetSeconds(&initialTime) + *minutes * 60, rtcTimeGetMillis(&initialTime));
@@ -279,7 +279,7 @@ bool dateTimeFormatLocal(char *buf, dateTime_t *dt)
     return dateTimeFormat(buf, dt, timeConfig()->tz_offset, true);
 }
 
-void dateTimeUTCToLocal(dateTime_t *utcDateTime, dateTime_t *localDateTime)
+void dateTimeUTCToLocal(dateTime_t *localDateTime, const dateTime_t *utcDateTime)
 {
     int16_t offset = timeConfig()->tz_offset;
     dateTimeWithOffset(localDateTime, utcDateTime, &offset, true);
@@ -329,6 +329,15 @@ bool rtcGetDateTime(dateTime_t *dt)
     }
     // No time stored, fill dt with 0000-01-01T00:00:00.000
     rtcGetDefaultDateTime(dt);
+    return false;
+}
+
+bool rtcGetDateTimeLocal(dateTime_t *dt)
+{
+    if (rtcGetDateTime(dt)) {
+        dateTimeUTCToLocal(dt, dt);
+        return true;
+    }
     return false;
 }
 

--- a/src/main/common/time.h
+++ b/src/main/common/time.h
@@ -93,7 +93,7 @@ typedef struct _dateTime_s {
 bool dateTimeFormatUTC(char *buf, dateTime_t *dt);
 bool dateTimeFormatLocal(char *buf, dateTime_t *dt);
 
-void dateTimeUTCToLocal(dateTime_t *utcDateTime, dateTime_t *localDateTime);
+void dateTimeUTCToLocal(dateTime_t *localDateTime, const dateTime_t *utcDateTime);
 // dateTimeSplitFormatted splits a formatted date into its date
 // and time parts. Note that the string pointed by formatted will
 // be modifed and will become invalid after calling this function.
@@ -105,4 +105,5 @@ bool rtcGet(rtcTime_t *t);
 bool rtcSet(rtcTime_t *t);
 
 bool rtcGetDateTime(dateTime_t *dt);
+bool rtcGetDateTimeLocal(dateTime_t *dt);
 bool rtcSetDateTime(dateTime_t *dt);

--- a/src/main/io/asyncfatfs/asyncfatfs.c
+++ b/src/main/io/asyncfatfs/asyncfatfs.c
@@ -2605,7 +2605,7 @@ static void afatfs_createFileContinue(afatfsFile_t *file)
 
                 memcpy(entry->filename, opState->filename, FAT_FILENAME_LENGTH);
                 entry->attrib = file->attrib;
-                if (rtcGetDateTime(&now)) {
+                if (rtcGetDateTimeLocal(&now)) {
                     entry->creationDate = FAT_MAKE_DATE(now.year, now.month, now.day);
                     entry->creationTime = FAT_MAKE_TIME(now.hours, now.minutes, now.seconds);
                 } else {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1956,9 +1956,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             // RTC not configured will show 00:00
             dateTime_t dateTime;
-            if (rtcGetDateTime(&dateTime)) {
-                dateTimeUTCToLocal(&dateTime, &dateTime);
-            }
+            rtcGetDateTimeLocal(&dateTime);
             buff[0] = SYM_CLOCK;
             tfp_sprintf(buff + 1, "%02u:%02u", dateTime.hours, dateTime.minutes);
             break;

--- a/src/main/io/rcdevice_cam.c
+++ b/src/main/io/rcdevice_cam.c
@@ -100,7 +100,7 @@ static void rcdeviceCameraUpdateTime(void)
     if (isFeatureSupported(RCDEVICE_PROTOCOL_FEATURE_DEVICE_SETTINGS_ACCESS) &&
         !hasSynchronizedTime && retries < 3) {
 
-        if (rtcGetDateTime(&dt)) {
+        if (rtcGetDateTimeLocal(&dt)) {
             retries++;
             tfp_sprintf(buf, "%04d%02d%02dT%02d%02d%02d.0",
                 dt.year, dt.month, dt.day,


### PR DESCRIPTION
- BB logs format the date in the local TZ, including the UTC
offset in the header line.
- Files created in the SD card use the local time for timestamps,
since FAT doesn't have any notion of timezones.
- Time sync with RC Split uses the local time, since it doesn't
support timezones.
- Added new rtcGetDateTimeLocal() function, which allows removing
some branching in osd.c

Saves 40 bytes of flash on F3

Fixes #3531