### PR TITLE
Fix the OSD emergency landing warning message

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -691,7 +691,10 @@ static const char * navigationStateMessage(void)
             // Not used
             break;
         case MW_NAV_STATE_LAND_START:
-            return OSD_MESSAGE_STR("STARTING EMERGENCY LANDING");
+            // Not used
+            break;
+        case MW_NAV_STATE_EMERGENCY_LANDING:
+            return OSD_MESSAGE_STR("EMERGENCY LANDING");
         case MW_NAV_STATE_LAND_IN_PROGRESS:
             return OSD_MESSAGE_STR("LANDING");
         case MW_NAV_STATE_HOVER_ABOVE_HOME:
@@ -2041,7 +2044,7 @@ static bool osdDrawSingleElement(uint8_t item)
                         // will cause it to be missing from some frames.
                     }
                 } else {
-                    if (FLIGHT_MODE(NAV_RTH_MODE) || FLIGHT_MODE(NAV_WP_MODE)) {
+                    if (FLIGHT_MODE(NAV_RTH_MODE) || FLIGHT_MODE(NAV_WP_MODE) || navigationIsExecutingAnEmergencyLanding()) {
                         const char *navStateMessage = navigationStateMessage();
                         if (navStateMessage) {
                             messages[messageCount++] = navStateMessage;

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -704,7 +704,7 @@ static const navigationFSMStateDescriptor_t navFSM[NAV_STATE_COUNT] = {
         .timeoutMs = 0,
         .stateFlags = NAV_CTL_EMERG | NAV_REQUIRE_ANGLE,
         .mapToFlightModes = 0,
-        .mwState = MW_NAV_STATE_LAND_START,
+        .mwState = MW_NAV_STATE_EMERGENCY_LANDING,
         .mwError = MW_NAV_ERROR_LANDING,
         .onEvent = {
             [NAV_FSM_EVENT_SUCCESS]                     = NAV_STATE_EMERGENCY_LANDING_IN_PROGRESS,
@@ -720,7 +720,7 @@ static const navigationFSMStateDescriptor_t navFSM[NAV_STATE_COUNT] = {
         .timeoutMs = 10,
         .stateFlags = NAV_CTL_EMERG | NAV_REQUIRE_ANGLE,
         .mapToFlightModes = 0,
-        .mwState = MW_NAV_STATE_LAND_IN_PROGRESS,
+        .mwState = MW_NAV_STATE_EMERGENCY_LANDING,
         .mwError = MW_NAV_ERROR_LANDING,
         .onEvent = {
             [NAV_FSM_EVENT_TIMEOUT]                     = NAV_STATE_EMERGENCY_LANDING_IN_PROGRESS,    // re-process the state
@@ -3047,6 +3047,11 @@ rthState_e getStateOfForcedRTH(void)
     else {
         return RTH_IDLE;
     }
+}
+
+bool navigationIsExecutingAnEmergencyLanding(void)
+{
+    return navGetCurrentStateFlags() & NAV_CTL_EMERG;
 }
 
 bool navigationIsControllingThrottle(void)

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -272,12 +272,13 @@ typedef enum {
     MW_NAV_STATE_WP_ENROUTE,              // WP Enroute
     MW_NAV_STATE_PROCESS_NEXT,            // Process next
     MW_NAV_STATE_DO_JUMP,                 // Jump
-    MW_NAV_STATE_LAND_START,              // Start Land
+    MW_NAV_STATE_LAND_START,              // Start Land (unused)
     MW_NAV_STATE_LAND_IN_PROGRESS,        // Land in Progress
     MW_NAV_STATE_LANDED,                  // Landed
     MW_NAV_STATE_LAND_SETTLE,             // Settling before land
     MW_NAV_STATE_LAND_START_DESCENT,      // Start descent
-    MW_NAV_STATE_HOVER_ABOVE_HOME         // Hover/Loitering above home
+    MW_NAV_STATE_HOVER_ABOVE_HOME,        // Hover/Loitering above home
+    MW_NAV_STATE_EMERGENCY_LANDING,       // Emergency landing
 } navSystemStatus_State_e;
 
 typedef enum {
@@ -384,6 +385,7 @@ rthState_e getStateOfForcedRTH(void);
 bool navigationIsControllingThrottle(void);
 bool isFixedWingAutoThrottleManuallyIncreased(void);
 bool navigationIsFlyingAutonomousMode(void);
+bool navigationIsExecutingAnEmergencyLanding(void);
 /* Returns true iff navConfig()->general.flags.rth_allow_landing is NAV_RTH_ALLOW_LANDING_ALWAYS
  * or if it's NAV_RTH_ALLOW_LANDING_FAILSAFE and failsafe mode is active.
  */


### PR DESCRIPTION
Nothing was displayed on the OSD when an emergency landing was triggered