### PR TITLE
add minimal board doc for Matek F722

### DIFF
--- a/docs/Board - MatekF722.md
+++ b/docs/Board - MatekF722.md
@@ -1,0 +1,14 @@
+# Board - MATEKSYS F722
+
+## Vendor Information / specification
+http://www.mateksys.com/?portfolio=f722-std
+
+## Firmware
+
+Two firmware variants are available.
+
+* `inav_x.y.z_MATEKF722.hex` 
+* `inav_x.y.z_MATEKF722_HEXSERVO.hex` 
+
+The only difference is that the `HEXSERVO` variant  provides a multi-rotor servo *only* on S7 (vice S6 and S7 in the standard firmware); this facilitates the use of a single servo on a hexcopter.
+


### PR DESCRIPTION
Minimal board document explaining why there are now  two firmware variants. 