### PR TITLE
Add rssi_offset, apply offset and scale to all protocols

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -349,6 +349,10 @@ groups:
       - name: rssi_invert
         field: rssiInvert
         type: bool
+      - name: rssi_offset
+        field: rssiOffset
+        min: RSSI_OFFSET_MIN
+        max: RSSI_OFFSET_MAX
       - name: sbus_sync_interval
         field: sbusSyncInterval
         min: 500

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -479,11 +479,8 @@ static inline void osdFormatFlyTime(char *buff, textAttributes_t *attr)
  */
 static uint16_t osdConvertRSSI(void)
 {
-    uint16_t osdRssi = getRSSI() * 100 / 1024; // change range
-    if (osdRssi >= 100) {
-        osdRssi = 99;
-    }
-    return osdRssi;
+    // change range to [0, 99]
+    return constrain(getRSSI() * 100 / RSSI_MAX_VALUE, 0, 99);
 }
 
 static void osdFormatCoordinate(char *buff, char sym, int32_t val)

--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -267,7 +267,7 @@ static uint8_t fportFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
                     } else {
                         result |= sbusChannelsDecode(rxRuntimeConfig, &frame->data.controlData.channels);
 
-                        setRSSI(scaleRange(constrain(frame->data.controlData.rssi, 0, 100), 0, 100, 0, 1024), RSSI_SOURCE_RX_PROTOCOL, false);
+                        setRSSI(scaleRange(frame->data.controlData.rssi, 0, 100, 0, RSSI_MAX_VALUE), RSSI_SOURCE_RX_PROTOCOL, false);
 
                         lastRcFrameReceivedMs = millis();
                     }

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -47,6 +47,8 @@
 #define DELAY_10_HZ (1000000 / 10)
 #define DELAY_5_HZ (1000000 / 5)
 
+#define RSSI_MAX_VALUE 1023
+
 typedef enum {
     RX_FRAME_PENDING = 0,               // No new data available from receiver
     RX_FRAME_COMPLETE = (1 << 0),       // There is new data available
@@ -101,6 +103,10 @@ extern int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];       // interval [1000;2
 #define RSSI_SCALE_MAX 255
 #define RSSI_SCALE_DEFAULT 100
 
+#define RSSI_OFFSET_MIN (-RSSI_MAX_VALUE)
+#define RSSI_OFFSET_MAX RSSI_MAX_VALUE
+#define RSSI_OFFSET_DEFAULT 0
+
 typedef struct rxChannelRangeConfig_s {
     uint16_t min;
     uint16_t max;
@@ -121,6 +127,7 @@ typedef struct rxConfig_s {
     uint8_t rssi_channel;
     uint8_t rssi_scale;
     uint8_t rssiInvert;
+    int16_t rssiOffset;
     uint16_t sbusSyncInterval;
     uint16_t mincheck;                      // minimum rc end
     uint16_t maxcheck;                      // maximum rc end
@@ -174,6 +181,7 @@ void parseRcChannels(const char *input);
 void setRSSI(uint16_t newRssi, rssiSource_e source, bool filtered);
 void setRSSIFromMSP(uint8_t newMspRssi);
 void updateRSSI(timeUs_t currentTimeUs);
+// Returns RSSI in [0, RSSI_MAX_VALUE] range.
 uint16_t getRSSI(void);
 rssiSource_e getRSSISource(void);
 


### PR DESCRIPTION
This allows any possible received RSSI to be mapped to [0, 100],
no matter the range and offset of value emitted by the RX.

Also, apply the RSSI scale and offset to all RSSI sources except
via MSP (via MSP we expect the sender to be well behaved and send
only values in [0, RSSI_MAX_VALUE]).

Fixes #2898
Fixes #3497
Fixes #3607