### PR TITLE
Ensured micros() doesn't return a smaller value on millisecond bound

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -51,7 +51,7 @@ void registerExtiCallbackHandler(IRQn_Type irqn, extiCallbackHandlerFunc *fn)
 // cycles per microsecond
 STATIC_UNIT_TESTED  timeUs_t usTicks = 0;
 // current uptime for 1kHz systick timer. will rollover after 49 days. hopefully we won't care.
-STATIC_UNIT_TESTED  volatile timeMs_t sysTickUptime = 0;
+STATIC_UNIT_TESTED volatile timeMs_t sysTickUptime = 0;
 STATIC_UNIT_TESTED volatile uint32_t sysTickValStamp = 0;
 // cached value of RCC->CSR
 uint32_t cachedRccCsrValue;

--- a/src/test/unit/time_unittest.cc
+++ b/src/test/unit/time_unittest.cc
@@ -25,6 +25,7 @@ extern "C" {
     #include "drivers/time.h"
     extern timeUs_t usTicks;
     extern volatile timeMs_t sysTickUptime;
+    extern volatile timeMs_t sysTickValStamp;
 }
 
 #include "unittest_macros.h"
@@ -44,7 +45,7 @@ TEST(TimeUnittest, TestMillis)
 TEST(TimeUnittest, TestMicros)
 {
     usTicks = 168;
-    SysTick->VAL = 1000 * usTicks;
+    sysTickValStamp = SysTick->VAL = 1000 * usTicks;
     sysTickUptime = 0;
     EXPECT_EQ(0, micros());
     sysTickUptime = 1;
@@ -58,7 +59,7 @@ TEST(TimeUnittest, TestMicros)
     EXPECT_EQ(500000000, micros());
 
     sysTickUptime = 0;
-    SysTick->VAL = 0;
+    sysTickValStamp = SysTick->VAL = 0;
     EXPECT_EQ(1000, micros());
     sysTickUptime = 1;
     EXPECT_EQ(2000, micros());


### PR DESCRIPTION
A direct cherry-pick of https://github.com/betaflight/betaflight/pull/6344 by @diehertz:

>Fixes negative numbers in CLI tasks output and possible issues with users of micros().
This problem first manifested itself on Cortex-M3, that's why nop inline assembly was added, but it wasn't a proper fix.
>
>Cortex-M interrupt entry latency is variable, can be anywhere from 8 to 32 cycles, and should be accounted for when relying on SysTick_Handler to be called on SysTick->VAL overflow. With M7 featuring I- and D-cache the problem started manifesting itself much more often, with one nop being insufficient.
>
>This PR adds a "marker" for remembering value of SysTick->VAL as observed by last invocation of SysTick_Handler. This value is checked in micros() lock-free loop to ensure we won't return a value ~1ms smaller than the previous one.