### PR TITLE
Limit Iterm on FW depending on stick position

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -958,6 +958,10 @@ groups:
         field: fixedWingCoordinatedYawGain
         min: 0
         max: 2
+      - name: fw_iterm_limit_stick_position
+        field: fixedWingItermLimitOnStickPosition
+        min: 0
+        max: 1
       - name: dterm_notch_hz
         field: dterm_soft_notch_hz
         condition: USE_DTERM_NOTCH

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -84,6 +84,7 @@ typedef struct {
 #ifdef USE_DTERM_NOTCH
     biquadFilter_t deltaNotchFilter;
 #endif
+    float stickPosition;
 } pidState_t;
 
 #ifdef USE_DTERM_NOTCH
@@ -107,7 +108,7 @@ int32_t axisPID_P[FLIGHT_DYNAMICS_INDEX_COUNT], axisPID_I[FLIGHT_DYNAMICS_INDEX_
 
 STATIC_FASTRAM pidState_t pidState[FLIGHT_DYNAMICS_INDEX_COUNT];
 
-PG_REGISTER_PROFILE_WITH_RESET_TEMPLATE(pidProfile_t, pidProfile, PG_PID_PROFILE, 4);
+PG_REGISTER_PROFILE_WITH_RESET_TEMPLATE(pidProfile_t, pidProfile, PG_PID_PROFILE, 5);
 
 PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
         .bank_mc = {
@@ -191,6 +192,7 @@ PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
         .fixedWingItermThrowLimit = FW_ITERM_THROW_LIMIT_DEFAULT,
         .fixedWingReferenceAirspeed = 1000,
         .fixedWingCoordinatedYawGain = 1.0f,
+        .fixedWingItermLimitOnStickPosition = 0.5f,
 );
 
 void pidInit(void)
@@ -352,6 +354,13 @@ void updatePIDCoefficients(void)
         }
     }
 
+    /*
+     * Compute stick position in range of [-1.0f : 1.0f] without deadband and expo
+     */
+    for (int axis = 0; axis < 3; axis++) {
+        pidState[axis].stickPosition = constrain(rcData[axis] - PWM_RANGE_MIDDLE, -500, 500) / 500.0f;
+    }
+
     // If nothing changed - don't waste time recalculating coefficients
     if (!pidGainsUpdateRequired) {
         return;
@@ -457,6 +466,11 @@ static void pidApplySetpointRateLimiting(pidState_t *pidState, flight_dynamics_i
     }
 }
 
+bool isFixedWingItermLimitActive(float stickPosition)
+{
+    return fabsf(stickPosition) > pidProfile()->fixedWingItermLimitOnStickPosition;
+}
+
 static void pidApplyFixedWingRateController(pidState_t *pidState, flight_dynamics_index_t axis)
 {
     const float rateError = pidState->rateTarget - pidState->gyroRate;
@@ -473,7 +487,7 @@ static void pidApplyFixedWingRateController(pidState_t *pidState, flight_dynamic
     // Calculate integral
     pidState->errorGyroIf += rateError * pidState->kI * dT;
 
-    if (STATE(ANTI_WINDUP)) {
+    if (STATE(ANTI_WINDUP) || isFixedWingItermLimitActive(pidState->stickPosition)) {
         pidState->errorGyroIf = constrainf(pidState->errorGyroIf, -pidState->errorGyroIfLimit, pidState->errorGyroIfLimit);
     } else {
         pidState->errorGyroIfLimit = ABS(pidState->errorGyroIf);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -468,6 +468,14 @@ static void pidApplySetpointRateLimiting(pidState_t *pidState, flight_dynamics_i
 
 bool isFixedWingItermLimitActive(float stickPosition)
 {
+    /*
+     * Iterm anti windup whould be active only when pilot controls the rotation
+     * velocity directly, not when ANGLE or HORIZON are used
+     */
+    if (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)) {
+        return false;
+    }
+
     return fabsf(stickPosition) > pidProfile()->fixedWingItermLimitOnStickPosition;
 }
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -104,6 +104,7 @@ typedef struct pidProfile_s {
     uint16_t    fixedWingItermThrowLimit;
     float       fixedWingReferenceAirspeed;     // Reference tuning airspeed for the airplane - the speed for which PID gains are tuned
     float       fixedWingCoordinatedYawGain;    // This is the gain of the yaw rate required to keep the yaw rate consistent with the turn rate for a coordinated turn.
+    float       fixedWingItermLimitOnStickPosition;   //Do not allow Iterm to grow when stick position is above this point
 } pidProfile_t;
 
 typedef struct pidAutotuneConfig_s {


### PR DESCRIPTION
It's not that simple to tune a FW for sharp turns especially when requested rates are close to the hardware limit. Too much or not enough FF leads to bounce-back or even follow-up when stick is released.

![adnotacja 2018-11-18 190857](https://user-images.githubusercontent.com/966811/48676399-c8089f80-eb66-11e8-8b97-7573b9248347.jpg)

![adnotacja 2018-11-18 191138](https://user-images.githubusercontent.com/966811/48676401-cb9c2680-eb66-11e8-93fc-d00cf03a110d.jpg)

Limit in this PR depends on a stick position, not the fact if output is saturated like in case of MR controller since it's harder to determine if any servo is actually at a limit or not.

Experimental, not tested yet