### PR TITLE
Remove redundant "isadjustingposition" variable assignment

### DIFF
--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -258,8 +258,6 @@ static void calculateVirtualPositionTarget_FW(float trackingPeriod)
             // Rotate this target shift from body frame to to earth frame and apply to position target
             virtualDesiredPosition.x += -rcShiftY * posControl.actualState.sinYaw;
             virtualDesiredPosition.y +=  rcShiftY * posControl.actualState.cosYaw;
-
-            posControl.flags.isAdjustingPosition = true;
         }
     }
 }


### PR DESCRIPTION
Redundant, since line 252 already checks if 'posControl.flags.isAdjustingPosition' is true.