### PR TITLE
[USB] Increase CDC buffer on F7 boards to accomodate max MSP packet size

### DIFF
--- a/src/main/vcp_hal/usbd_cdc_interface.c
+++ b/src/main/vcp_hal/usbd_cdc_interface.c
@@ -56,8 +56,8 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-#define APP_RX_DATA_SIZE  2048
-#define APP_TX_DATA_SIZE  2048
+#define APP_RX_DATA_SIZE  4096
+#define APP_TX_DATA_SIZE  4096
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/


### PR DESCRIPTION
Fixes #4175