### PR TITLE
Update AUTHORS list. Add Contributor Code of Conduct

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,9 +3,11 @@ If you believe you should be on this list - feel free to open a PR updating it. 
 inclusion into this list please provide information about which part of code belongs to you.
 
 Albert Kravcov
+Alberto García Hierro
 Alex Gorbatchev
 Alex Zaitsev
 Alexander Fedorov
+Alexey Stankevich
 Andre Bernet
 Andreas Tacke
 Andrew Payne
@@ -30,6 +32,7 @@ Fredrik Steen
 Gareth Wilkins
 Gaël James
 Gregor Ottmann
+Google LLC
 Hyon Lim
 James Harrison
 Jan Staal
@@ -56,10 +59,12 @@ Max Winterstein
 Michael Corcoran
 Michael Hope
 Michael Jakob
+Michel Pastor
 Miha Valencic
 Mikael Blomqvist
 Moritz Ulrich
 Moshen Chan
+Nathan Tsoi
 Nicholas Sherlock
 Paul Fertser
 Paul Rogalinski
@@ -77,8 +82,10 @@ Samuel Brucksch
 Scott Shawcroft
 Sean Vig
 Stefan Grufman
+Stefan Haubold
 Steve Amor
 Thomas Buck
+Tim Eckel
 Trey Marc
 Tuomas Kuosmanen
 Zap Andersson

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
Added more contributors. If I missed someone - drop in, I'll amend the list.
Code of conduct is derived from default template suggested by GitHub.