### PR TITLE
Make sure olc_encode() uses the same units as the GPS

### DIFF
--- a/src/main/common/olc.h
+++ b/src/main/common/olc.h
@@ -3,9 +3,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define OLC_DEG_MULTIPLIER ((olc_coord_t)1e6f)
+#define OLC_DEG_MULTIPLIER ((olc_coord_t)10000000LL) // 1e7
 
 typedef int32_t olc_coord_t;
+typedef uint32_t uolc_coord_t;
 
 // olc_encodes the given coordinates in lat and lon (deg * OLC_DEG_MULTIPLIER)
 // as an OLC code of the given length. It returns the number of characters

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2340,6 +2340,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_PLUS_CODE:
         {
+            STATIC_ASSERT(GPS_DEGREES_DIVIDER == OLC_DEG_MULTIPLIER, invalid_olc_deg_multiplier);
             int digits = osdConfig()->plus_code_digits;
             if (STATE(GPS_FIX)) {
                 olc_encode(gpsSol.llh.lat, gpsSol.llh.lon, digits, buff, sizeof(buff));

--- a/src/test/unit/olc_unittest.cc
+++ b/src/test/unit/olc_unittest.cc
@@ -10,15 +10,49 @@ extern "C" {
 using std::string;
 
 struct EncodeCase {
+    string result;
     double lat;
     double lon;
-    size_t length;
-    string result;
+
+    int length();
 };
 
+int EncodeCase::length()
+{
+    int n = 0;
+    for (size_t ii = 0; ii < this->result.length(); ii++) {
+        if (result[ii] == '0') {
+            break;
+        }
+        if (result[ii] != '+') {
+            n++;
+        }
+    }
+    return n;
+}
+
+// Tests cases from https://github.com/google/open-location-code/blob/master/test_data/encodingTests.csv
 struct EncodeCase encodeCases[] = {
-    {47.0000625, 8.0000625, 10, "8FVC2222+22"},
-    {47.0000625, 8.0000625, 13, "8FVC2222+22GCC"},
+    {"7FG49Q00+",       20.375, 2.775},
+    {"7FG49QCJ+2V",     20.3700625, 2.7821875},
+    {"7FG49QCJ+2VX",    20.3701125, 2.782234375},
+    {"7FG49QCJ+2VXGJ",  20.3701135, 2.78223535156},
+    {"8FVC2222+22",     47.0000625, 8.0000625},
+    {"4VCPPQGP+Q9",     -41.2730625, 174.7859375},
+    {"62G20000+",       0.5, -179.5},
+    {"22220000+",       -89.5, -179.5},
+    {"7FG40000+",       20.5, 2.5},
+    {"22222222+22",     -89.9999375, -179.9999375},
+    {"6VGX0000+",       0.5, 179.5},
+    {"6FH32222+222",    1, 1},
+    // Special cases over 90 latitude and 180 longitude
+    {"CFX30000+",       90, 1},
+    {"CFX30000+",       92, 1},
+    {"62H20000+",       1, 180},
+    {"62H30000+",       1, 181},
+    {"CFX3X2X2+X2",     90, 1},
+    // Test non-precise latitude/longitude value
+    {"6FH56C22+22",     1.2, 3.4},
 };
 
 TEST(OLCTest, TestEncode)
@@ -29,7 +63,7 @@ TEST(OLCTest, TestEncode)
         struct EncodeCase c = encodeCases[ii];
         int32_t lat = c.lat * OLC_DEG_MULTIPLIER;
         int32_t lon = c.lon * OLC_DEG_MULTIPLIER;
-        EXPECT_GT(olc_encode(lat, lon, c.length, buf, sizeof(buf)), 0);
+        EXPECT_GT(olc_encode(lat, lon, c.length(), buf, sizeof(buf)), 0);
         EXPECT_EQ(c.result, (string)buf);
     }
 }


### PR DESCRIPTION
Namely, 1e7. To accomplish this, we need to carefully convert
the values to unsigned after the initial normalization, because
OLC normalizes all values to lat to [0, 180] and lon to [0, 360]
and 360 * 1e7 overflows an int32.

Also, import all the tests from the original OLC C library.