### PR TITLE
OSD, adding the "near home" icon

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -102,7 +102,7 @@
 
 #define SYM_DIRECTION             0x72 // 114 to 121, directional little arrows
 
-//                                0x7A // 122 -
+#define SYM_HOME_NEAR             0x7A // 122 Home, near
 
 //                                0x7B // 123 to 125 ASCII
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1293,14 +1293,20 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_HOME_DIR:
         {
             if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME) && isImuHeadingValid()) {
-                // There are 16 orientations for the home direction arrow.
-                // so we use 22.5deg per image, where the 1st image is used
-                // for [349, 11], the 2nd for [12, 33], etc...
-                int homeDirection = GPS_directionToHome - DECIDEGREES_TO_DEGREES(osdGetHeading());
-                // Add 11 to the angle, so first character maps to [349, 11]
-                int homeArrowDir = osdGetHeadingAngle(homeDirection + 11);
-                unsigned arrowOffset = homeArrowDir * 2 / 45;
-                buff[0] = SYM_ARROW_UP + arrowOffset;
+			    if (GPS_distanceToHome<10) {
+				    buff[0] = SYM_HOME_NEAR;
+				}
+				else
+				{
+			        // There are 16 orientations for the home direction arrow.
+                    // so we use 22.5deg per image, where the 1st image is used
+                    // for [349, 11], the 2nd for [12, 33], etc...
+                    int homeDirection = GPS_directionToHome - DECIDEGREES_TO_DEGREES(osdGetHeading());
+                    // Add 11 to the angle, so first character maps to [349, 11]
+                    int homeArrowDir = osdGetHeadingAngle(homeDirection + 11);
+                    unsigned arrowOffset = homeArrowDir * 2 / 45;
+                    buff[0] = SYM_ARROW_UP + arrowOffset;
+				}
             } else {
                 // No home or no fix or unknown heading, blink.
                 // If we're unarmed, show the arrow pointing up so users can see the arrow

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1293,12 +1293,12 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_HOME_DIR:
         {
             if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME) && isImuHeadingValid()) {
-			    if (GPS_distanceToHome<10) {
-				    buff[0] = SYM_HOME_NEAR;
-				}
-				else
-				{
-			        // There are 16 orientations for the home direction arrow.
+                if (GPS_distanceToHome<10) {
+                    buff[0] = SYM_HOME_NEAR;
+                }
+                else
+                {
+                    // There are 16 orientations for the home direction arrow.
                     // so we use 22.5deg per image, where the 1st image is used
                     // for [349, 11], the 2nd for [12, 33], etc...
                     int homeDirection = GPS_directionToHome - DECIDEGREES_TO_DEGREES(osdGetHeading());
@@ -1306,7 +1306,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     int homeArrowDir = osdGetHeadingAngle(homeDirection + 11);
                     unsigned arrowOffset = homeArrowDir * 2 / 45;
                     buff[0] = SYM_ARROW_UP + arrowOffset;
-				}
+                }
             } else {
                 // No home or no fix or unknown heading, blink.
                 // If we're unarmed, show the arrow pointing up so users can see the arrow

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1293,7 +1293,7 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_HOME_DIR:
         {
             if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME) && isImuHeadingValid()) {
-                if (GPS_distanceToHome<10) {
+                if (GPS_distanceToHome < navConfig()->general.min_rth_distance) {
                     buff[0] = SYM_HOME_NEAR;
                 }
                 else

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1293,7 +1293,7 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_HOME_DIR:
         {
             if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME) && isImuHeadingValid()) {
-                if (GPS_distanceToHome < navConfig()->general.min_rth_distance) {
+                if (GPS_distanceToHome < (navConfig()->general.min_rth_distance / 100) ) {
                     buff[0] = SYM_HOME_NEAR;
                 }
                 else


### PR DESCRIPTION
When the aircraft is closer than min_rth_distance, the arrow to home is replaced by a different icon to show close home proximity.
Using OSD char n°122