### PR TITLE
Enable MSP_DISPLAYPORT on targets with flash > 128 and no OSD

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -29,3 +29,9 @@
 # undef USE_DASHBOARD
 # undef USE_OLED_UG2864
 #endif
+
+// Enable MSP_DISPLAYPORT for F3 targets without builtin OSD,
+// since it's used to display CMS on MWOSD
+#if !defined(USE_MSP_DISPLAYPORT) && (FLASH_SIZE > 128) && !defined(USE_OSD)
+#define USE_MSP_DISPLAYPORT
+#endif


### PR DESCRIPTION
MSP_DISPLAYPORT is used to display CMS on MWOSD, which is useful
for targets without a builtin OSD. Since those targets also have
a bit more flash/ram to spare, we have room for this feature as
long as no builtin OSD is present.