### PR TITLE
IMU orientation sanity check improvements

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1680,7 +1680,7 @@ void blackboxLogEvent(FlightLogEvent event, flightLogEventData_t *data)
         blackboxWriteUnsignedVB(data->loggingResume.currentTimeUs);
         break;
     case FLIGHT_LOG_EVENT_IMU_FAILURE:
-        blackboxWrite(0);
+        blackboxWriteUnsignedVB(data->imuError.errorCode);
         break;
     case FLIGHT_LOG_EVENT_LOG_END:
         blackboxPrintf("End of log (disarm reason:%d)", getDisarmReason());

--- a/src/main/blackbox/blackbox_fielddefs.h
+++ b/src/main/blackbox/blackbox_fielddefs.h
@@ -139,6 +139,10 @@ typedef struct flightLogEvent_loggingResume_s {
     timeUs_t currentTimeUs;
 } flightLogEvent_loggingResume_t;
 
+typedef struct flightLogEvent_IMUError_s {
+    uint32_t errorCode;
+} flightLogEvent_IMUError_t;
+
 #define FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT_FUNCTION_FLOAT_VALUE_FLAG 128
 
 typedef union flightLogEventData_u {
@@ -146,6 +150,7 @@ typedef union flightLogEventData_u {
     flightLogEvent_flightMode_t flightMode; // New event data
     flightLogEvent_inflightAdjustment_t inflightAdjustment;
     flightLogEvent_loggingResume_t loggingResume;
+    flightLogEvent_IMUError_t imuError;
 } flightLogEventData_t;
 
 typedef struct flightLogEvent_s {

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -236,27 +236,48 @@ static void imuResetOrientationQuaternion(const fpVector3_t * accBF)
     quaternionNormalize(&orientation, &orientation);
 }
 
-static void imuCheckAndResetOrientationQuaternion(const fpVector3_t * accBF)
+static bool imuValidateQuaternion(const fpQuaternion_t * quat)
 {
-    // Check if some calculation in IMU update yield NAN or zero quaternion
-    // Reset quaternion from accelerometer - this might be incorrect, but it's better than no attitude at all
-    const float check = fabs(orientation.q0) + fabs(orientation.q1) + fabs(orientation.q2) + fabs(orientation.q3);
+    const float check = fabs(quat->q0) + fabs(quat->q1) + fabs(quat->q2) + fabs(quat->q3);
 
     if (!isnan(check) && !isinf(check)) {
-        return;
+        return true;
     }
 
     const float normSq = quaternionNormSqared(&orientation);
     if (normSq > (1.0f - 1e-6f) && normSq < (1.0f + 1e-6f)) {
+        return true;
+    }
+
+    return false;
+}
+
+static void imuCheckAndResetOrientationQuaternion(const fpQuaternion_t * quat, const fpVector3_t * accBF)
+{
+    // Check if some calculation in IMU update yield NAN or zero quaternion
+    if (imuValidateQuaternion(&orientation)) {
         return;
     }
 
-    imuResetOrientationQuaternion(accBF);
-    DEBUG_TRACE("AHRS orientation quaternion error");
+    flightLogEvent_IMUError_t imuErrorEvent;
+
+    // Orientation is invalid. We need to reset it
+    if (imuValidateQuaternion(quat)) {
+        // Previous quaternion valid. Reset to it
+        orientation = *quat;
+        imuErrorEvent.errorCode = 1;
+        DEBUG_TRACE("AHRS orientation quaternion error. Reset to last known good value");
+    }
+    else {
+        // No valid reference. Best guess from accelerometer
+        imuResetOrientationQuaternion(accBF);
+        imuErrorEvent.errorCode = 2;
+        DEBUG_TRACE("AHRS orientation quaternion error. Best guess from ACC");
+    }
 
 #ifdef USE_BLACKBOX
     if (feature(FEATURE_BLACKBOX)) {
-        blackboxLogEvent(FLIGHT_LOG_EVENT_IMU_FAILURE, NULL);
+        blackboxLogEvent(FLIGHT_LOG_EVENT_IMU_FAILURE, (flightLogEventData_t*)&imuErrorEvent);
     }
 #endif
 }
@@ -265,6 +286,7 @@ static void imuMahonyAHRSupdate(float dt, const fpVector3_t * gyroBF, const fpVe
 {
     STATIC_FASTRAM fpVector3_t vGyroDriftEstimate = { 0 };
 
+    fpQuaternion_t prevOrientation = orientation;
     fpVector3_t vRotation = *gyroBF;
 
     /* Calculate general spin rate (rad/s) */
@@ -290,15 +312,18 @@ static void imuMahonyAHRSupdate(float dt, const fpVector3_t * gyroBF, const fpVe
             // Ignore magnetic inclination
             vMag.z = 0.0f;
 
-            // Normalize to unit vector
-            vectorNormalize(&vMag, &vMag);
+            // We zeroed out vMag.z -  make sure the whole vector didn't go to zero
+            if (vectorNormSquared(&vMag) > 0.01f) {
+                // Normalize to unit vector
+                vectorNormalize(&vMag, &vMag);
 
-            // Reference mag field vector heading is Magnetic North in EF. We compute that by rotating True North vector by declination and assuming Z-component is zero
-            // magnetometer error is cross product between estimated magnetic north and measured magnetic north (calculated in EF)
-            vectorCrossProduct(&vErr, &vMag, &vCorrectedMagNorth);
+                // Reference mag field vector heading is Magnetic North in EF. We compute that by rotating True North vector by declination and assuming Z-component is zero
+                // magnetometer error is cross product between estimated magnetic north and measured magnetic north (calculated in EF)
+                vectorCrossProduct(&vErr, &vMag, &vCorrectedMagNorth);
 
-            // Rotate error back into body frame
-            quaternionRotateVector(&vErr, &vErr, &orientation);
+                // Rotate error back into body frame
+                quaternionRotateVector(&vErr, &vErr, &orientation);
+            }
         }
         else if (useCOG) {
             fpVector3_t vHeadingEF;
@@ -318,14 +343,17 @@ static void imuMahonyAHRSupdate(float dt, const fpVector3_t * gyroBF, const fpVe
             quaternionRotateVectorInv(&vHeadingEF, &vForward, &orientation);
             vHeadingEF.z = 0.0f;
 
-            // Normalize to unit vector
-            vectorNormalize(&vHeadingEF, &vHeadingEF);
+            // We zeroed out vHeadingEF.z -  make sure the whole vector didn't go to zero
+            if (vectorNormSquared(&vHeadingEF) > 0.01f) {
+                // Normalize to unit vector
+                vectorNormalize(&vHeadingEF, &vHeadingEF);
 
-            // error is cross product between reference heading and estimated heading (calculated in EF)
-            vectorCrossProduct(&vErr, &vCoG, &vHeadingEF);
+                // error is cross product between reference heading and estimated heading (calculated in EF)
+                vectorCrossProduct(&vErr, &vCoG, &vHeadingEF);
 
-            // Rotate error back into body frame
-            quaternionRotateVector(&vErr, &vErr, &orientation);
+                // Rotate error back into body frame
+                quaternionRotateVector(&vErr, &vErr, &orientation);
+            }
         }
 
         // Compute and apply integral feedback if enabled
@@ -408,8 +436,8 @@ static void imuMahonyAHRSupdate(float dt, const fpVector3_t * gyroBF, const fpVe
         quaternionNormalize(&orientation, &orientation);
     }
 
-    // Check for invalid quaternion
-    imuCheckAndResetOrientationQuaternion(accBF);
+    // Check for invalid quaternion and reset to previous known good one
+    imuCheckAndResetOrientationQuaternion(&prevOrientation, accBF);
 
     // Pre-compute rotation matrix from quaternion
     imuComputeRotationMatrix();


### PR DESCRIPTION
Several fixes:

- [x] Check if `vectorNormalize` is safe to call - avoid `NaN` in calculations
- [x] In case of computation error reset orientation to previous known good one (if not possible - do a best guess from acceleration vector)
- [x] Log IMU reset source of truth to BB
- [ ] Add OSD indication of IMU reset