### PR TITLE
Align OSD_FLYMODE to 13th column by default

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2448,7 +2448,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->item_pos[0][OSD_GPS_HDOP] = OSD_POS(0, 10);
 
     osdConfig->item_pos[0][OSD_GPS_LAT] = OSD_POS(0, 12);
-    osdConfig->item_pos[0][OSD_FLYMODE] = OSD_POS(12, 12) | OSD_VISIBLE_FLAG;
+    osdConfig->item_pos[0][OSD_FLYMODE] = OSD_POS(13, 12) | OSD_VISIBLE_FLAG;
     osdConfig->item_pos[0][OSD_GPS_LON] = OSD_POS(18, 12);
 
     osdConfig->item_pos[0][OSD_ROLL_PIDS] = OSD_POS(2, 10);


### PR DESCRIPTION
Since OSD_FLYMODE is 4 characters and the display is 30 characters,
to center it we should place it on the 13th instead of the 12th.