### PR TITLE
Eliminate 500us Smarport response delay

### DIFF
--- a/src/main/telemetry/smartport.h
+++ b/src/main/telemetry/smartport.h
@@ -52,7 +52,7 @@ bool initSmartPortTelemetryExternal(smartPortWriteFrameFn *smartPortWriteFrameEx
 void handleSmartPortTelemetry(void);
 void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *hasRequest, const uint32_t *requestTimeout);
 
-smartPortPayload_t *smartPortDataReceive(uint16_t c, bool *clearToSend, timeUs_t *clearToSendAt, smartPortCheckQueueEmptyFn *checkQueueEmpty, bool withChecksum);
+smartPortPayload_t *smartPortDataReceive(uint16_t c, bool *clearToSend, smartPortCheckQueueEmptyFn *checkQueueEmpty, bool withChecksum);
 
 struct serialPort_s;
 void smartPortWriteFrameSerial(const smartPortPayload_t *payload, struct serialPort_s *port, uint16_t checksum);


### PR DESCRIPTION
In 1.9.1, we didn't have any delays due to a bug which
wasn't updating the time of the last received S.Port request
but no problems were reported besides the lost of all sensors
after 35 minutes (caused by the overflow of the time
comparison).

However, enforcing the delay seems to cause issues with MSP
over SmartPort, see the following BF issues which has
already included the fixed delay in a release:

https://github.com/betaflight/betaflight/issues/6313
https://github.com/betaflight/betaflight/issues/6360
https://github.com/betaflight/betaflight/issues/6369

Tracing back the origin of the delay, it looks like it was added
as a cautionary measure at some point because FPort does need it,
but everything indicates S.Port works fine without it.