### PR TITLE
Initialize timer pins in a backward-compatible way.

### DIFF
--- a/src/main/drivers/system_stm32f4xx.c
+++ b/src/main/drivers/system_stm32f4xx.c
@@ -94,10 +94,10 @@ void enableGPIOPowerUsageAndNoiseReductions(void)
         RCC_APB1Periph_I2C1 |
         RCC_APB1Periph_I2C2 |
         RCC_APB1Periph_I2C3 |
-        RCC_APB1Periph_CAN1 |
-        RCC_APB1Periph_CAN2 |
+        // RCC_APB1Periph_CAN1 |
+        // RCC_APB1Periph_CAN2 |
         RCC_APB1Periph_PWR |
-        RCC_APB1Periph_DAC |
+        // RCC_APB1Periph_DAC |
         0, ENABLE);
 
     RCC_APB2PeriphClockCmd(
@@ -109,7 +109,7 @@ void enableGPIOPowerUsageAndNoiseReductions(void)
         RCC_APB2Periph_ADC1 |
         RCC_APB2Periph_ADC2 |
         RCC_APB2Periph_ADC3 |
-        RCC_APB2Periph_SDIO |
+        // RCC_APB2Periph_SDIO |
         RCC_APB2Periph_SPI1 |
         RCC_APB2Periph_SYSCFG |
         RCC_APB2Periph_TIM9 |
@@ -119,7 +119,7 @@ void enableGPIOPowerUsageAndNoiseReductions(void)
 
     GPIO_InitTypeDef GPIO_InitStructure;
     GPIO_StructInit(&GPIO_InitStructure);
-    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP; // default is un-pulled input
+    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
 
     GPIO_InitStructure.GPIO_Pin  = GPIO_Pin_All;
     GPIO_InitStructure.GPIO_Pin &= ~(GPIO_Pin_11 | GPIO_Pin_12); // leave USB D+/D- alone

--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -188,8 +188,14 @@ void timerInit(void)
     /* enable the timer peripherals */
     for (int i = 0; i < timerHardwareCount; i++) {
         unsigned timer = lookupTimerIndex(timerHardware[i].tim);
-        
         RCC_ClockCmd(timerDefinitions[timer].rcc, ENABLE);
+    }
+
+    /* Before 2.0 timer outputs were initialized to IOCFG_AF_PP_PD even if not used */
+    /* To keep compatibility make sure all timer output pins are mapped to INPUT with weak pull-down */
+    for (int i = 0; i < timerHardwareCount; i++) {
+        const timerHardware_t *timerHardwarePtr = &timerHardware[i];
+        IOConfigGPIO(IOGetByTag(timerHardwarePtr->tag), IOCFG_IPD);
     }
 }
 


### PR DESCRIPTION
INAV <2.0 initializes all timer pins even if they are not used. Pins were connected to timers and initialized with weak pull-down.

In INAV 2.0+ we initialize all pins with pull-ups by default which may cause issues with peripherals that rely on default pin state.

This pr initializes all timer pins as IN_PD. In addition on F4 we initialize all pins as floating at boot and disable some unused clock peripherals.

Bench-tested, seems to work well.