### PR TITLE
Fix bug in bitArrayFindFirstSet(), add functions for setting and clearing the whole array

### DIFF
--- a/src/main/common/bitarray.c
+++ b/src/main/common/bitarray.c
@@ -67,7 +67,7 @@ int bitArrayFindFirstSet(const bitarrayElement_t *array, unsigned start, size_t 
     // First iteration might need to mask some bits
     uint32_t mask = 0xFFFFFFFF << (start % (8 * 4));
     if ((ret = __CTZ(*p & mask)) != 32) {
-        return ret;
+        return (((char *)p) - ((char *)ptr)) * 8 + ret;
     }
     p++;
     while (p < end) {

--- a/src/main/common/bitarray.c
+++ b/src/main/common/bitarray.c
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "bitarray.h"
 
@@ -35,6 +36,16 @@ void bitArraySet(bitarrayElement_t *array, unsigned bit)
 void bitArrayClr(bitarrayElement_t *array, unsigned bit)
 {
     BITARRAY_BIT_OP((uint32_t*)array, bit, &=~);
+}
+
+void bitArraySetAll(bitarrayElement_t *array, size_t size)
+{
+    memset(array, 0xFF, size);
+}
+
+void bitArrayClrAll(bitarrayElement_t *array, size_t size)
+{
+    memset(array, 0, size);
 }
 
 __attribute__((always_inline)) static inline uint8_t __CTZ(uint32_t val)

--- a/src/main/common/bitarray.h
+++ b/src/main/common/bitarray.h
@@ -34,6 +34,12 @@ bool bitArrayGet(const bitarrayElement_t *array, unsigned bit);
 void bitArraySet(bitarrayElement_t *array, unsigned bit);
 void bitArrayClr(bitarrayElement_t *array, unsigned bit);
 
+void bitArraySetAll(bitarrayElement_t *array, size_t size);
+void bitArrayClrAll(bitarrayElement_t *array, size_t size);
+
+#define BITARRAY_SET_ALL(array) bitArraySetAll(array, sizeof(array))
+#define BITARRAY_CLR_ALL(array) bitArrayClrAll(array, sizeof(array))
+
 // Returns the first set bit with pos >= start_bit, or -1 if all bits
 // are zero. Note that size must indicate the size of array in bytes.
 // In most cases, you should use the BITARRAY_FIND_FIRST_SET() macro

--- a/src/test/unit/bitarray_unittest.cc
+++ b/src/test/unit/bitarray_unittest.cc
@@ -67,3 +67,19 @@ TEST(BitArrayTest, TestFind)
     EXPECT_EQ(bitArrayFindFirstSet(p, 0, sizeof(p)), -1);
     EXPECT_EQ(bitArrayFindFirstSet(p, 64, sizeof(p)), -1);
 }
+
+TEST(BitArrayTest, TestSetClrAll)
+{
+    const int bits = 32 * 4;
+
+    BITARRAY_DECLARE(p, bits);
+    BITARRAY_CLR_ALL(p);
+
+    EXPECT_EQ(-1, BITARRAY_FIND_FIRST_SET(p, 0));
+
+    BITARRAY_SET_ALL(p);
+
+    for (int ii = 0; ii < bits; ii++) {
+        EXPECT_EQ(ii, BITARRAY_FIND_FIRST_SET(p, ii));
+    }
+}

--- a/src/test/unit/bitarray_unittest.cc
+++ b/src/test/unit/bitarray_unittest.cc
@@ -59,6 +59,8 @@ TEST(BitArrayTest, TestFind)
     EXPECT_EQ(bitArrayFindFirstSet(p, 16, sizeof(p)), 44);
     EXPECT_EQ(bitArrayFindFirstSet(p, 17, sizeof(p)), 44);
     EXPECT_EQ(bitArrayFindFirstSet(p, 18, sizeof(p)), 44);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 43, sizeof(p)), 44);
+    EXPECT_EQ(bitArrayFindFirstSet(p, 44, sizeof(p)), 44);
     EXPECT_EQ(bitArrayFindFirstSet(p, 45, sizeof(p)), -1);
 
     bitArrayClr(p, 44);


### PR DESCRIPTION
- Fix incorrect return value in bitArrayFindFirstSet() when using non-zero start
- Add bitarray functions for setting and clearing all the array