### PR TITLE
Add new target DALRCF722DUAL and add DALRCF405 board description

### DIFF
--- a/docs/Board - DALRCF405.md
+++ b/docs/Board - DALRCF405.md
@@ -1,0 +1,106 @@
+# Board - DALRCF405
+
+The DALRCF405  described here:
+http://www.dalrcmodel.com/DALRC/plus/view.php?aid=184
+
+This board use the STM32F405RGT6 microcontroller and have the following features:
+* 1024K bytes of flash memory,192K bytes RAM,168 MHz CPU/210 DMIPS
+
+* The 16M byte SPI flash for data logging
+* USB VCP and boot select button on board(for DFU)
+* Stable voltage regulation,9V/2A DCDC BEC for VTX/camera etc.And could select 5v/9v
+* Serial LED interface(LED_STRIP)
+* VBAT/CURR/RSSI sensors input
+* Suppose IRC Tramp/smart audio/FPV Camera Control/FPORT/telemetry
+* Supports SBus, Spektrum1024/2048, PPM. No external inverters required (built-in).
+* Supports I2C device extend(baro/compass/OLED etc)
+* Supports GPS 
+
+### Uarts 
+| Value | Identifier   | RX   | TX   | Notes                                                                                       |
+| ----- | ------------ | -----| -----| ------------------------------------------------------------------------------------------- |
+| 1     | USART1       | PB7  |  PA9 |  PB7 FOR SBUS IN(inverter build in)                                                         |
+| 2     | USART2       | PA3  |  PA2 |  PAD USE FOR TRAMP/smart audio                                                              |
+| 3     | USART3       | PB11 |  PB10|  USE FOR GPS                                                                                |
+| 4     | USART4       | PA1  |  PA0 |  PA0 FOR RSSI/FPORT/TEL etc                                                                 |
+| 5     | USART5       | PD2  |  PC12|  PAD                                                                                        |
+
+
+### I2C with GPS port together.Use for BARO or compass etc 
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | I2C1         |    SDA   |  PB9   | with GPS outlet
+| 2     | I2C1         |    SCL   |  PB8   | with GPS outlet
+
+
+### Buzzer/LED output 
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | LED0         |    LED   |  PC14  | 
+| 2     | BEEPER       |    BEE   |  PC13  | 
+
+
+### VBAT input with 1/10 divider ratio,Current signal input,Analog/digit RSSI input
+| Value | Identifier   | function  |  pin  | Notes                                                                                 |
+| ----- | ------------ | ----------| ------| ------------------------------------------------------------------------------------- |                                                                                       
+| 1     | ADC1         |    VBAT   |  PC2  |  DMA2_Stream0
+| 2     | ADC1         |    CURR   |  PC1  |  DMA2_Stream0
+| 3     | ADC1         |    RSSI   |  PA0  |  DMA2_Stream0
+| 4     | ADC1         |    extend |  PC0  |  DMA2_Stream0 extend for other senser(PAD)
+
+
+### 8 Outputs, 1 PPM input 
+| Value | Identifier   | function  |  pin  | Notes                                                                                 |
+| ----- | ------------ | ----------| ------| ------------------------------------------------------------------------------------- |                                                                                       
+| 1     | TIM12_CH2    |    PPM    |  PB15 |  PPM
+| 2     | TIM3_CH3     |    OUPUT1 |  PB0  |  DMA1_Stream7
+| 3     | TIM8_CH1     |    OUPUT2 |  PC6  |  DMA2_Stream2
+| 4     | TIM1_CH3     |    OUPUT3 |  PA10 |  DMA2_Stream6
+| 5     | TIM1_CH1     |    OUPUT4 |  PA8  |  DMA2_Stream1
+| 6     | TIM8_CH3     |    OUPUT5 |  PC8  |  DMA2_Stream4
+| 7     | TIM3_CH4     |    OUPUT6 |  PB1  |  DMA1_Stream2
+| 8     | TIM3_CH2     |    OUPUT7 |  PC7  |  DMA1_Stream5   
+| 9     | TIM8_CH4     |    OUPUT8 |  PC9  |  DMA2_Stream7   
+| 10    | TIM4_CH1     |    PWM    |  PB6  |  DMA1_Stream0   LED_STRIP
+| 11    | TIM2_CH1     |    PWM    |  PA5  |  FPV Camera Control(FCAM)
+
+
+### Gyro & ACC ,suppose ICM20689/MPU6000
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI1         |    SCK   |  PB3   | 
+| 2     | SPI1         |    MISO  |  PA6   | 
+| 3     | SPI1         |    MOSI  |  PA7   | 
+| 4     | SPI1         |    CS    |  PC4   | 
+
+### OSD MAX7456
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI3         |    SCK   |  PC10  | 
+| 2     | SPI3         |    MISO  |  PC11  | 
+| 3     | SPI3         |    MOSI  |  PB5   | 
+| 4     | SPI3         |    CS    |  PA15  |
+
+### 16Mbyte flash
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI2         |    SCK   |  PB13  | 
+| 2     | SPI2         |    MISO  |  PB14  | 
+| 3     | SPI2         |    MOSI  |  PC3   | 
+| 4     | SPI2         |    CS    |  PB12  | 
+
+### SWD
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | SWCLK          | PAD                                          |
+| 2   | Ground         | PAD                                          |
+| 3   | SWDIO          | PAD                                          |
+| 4   | 3V3            | PAD                                          |
+
+###Designers
+* ZhengNyway(nyway@vip.qq.com) FROM DALRC
+
+
+
+
+

--- a/docs/Board - DALRCF722DUAL.md
+++ b/docs/Board - DALRCF722DUAL.md
@@ -1,0 +1,111 @@
+# Board - DALRCF722DUAL
+
+The DALRCF722DUAL  described here:
+http://www.dalrcmodel.com/DALRC/plus/view.php?aid=188
+
+This board use the STM32F722RET6 microcontroller and have the following features:
+* High-performance and DSP with FPU, ARM Cortex-M7 MCU with 512 Kbytes Flash 
+* 216 MHz CPU,462 DMIPS/2.14 DMIPS/MHz (Dhrystone 2.1) and DSP instructions, Art Accelerator, L1 cache, SDRAM
+* DUAL gyro MPU6000 and ICM20602,could choose mpu6000,more stable and smooth.Or choose ICM20602,higher rate(32K/32K).Choose on CLI mode,experience different feature gyro on same board
+* OSD on board
+* The 16M byte SPI flash on board for data logging
+* USB VCP and boot select button on board(for DFU)
+* Stable voltage regulation,DUAL BEC  5v/2.5A and 10v/2A for VTX/camera etc.And could select 5v/10v with pad
+* Serial LED interface(LED_STRIP)
+* VBAT/CURR/RSSI sensors input
+* Suppose IRC Tramp/smart audio/FPV Camera Control/FPORT/telemetry
+* Supports SBus(built-in inverters), Spektrum1024/2048, PPM
+* Supports I2C device extend(baro/compass/OLED etc)(socket)
+* Supports GPS (socket)
+
+### All uarts have pad on board 
+| Value | Identifier   | RX   | TX   | Notes                                                                                       |
+| ----- | ------------ | -----| -----| ------------------------------------------------------------------------------------------- |
+| 1     | USART1       | PB7  |  PB6 |  PB7 FOR SBUS IN(inverter build in)/PPM                                                         |
+| 2     | USART2       | PA3  |  PA2 |  PAD USE FOR TRAMP/smart audio                                                              |
+| 3     | USART3       | PC11 |  PC10|  USE FOR GPS                                                                                |
+| 4     | USART4       | PA1  |  PA0 |  PA0 FOR RSSI/FPORT/TEL etc                                                                 |
+| 5     | USART5       | PD2  |  PC12|  PAD                                                                                        |
+
+
+### I2C with GPS port together.Use for BARO or compass etc 
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | I2C1         |    SDA   |  PB9   | 
+| 2     | I2C1         |    SCL   |  PB8   | 
+
+
+### Buzzer/LED output 
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | LED0         |    LED   |  PC14  |On board
+| 2     | BEEPER       |    BEE   |  PC13  |Pad 
+
+
+### VBAT input with 1/10 divider ratio,Current signal input,Analog/digit RSSI input
+| Value | Identifier   | function  |  pin  | Notes                                                                                 |
+| ----- | ------------ | ----------| ------| ------------------------------------------------------------------------------------- |                                                                                       
+| 1     | ADC1         |    VBAT   |  PC1  |  
+| 2     | ADC1         |    CURR   |  PC0  |  
+| 3     | ADC1         |    RSSI   |  PA0  |   
+
+
+### 8 Outputs 
+| Value | Identifier   | function  |  pin  | Notes                                                                                 |
+| ----- | ------------ | ----------| ------| ------------------------------------------------------------------------------------- |                                                                                       
+| 1     | TIM4_CH2     |    PPM    |  PB7  |  PPM
+| 2     | TIM8_CH1     |    OUPUT1 |  PC6  |  DMA
+| 3     | TIM8_CH2     |    OUPUT2 |  PC7  |  DMA
+| 4     | TIM8_CH3     |    OUPUT3 |  PC8  |  DMA
+| 5     | TIM8_CH4     |    OUPUT4 |  PC9  |  DMA
+| 6     | TIM1_CH1     |    OUPUT5 |  PA8  |  DMA
+| 7     | TIM1_CH2     |    OUPUT6 |  PA9  |  DMA  
+| 8     | TIM1_CH3     |    OUPUT7 |  PA10 |  DMA   NO PAD
+| 9     | TIM2_CH4     |    OUPUT8 |  PB11 |  NO PAD
+| 10    | TIM2_CH1     |    PWM    |  PA15 |  DMA  LED_STRIP
+| 11    | TIM3_CH4     |    PWM    |  PB1  |  FPV Camera Control(FCAM)
+
+
+### Gyro & ACC ,support ICM20602 and MPU6000
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI1         |    SCK   |  PA5   | MPU6000 & ICM20602
+| 2     | SPI1         |    MISO  |  PA6   | MPU6000 & ICM20602
+| 3     | SPI1         |    MOSI  |  PA7   | MPU6000 & ICM20602
+| 4     | SPI1         |    CS1   |  PB0   | MPU6000
+| 5     | SPI1         |    CS2   |  PA4   | ICM20602 
+| 6     | SPI1         |    INT1  |  PB10  | MPU6000
+| 7     | SPI1         |    INT2  |  PC4   | ICM20602
+
+### OSD MAX7456
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI2         |    SCK   |  PB13  | 
+| 2     | SPI2         |    MISO  |  PB14  | 
+| 3     | SPI2         |    MOSI  |  PB15  | 
+| 4     | SPI2         |    CS    |  PB12  |
+
+### 16Mbyte flash
+| Value | Identifier   | function |  pin   | Notes                                                                                 |
+| ----- | ------------ | ---------| -------| ------------------------------------------------------------------------------------- |                                                                                      
+| 1     | SPI3         |    SCK   |  PB3   | 
+| 2     | SPI3         |    MISO  |  PB4   | 
+| 3     | SPI3         |    MOSI  |  PB4   | 
+| 4     | SPI3         |    CS    |  PB2   | 
+
+### SWD
+| Pin | Function       | Notes                                        |
+| --- | -------------- | -------------------------------------------- |
+| 1   | SWCLK          | PAD                                          |
+| 2   | Ground         | PAD                                          |
+| 3   | SWDIO          | PAD                                          |
+| 4   | 3V3            | PAD                                          |
+
+
+###Designers
+* ZhengNyway(nyway@vip.qq.com) FROM DALRC
+
+
+
+
+

--- a/src/main/target/DALRCF722DUAL/hardware_setup.c
+++ b/src/main/target/DALRCF722DUAL/hardware_setup.c
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+
+#include "drivers/io_impl.h"
+
+#ifdef USE_HARDWARE_PREBOOT_SETUP
+
+
+void initialisePreBootHardware(void)
+{
+    //DALRC F722 have dual GYRO:mpu6000 and icm20602,they use same SPI but different CS pin.Just use mpu6000 for INAV.
+    //So set icm20602 CS pin high to block icm20602 SPI .
+    IOInit(DEFIO_IO(PA4), OWNER_SYSTEM, RESOURCE_OUTPUT, 0);
+    IOConfigGPIO(DEFIO_IO(PA4), IOCFG_OUT_PP);
+    IOHi(DEFIO_IO(PA4));
+}
+#endif
+
+

--- a/src/main/target/DALRCF722DUAL/target.c
+++ b/src/main/target/DALRCF722DUAL/target.c
@@ -1,0 +1,44 @@
+/*
+* This file is part of Cleanflight.
+*
+* Cleanflight is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Cleanflight is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+#define TIM_EN      TIMER_OUTPUT_ENABLED
+#define TIM_EN_N    TIMER_OUTPUT_ENABLED | TIMER_OUTPUT_N_CHANNEL
+
+const timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM4, CH2, PB7, TIM_USE_PPM ,0, 0),
+
+    DEF_TIM(TIM8, CH1, PC6, TIM_USE_MC_MOTOR |  TIM_USE_FW_MOTOR,0,0), //S1 DMA2_ST2  T8CH1
+    DEF_TIM(TIM8, CH2, PC7, TIM_USE_MC_MOTOR |  TIM_USE_FW_SERVO,0,0), //S2 DMA2_ST3  T8CH2
+    DEF_TIM(TIM8, CH3, PC8, TIM_USE_MC_MOTOR |  TIM_USE_FW_SERVO,0,0), //S3 DMA2_ST4  T8CH3
+    DEF_TIM(TIM8, CH4, PC9, TIM_USE_MC_MOTOR |  TIM_USE_FW_SERVO,0,0), //S4 DMA2_ST7  T8CH4
+    DEF_TIM(TIM1, CH1, PA8, TIM_USE_MC_MOTOR |  TIM_USE_FW_MOTOR,0,0), //S5 DMA2_ST1  T1CH1
+    DEF_TIM(TIM1, CH2, PA9, TIM_USE_MC_MOTOR |  TIM_USE_FW_SERVO,0,0), //S6 DMA2_ST6  T1CH2
+
+    DEF_TIM(TIM2, CH1, PA15,TIM_USE_LED,0,0), //2812 STRIP DMA1_ST5
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);
+

--- a/src/main/target/DALRCF722DUAL/target.h
+++ b/src/main/target/DALRCF722DUAL/target.h
@@ -1,0 +1,151 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "DLF7"
+#define USBD_PRODUCT_STRING  "DALRCF722DUAL"
+
+#define USE_HARDWARE_PREBOOT_SETUP 
+
+#define LED0                    PC14
+#define BEEPER                  PC13
+#define BEEPER_INVERTED
+
+#define USE_GYRO
+#define USE_ACC
+
+// MPU6000
+#define MPU6000_CS_PIN          PB0
+#define MPU6000_SPI_BUS         BUS_SPI1
+#define USE_GYRO_MPU6000
+#define GYRO_MPU6000_ALIGN      CW180_DEG
+#define USE_ACC_MPU6000
+#define ACC_MPU6000_ALIGN       CW180_DEG
+
+#define USE_EXTI
+#define GYRO_INT_EXTI            PB10
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PB6
+#define UART1_RX_PIN            PB7
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define USE_UART3
+#define UART3_TX_PIN            PC10
+#define UART3_RX_PIN            PC11
+
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1
+
+#define USE_UART5
+#define UART5_TX_PIN            PC12
+#define UART5_RX_PIN            PD2
+#define SERIAL_PORT_COUNT       6
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8        
+#define I2C1_SDA                PB9       
+
+
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_BMP085
+
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define USE_MAG_IST8310
+#define USE_MAG_IST8308
+#define USE_MAG_MAG3110
+#define USE_MAG_LIS3MDL
+
+#define USE_PITOT_MS4525
+#define PITOT_I2C_BUS           BUS_I2C1
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_SPI_DEVICE_2
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_SPI_DEVICE_3
+#define SPI3_NSS_PIN            NONE
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          SPI2_NSS_PIN
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define M25P16_CS_PIN           PB2
+#define M25P16_SPI_BUS          BUS_SPI3
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+
+#define USE_ADC
+#define ADC_CHANNEL_1_PIN               PC0
+#define ADC_CHANNEL_2_PIN               PC1
+#define ADC_CHANNEL_3_PIN               PA0
+
+#define CURRENT_METER_ADC_CHANNEL       ADC_CHN_1
+#define VBAT_ADC_CHANNEL                ADC_CHN_2
+#define RSSI_ADC_CHANNEL                ADC_CHN_3
+#define VBAT_SCALE_DEFAULT              1600
+
+#define USE_LED_STRIP
+#define WS2811_PIN                      PA15   
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST5_HANDLER
+#define WS2811_DMA_STREAM               DMA1_Stream5
+#define WS2811_DMA_CHANNEL              DMA_CHANNEL_3
+
+#define DEFAULT_FEATURES                (FEATURE_VBAT | FEATURE_OSD  )
+#define DEFAULT_RX_TYPE                 RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER               SERIALRX_SBUS
+#define SERIALRX_UART                   SERIAL_PORT_USART1
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define MAX_PWM_OUTPUT_PORTS    6
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+

--- a/src/main/target/DALRCF722DUAL/target.mk
+++ b/src/main/target/DALRCF722DUAL/target.mk
@@ -1,0 +1,19 @@
+F7X2RE_TARGETS += $(TARGET)
+FEATURES        += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+            drivers/accgyro/accgyro_mpu.c \
+            drivers/accgyro/accgyro_mpu6000.c \
+            drivers/barometer/barometer_bmp085.c \
+            drivers/barometer/barometer_bmp280.c \
+            drivers/barometer/barometer_ms56xx.c \
+            drivers/compass/compass_hmc5883l.c \
+            drivers/compass/compass_qmc5883l.c \
+            drivers/compass/compass_ist8310.c \
+            drivers/compass/compass_ist8308.c \
+            drivers/compass/compass_mag3110.c \
+            drivers/compass/compass_lis3mdl.c \
+            drivers/light_ws2811strip.c \
+            drivers/max7456.c \
+            drivers/pitotmeter_ms4525.c \
+            drivers/pitotmeter_adc.c \


### PR DESCRIPTION
Add new target DALRCF722DUAL and add DALRCF405 board description to development branch.
More about DALRCF722 detal here:
http://www.dalrcmodel.com/DALRC/plus/view.php?aid=188