### PR TITLE
Drop multiwii I2C gps board support for OMNIBUS

### DIFF
--- a/src/main/target/OMNIBUS/target.h
+++ b/src/main/target/OMNIBUS/target.h
@@ -60,6 +60,8 @@
 #define USE_MAG_MAG3110
 #define USE_MAG_LIS3MDL
 
+#undef USE_GPS_PROTO_I2C_NAV //Save some flash space
+
 #define USB_CABLE_DETECTION
 #define USB_DETECT_PIN          PB5
 


### PR DESCRIPTION
Saves 400bytes of flash allowing us to easily release 2.0 for OMNIBUS boards without loosing anything useful.

MultiWII I2C GPS boards are not used by anyone sane of mind nowadays 