### PR TITLE
Check for the correct display coordinate when drawing POI

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -987,7 +987,7 @@ static void osdDrawMap(int referenceHeading, uint8_t referenceSym, uint8_t cente
             } else {
 
                 uint8_t c;
-                if (displayReadCharWithAttr(osdDisplayPort, poiY, poiY, &c, NULL) && c != SYM_BLANK) {
+                if (displayReadCharWithAttr(osdDisplayPort, poiX, poiY, &c, NULL) && c != SYM_BLANK) {
                     // Something else written here, increase scale. If the display doesn't support reading
                     // back characters, we assume there's nothing.
                     continue;


### PR DESCRIPTION
When checking the display, we were testing for (poiY, poiY) rather
than (poiX, poiY), which was specially visible when drawing across
the horizontal line over the map center, since the test was always
for (0, 0), causing the scale to go to the maximum value since
(0, 0) always contains the map center symbol.

Fixes #3508