### PR TITLE
Switch navTgtPos BB to int32_t

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -990,7 +990,7 @@ static void writeInterframe(void)
     }
 
     for (int x = 0; x < XYZ_AXIS_COUNT; x++) {
-        blackboxWriteSignedVB(blackboxHistory[0]->navTargetPos[x] - (blackboxHistory[1]->navTargetPos[x] + blackboxHistory[2]->navTargetPos[x]) / 2);
+        blackboxWriteSignedVB(blackboxHistory[0]->navTargetPos[x] - blackboxLast->navTargetPos[x]);
     }
 
     blackboxWriteSignedVB(blackboxCurrent->navSurface - blackboxLast->navSurface);

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -419,7 +419,7 @@ typedef struct blackboxMainState_s {
     int16_t navRealVel[XYZ_AXIS_COUNT];
     int16_t navAccNEU[XYZ_AXIS_COUNT];
     int16_t navTargetVel[XYZ_AXIS_COUNT];
-    int16_t navTargetPos[XYZ_AXIS_COUNT];
+    int32_t navTargetPos[XYZ_AXIS_COUNT];
     int16_t navHeading;
     int16_t navTargetHeading;
     int16_t navSurface;

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -163,7 +163,7 @@ int16_t navActualVelocity[3];
 int16_t navDesiredVelocity[3];
 int16_t navActualHeading;
 int16_t navDesiredHeading;
-int16_t navTargetPosition[3];
+int32_t navTargetPosition[3];
 int32_t navLatestActualPosition[3];
 int16_t navActualSurface;
 uint16_t navFlags;
@@ -2644,9 +2644,9 @@ void applyWaypointNavigationAndAltitudeHold(void)
     if (posControl.flags.isAdjustingAltitude)       navFlags |= (1 << 7);
     if (posControl.flags.isAdjustingHeading)        navFlags |= (1 << 8);
 
-    navTargetPosition[X] = constrain(lrintf(posControl.desiredState.pos.x), -32678, 32767);
-    navTargetPosition[Y] = constrain(lrintf(posControl.desiredState.pos.y), -32678, 32767);
-    navTargetPosition[Z] = constrain(lrintf(posControl.desiredState.pos.z), -32678, 32767);
+    navTargetPosition[X] = lrintf(posControl.desiredState.pos.x);
+    navTargetPosition[Y] = lrintf(posControl.desiredState.pos.y);
+    navTargetPosition[Z] = lrintf(posControl.desiredState.pos.z);
 #endif
 }
 

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -413,7 +413,7 @@ extern navSystemStatus_t    NAV_Status;
 extern int16_t navCurrentState;
 extern int16_t navActualVelocity[3];
 extern int16_t navDesiredVelocity[3];
-extern int16_t navTargetPosition[3];
+extern int32_t navTargetPosition[3];
 extern int32_t navLatestActualPosition[3];
 extern int16_t navActualSurface;
 extern uint16_t navFlags;


### PR DESCRIPTION
This fixes:

- Impossibility of logging values higher than 327m which makes debug almost impossibile in most of the logs we receive.
- Actual bug in the way navTgtPos was encoded into the BB using wrong prediction. 