### PR TITLE
add raw accelerometer values "ACC" debug_mode

### DIFF
--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -67,6 +67,7 @@ typedef enum {
     DEBUG_CRUISE,
     DEBUG_REM_FLIGHT_TIME,
     DEBUG_SMARTAUDIO,
+    DEBUG_ACC,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -72,7 +72,7 @@ tables:
   - name: debug_modes
     values: ["NONE", "GYRO", "NOTCH", "NAV_LANDING", "FW_ALTITUDE", "AGL", "FLOW_RAW",
       "FLOW", "SBUS", "FPORT", "ALWAYS", "STAGE2", "WIND_ESTIMATOR", "SAG_COMP_VOLTAGE",
-      "VIBE", "CRUISE", "REM_FLIGHT_TIME", "SMARTAUDIO"]
+      "VIBE", "CRUISE", "REM_FLIGHT_TIME", "SMARTAUDIO","ACC"]
   - name: async_mode
     values: ["NONE", "GYRO", "ALL"]
   - name: aux_operator

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -513,6 +513,7 @@ void accUpdate(void)
 
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         accADC[axis] = acc.dev.ADCRaw[axis];
+        DEBUG_SET(DEBUG_ACC, axis, accADC[axis]);
     }
 
     if (!accIsCalibrationComplete()) {


### PR DESCRIPTION
Having raw accelerometers values in the BB can be used for further vibration analysis and tuning of the LPF filter / NOTCH filter.