### PR TITLE
Update Slack auto-invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See: https://github.com/iNavFlight/inav/blob/master/docs/Installation.md
 
 * [Official documentation](https://github.com/iNavFlight/inav/tree/master/docs)
 * [Official Wiki](https://github.com/iNavFlight/inav/wiki)
-* [Slack channel](https://inavflight.signup.team/)
+* [Slack channel](https://publicslack.com/slacks/inavflight/invites/new)
 * [RC Groups Support](https://www.rcgroups.com/forums/showthread.php?2495732-Cleanflight-iNav-(navigation-rewrite)-project)
 * [Video series by Painless360](https://www.youtube.com/playlist?list=PLYsWjANuAm4qdXEGFSeUhOZ10-H8YTSnH)
 * [Video series by Paweł Spychalski](https://www.youtube.com/playlist?list=PLOUQ8o2_nCLloACrA6f1_daCjhqY2x0fB)


### PR DESCRIPTION
Replace signup.team, which has been down for some time, with
publicslack.com