### PR TITLE
Revert "PWM driver - startup value fix"

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -76,6 +76,8 @@ static void pwmOutConfigTimer(pwmOutputPort_t * p, const timerHardware_t *timerH
     p->ccr = timerCCR(timerHardware->tim, timerHardware->channel);
     p->period = period;
     p->tim = timerHardware->tim;
+
+    *p->ccr = 0;
 }
 
 static pwmOutputPort_t *pwmOutConfigMotor(const timerHardware_t *timerHardware, uint8_t mhz, uint16_t period, uint16_t value, bool enableOutput)


### PR DESCRIPTION
Revert https://github.com/iNavFlight/inav/pull/3540

- It is causing the issue of the elevons not going directly exactly to set mid point on startup
- It is causing issues with ESCs for @giacomo892 
- It is not needed it was not the cause of the startup servo twitch 