### PR TITLE
Fix sbus_sync_interval min/max values.

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -351,8 +351,8 @@ groups:
         type: bool
       - name: sbus_sync_interval
         field: sbusSyncInterval
-        min: 10000
-        max: 500
+        min: 500
+        max: 10000
       - name: rc_smoothing
         field: rcSmoothing
         type: bool


### PR DESCRIPTION
Switched min / max values for the sbus_sync_interval setting. 