### PR TITLE
Fix PPM input on MATEKF405SE

### DIFF
--- a/src/main/target/MATEKF405SE/target.c
+++ b/src/main/target/MATEKF405SE/target.c
@@ -22,6 +22,8 @@
 #include "drivers/timer.h"
 
 const timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM9,  CH2, PA3,  TIM_USE_PPM,   0, 0), //RX2
+    
     DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_MC_MOTOR  | TIM_USE_FW_MOTOR,   1, 0), // S1
     DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_MC_MOTOR  | TIM_USE_FW_MOTOR,   1, 0), // S2
 
@@ -35,7 +37,6 @@ const timerHardware_t timerHardware[] = {
 
     DEF_TIM(TIM2,  CH1, PA15, TIM_USE_LED,   0, 0), //2812LED
 
-    DEF_TIM(TIM9,  CH2, PA3,  TIM_USE_PPM,   0, 0), //RX2
     DEF_TIM(TIM5,  CH3, PA2,  TIM_USE_ANY,   0, 0), //TX2  softserial1_Tx
 };
 


### PR DESCRIPTION
After refactoring of TIM/DMA framework #3833 PPM input stopped working on Matek F405 Wing target (MATEKF405SE).
Issue #3947. 
Although it is fine on other F4 boards.
The difference between this target and the others was the 'timerHardware' sequence. PPM timer is always initialized the first on every F4 controller.
When I moved PPM timer to the 1st position here, receiver started working again.