### PR TITLE
minor gcc 8.2 cleanup for unnecessary use of packed in f7 USB driver

### DIFF
--- a/lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c
+++ b/lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c
@@ -5,21 +5,21 @@
   * @version V1.2.2
   * @date    14-April-2017
   * @brief   USB Low Layer HAL module driver.
-  *    
-  *          This file provides firmware functions to manage the following 
+  *
+  *          This file provides firmware functions to manage the following
   *          functionalities of the USB Peripheral Controller:
   *           + Initialization/de-initialization functions
   *           + I/O operation functions
-  *           + Peripheral Control functions 
+  *           + Peripheral Control functions
   *           + Peripheral State functions
-  *         
+  *
   @verbatim
   ==============================================================================
                     ##### How to use this driver #####
   ==============================================================================
     [..]
       (#) Fill parameters of Init structure in USB_OTG_CfgTypeDef structure.
-  
+
       (#) Call USB_CoreInit() API to initialize the USB Core peripheral.
 
       (#) The upper HAL HCD/PCD driver will call the right routines for its internal processes.
@@ -53,7 +53,7 @@
   * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   *
   ******************************************************************************
-  */ 
+  */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f7xx_hal.h"
@@ -72,7 +72,7 @@
 /* Private functions ---------------------------------------------------------*/
 static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx);
 
-#ifdef USB_HS_PHYC 
+#ifdef USB_HS_PHYC
 static HAL_StatusTypeDef USB_HS_PHYCInit(USB_OTG_GlobalTypeDef *USBx);
 #endif
 
@@ -81,15 +81,15 @@ static HAL_StatusTypeDef USB_HS_PHYCInit(USB_OTG_GlobalTypeDef *USBx);
   * @{
   */
 
-/** @defgroup LL_USB_Group1 Initialization/de-initialization functions 
- *  @brief    Initialization and Configuration functions 
+/** @defgroup LL_USB_Group1 Initialization/de-initialization functions
+ *  @brief    Initialization and Configuration functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
               ##### Initialization/de-initialization functions #####
  ===============================================================================
     [..]  This section provides functions allowing to:
- 
+
 @endverbatim
   * @{
   */
@@ -105,12 +105,12 @@ HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 {
   if (cfg.phy_itface == USB_OTG_ULPI_PHY)
   {
-    
+
     USBx->GCCFG &= ~(USB_OTG_GCCFG_PWRDWN);
 
     /* Init The ULPI Interface */
     USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_TSDPS | USB_OTG_GUSBCFG_ULPIFSLS | USB_OTG_GUSBCFG_PHYSEL);
-   
+
     /* Select vbus source */
     USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_ULPIEVBUSD | USB_OTG_GUSBCFG_ULPIEVBUSI);
     if(cfg.use_external_vbus == 1)
@@ -118,53 +118,53 @@ HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
       USBx->GUSBCFG |= USB_OTG_GUSBCFG_ULPIEVBUSD;
     }
     /* Reset after a PHY select  */
-    USB_CoreReset(USBx); 
+    USB_CoreReset(USBx);
   }
-#ifdef USB_HS_PHYC 
-  
+#ifdef USB_HS_PHYC
+
   else if (cfg.phy_itface == USB_OTG_HS_EMBEDDED_PHY)
   {
     USBx->GCCFG &= ~(USB_OTG_GCCFG_PWRDWN);
-    
+
     /* Init The UTMI Interface */
     USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_TSDPS | USB_OTG_GUSBCFG_ULPIFSLS | USB_OTG_GUSBCFG_PHYSEL);
-    
+
     /* Select vbus source */
     USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_ULPIEVBUSD | USB_OTG_GUSBCFG_ULPIEVBUSI);
-    
+
     /* Select UTMI Interace */
     USBx->GUSBCFG &= ~ USB_OTG_GUSBCFG_ULPI_UTMI_SEL;
     USBx->GCCFG |= USB_OTG_GCCFG_PHYHSEN;
-    
+
     /* Enables control of a High Speed USB PHY */
     USB_HS_PHYCInit(USBx);
-    
+
     if(cfg.use_external_vbus == 1)
     {
       USBx->GUSBCFG |= USB_OTG_GUSBCFG_ULPIEVBUSD;
     }
     /* Reset after a PHY select  */
-    USB_CoreReset(USBx); 
-    
+    USB_CoreReset(USBx);
+
   }
 #endif
   else /* FS interface (embedded Phy) */
   {
     /* Select FS Embedded PHY */
     USBx->GUSBCFG |= USB_OTG_GUSBCFG_PHYSEL;
-    
+
     /* Reset after a PHY select and set Host mode */
     USB_CoreReset(USBx);
-    
+
     /* Deactivate the power down*/
     USBx->GCCFG = USB_OTG_GCCFG_PWRDWN;
   }
- 
+
   if(cfg.dma_enable == ENABLE)
   {
     USBx->GAHBCFG |= USB_OTG_GAHBCFG_HBSTLEN_2;
     USBx->GAHBCFG |= USB_OTG_GAHBCFG_DMAEN;
-  }  
+  }
 
   return HAL_OK;
 }
@@ -193,7 +193,7 @@ HAL_StatusTypeDef USB_DisableGlobalInt(USB_OTG_GlobalTypeDef *USBx)
   USBx->GAHBCFG &= ~USB_OTG_GAHBCFG_GINT;
   return HAL_OK;
 }
-   
+
 /**
   * @brief  USB_SetCurrentMode : Set functional mode
   * @param  USBx : Selected device
@@ -201,28 +201,28 @@ HAL_StatusTypeDef USB_DisableGlobalInt(USB_OTG_GlobalTypeDef *USBx)
   *          This parameter can be one of these values:
   *            @arg USB_OTG_DEVICE_MODE: Peripheral mode
   *            @arg USB_OTG_HOST_MODE: Host mode
-  *            @arg USB_OTG_DRD_MODE: Dual Role Device mode  
+  *            @arg USB_OTG_DRD_MODE: Dual Role Device mode
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_OTG_ModeTypeDef mode)
 {
-  USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_FHMOD | USB_OTG_GUSBCFG_FDMOD); 
-  
+  USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_FHMOD | USB_OTG_GUSBCFG_FDMOD);
+
   if ( mode == USB_OTG_HOST_MODE)
   {
-    USBx->GUSBCFG |= USB_OTG_GUSBCFG_FHMOD; 
+    USBx->GUSBCFG |= USB_OTG_GUSBCFG_FHMOD;
   }
   else if ( mode == USB_OTG_DEVICE_MODE)
   {
-    USBx->GUSBCFG |= USB_OTG_GUSBCFG_FDMOD; 
+    USBx->GUSBCFG |= USB_OTG_GUSBCFG_FDMOD;
   }
   HAL_Delay(50);
-  
+
   return HAL_OK;
 }
 
 /**
-  * @brief  USB_DevInit : Initializes the USB_OTG controller registers 
+  * @brief  USB_DevInit : Initializes the USB_OTG controller registers
   *         for device mode
   * @param  USBx : Selected device
   * @param  cfg  : pointer to a USB_OTG_CfgTypeDef structure that contains
@@ -235,51 +235,51 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 
   /*Activate VBUS Sensing B */
   USBx->GCCFG |= USB_OTG_GCCFG_VBDEN;
-  
+
   if (cfg.vbus_sensing_enable == 0)
   {
     /* Deactivate VBUS Sensing B */
     USBx->GCCFG &= ~ USB_OTG_GCCFG_VBDEN;
-    
-    /* B-peripheral session valid override enable*/ 
+
+    /* B-peripheral session valid override enable*/
     USBx->GOTGCTL |= USB_OTG_GOTGCTL_BVALOEN;
     USBx->GOTGCTL |= USB_OTG_GOTGCTL_BVALOVAL;
   }
-   
+
   /* Restart the Phy Clock */
   USBx_PCGCCTL = 0;
 
   /* Device mode configuration */
   USBx_DEVICE->DCFG |= DCFG_FRAME_INTERVAL_80;
-  
+
   if(cfg.phy_itface  == USB_OTG_ULPI_PHY)
   {
     if(cfg.speed == USB_OTG_SPEED_HIGH)
-    {      
+    {
       /* Set High speed phy */
       USB_SetDevSpeed (USBx , USB_OTG_SPEED_HIGH);
     }
-    else 
+    else
     {
       /* set High speed phy in Full speed mode */
       USB_SetDevSpeed (USBx , USB_OTG_SPEED_HIGH_IN_FULL);
     }
   }
-  
+
   else if(cfg.phy_itface  == USB_OTG_HS_EMBEDDED_PHY)
   {
     if(cfg.speed == USB_OTG_SPEED_HIGH)
-    {      
+    {
       /* Set High speed phy */
       USB_SetDevSpeed (USBx , USB_OTG_SPEED_HIGH);
     }
-    else 
+    else
     {
       /* set High speed phy in Full speed mode */
       USB_SetDevSpeed (USBx , USB_OTG_SPEED_HIGH_IN_FULL);
     }
   }
-  
+
   else
   {
     /* Set Full speed phy */
@@ -289,13 +289,13 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   /* Flush the FIFOs */
   USB_FlushTxFifo(USBx , 0x10); /* all Tx FIFOs */
   USB_FlushRxFifo(USBx);
-  
+
   /* Clear all pending Device Interrupts */
   USBx_DEVICE->DIEPMSK = 0;
   USBx_DEVICE->DOEPMSK = 0;
   USBx_DEVICE->DAINT = 0xFFFFFFFF;
   USBx_DEVICE->DAINTMSK = 0;
-  
+
   for (i = 0; i < cfg.dev_endpoints; i++)
   {
     if ((USBx_INEP(i)->DIEPCTL & USB_OTG_DIEPCTL_EPENA) == USB_OTG_DIEPCTL_EPENA)
@@ -306,11 +306,11 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     {
       USBx_INEP(i)->DIEPCTL = 0;
     }
-    
+
     USBx_INEP(i)->DIEPTSIZ = 0;
     USBx_INEP(i)->DIEPINT  = 0xFF;
   }
-  
+
   for (i = 0; i < cfg.dev_endpoints; i++)
   {
     if ((USBx_OUTEP(i)->DOEPCTL & USB_OTG_DOEPCTL_EPENA) == USB_OTG_DOEPCTL_EPENA)
@@ -321,40 +321,40 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     {
       USBx_OUTEP(i)->DOEPCTL = 0;
     }
-    
+
     USBx_OUTEP(i)->DOEPTSIZ = 0;
     USBx_OUTEP(i)->DOEPINT  = 0xFF;
   }
-  
+
   USBx_DEVICE->DIEPMSK &= ~(USB_OTG_DIEPMSK_TXFURM);
-  
+
   if (cfg.dma_enable == 1)
   {
     /*Set threshold parameters */
     USBx_DEVICE->DTHRCTL = (USB_OTG_DTHRCTL_TXTHRLEN_6 | USB_OTG_DTHRCTL_RXTHRLEN_6);
     USBx_DEVICE->DTHRCTL |= (USB_OTG_DTHRCTL_RXTHREN | USB_OTG_DTHRCTL_ISOTHREN | USB_OTG_DTHRCTL_NONISOTHREN);
-    
+
     i= USBx_DEVICE->DTHRCTL;
   }
-  
+
   /* Disable all interrupts. */
   USBx->GINTMSK = 0;
-  
+
   /* Clear any pending interrupts */
   USBx->GINTSTS = 0xBFFFFFFF;
 
   /* Enable the common interrupts */
   if (cfg.dma_enable == DISABLE)
   {
-    USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM; 
+    USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }
-  
+
   /* Enable interrupts matching to the Device mode ONLY */
   USBx->GINTMSK |= (USB_OTG_GINTMSK_USBSUSPM | USB_OTG_GINTMSK_USBRST |\
                     USB_OTG_GINTMSK_ENUMDNEM | USB_OTG_GINTMSK_IEPINT |\
                     USB_OTG_GINTMSK_OEPINT   | USB_OTG_GINTMSK_IISOIXFRM|\
                     USB_OTG_GINTMSK_PXFRM_IISOOXFRM | USB_OTG_GINTMSK_WUIM);
-  
+
   if(cfg.Sof_enable)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_SOFM;
@@ -362,9 +362,9 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 
   if (cfg.vbus_sensing_enable == ENABLE)
   {
-    USBx->GINTMSK |= (USB_OTG_GINTMSK_SRQIM | USB_OTG_GINTMSK_OTGINT); 
+    USBx->GINTMSK |= (USB_OTG_GINTMSK_SRQIM | USB_OTG_GINTMSK_OTGINT);
   }
-  
+
   return HAL_OK;
 }
 
@@ -380,9 +380,9 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 HAL_StatusTypeDef USB_FlushTxFifo (USB_OTG_GlobalTypeDef *USBx, uint32_t num )
 {
   uint32_t count = 0;
- 
-  USBx->GRSTCTL = ( USB_OTG_GRSTCTL_TXFFLSH |(uint32_t)( num << 6)); 
- 
+
+  USBx->GRSTCTL = ( USB_OTG_GRSTCTL_TXFFLSH |(uint32_t)( num << 6));
+
   do
   {
     if (++count > 200000)
@@ -391,7 +391,7 @@ HAL_StatusTypeDef USB_FlushTxFifo (USB_OTG_GlobalTypeDef *USBx, uint32_t num )
     }
   }
   while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_TXFFLSH) == USB_OTG_GRSTCTL_TXFFLSH);
-  
+
   return HAL_OK;
 }
 
@@ -404,9 +404,9 @@ HAL_StatusTypeDef USB_FlushTxFifo (USB_OTG_GlobalTypeDef *USBx, uint32_t num )
 HAL_StatusTypeDef USB_FlushRxFifo(USB_OTG_GlobalTypeDef *USBx)
 {
   uint32_t count = 0;
-  
+
   USBx->GRSTCTL = USB_OTG_GRSTCTL_RXFFLSH;
-  
+
   do
   {
     if (++count > 200000)
@@ -415,12 +415,12 @@ HAL_StatusTypeDef USB_FlushRxFifo(USB_OTG_GlobalTypeDef *USBx)
     }
   }
   while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_RXFFLSH) == USB_OTG_GRSTCTL_RXFFLSH);
-  
+
   return HAL_OK;
 }
 
 /**
-  * @brief  USB_SetDevSpeed :Initializes the DevSpd field of DCFG register 
+  * @brief  USB_SetDevSpeed :Initializes the DevSpd field of DCFG register
   *         depending the PHY type and the enumeration speed of the device.
   * @param  USBx : Selected device
   * @param  speed : device speed
@@ -438,7 +438,7 @@ HAL_StatusTypeDef USB_SetDevSpeed(USB_OTG_GlobalTypeDef *USBx , uint8_t speed)
 }
 
 /**
-  * @brief  USB_GetDevSpeed :Return the  Dev Speed 
+  * @brief  USB_GetDevSpeed :Return the  Dev Speed
   * @param  USBx : Selected device
   * @retval speed : device speed
   *          This parameter can be one of these values:
@@ -449,7 +449,7 @@ HAL_StatusTypeDef USB_SetDevSpeed(USB_OTG_GlobalTypeDef *USBx , uint8_t speed)
 uint8_t USB_GetDevSpeed(USB_OTG_GlobalTypeDef *USBx)
 {
   uint8_t speed = 0;
-  
+
   if((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_HS_PHY_30MHZ_OR_60MHZ)
   {
     speed = USB_OTG_SPEED_HIGH;
@@ -463,7 +463,7 @@ uint8_t USB_GetDevSpeed(USB_OTG_GlobalTypeDef *USBx)
   {
     speed = USB_OTG_SPEED_LOW;
   }
-  
+
   return speed;
 }
 
@@ -478,23 +478,23 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTy
   if (ep->is_in == 1)
   {
    USBx_DEVICE->DAINTMSK |= USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num)));
-   
+
     if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_USBAEP) == 0)
     {
       USBx_INEP(ep->num)->DIEPCTL |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
-        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP)); 
-    } 
+        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP));
+    }
 
   }
   else
   {
      USBx_DEVICE->DAINTMSK |= USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16);
-     
+
     if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_USBAEP) == 0)
     {
       USBx_OUTEP(ep->num)->DOEPCTL |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
        (USB_OTG_DIEPCTL_SD0PID_SEVNFRM)| (USB_OTG_DOEPCTL_USBAEP));
-    } 
+    }
   }
   return HAL_OK;
 }
@@ -507,20 +507,20 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTy
 HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
 {
   static __IO uint32_t debug = 0;
-  
+
   /* Read DEPCTLn register */
   if (ep->is_in == 1)
   {
     if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_USBAEP) == 0)
     {
       USBx_INEP(ep->num)->DIEPCTL |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
-        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP)); 
-    } 
-    
-    
+        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP));
+    }
+
+
     debug  |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
-        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP)); 
-    
+        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP));
+
    USBx_DEVICE->DEACHMSK |= USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num)));
   }
   else
@@ -529,13 +529,13 @@ HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB
     {
       USBx_OUTEP(ep->num)->DOEPCTL |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
         ((ep->num) << 22 ) | (USB_OTG_DOEPCTL_USBAEP));
-      
+
       debug = (uint32_t)(((uint32_t )USBx) + USB_OTG_OUT_ENDPOINT_BASE + (0)*USB_OTG_EP_REG_SIZE);
       debug = (uint32_t )&USBx_OUTEP(ep->num)->DOEPCTL;
       debug |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
-        ((ep->num) << 22 ) | (USB_OTG_DOEPCTL_USBAEP)); 
-    } 
-    
+        ((ep->num) << 22 ) | (USB_OTG_DOEPCTL_USBAEP));
+    }
+
      USBx_DEVICE->DEACHMSK |= USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16);
   }
 
@@ -553,14 +553,14 @@ HAL_StatusTypeDef USB_DeactivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EP
   if (ep->is_in == 1)
   {
    USBx_DEVICE->DEACHMSK &= ~(USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num))));
-   USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num))));   
-   USBx_INEP(ep->num)->DIEPCTL &= ~ USB_OTG_DIEPCTL_USBAEP;   
+   USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num))));
+   USBx_INEP(ep->num)->DIEPCTL &= ~ USB_OTG_DIEPCTL_USBAEP;
   }
   else
   {
      USBx_DEVICE->DEACHMSK &= ~(USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16));
-     USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16));     
-     USBx_OUTEP(ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_USBAEP;      
+     USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16));
+     USBx_OUTEP(ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_USBAEP;
   }
   return HAL_OK;
 }
@@ -581,7 +581,7 @@ HAL_StatusTypeDef USB_DeactivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, U
   }
   else
   {
-     USBx_OUTEP(ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_USBAEP; 
+     USBx_OUTEP(ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_USBAEP;
      USBx_DEVICE->DAINTMSK &= ~(USB_OTG_DAINTMSK_OEPM & ((1 << (ep->num)) << 16));
   }
   return HAL_OK;
@@ -591,25 +591,25 @@ HAL_StatusTypeDef USB_DeactivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, U
   * @brief  USB_EPStartXfer : setup and starts a transfer over an EP
   * @param  USBx : Selected device
   * @param  ep: pointer to endpoint structure
-  * @param  dma: USB dma enabled or disabled 
+  * @param  dma: USB dma enabled or disabled
   *          This parameter can be one of these values:
-  *           0 : DMA feature not used 
-  *           1 : DMA feature used  
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_EPStartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma)
 {
   uint16_t pktcnt = 0;
-  
+
   /* IN endpoint */
   if (ep->is_in == 1)
   {
     /* Zero Length Packet? */
     if (ep->xfer_len == 0)
     {
-      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT); 
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT);
       USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (1 << 19)) ;
-      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ); 
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ);
     }
     else
     {
@@ -619,15 +619,15 @@ HAL_StatusTypeDef USB_EPStartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDe
       * exist ? 1 : 0)
       */
       USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ);
-      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT); 
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT);
       USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (((ep->xfer_len + ep->maxpacket -1)/ ep->maxpacket) << 19)) ;
-      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_XFRSIZ & ep->xfer_len); 
-      
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_XFRSIZ & ep->xfer_len);
+
       if (ep->type == EP_TYPE_ISOC)
       {
-        USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_MULCNT); 
-        USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_MULCNT & (1 << 29)); 
-      }       
+        USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_MULCNT);
+        USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_MULCNT & (1 << 29));
+      }
     }
 
     if (dma == 1)
@@ -656,42 +656,42 @@ HAL_StatusTypeDef USB_EPStartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDe
       {
         USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_SD0PID_SEVNFRM;
       }
-    } 
-    
+    }
+
     /* EP enable, IN data in FIFO */
     USBx_INEP(ep->num)->DIEPCTL |= (USB_OTG_DIEPCTL_CNAK | USB_OTG_DIEPCTL_EPENA);
-    
+
     if (ep->type == EP_TYPE_ISOC)
     {
-      USB_WritePacket(USBx, ep->xfer_buff, ep->num, ep->xfer_len, dma);   
-    }    
+      USB_WritePacket(USBx, ep->xfer_buff, ep->num, ep->xfer_len, dma);
+    }
   }
   else /* OUT endpoint */
   {
     /* Program the transfer size and packet count as follows:
     * pktcnt = N
     * xfersize = N * maxpacket
-    */  
-    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_XFRSIZ); 
-    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_PKTCNT); 
-      
+    */
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_XFRSIZ);
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_PKTCNT);
+
     if (ep->xfer_len == 0)
     {
       USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & ep->maxpacket);
-      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (1 << 19)) ;      
+      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (1 << 19)) ;
     }
     else
     {
-      pktcnt = (ep->xfer_len + ep->maxpacket -1)/ ep->maxpacket; 
+      pktcnt = (ep->xfer_len + ep->maxpacket -1)/ ep->maxpacket;
       USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (pktcnt << 19));
-      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & (ep->maxpacket * pktcnt)); 
+      USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & (ep->maxpacket * pktcnt));
     }
 
     if (dma == 1)
     {
       USBx_OUTEP(ep->num)->DOEPDMA = (uint32_t)ep->xfer_buff;
     }
-    
+
     if (ep->type == EP_TYPE_ISOC)
     {
       if ((USBx_DEVICE->DSTS & ( 1 << 8 )) == 0)
@@ -713,10 +713,10 @@ HAL_StatusTypeDef USB_EPStartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDe
   * @brief  USB_EP0StartXfer : setup and starts a transfer over the EP  0
   * @param  USBx : Selected device
   * @param  ep: pointer to endpoint structure
-  * @param  dma: USB dma enabled or disabled 
+  * @param  dma: USB dma enabled or disabled
   *          This parameter can be one of these values:
-  *           0 : DMA feature not used 
-  *           1 : DMA feature used  
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma)
@@ -727,9 +727,9 @@ HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeD
     /* Zero Length Packet? */
     if (ep->xfer_len == 0)
     {
-      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT); 
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT);
       USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (1 << 19)) ;
-      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ); 
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ);
     }
     else
     {
@@ -739,20 +739,20 @@ HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeD
       * exist ? 1 : 0)
       */
       USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_XFRSIZ);
-      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT); 
-      
+      USBx_INEP(ep->num)->DIEPTSIZ &= ~(USB_OTG_DIEPTSIZ_PKTCNT);
+
       if(ep->xfer_len > ep->maxpacket)
       {
         ep->xfer_len = ep->maxpacket;
       }
       USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_PKTCNT & (1 << 19)) ;
-      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_XFRSIZ & ep->xfer_len); 
-    
+      USBx_INEP(ep->num)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_XFRSIZ & ep->xfer_len);
+
     }
-    
+
     /* EP enable, IN data in FIFO */
     USBx_INEP(ep->num)->DIEPCTL |= (USB_OTG_DIEPCTL_CNAK | USB_OTG_DIEPCTL_EPENA);
-    
+
     if (dma == 1)
     {
       USBx_INEP(ep->num)->DIEPDMA = (uint32_t)(ep->dma_addr);
@@ -764,7 +764,7 @@ HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeD
       {
         USBx_DEVICE->DIEPEMPMSK |= 1U << (ep->num);
       }
-    }  
+    }
   }
   else /* OUT endpoint */
   {
@@ -772,79 +772,79 @@ HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeD
     * pktcnt = N
     * xfersize = N * maxpacket
     */
-    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_XFRSIZ); 
-    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_PKTCNT); 
-      
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_XFRSIZ);
+    USBx_OUTEP(ep->num)->DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_PKTCNT);
+
     if (ep->xfer_len > 0)
     {
       ep->xfer_len = ep->maxpacket;
     }
-    
+
     USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (1 << 19));
-    USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & (ep->maxpacket)); 
-    
+    USBx_OUTEP(ep->num)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & (ep->maxpacket));
+
 
     if (dma == 1)
     {
       USBx_OUTEP(ep->num)->DOEPDMA = (uint32_t)(ep->xfer_buff);
     }
-    
+
     /* EP enable */
-    USBx_OUTEP(ep->num)->DOEPCTL |= (USB_OTG_DOEPCTL_CNAK | USB_OTG_DOEPCTL_EPENA);    
+    USBx_OUTEP(ep->num)->DOEPCTL |= (USB_OTG_DOEPCTL_CNAK | USB_OTG_DOEPCTL_EPENA);
   }
   return HAL_OK;
 }
 
 /**
-  * @brief  USB_WritePacket : Writes a packet into the Tx FIFO associated 
+  * @brief  USB_WritePacket : Writes a packet into the Tx FIFO associated
   *         with the EP/channel
-  * @param  USBx : Selected device           
+  * @param  USBx : Selected device
   * @param  src :  pointer to source buffer
   * @param  ch_ep_num : endpoint or host channel number
   * @param  len : Number of bytes to write
-  * @param  dma: USB dma enabled or disabled 
+  * @param  dma: USB dma enabled or disabled
   *          This parameter can be one of these values:
-  *           0 : DMA feature not used 
-  *           1 : DMA feature used  
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uint8_t ch_ep_num, uint16_t len, uint8_t dma)
 {
   uint32_t count32b= 0 , i= 0;
-  
+
   if (dma == 0)
   {
     count32b =  (len + 3) / 4;
     for (i = 0; i < count32b; i++, src += 4)
     {
-      USBx_DFIFO(ch_ep_num) = *((__packed uint32_t *)src);
+      USBx_DFIFO(ch_ep_num) = *((uint32_t *)src);
     }
   }
   return HAL_OK;
 }
 
 /**
-  * @brief  USB_ReadPacket : read a packet from the Tx FIFO associated 
+  * @brief  USB_ReadPacket : read a packet from the Tx FIFO associated
   *         with the EP/channel
-  * @param  USBx : Selected device  
+  * @param  USBx : Selected device
   * @param  src : source pointer
   * @param  ch_ep_num : endpoint or host channel number
   * @param  len : Number of bytes to read
-  * @param  dma: USB dma enabled or disabled 
+  * @param  dma: USB dma enabled or disabled
   *          This parameter can be one of these values:
-  *           0 : DMA feature not used 
-  *           1 : DMA feature used  
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
   * @retval pointer to destination buffer
   */
 void *USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len)
 {
   uint32_t i=0;
   uint32_t count32b = (len + 3) / 4;
-  
+
   for ( i = 0; i < count32b; i++, dest += 4 )
   {
-    *(__packed uint32_t *)dest = USBx_DFIFO(0);
-    
+    *(uint32_t *)dest = USBx_DFIFO(0);
+
   }
   return ((void *)dest);
 }
@@ -852,7 +852,7 @@ void *USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len)
 /**
   * @brief  USB_EPSetStall : set a stall condition over an EP
   * @param  USBx : Selected device
-  * @param  ep: pointer to endpoint structure   
+  * @param  ep: pointer to endpoint structure
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_EPSetStall(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep)
@@ -861,16 +861,16 @@ HAL_StatusTypeDef USB_EPSetStall(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef
   {
     if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_EPENA) == 0)
     {
-      USBx_INEP(ep->num)->DIEPCTL &= ~(USB_OTG_DIEPCTL_EPDIS); 
-    } 
+      USBx_INEP(ep->num)->DIEPCTL &= ~(USB_OTG_DIEPCTL_EPDIS);
+    }
     USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_STALL;
   }
   else
   {
     if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_EPENA) == 0)
     {
-      USBx_OUTEP(ep->num)->DOEPCTL &= ~(USB_OTG_DOEPCTL_EPDIS); 
-    } 
+      USBx_OUTEP(ep->num)->DOEPCTL &= ~(USB_OTG_DOEPCTL_EPDIS);
+    }
     USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_STALL;
   }
   return HAL_OK;
@@ -880,7 +880,7 @@ HAL_StatusTypeDef USB_EPSetStall(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef
 /**
   * @brief  USB_EPClearStall : Clear a stall condition over an EP
   * @param  USBx : Selected device
-  * @param  ep: pointer to endpoint structure   
+  * @param  ep: pointer to endpoint structure
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_EPClearStall(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
@@ -891,7 +891,7 @@ HAL_StatusTypeDef USB_EPClearStall(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDe
     if (ep->type == EP_TYPE_INTR || ep->type == EP_TYPE_BULK)
     {
        USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_SD0PID_SEVNFRM; /* DATA0 */
-    }    
+    }
   }
   else
   {
@@ -899,7 +899,7 @@ HAL_StatusTypeDef USB_EPClearStall(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDe
     if (ep->type == EP_TYPE_INTR || ep->type == EP_TYPE_BULK)
     {
       USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_SD0PID_SEVNFRM; /* DATA0 */
-    }    
+    }
   }
   return HAL_OK;
 }
@@ -912,7 +912,7 @@ HAL_StatusTypeDef USB_EPClearStall(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDe
 HAL_StatusTypeDef USB_StopDevice(USB_OTG_GlobalTypeDef *USBx)
 {
   uint32_t i;
-  
+
   /* Clear Pending interrupt */
   for (i = 0; i < 15 ; i++)
   {
@@ -920,16 +920,16 @@ HAL_StatusTypeDef USB_StopDevice(USB_OTG_GlobalTypeDef *USBx)
     USBx_OUTEP(i)->DOEPINT  = 0xFF;
   }
   USBx_DEVICE->DAINT = 0xFFFFFFFF;
-  
+
   /* Clear interrupt masks */
   USBx_DEVICE->DIEPMSK  = 0;
   USBx_DEVICE->DOEPMSK  = 0;
   USBx_DEVICE->DAINTMSK = 0;
-  
+
   /* Flush the FIFO */
   USB_FlushRxFifo(USBx);
-  USB_FlushTxFifo(USBx ,  0x10 );  
-  
+  USB_FlushTxFifo(USBx ,  0x10 );
+
   return HAL_OK;
 }
 
@@ -944,8 +944,8 @@ HAL_StatusTypeDef  USB_SetDevAddress (USB_OTG_GlobalTypeDef *USBx, uint8_t addre
 {
   USBx_DEVICE->DCFG &= ~ (USB_OTG_DCFG_DAD);
   USBx_DEVICE->DCFG |= (address << 4) & USB_OTG_DCFG_DAD ;
-  
-  return HAL_OK;  
+
+  return HAL_OK;
 }
 
 /**
@@ -957,8 +957,8 @@ HAL_StatusTypeDef  USB_DevConnect (USB_OTG_GlobalTypeDef *USBx)
 {
   USBx_DEVICE->DCTL &= ~USB_OTG_DCTL_SDIS ;
   HAL_Delay(3);
-  
-  return HAL_OK;  
+
+  return HAL_OK;
 }
 
 /**
@@ -970,8 +970,8 @@ HAL_StatusTypeDef  USB_DevDisconnect (USB_OTG_GlobalTypeDef *USBx)
 {
   USBx_DEVICE->DCTL |= USB_OTG_DCTL_SDIS ;
   HAL_Delay(3);
-  
-  return HAL_OK;  
+
+  return HAL_OK;
 }
 
 /**
@@ -982,10 +982,10 @@ HAL_StatusTypeDef  USB_DevDisconnect (USB_OTG_GlobalTypeDef *USBx)
 uint32_t  USB_ReadInterrupts (USB_OTG_GlobalTypeDef *USBx)
 {
   uint32_t v = 0;
-  
+
   v = USBx->GINTSTS;
   v &= USBx->GINTMSK;
-  return v;  
+  return v;
 }
 
 /**
@@ -1039,7 +1039,7 @@ uint32_t USB_ReadDevOutEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum)
 uint32_t USB_ReadDevInEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum)
 {
   uint32_t v, msk, emp;
-  
+
   msk = USBx_DEVICE->DIEPMSK;
   emp = USBx_DEVICE->DIEPEMPMSK;
   msk |= ((emp >> epnum) & 0x1) << 7;
@@ -1055,7 +1055,7 @@ uint32_t USB_ReadDevInEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum)
   */
 void  USB_ClearInterrupts (USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt)
 {
-  USBx->GINTSTS |= interrupt; 
+  USBx->GINTSTS |= interrupt;
 }
 
 /**
@@ -1063,7 +1063,7 @@ void  USB_ClearInterrupts (USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt)
   * @param  USBx : Selected device
   * @retval return core mode : Host or Device
   *          This parameter can be one of these values:
-  *           0 : Host 
+  *           0 : Host
   *           1 : Device
   */
 uint32_t USB_GetMode(USB_OTG_GlobalTypeDef *USBx)
@@ -1081,7 +1081,7 @@ HAL_StatusTypeDef  USB_ActivateSetup (USB_OTG_GlobalTypeDef *USBx)
 {
   /* Set the MPS of the IN EP based on the enumeration speed */
   USBx_INEP(0)->DIEPCTL &= ~USB_OTG_DIEPCTL_MPSIZ;
-  
+
   if((USBx_DEVICE->DSTS & USB_OTG_DSTS_ENUMSPD) == DSTS_ENUMSPD_LS_PHY_6MHZ)
   {
     USBx_INEP(0)->DIEPCTL |= 3;
@@ -1095,10 +1095,10 @@ HAL_StatusTypeDef  USB_ActivateSetup (USB_OTG_GlobalTypeDef *USBx)
 /**
   * @brief  Prepare the EP0 to start the first control setup
   * @param  USBx : Selected device
-  * @param  dma: USB dma enabled or disabled 
+  * @param  dma: USB dma enabled or disabled
   *          This parameter can be one of these values:
-  *           0 : DMA feature not used 
-  *           1 : DMA feature used  
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
   * @param  psetup : pointer to setup packet
   * @retval HAL status
   */
@@ -1107,16 +1107,16 @@ HAL_StatusTypeDef USB_EP0_OutStart(USB_OTG_GlobalTypeDef *USBx, uint8_t dma, uin
   USBx_OUTEP(0)->DOEPTSIZ = 0;
   USBx_OUTEP(0)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_PKTCNT & (1 << 19)) ;
   USBx_OUTEP(0)->DOEPTSIZ |= (3 * 8);
-  USBx_OUTEP(0)->DOEPTSIZ |=  USB_OTG_DOEPTSIZ_STUPCNT;  
-  
+  USBx_OUTEP(0)->DOEPTSIZ |=  USB_OTG_DOEPTSIZ_STUPCNT;
+
   if (dma == 1)
   {
     USBx_OUTEP(0)->DOEPDMA = (uint32_t)psetup;
     /* EP enable */
     USBx_OUTEP(0)->DOEPCTL = 0x80008000;
   }
-  
-  return HAL_OK;  
+
+  return HAL_OK;
 }
 
 
@@ -1138,7 +1138,7 @@ static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx)
     }
   }
   while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_AHBIDL) == 0);
-  
+
   /* Core Soft Reset */
   count = 0;
   USBx->GRSTCTL |= USB_OTG_GRSTCTL_CSRST;
@@ -1151,24 +1151,24 @@ static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx)
     }
   }
   while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_CSRST) == USB_OTG_GRSTCTL_CSRST);
-  
+
   return HAL_OK;
 }
 
-#ifdef USB_HS_PHYC 
+#ifdef USB_HS_PHYC
 /**
   * @brief  Enables control of a High Speed USB PHY’s
-  *         Init the low level hardware : GPIO, CLOCK, NVIC... 
+  *         Init the low level hardware : GPIO, CLOCK, NVIC...
   * @param  USBx : Selected device
   * @retval HAL status
   */
 static HAL_StatusTypeDef USB_HS_PHYCInit(USB_OTG_GlobalTypeDef *USBx)
 {
   uint32_t count = 0;
-  
+
   /* Enable LDO */
   USB_HS_PHYC->USB_HS_PHYC_LDO |= USB_HS_PHYC_LDO_ENABLE;
-  
+
   /* wait for LDO Ready */
   while((USB_HS_PHYC->USB_HS_PHYC_LDO & USB_HS_PHYC_LDO_STATUS) == RESET)
   {
@@ -1191,7 +1191,7 @@ static HAL_StatusTypeDef USB_HS_PHYCInit(USB_OTG_GlobalTypeDef *USBx)
   {
     USB_HS_PHYC->USB_HS_PHYC_PLL = (uint32_t)(0x3 << 1);
   }
-  
+
   else if (HSE_VALUE == 24000000) /* HSE = 24MHz */
   {
     USB_HS_PHYC->USB_HS_PHYC_PLL = (uint32_t)(0x4 << 1);
@@ -1204,23 +1204,23 @@ static HAL_StatusTypeDef USB_HS_PHYCInit(USB_OTG_GlobalTypeDef *USBx)
   {
     USB_HS_PHYC->USB_HS_PHYC_PLL = (uint32_t)(0x7 << 1);
   }
-  
+
   /* Control the tuning interface of the High Speed PHY */
   USB_HS_PHYC->USB_HS_PHYC_TUNE |= USB_HS_PHYC_TUNE_VALUE;
-  
+
   /* Enable PLL internal PHY */
   USB_HS_PHYC->USB_HS_PHYC_PLL |= USB_HS_PHYC_PLL_PLLEN;
 
   /* 2ms Delay required to get internal phy clock stable */
   HAL_Delay(2);
-  
+
   return HAL_OK;
 }
 
 #endif /* USB_HS_PHYC */
 /**
-  * @brief  USB_HostInit : Initializes the USB OTG controller registers 
-  *         for Host mode 
+  * @brief  USB_HostInit : Initializes the USB OTG controller registers
+  *         for Host mode
   * @param  USBx : Selected device
   * @param  cfg  : pointer to a USB_OTG_CfgTypeDef structure that contains
   *         the configuration information for the specified USBx peripheral.
@@ -1229,22 +1229,22 @@ static HAL_StatusTypeDef USB_HS_PHYCInit(USB_OTG_GlobalTypeDef *USBx)
 HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
 {
   uint32_t i;
-  
+
   /* Restart the Phy Clock */
   USBx_PCGCCTL = 0;
-  
+
   /*Activate VBUS Sensing B */
   USBx->GCCFG |= USB_OTG_GCCFG_VBDEN;
-  
+
   /* Disable the FS/LS support mode only */
   if((cfg.speed == USB_OTG_SPEED_FULL)&&
      (USBx != USB_OTG_FS))
   {
-    USBx_HOST->HCFG |= USB_OTG_HCFG_FSLSS; 
+    USBx_HOST->HCFG |= USB_OTG_HCFG_FSLSS;
   }
   else
   {
-    USBx_HOST->HCFG &= ~(USB_OTG_HCFG_FSLSS);  
+    USBx_HOST->HCFG &= ~(USB_OTG_HCFG_FSLSS);
   }
 
   /* Make sure the FIFOs are flushed. */
@@ -1257,39 +1257,39 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
     USBx_HC(i)->HCINT = 0xFFFFFFFF;
     USBx_HC(i)->HCINTMSK = 0;
   }
-  
+
   /* Enable VBUS driving */
   USB_DriveVbus(USBx, 1);
-  
+
   HAL_Delay(200);
-  
+
   /* Disable all interrupts. */
   USBx->GINTMSK = 0;
-  
+
   /* Clear any pending interrupts */
   USBx->GINTSTS = 0xFFFFFFFF;
-  
+
   if(USBx == USB_OTG_FS)
   {
     /* set Rx FIFO size */
-    USBx->GRXFSIZ  = (uint32_t )0x80; 
+    USBx->GRXFSIZ  = (uint32_t )0x80;
     USBx->DIEPTXF0_HNPTXFSIZ = (uint32_t )(((0x60 << 16)& USB_OTG_NPTXFD) | 0x80);
     USBx->HPTXFSIZ = (uint32_t )(((0x40 << 16)& USB_OTG_HPTXFSIZ_PTXFD) | 0xE0);
   }
   else
   {
     /* set Rx FIFO size */
-    USBx->GRXFSIZ  = (uint32_t )0x200; 
+    USBx->GRXFSIZ  = (uint32_t )0x200;
     USBx->DIEPTXF0_HNPTXFSIZ = (uint32_t )(((0x100 << 16)& USB_OTG_NPTXFD) | 0x200);
     USBx->HPTXFSIZ = (uint32_t )(((0xE0 << 16)& USB_OTG_HPTXFSIZ_PTXFD) | 0x300);
   }
-  
+
   /* Enable the common interrupts */
   if (cfg.dma_enable == DISABLE)
   {
-    USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM; 
+    USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }
-  
+
   /* Enable interrupts matching to the Host mode ONLY */
   USBx->GINTMSK |= (USB_OTG_GINTMSK_PRTIM            | USB_OTG_GINTMSK_HCIM |\
                     USB_OTG_GINTMSK_SOFM             |USB_OTG_GINTSTS_DISCINT|\
@@ -1299,20 +1299,20 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
 }
 
 /**
-  * @brief  USB_InitFSLSPClkSel : Initializes the FSLSPClkSel field of the 
+  * @brief  USB_InitFSLSPClkSel : Initializes the FSLSPClkSel field of the
   *         HCFG register on the PHY type and set the right frame interval
   * @param  USBx : Selected device
   * @param  freq : clock frequency
   *          This parameter can be one of these values:
-  *           HCFG_48_MHZ : Full Speed 48 MHz Clock 
-  *           HCFG_6_MHZ : Low Speed 6 MHz Clock 
+  *           HCFG_48_MHZ : Full Speed 48 MHz Clock
+  *           HCFG_6_MHZ : Low Speed 6 MHz Clock
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_InitFSLSPClkSel(USB_OTG_GlobalTypeDef *USBx , uint8_t freq)
 {
   USBx_HOST->HCFG &= ~(USB_OTG_HCFG_FSLSPCS);
   USBx_HOST->HCFG |= (freq & USB_OTG_HCFG_FSLSPCS);
-  
+
   if (freq ==  HCFG_48_MHZ)
   {
     USBx_HOST->HFIR = (uint32_t)48000;
@@ -1320,8 +1320,8 @@ HAL_StatusTypeDef USB_InitFSLSPClkSel(USB_OTG_GlobalTypeDef *USBx , uint8_t freq
   else if (freq ==  HCFG_6_MHZ)
   {
     USBx_HOST->HFIR = (uint32_t)6000;
-  } 
-  return HAL_OK;  
+  }
+  return HAL_OK;
 }
 
 /**
@@ -1340,9 +1340,9 @@ HAL_StatusTypeDef USB_ResetPort(USB_OTG_GlobalTypeDef *USBx)
   hprt0 &= ~(USB_OTG_HPRT_PENA | USB_OTG_HPRT_PCDET |
              USB_OTG_HPRT_PENCHNG | USB_OTG_HPRT_POCCHNG);
 
-  USBx_HPRT0 = (USB_OTG_HPRT_PRST | hprt0);  
+  USBx_HPRT0 = (USB_OTG_HPRT_PRST | hprt0);
   HAL_Delay (100);                                /* See Note #1 */
-  USBx_HPRT0 = ((~USB_OTG_HPRT_PRST) & hprt0); 
+  USBx_HPRT0 = ((~USB_OTG_HPRT_PRST) & hprt0);
   HAL_Delay (10);
 
   return HAL_OK;
@@ -1352,7 +1352,7 @@ HAL_StatusTypeDef USB_ResetPort(USB_OTG_GlobalTypeDef *USBx)
   * @brief  USB_DriveVbus : activate or de-activate vbus
   * @param  state : VBUS state
   *          This parameter can be one of these values:
-  *           0 : VBUS Active 
+  *           0 : VBUS Active
   *           1 : VBUS Inactive
   * @retval HAL status
 */
@@ -1367,13 +1367,13 @@ HAL_StatusTypeDef USB_DriveVbus (USB_OTG_GlobalTypeDef *USBx, uint8_t state)
 
   if (((hprt0 & USB_OTG_HPRT_PPWR) == 0 ) && (state == 1 ))
   {
-    USBx_HPRT0 = (USB_OTG_HPRT_PPWR | hprt0); 
+    USBx_HPRT0 = (USB_OTG_HPRT_PPWR | hprt0);
   }
   if (((hprt0 & USB_OTG_HPRT_PPWR) == USB_OTG_HPRT_PPWR) && (state == 0 ))
   {
-    USBx_HPRT0 = ((~USB_OTG_HPRT_PPWR) & hprt0); 
+    USBx_HPRT0 = ((~USB_OTG_HPRT_PPWR) & hprt0);
   }
-  return HAL_OK; 
+  return HAL_OK;
 }
 
 /**
@@ -1388,7 +1388,7 @@ HAL_StatusTypeDef USB_DriveVbus (USB_OTG_GlobalTypeDef *USBx, uint8_t state)
 uint32_t USB_GetHostSpeed (USB_OTG_GlobalTypeDef *USBx)
 {
   __IO uint32_t hprt0;
-  
+
   hprt0 = USBx_HPRT0;
   return ((hprt0 & USB_OTG_HPRT_PSPD) >> 17);
 }
@@ -1427,7 +1427,7 @@ uint32_t USB_GetCurrentFrame (USB_OTG_GlobalTypeDef *USBx)
   *          This parameter can be a value from 0 to32K
   * @retval HAL state
   */
-HAL_StatusTypeDef USB_HC_Init(USB_OTG_GlobalTypeDef *USBx,  
+HAL_StatusTypeDef USB_HC_Init(USB_OTG_GlobalTypeDef *USBx,
                               uint8_t ch_num,
                               uint8_t epnum,
                               uint8_t dev_address,
@@ -1435,28 +1435,28 @@ HAL_StatusTypeDef USB_HC_Init(USB_OTG_GlobalTypeDef *USBx,
                               uint8_t ep_type,
                               uint16_t mps)
 {
-    
+
   /* Clear old interrupt conditions for this host channel. */
   USBx_HC(ch_num)->HCINT = 0xFFFFFFFF;
-  
+
   /* Enable channel interrupts required for this transfer. */
-  switch (ep_type) 
+  switch (ep_type)
   {
   case EP_TYPE_CTRL:
   case EP_TYPE_BULK:
-    
+
     USBx_HC(ch_num)->HCINTMSK = USB_OTG_HCINTMSK_XFRCM  |\
                                 USB_OTG_HCINTMSK_STALLM |\
                                 USB_OTG_HCINTMSK_TXERRM |\
                                 USB_OTG_HCINTMSK_DTERRM |\
                                 USB_OTG_HCINTMSK_AHBERR |\
                                 USB_OTG_HCINTMSK_NAKM ;
- 
-    if (epnum & 0x80) 
+
+    if (epnum & 0x80)
     {
       USBx_HC(ch_num)->HCINTMSK |= USB_OTG_HCINTMSK_BBERRM;
-    } 
-    else 
+    }
+    else
     {
       if(USBx != USB_OTG_FS)
       {
@@ -1464,43 +1464,43 @@ HAL_StatusTypeDef USB_HC_Init(USB_OTG_GlobalTypeDef *USBx,
       }
     }
     break;
-    
+
   case EP_TYPE_INTR:
-    
+
     USBx_HC(ch_num)->HCINTMSK = USB_OTG_HCINTMSK_XFRCM  |\
                                 USB_OTG_HCINTMSK_STALLM |\
                                 USB_OTG_HCINTMSK_TXERRM |\
                                 USB_OTG_HCINTMSK_DTERRM |\
                                 USB_OTG_HCINTMSK_NAKM   |\
                                 USB_OTG_HCINTMSK_AHBERR |\
-                                USB_OTG_HCINTMSK_FRMORM ;    
-    
-    if (epnum & 0x80) 
+                                USB_OTG_HCINTMSK_FRMORM ;
+
+    if (epnum & 0x80)
     {
       USBx_HC(ch_num)->HCINTMSK |= USB_OTG_HCINTMSK_BBERRM;
     }
-    
+
     break;
   case EP_TYPE_ISOC:
-    
+
     USBx_HC(ch_num)->HCINTMSK = USB_OTG_HCINTMSK_XFRCM  |\
                                 USB_OTG_HCINTMSK_ACKM   |\
                                 USB_OTG_HCINTMSK_AHBERR |\
-                                USB_OTG_HCINTMSK_FRMORM ;   
-    
-    if (epnum & 0x80) 
+                                USB_OTG_HCINTMSK_FRMORM ;
+
+    if (epnum & 0x80)
     {
-      USBx_HC(ch_num)->HCINTMSK |= (USB_OTG_HCINTMSK_TXERRM | USB_OTG_HCINTMSK_BBERRM);      
+      USBx_HC(ch_num)->HCINTMSK |= (USB_OTG_HCINTMSK_TXERRM | USB_OTG_HCINTMSK_BBERRM);
     }
     break;
   }
-  
+
   /* Enable the top level host channel interrupt. */
   USBx_HOST->HAINTMSK |= (1 << ch_num);
-  
+
   /* Make sure host channel interrupts are enabled. */
   USBx->GINTMSK |= USB_OTG_GINTMSK_HCIM;
-  
+
   /* Program the HCCHAR register */
   USBx_HC(ch_num)->HCCHAR = (((dev_address << 22) & USB_OTG_HCCHAR_DAD)  |\
                              (((epnum & 0x7F)<< 11) & USB_OTG_HCCHAR_EPNUM)|\
@@ -1508,33 +1508,33 @@ HAL_StatusTypeDef USB_HC_Init(USB_OTG_GlobalTypeDef *USBx,
                              (((speed == HPRT0_PRTSPD_LOW_SPEED)<< 17) & USB_OTG_HCCHAR_LSDEV)|\
                              ((ep_type << 18) & USB_OTG_HCCHAR_EPTYP)|\
                              (mps & USB_OTG_HCCHAR_MPSIZ));
-    
+
   if (ep_type == EP_TYPE_INTR)
   {
     USBx_HC(ch_num)->HCCHAR |= USB_OTG_HCCHAR_ODDFRM ;
   }
 
-  return HAL_OK; 
+  return HAL_OK;
 }
 
 /**
   * @brief  Start a transfer over a host channel
   * @param  USBx : Selected device
   * @param  hc : pointer to host channel structure
-  * @param  dma: USB dma enabled or disabled 
+  * @param  dma: USB dma enabled or disabled
   *          This parameter can be one of these values:
-  *           0 : DMA feature not used 
-  *           1 : DMA feature used  
+  *           0 : DMA feature not used
+  *           1 : DMA feature used
   * @retval HAL state
   */
 HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDef *hc, uint8_t dma)
 {
   static __IO uint32_t tmpreg = 0;
-  uint8_t  is_oddframe = 0; 
-  uint16_t len_words = 0;   
+  uint8_t  is_oddframe = 0;
+  uint16_t len_words = 0;
   uint16_t num_packets = 0;
   uint16_t max_hc_pkt_count = 256;
-    
+
   if((USBx != USB_OTG_FS) && (hc->speed == USB_OTG_SPEED_HIGH))
   {
     if((dma == 0) && (hc->do_ping == 1))
@@ -1548,12 +1548,12 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDe
       hc->do_ping = 0;
     }
   }
-  
+
   /* Compute the expected number of packets associated to the transfer */
   if (hc->xfer_len > 0)
   {
     num_packets = (hc->xfer_len + hc->max_packet - 1) / hc->max_packet;
-    
+
     if (num_packets > max_hc_pkt_count)
     {
       num_packets = max_hc_pkt_count;
@@ -1568,40 +1568,40 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDe
   {
     hc->xfer_len = num_packets * hc->max_packet;
   }
-  
+
   /* Initialize the HCTSIZn register */
   USBx_HC(hc->ch_num)->HCTSIZ = (((hc->xfer_len) & USB_OTG_HCTSIZ_XFRSIZ)) |\
     ((num_packets << 19) & USB_OTG_HCTSIZ_PKTCNT) |\
       (((hc->data_pid) << 29) & USB_OTG_HCTSIZ_DPID);
-  
+
   if (dma)
   {
     /* xfer_buff MUST be 32-bits aligned */
     USBx_HC(hc->ch_num)->HCDMA = (uint32_t)hc->xfer_buff;
   }
-  
+
   is_oddframe = (USBx_HOST->HFNUM & 0x01) ? 0 : 1;
   USBx_HC(hc->ch_num)->HCCHAR &= ~USB_OTG_HCCHAR_ODDFRM;
   USBx_HC(hc->ch_num)->HCCHAR |= (is_oddframe << 29);
-  
+
   /* Set host channel enable */
   tmpreg = USBx_HC(hc->ch_num)->HCCHAR;
   tmpreg &= ~USB_OTG_HCCHAR_CHDIS;
   tmpreg |= USB_OTG_HCCHAR_CHENA;
   USBx_HC(hc->ch_num)->HCCHAR = tmpreg;
-  
+
   if (dma == 0) /* Slave mode */
-  {  
+  {
     if((hc->ep_is_in == 0) && (hc->xfer_len > 0))
     {
-      switch(hc->ep_type) 
+      switch(hc->ep_type)
       {
         /* Non periodic transfer */
       case EP_TYPE_CTRL:
       case EP_TYPE_BULK:
-        
+
         len_words = (hc->xfer_len + 3) / 4;
-        
+
         /* check if there is enough space in FIFO space */
         if(len_words > (USBx->HNPTXSTS & 0xFFFF))
         {
@@ -1617,19 +1617,19 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDe
         if(len_words > (USBx_HOST->HPTXSTS & 0xFFFF)) /* split the transfer */
         {
           /* need to process data in ptxfempty interrupt */
-          USBx->GINTMSK |= USB_OTG_GINTMSK_PTXFEM;          
+          USBx->GINTMSK |= USB_OTG_GINTMSK_PTXFEM;
         }
         break;
-        
+
       default:
         break;
       }
-      
+
       /* Write packet into the Tx FIFO. */
       USB_WritePacket(USBx, hc->xfer_buff, hc->ch_num, hc->xfer_len, 0);
     }
   }
-  
+
   return HAL_OK;
 }
 
@@ -1653,56 +1653,56 @@ uint32_t USB_HC_ReadInterrupt (USB_OTG_GlobalTypeDef *USBx)
 HAL_StatusTypeDef USB_HC_Halt(USB_OTG_GlobalTypeDef *USBx , uint8_t hc_num)
 {
   uint32_t count = 0;
-  
+
   /* Check for space in the request queue to issue the halt. */
   if (((((USBx_HC(hc_num)->HCCHAR) & USB_OTG_HCCHAR_EPTYP) >> 18) == HCCHAR_CTRL) ||
      (((((USBx_HC(hc_num)->HCCHAR) & USB_OTG_HCCHAR_EPTYP) >> 18) == HCCHAR_BULK)))
   {
     USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHDIS;
-    
+
     if ((USBx->HNPTXSTS & 0xFFFF) == 0)
     {
       USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHENA;
-      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;  
+      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
       USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_EPDIR;
-      do 
+      do
       {
-        if (++count > 1000) 
+        if (++count > 1000)
         {
           break;
         }
-      } 
-      while ((USBx_HC(hc_num)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);     
+      }
+      while ((USBx_HC(hc_num)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);
     }
     else
     {
-      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA; 
+      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
     }
   }
   else
   {
     USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHDIS;
-    
+
     if ((USBx_HOST->HPTXSTS & 0xFFFF) == 0)
     {
       USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHENA;
-      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;  
+      USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
       USBx_HC(hc_num)->HCCHAR &= ~USB_OTG_HCCHAR_EPDIR;
-      do 
+      do
       {
-        if (++count > 1000) 
+        if (++count > 1000)
         {
           break;
         }
-      } 
-      while ((USBx_HC(hc_num)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);     
+      }
+      while ((USBx_HC(hc_num)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);
     }
     else
     {
-       USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA; 
+       USBx_HC(hc_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
     }
   }
-  
+
   return HAL_OK;
 }
 
@@ -1720,14 +1720,14 @@ HAL_StatusTypeDef USB_DoPing(USB_OTG_GlobalTypeDef *USBx , uint8_t ch_num)
 
   USBx_HC(ch_num)->HCTSIZ = ((num_packets << 19) & USB_OTG_HCTSIZ_PKTCNT) |\
                                 USB_OTG_HCTSIZ_DOPING;
-  
+
   /* Set host channel enable */
   tmpreg = USBx_HC(ch_num)->HCCHAR;
   tmpreg &= ~USB_OTG_HCCHAR_CHDIS;
   tmpreg |= USB_OTG_HCCHAR_CHENA;
   USBx_HC(ch_num)->HCCHAR = tmpreg;
-  
-  return HAL_OK;  
+
+  return HAL_OK;
 }
 
 /**
@@ -1740,41 +1740,41 @@ HAL_StatusTypeDef USB_StopHost(USB_OTG_GlobalTypeDef *USBx)
   uint8_t i;
   uint32_t count = 0;
   uint32_t value;
-  
+
   USB_DisableGlobalInt(USBx);
-  
+
     /* Flush FIFO */
   USB_FlushTxFifo(USBx, 0x10);
   USB_FlushRxFifo(USBx);
-  
+
   /* Flush out any leftover queued requests. */
   for (i = 0; i <= 15; i++)
-  {   
+  {
 
     value = USBx_HC(i)->HCCHAR ;
     value |=  USB_OTG_HCCHAR_CHDIS;
-    value &= ~USB_OTG_HCCHAR_CHENA;  
+    value &= ~USB_OTG_HCCHAR_CHENA;
     value &= ~USB_OTG_HCCHAR_EPDIR;
     USBx_HC(i)->HCCHAR = value;
   }
-  
-  /* Halt all channels to put them into a known state. */  
+
+  /* Halt all channels to put them into a known state. */
   for (i = 0; i <= 15; i++)
   {
     value = USBx_HC(i)->HCCHAR ;
-    
+
     value |= USB_OTG_HCCHAR_CHDIS;
-    value |= USB_OTG_HCCHAR_CHENA;  
+    value |= USB_OTG_HCCHAR_CHENA;
     value &= ~USB_OTG_HCCHAR_EPDIR;
-    
+
     USBx_HC(i)->HCCHAR = value;
-    do 
+    do
     {
-      if (++count > 1000) 
+      if (++count > 1000)
       {
         break;
       }
-    } 
+    }
     while ((USBx_HC(i)->HCCHAR & USB_OTG_HCCHAR_CHENA) == USB_OTG_HCCHAR_CHENA);
   }
 
@@ -1782,7 +1782,7 @@ HAL_StatusTypeDef USB_StopHost(USB_OTG_GlobalTypeDef *USBx)
   USBx_HOST->HAINT = 0xFFFFFFFF;
   USBx->GINTSTS = 0xFFFFFFFF;
   USB_EnableGlobalInt(USBx);
-  return HAL_OK;  
+  return HAL_OK;
 }
 /**
   * @}


### PR DESCRIPTION
fixes the new gcc 8(.2)  compiler warning for pointless use of packed for F7 (follow up to earlier F4 update).

```
./lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c: In function 'USB_WritePacket':
./lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c:820:7: warning: 'packed' attribute ignored for type 'uint32_t *' {aka 'long unsigned int *'} [-Wattributes]
       USBx_DFIFO(ch_ep_num) = *((__packed uint32_t *)src);
       ^
./lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c: In function 'USB_ReadPacket':
./lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c:846:5: warning: 'packed' attribute ignored for type 'uint32_t *' {aka 'long unsigned int *'} [-Wattributes]
     *(__packed uint32_t *)dest = USBx_DFIFO(0);
     ^
```