### PR TITLE
Draw missing AHI character when it overlaps with the crosshairs

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1601,7 +1601,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 osdCrosshairsBounds(&cx, &cy, &cl);
                 crosshairsX = cx - elemPosX;
                 crosshairsY = cy - elemPosY;
-                crosshairsXEnd = crosshairsX + cl;
+                crosshairsXEnd = crosshairsX + cl - 1;
             }
 
             for (int x = -4; x <= 4; x++) {


### PR DESCRIPTION
The crosshairs bounds were incorrectly calculated, causing the
character at the right of the crosshairs to not be drawn.

References #3449