### PR TITLE
Replace rssi_scale and rssi_invert with rssi_min and rssi_max

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -103,8 +103,8 @@ After restoring it's always a good idea to `dump` or `diff` the settings once ag
 |  min_check  | 1100 | These are min/max values (in us) which, when a channel is smaller (min) or larger (max) than the value will activate various RC commands, such as arming, or stick configuration. Normally, every RC channel should be set so that min = 1000us, max = 2000us. On most transmitters this usually means 125% endpoints. Default check values are 100us above/below this value. |
 |  max_check  | 1900 | These are min/max values (in us) which, when a channel is smaller (min) or larger (max) than the value will activate various RC commands, such as arming, or stick configuration. Normally, every RC channel should be set so that min = 1000us, max = 2000us. On most transmitters this usually means 125% endpoints. Default check values are 100us above/below this value. |
 |  rssi_channel  | 0 | RX channel containing the RSSI signal |
-|  rssi_scale  | 100 | By default RSSI expects to use full span of the input (0-3.3V for ADC, 1000-2000 for AUX channel). This scale (percentage) allows you to adjust the scaling to get 100% RSSI shown correctly |
-|  rssi_invert  | OFF |  |
+|  rssi_min  | 0 | The minimum RSSI value sent by the receiver, in %. For example, if your receiver's minimum RSSI value shows as 42% in the configurator/OSD set this parameter to 42. See also rssi_max. Note that rssi_min can be set to a value bigger than rssi_max to invert the RSSI calculation (i.e. bigger values mean lower RSSI). |
+|  rssi_max  | 100 | The maximum RSSI value sent by the receiver, in %. For example, if your receiver's maximum RSSI value shows as 83% in the configurator/OSD set this parameter to 83. See also rssi_min. |
 |  rc_smoothing  | ON | Interpolation of Rc data during looptimes when there are no new updates. This gives smoother RC input to PID controller and cleaner PIDsum |
 |  input_filtering_mode  | OFF | Filter out noise from OpenLRS Telemetry RX |
 |  min_throttle  | 1150 | These are min/max values (in us) that are sent to esc when armed. Defaults of 1150/1850 are OK for everyone, for use with AfroESC, they could be set to 1064/1864. |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -343,12 +343,14 @@ groups:
       - name: rssi_channel
         min: 0
         max: MAX_SUPPORTED_RC_CHANNEL_COUNT
-      - name: rssi_scale
-        min: RSSI_SCALE_MIN
-        max: RSSI_SCALE_MAX
-      - name: rssi_invert
-        field: rssiInvert
-        type: bool
+      - name: rssi_min
+        field: rssiMin
+        min: RSSI_VISIBLE_VALUE_MIN
+        max: RSSI_VISIBLE_VALUE_MAX
+      - name: rssi_max
+        field: rssiMax
+        min: RSSI_VISIBLE_VALUE_MIN
+        max: RSSI_VISIBLE_VALUE_MAX
       - name: sbus_sync_interval
         field: sbusSyncInterval
         min: 500

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -479,11 +479,8 @@ static inline void osdFormatFlyTime(char *buff, textAttributes_t *attr)
  */
 static uint16_t osdConvertRSSI(void)
 {
-    uint16_t osdRssi = getRSSI() * 100 / 1024; // change range
-    if (osdRssi >= 100) {
-        osdRssi = 99;
-    }
-    return osdRssi;
+    // change range to [0, 99]
+    return constrain(getRSSI() * 100 / RSSI_MAX_VALUE, 0, 99);
 }
 
 static void osdFormatCoordinate(char *buff, char sym, int32_t val)

--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -267,7 +267,7 @@ static uint8_t fportFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
                     } else {
                         result |= sbusChannelsDecode(rxRuntimeConfig, &frame->data.controlData.channels);
 
-                        setRSSI(scaleRange(constrain(frame->data.controlData.rssi, 0, 100), 0, 100, 0, 1024), RSSI_SOURCE_RX_PROTOCOL, false);
+                        setRSSI(scaleRange(frame->data.controlData.rssi, 0, 100, 0, RSSI_MAX_VALUE), RSSI_SOURCE_RX_PROTOCOL, false);
 
                         lastRcFrameReceivedMs = millis();
                     }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -100,7 +100,7 @@ uint32_t rcInvalidPulsPeriod[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 rxRuntimeConfig_t rxRuntimeConfig;
 static uint8_t rcSampleIndex = 0;
 
-PG_REGISTER_WITH_RESET_TEMPLATE(rxConfig_t, rxConfig, PG_RX_CONFIG, 5);
+PG_REGISTER_WITH_RESET_TEMPLATE(rxConfig_t, rxConfig, PG_RX_CONFIG, 6);
 
 #ifndef RX_SPI_DEFAULT_PROTOCOL
 #define RX_SPI_DEFAULT_PROTOCOL 0
@@ -127,8 +127,8 @@ PG_RESET_TEMPLATE(rxConfig_t, rxConfig,
     .rx_min_usec = RX_MIN_USEX,          // any of first 4 channels below this value will trigger rx loss detection
     .rx_max_usec = 2115,         // any of first 4 channels above this value will trigger rx loss detection
     .rssi_channel = 0,
-    .rssi_scale = RSSI_SCALE_DEFAULT,
-    .rssiInvert = 0,
+    .rssiMin = RSSI_VISIBLE_VALUE_MIN,
+    .rssiMax = RSSI_VISIBLE_VALUE_MAX,
     .sbusSyncInterval = SBUS_DEFAULT_INTERFRAME_DELAY_US,
     .rcSmoothing = 1,
 );
@@ -334,22 +334,40 @@ void rxUpdateRSSISource(void)
         return;
     }
 
-#ifdef USE_SERIAL_RX
     bool serialProtocolSupportsRSSI = false;
-    if (rxConfig()->receiverType) {
+    switch (rxConfig()->receiverType) {
+#if defined(USE_SERIAL_RX)
+    case RX_TYPE_SERIAL:
         switch (rxConfig()->serialrx_provider) {
-#ifdef USE_SERIALRX_FPORT
+#if defined(USE_SERIALRX_FPORT)
         case SERIALRX_FPORT:
             serialProtocolSupportsRSSI = true;
             break;
 #endif
+        default:
+            break;
         }
+        break;
+#endif
+#if defined(USE_RX_SPI)
+    case RX_TYPE_SPI:
+        switch (rxConfig()->rx_spi_protocol) {
+#if defined(USE_RX_ELERES)
+        case RFM22_ELERES:
+            serialProtocolSupportsRSSI = true;
+            break;
+        break;
+#endif
+        default:
+            break;
+        }
+#endif
+        break;
     }
     if (serialProtocolSupportsRSSI) {
         rssiSource = RSSI_SOURCE_RX_PROTOCOL;
         return;
     }
-#endif
 }
 
 static uint8_t calculateChannelRemapping(const uint8_t *channelMap, uint8_t channelMapEntryCount, uint8_t channelToRemap)
@@ -549,7 +567,6 @@ void parseRcChannels(const char *input)
 }
 
 #define RSSI_SAMPLE_COUNT 16
-#define RSSI_MAX_VALUE 1023
 
 void setRSSI(uint16_t rssiValue, rssiSource_e source, bool filtered)
 {
@@ -575,6 +592,18 @@ void setRSSI(uint16_t rssiValue, rssiSource_e source, bool filtered)
 
         rssi = rssiMean;
     }
+
+    // Apply min/max values
+    int rssiMin = rxConfig()->rssiMin * RSSI_VISIBLE_FACTOR;
+    int rssiMax = rxConfig()->rssiMax * RSSI_VISIBLE_FACTOR;
+    if (rssiMin > rssiMax) {
+        int tmp = rssiMax;
+        rssiMax = rssiMin;
+        rssiMin = tmp;
+        int delta = rssi >= rssiMin ? rssi - rssiMin : 0;
+        rssi = rssiMax >= delta ? rssiMax - delta : 0;
+    }
+    rssi = constrain(scaleRange(rssi, rssiMin, rssiMax, 0, RSSI_MAX_VALUE), 0, RSSI_MAX_VALUE);
 }
 
 void setRSSIFromMSP(uint8_t newMspRssi)
@@ -590,15 +619,14 @@ void setRSSIFromMSP(uint8_t newMspRssi)
 }
 
 #ifdef USE_RX_ELERES
-static bool updateRSSIeleres(uint32_t currentTime)
+static void updateRSSIeleres(uint32_t currentTime)
 {
     UNUSED(currentTime);
-    rssi = eleresRssi();
-    return true;
+    setRSSI(eleresRssi(), RSSI_SOURCE_RX_PROTOCOL, true);
 }
 #endif // USE_RX_ELERES
 
-static bool updateRSSIPWM(void)
+static void updateRSSIPWM(void)
 {
     int16_t pwmRssi = 0;
     // Read value of AUX channel as rssi
@@ -608,34 +636,26 @@ static bool updateRSSIPWM(void)
         // Range of rawPwmRssi is [1000;2000]. rssi should be in [0;1023];
         uint16_t rawRSSI = (uint16_t)((constrain(pwmRssi - 1000, 0, 1000) / 1000.0f) * (RSSI_MAX_VALUE * 1.0f));
         setRSSI(rawRSSI, RSSI_SOURCE_RX_CHANNEL, false);
-
-        return true;
     }
-    return false;
 }
 
-static bool updateRSSIADC(void)
+static void updateRSSIADC(void)
 {
 #ifdef USE_ADC
     uint16_t rawRSSI = adcGetChannel(ADC_RSSI) / 4;    // Reduce to [0;1023]
     setRSSI(rawRSSI, RSSI_SOURCE_ADC, false);
-    return true;
-#else
-    return false;
 #endif
 }
 
 void updateRSSI(timeUs_t currentTimeUs)
 {
-    bool rssiUpdated = false;
-
     // Read RSSI
     switch (rssiSource) {
     case RSSI_SOURCE_RX_CHANNEL:
-        rssiUpdated = updateRSSIPWM();
+        updateRSSIPWM();
         break;
     case RSSI_SOURCE_ADC:
-        rssiUpdated = updateRSSIADC();
+        updateRSSIADC();
         break;
     case RSSI_SOURCE_MSP:
         if (cmpTimeUs(currentTimeUs, lastMspRssiUpdateUs) > MSP_RSSI_TIMEOUT_US) {
@@ -645,20 +665,10 @@ void updateRSSI(timeUs_t currentTimeUs)
     default:
 #ifdef USE_RX_ELERES
         if (rxConfig()->receiverType == RX_TYPE_SPI && rxConfig()->rx_spi_protocol == RFM22_ELERES) {
-            rssiUpdated = updateRSSIeleres(currentTimeUs);
+            updateRSSIeleres(currentTimeUs);
         }
 #endif
         break;
-    }
-
-    if (rssiUpdated) {
-        // Apply RSSI inversion
-        if (rxConfig()->rssiInvert) {
-            rssi = RSSI_MAX_VALUE - rssi;
-        }
-
-        // Apply scaling
-        rssi = constrain((uint32_t)rssi * rxConfig()->rssi_scale / 100, 0, RSSI_MAX_VALUE);
     }
 }
 

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -47,6 +47,8 @@
 #define DELAY_10_HZ (1000000 / 10)
 #define DELAY_5_HZ (1000000 / 5)
 
+#define RSSI_MAX_VALUE 1023
+
 typedef enum {
     RX_FRAME_PENDING = 0,               // No new data available from receiver
     RX_FRAME_COMPLETE = (1 << 0),       // There is new data available
@@ -97,9 +99,9 @@ extern int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];       // interval [1000;2
 
 #define MAX_MAPPABLE_RX_INPUTS 4
 
-#define RSSI_SCALE_MIN 1
-#define RSSI_SCALE_MAX 255
-#define RSSI_SCALE_DEFAULT 100
+#define RSSI_VISIBLE_VALUE_MIN 0
+#define RSSI_VISIBLE_VALUE_MAX 100
+#define RSSI_VISIBLE_FACTOR (RSSI_MAX_VALUE/(float)RSSI_VISIBLE_VALUE_MAX)
 
 typedef struct rxChannelRangeConfig_s {
     uint16_t min;
@@ -119,8 +121,8 @@ typedef struct rxConfig_s {
     uint8_t spektrum_sat_bind;              // number of bind pulses for Spektrum satellite receivers
     uint8_t spektrum_sat_bind_autoreset;    // whenever we will reset (exit) binding mode after hard reboot
     uint8_t rssi_channel;
-    uint8_t rssi_scale;
-    uint8_t rssiInvert;
+    uint8_t rssiMin;                        // minimum RSSI sent by the RX - [RSSI_VISIBLE_VALUE_MIN, RSSI_VISIBLE_VALUE_MAX]
+    uint8_t rssiMax;                        // maximum RSSI sent by the RX - [RSSI_VISIBLE_VALUE_MIN, RSSI_VISIBLE_VALUE_MAX]
     uint16_t sbusSyncInterval;
     uint16_t mincheck;                      // minimum rc end
     uint16_t maxcheck;                      // maximum rc end
@@ -174,6 +176,7 @@ void parseRcChannels(const char *input);
 void setRSSI(uint16_t newRssi, rssiSource_e source, bool filtered);
 void setRSSIFromMSP(uint8_t newMspRssi);
 void updateRSSI(timeUs_t currentTimeUs);
+// Returns RSSI in [0, RSSI_MAX_VALUE] range.
 uint16_t getRSSI(void);
 rssiSource_e getRSSISource(void);
 


### PR DESCRIPTION
rssi_min and rssi_max allow users to specify their RSSI range by
simply introducing the smaller and bigger values they see in the
configurator or OSD, similarly to how rxrange works.

Supersedes #3611
Fixes #2898,  #3497 and #3607