### PR TITLE
Updated CRSF frame format to use the sync byte instead of the frame address

### DIFF
--- a/src/main/rx/crsf.h
+++ b/src/main/rx/crsf.h
@@ -59,7 +59,7 @@ enum {
     CRSF_ADDRESS_CRSF_TRANSMITTER = 0xEE
 };
 
-#define CRSF_PAYLOAD_SIZE_MAX   32 // !!TODO needs checking
+#define CRSF_PAYLOAD_SIZE_MAX   62
 #define CRSF_FRAME_SIZE_MAX     (CRSF_PAYLOAD_SIZE_MAX + 4)
 
 typedef struct crsfFrameDef_s {

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -57,7 +57,13 @@
 #include "telemetry/telemetry.h"
 
 
-#define CRSF_CYCLETIME_US                   100000 // 100ms, 10 Hz
+#define CRSF_CYCLETIME_US                   100000  // 100ms, 10 Hz
+
+// According to TBS: "CRSF over serial should always use a sync byte at the beginning of each frame.
+// To get better performance it's recommended to use the sync byte 0xC8 to get better performance"
+//
+// Digitalentity: Using frame address byte as a sync field looks somewhat hacky to me, but seems it's needed to get CRSF working properly
+#define CRSF_TELEMETRY_SYNC_BYTE            0xC8
 
 static bool crsfTelemetryEnabled;
 static uint8_t crsfCrc;
@@ -69,7 +75,7 @@ static void crsfInitializeFrame(sbuf_t *dst)
     dst->ptr = crsfFrame;
     dst->end = ARRAYEND(crsfFrame);
 
-    sbufWriteU8(dst, CRSF_ADDRESS_BROADCAST);
+    sbufWriteU8(dst, CRSF_TELEMETRY_SYNC_BYTE);
 }
 
 static void crsfSerialize8(sbuf_t *dst, uint8_t v)


### PR DESCRIPTION
Per https://github.com/iNavFlight/inav/issues/3632
@sirPerna, FYI