### PR TITLE
smix reverse removed

### DIFF
--- a/docs/Mixer.md
+++ b/docs/Mixer.md
@@ -116,8 +116,6 @@ Servo speed might be useful for functions like flaps, landing gear retraction an
 
 Servos can be reversed using Configurator _Servo_ tab and _Reverse_ checkbox.
 
-`smix reverse` command is still working but it is advised not to use it anymore and it might be removed in next releases of firmware.
-
 ## Servo configuration
 
 The cli `servo` command defines the settings for the servo outputs.

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -447,7 +447,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
             sbufWriteU8(dst, 0);
             sbufWriteU8(dst, 0);
             sbufWriteU8(dst, 255); // used to be forwardFromChannel, not used anymore, send 0xff for compatibility reasons
-            sbufWriteU32(dst, servoParams(i)->reversedSources);
+            sbufWriteU32(dst, 0); //Input reversing is not required since it can be done on mixer level
         }
         break;
     case MSP_SERVO_MIX_RULES:
@@ -1763,7 +1763,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             sbufReadU8(src);
             sbufReadU8(src);
             sbufReadU8(src); // used to be forwardFromChannel, ignored
-            servoParamsMutable(tmp_u8)->reversedSources = sbufReadU32(src);
+            sbufReadU32(src); // used to be reversedSources
             servoComputeScalingFactors(tmp_u8);
         }
         break;

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -64,7 +64,7 @@ PG_RESET_TEMPLATE(servoConfig_t, servoConfig,
 
 PG_REGISTER_ARRAY(servoMixer_t, MAX_SERVO_RULES, customServoMixers, PG_SERVO_MIXER, 0);
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(servoParam_t, MAX_SUPPORTED_SERVOS, servoParams, PG_SERVO_PARAMS, 1);
+PG_REGISTER_ARRAY_WITH_RESET_FN(servoParam_t, MAX_SUPPORTED_SERVOS, servoParams, PG_SERVO_PARAMS, 2);
 
 void pgResetFn_servoParams(servoParam_t *instance)
 {
@@ -101,15 +101,6 @@ int16_t getFlaperonDirection(uint8_t servoPin)
     } else {
         return 1;
     }
-}
-
-int servoDirection(int servoIndex, int inputSource)
-{
-    // determine the direction (reversed or not) from the direction bitfield of the servo
-    if (servoParams(servoIndex)->reversedSources & (1 << inputSource))
-        return -1;
-    else
-        return 1;
 }
 
 /*
@@ -290,7 +281,7 @@ void servoMixer(float dT)
          */
         int16_t inputLimited = (int16_t) rateLimitFilterApply4(&servoSpeedLimitFilter[i], input[from], currentServoMixer[i].speed * 10, dT);
 
-        servo[target] += servoDirection(target, from) * ((int32_t)inputLimited * currentServoMixer[i].rate) / 100;
+        servo[target] += ((int32_t)inputLimited * currentServoMixer[i].rate) / 100;
     }
 
     for (int i = 0; i < MAX_SUPPORTED_SERVOS; i++) {

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -21,7 +21,7 @@
 
 #define MAX_SUPPORTED_SERVOS 8
 
-// These must be consecutive, see 'reversedSources'
+// These must be consecutive
 typedef enum {
     INPUT_STABILIZED_ROLL       = 0,
     INPUT_STABILIZED_PITCH      = 1,
@@ -104,7 +104,6 @@ typedef struct servoMixer_s {
 PG_DECLARE_ARRAY(servoMixer_t, MAX_SERVO_RULES, customServoMixers);
 
 typedef struct servoParam_s {
-    uint32_t reversedSources;               // the direction of servo movement for each input source of the servo mixer, bit set=inverted
     int16_t min;                            // servo min
     int16_t max;                            // servo max
     int16_t middle;                         // servo middle
@@ -136,7 +135,6 @@ bool isServoOutputEnabled(void);
 bool isMixerUsingServos(void);
 void writeServos(void);
 void loadCustomServoMixer(void);
-int servoDirection(int servoIndex, int fromChannel);
 void servoMixer(float dT);
 void servoComputeScalingFactors(uint8_t servoIndex);
 void servosInit(void);


### PR DESCRIPTION
we do not need `smix reverse` as everything goes through servo mixer. That means, input reversal can be done right now on the mixer level per each rule.

Configurator minor cleanup, a this was not available in GUI, will follow

Merge togrther with iNavFlight/inav-configurator#626