### PR TITLE
Calculate batt. percentage based on sag comp. voltage

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -552,7 +552,7 @@ uint8_t calculateBatteryPercentage(void)
         uint32_t capacityDiffBetweenFullAndEmpty = currentBatteryProfile->capacity.value - currentBatteryProfile->capacity.critical;
         return constrain(batteryRemainingCapacity * 100 / capacityDiffBetweenFullAndEmpty, 0, 100);
     } else
-        return constrain((vbat - batteryCriticalVoltage) * 100L / (batteryFullVoltage - batteryCriticalVoltage), 0, 100);
+        return constrain((getBatteryVoltage() - batteryCriticalVoltage) * 100L / (batteryFullVoltage - batteryCriticalVoltage), 0, 100);
 }
 
 void batteryDisableProfileAutoswitch(void) {


### PR DESCRIPTION
If `bat_voltage_src` is set to SAG_COMP

Closes #3803 