### PR TITLE
Thrust linearization

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -353,6 +353,8 @@ static void activateConfig(void)
     activateControlRateConfig();
     activateBatteryProfile();
 
+    generateLinThrottleCurve();
+
     resetAdjustmentStates();
 
     updateUsedModeActivationConditionFlags();

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -81,7 +81,7 @@ void setControlRateProfile(uint8_t profileIndex)
 
 void activateControlRateConfig(void)
 {
-    generateThrottleCurve(currentControlRateProfile);
+    generateRCThrottleCurve(currentControlRateProfile);
 }
 
 void changeControlRateProfile(uint8_t profileIndex)

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -370,8 +370,6 @@ static bool emergencyArmingIsEnabled(void)
 
 void annexCode(void)
 {
-    int32_t throttleValue;
-
     if (failsafeShouldApplyControlInput()) {
         // Failsafe will apply rcCommand for us
         failsafeApplyControlInput();
@@ -390,9 +388,7 @@ void annexCode(void)
         }
 
         //Compute THROTTLE command
-        throttleValue = constrain(rxGetChannelValue(THROTTLE), rxConfig()->mincheck, PWM_RANGE_MAX);
-        throttleValue = (uint32_t)(throttleValue - rxConfig()->mincheck) * PWM_RANGE_MIN / (PWM_RANGE_MAX - rxConfig()->mincheck);       // [MINCHECK;2000] -> [0;1000]
-        rcCommand[THROTTLE] = rcLookupThrottle(throttleValue);
+        rcCommand[THROTTLE] = rcLookupThrottle(rxGetChannelValue(THROTTLE));
 
         // Signal updated rcCommand values to Failsafe system
         failsafeUpdateRcCommandValues();

--- a/src/main/fc/rc_curves.h
+++ b/src/main/fc/rc_curves.h
@@ -17,9 +17,12 @@
 
 #pragma once
 
-struct controlRateConfig_s;
-void generateThrottleCurve(const struct controlRateConfig_s *controlRateConfig);
+#include "fc/controlrate_profile.h"
 
-int16_t rcLookup(int32_t stickDeflection, uint8_t expo);
-uint16_t rcLookupThrottle(uint16_t tmp);
-int16_t rcLookupThrottleMid(void);
+void generateRCThrottleCurve(const controlRateConfig_t *controlRateConfig);
+void generateLinThrottleCurve(void);
+
+int16_t rcLookup(int16_t stickDeflection, uint8_t expo);
+uint16_t rcLookupThrottle(uint16_t throttle);
+uint16_t linLookupThrottle(uint16_t throttle);
+uint16_t rcLookupThrottleMid(void);

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -843,6 +843,12 @@ groups:
         condition: "USE_DSHOT"
         min: 0
         max: 100
+      - name: motor_thr_expo
+        description: "Amount of inverse exposition applied to the throttle to cancel the ESC's throttle curve and make the thrust linear with requested throttle"
+        default_value: 0
+        field: thrExpo
+        min: -100
+        max: 100
 
   - name: PG_FAILSAFE_CONFIG
     type: failsafeConfig_t

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -40,6 +40,7 @@ FILE_COMPILE_FOR_SPEED
 
 #include "fc/config.h"
 #include "fc/rc_controls.h"
+#include "fc/rc_curves.h"
 #include "fc/rc_modes.h"
 #include "fc/runtime_config.h"
 #include "fc/controlrate_profile.h"
@@ -118,6 +119,7 @@ PG_RESET_TEMPLATE(motorConfig_t, motorConfig,
 #ifdef USE_DSHOT
     .flipOverAfterPowerFactor = SETTING_FLIP_OVER_AFTER_CRASH_POWER_FACTOR_DEFAULT,
 #endif
+    .thrExpo = 0
 );
 
 PG_REGISTER_ARRAY(motorMixer_t, MAX_SUPPORTED_MOTORS, primaryMotorMixer, PG_MOTOR_MIXER, 0);
@@ -653,8 +655,10 @@ void FAST_CODE mixTable(const float dT)
             }
 
             // Motor stop handling
-            if (currentMotorStatus != MOTOR_RUNNING) {
+            if (ARMING_FLAG(ARMED) && (currentMotorStatus != MOTOR_RUNNING)) {
                 motor[i] = motorValueWhenStopped;
+            } else {
+                motor[i] = linLookupThrottle(motor[i]);
             }
         }
     } else {

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -93,6 +93,7 @@ typedef struct motorConfig_s {
     float throttleScale;                    // Scaling factor for throttle.
     uint8_t motorPoleCount;                 // Magnetic poles in the motors for calculating actual RPM from eRPM provided by ESC telemetry
     uint8_t flipOverAfterPowerFactor;       // Power factor from 0 to 100% of flip over after crash
+    int8_t thrExpo;
 } motorConfig_t;
 
 PG_DECLARE(motorConfig_t, motorConfig);


### PR DESCRIPTION
The FC expects the thrust to be linear relative to the ESC command but ESCs apply their own curves. This add a new `motor_thr_expo` setting that allows to adjust the throttle curve the FC is using to compensate for it.