### PR TITLE
OSD CMS fixing & into +

### DIFF
--- a/src/main/cms/cms_menu_builtin.c
+++ b/src/main/cms/cms_menu_builtin.c
@@ -155,10 +155,10 @@ static const OSD_Entry menuMainEntries[] =
     OSD_SUBMENU_ENTRY("OSD", &cmsx_menuOsd),
 #endif
     OSD_SUBMENU_ENTRY("BATTERY", &cmsx_menuBattery),
-    OSD_SUBMENU_ENTRY("FC&FW INFO", &menuInfo),
+    OSD_SUBMENU_ENTRY("FC+FW INFO", &menuInfo),
     OSD_SUBMENU_ENTRY("MISC", &cmsx_menuMisc),
 
-    {"SAVE&REBOOT", OME_OSD_Exit, {.func = cmsMenuExit}, (void*)CMS_EXIT_SAVEREBOOT, 0},
+    {"SAVE+REBOOT", OME_OSD_Exit, {.func = cmsMenuExit}, (void*)CMS_EXIT_SAVEREBOOT, 0},
     {"EXIT",        OME_OSD_Exit, {.func = cmsMenuExit}, (void*)CMS_EXIT, 0},
 #ifdef CMS_MENU_DEBUG
     OSD_SUBMENU_ENTRY("ERR SAMPLE", &menuInfoEntries[0]),


### PR DESCRIPTION
Changed the "&" in CMS home page, so it does not use the ASCII char 38 that is actually the left side of the default crossair in the font.
Replaced by "+"