### PR TITLE
Add workaround for AKK VTX with S.Audio bug

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -447,6 +447,11 @@ static void saSendFrame(uint8_t *buf, int len)
         serialWrite(smartAudioSerialPort, buf[i]);
     }
 
+    // XXX: Workaround for early AKK SAudio-enabled VTX bug,
+    // shouldn't cause any problems with VTX with properly
+    // implemented SAudio.
+    serialWrite(smartAudioSerialPort, 0x00);
+
     sa_lastTransmissionMs = millis();
     saStat.pktsent++;
 }


### PR DESCRIPTION
It shouldn't affect VTX properly implementing SmartAudio, since
the workaround only requires sending an extra zero byte. Tested
with AKK X2 Ultimate.

Fixes #3625