### PR TITLE
Fix for RC Adjustment Ranges index wrongfully Accessing States Array

### DIFF
--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -643,7 +643,7 @@ void updateAdjustmentStates(bool canUseRxData)
         if (canUseRxData && isRangeActive(adjustmentRange->auxChannelIndex, &adjustmentRange->range)) {
             configureAdjustment(adjustmentRange->adjustmentIndex, adjustmentRange->auxSwitchChannelIndex, adjustmentConfig);
         } else {
-            adjustmentState_t * const adjustmentState = &adjustmentStates[index];
+            adjustmentState_t * const adjustmentState = &adjustmentStates[adjustmentRange->adjustmentIndex];
             if (adjustmentState->config == adjustmentConfig) {
                 adjustmentState->config = NULL;
             }


### PR DESCRIPTION
Previously, the States Array(length of 4, includes info about function/configuration for adjustments to be made in Real Time) was being accessed with the index of 'Adjustment Range' for loop.

So what that did was because there can be 12 adjustment ranges, it was accessing "adjustmentStates[]" array from index 0 to 11. Which, if unlucky can corrupt other data.
***
But more serious problem is that Nth range can affect all the ranges using Nth 'Slot'.

I discovered this problem by setting 0th range as
(Channel 7 <Condition> / 900 1200 <Range> / Pitch_P <AdjustFunction> / 1 <Slot> / Channel 7 <via>)
(Channel 7<Condition> / 1800 2100<Range> / Pitch_P <AdjustFunction> / 1 <Slot> / Channel 7 <via>)

=> In this case, if you signal Ch7 HIGH(2000), the adjustment happens EVERY 'processRx()' function in fc_core.
1) This is because For First range(idx = 0), the condition is False. And **because of the previous typo, it sets "&adjustmentStates[0]->config" to NULL**, which was Previously set by Second range...
2) For Second Range, condition is True(signal HIGH). And since the First range had set config to NULL, the **"configureAdjustment()" function will configure adjustmentState[0]. And the BUSY flag will be removed**, therefore ignoring timeout(0.5 seconds) inside processRcAdjustments() function. And this cycle repeated itself...
***
If, anyone had similar configuration(basically if you use any of first 4 ranges), they might have encountered some issues(potentially dangerous, if done like so above => Pid P instantly becomes 200!)

That was probably TL;DR. Anyhow, this is a typo for sure.