### PR TITLE
Fix PPM input initialization

### DIFF
--- a/src/main/drivers/rx_pwm.c
+++ b/src/main/drivers/rx_pwm.c
@@ -344,7 +344,7 @@ void pwmInConfig(const timerHardware_t *timerHardwarePtr, uint8_t channel)
 {
     pwmInputPort_t *self = &pwmInputPorts[channel];
 
-    TCH_t * tch = timerGetTCH(timerHardware);
+    TCH_t * tch = timerGetTCH(timerHardwarePtr);
     if (tch == NULL) {
         return NULL;
     }
@@ -370,7 +370,7 @@ void pwmInConfig(const timerHardware_t *timerHardwarePtr, uint8_t channel)
 
 void ppmInConfig(const timerHardware_t *timerHardwarePtr)
 {
-    TCH_t * tch = timerGetTCH(timerHardware);
+    TCH_t * tch = timerGetTCH(timerHardwarePtr);
     if (tch == NULL) {
         return NULL;
     }


### PR DESCRIPTION
Pointer 'timerHardware' refers to the first timer in 'target.c'. 
That is why PPM worked on some targets and failed on others.
No need to merge #4039.