### PR TITLE
claim flash for F3 

### DIFF
--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -117,7 +117,7 @@
 #define USE_PITOT
 #define USE_PITOT_ADC
 
-//Enable VTX controll
+//Enable VTX control
 #define USE_VTX_COMMON
 #define USE_VTX_CONTROL
 #define USE_VTX_SMARTAUDIO
@@ -128,11 +128,13 @@
 // Wind estimator
 #define USE_WIND_ESTIMATOR
 
-#else // FLASH_SIZE < 128
+//save flash for F3 targets
 #define CLI_MINIMAL_VERBOSITY
-#define SKIP_TASK_STATISTICS
 #define SKIP_CLI_COMMAND_HELP
 #define SKIP_CLI_RESOURCES
-#define NAV_MAX_WAYPOINTS       30
-#define MAX_BOOTLOG_ENTRIES     32
+
+#else // FLASH_SIZE < 128
+
+#define SKIP_TASK_STATISTICS
+
 #endif

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -39,6 +39,10 @@
 
 #if defined(STM32F3)
 #define USE_UNDERCLOCK
+//save flash for F3 targets
+#define CLI_MINIMAL_VERBOSITY
+#define SKIP_CLI_COMMAND_HELP
+#define SKIP_CLI_RESOURCES
 #endif
 
 #if defined(STM32F3) || defined(STM32F4)
@@ -127,11 +131,6 @@
 #define RTC_AUTOMATIC_DST
 // Wind estimator
 #define USE_WIND_ESTIMATOR
-
-//save flash for F3 targets
-#define CLI_MINIMAL_VERBOSITY
-#define SKIP_CLI_COMMAND_HELP
-#define SKIP_CLI_RESOURCES
 
 #else // FLASH_SIZE < 128
 


### PR DESCRIPTION
Claim for flash of F3 removing some not very useful CLI stuff.
Leaving CLI STATISTICS  in place seems they can be useful detecting that users are abusing of F3.

Saves around 2.4k of FLASH.

superseeds #3949  