### PR TITLE
Camera Control for Caddx Turtle v2

### DIFF
--- a/docs/Camera_control.md
+++ b/docs/Camera_control.md
@@ -16,7 +16,7 @@ Caddx: Connect Only Rx Pad at Caddx Turtle v2 to an unused Tx Pad on your FC.
 
 ## Configuration
 Select "Runcam" in the configurator for the port that you would like to use.
-in CLI: set cam_provider = CADDX_V2
+in CLI: set cam_provider = CADDX_V2 (Default is RUNCAM)
 in modes tab assign the function you want to channels/switches:
 CAMERA POWER Caddx: Photo shot
 CAMERA CHANGE MODE Caddx: Stop recording

--- a/docs/Camera_control.md
+++ b/docs/Camera_control.md
@@ -1,0 +1,26 @@
+# Camera control
+
+This feature allows the control of cameras such as Caddx Turtle, Rucam models such as Split, Box etc.
+It's built on BetaFlights runcam impementation. See https://github.com/betaflight/betaflight/wiki/RunCam-Device-Protocol
+
+## Additional features
+
+This feature ads support for Caddx Turtle v2
+- Start and Stop for record
+- Photo
+- Stick control from transmitter for settings of Caddx Turtle v2
+
+## Hardware setup
+Runcam: See the Betaflight link above
+Caddx: Connect Only Rx Pad at Caddx Turtle v2 to an unused Tx Pad on your FC.
+
+## Configuration
+Select "Runcam" in the configurator for the port that you would like to use.
+in CLI: set cam_provider = CADDX_V2
+in modes tab assign the function you want to channels/switches:
+CAMERA POWER Caddx: Photo shot
+CAMERA CHANGE MODE Caddx: Stop recording
+CAMERA WI-FI Caddx: Start recording
+
+## Usage
+Stick contol/menu control - see the linked Wiki on betaflight above

--- a/src/main/config/parameter_group_ids.h
+++ b/src/main/config/parameter_group_ids.h
@@ -83,6 +83,7 @@
 
 // cleanflight v2 specific parameter group ids start at 256
 #define PG_VTX_SETTINGS_CONFIG 259
+#define PG_CAM_CONFIG 260
 
 // iNav specific parameter group ids start at 1000
 #define PG_INAV_START 1000

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -107,7 +107,10 @@ tables:
   - name: vtx_low_power_disarm
     values: ["OFF", "ON", "UNTIL_FIRST_ARM"]
     enum: vtxLowerPowerDisarm_e
-
+  - name: cam_provider
+    values: ["RUNCAM", "CADDX_V2"]
+    enum: camProvider_e
+    
 groups:
   - name: PG_GYRO_CONFIG
     type: gyroConfig_t
@@ -1767,5 +1770,14 @@ groups:
         field: permanentId[3]
         min: 0
         max: 255
+        type: uint8_t
+  - name: PG_CAM_CONFIG
+    type: camConfig_t
+    headers: ["io/rcdevice.h"]
+    condition: USE_RCDEVICE
+    members:
+      - name: cam_provider
+        field: provider
+        table: cam_provider
         type: uint8_t
 

--- a/src/main/io/rcdevice.c
+++ b/src/main/io/rcdevice.c
@@ -36,7 +36,7 @@
 #include "rcdevice.h"
 #include "rcdevice_cam.h"
 
-def USE_RCDEVICE
+#ifdef USE_RCDEVICE
 
 typedef enum {
     RCDP_SETTING_PARSE_WAITING_ID,

--- a/src/main/io/rcdevice.h
+++ b/src/main/io/rcdevice.h
@@ -37,6 +37,7 @@
 #define RCDEVICE_PROTOCOL_COMMAND_GET_DEVICE_INFO                   0x00
 // camera control
 #define RCDEVICE_PROTOCOL_COMMAND_CAMERA_CONTROL                    0x01
+#define CADDXDEVICE_PROTOCOL_COMMAND_CAMERA_CONTROL                 0x01
 // 5 key osd cable simulation
 #define RCDEVICE_PROTOCOL_COMMAND_5KEY_SIMULATION_PRESS             0x02
 #define RCDEVICE_PROTOCOL_COMMAND_5KEY_SIMULATION_RELEASE           0x03
@@ -44,6 +45,24 @@
 // device setting access
 #define RCDEVICE_PROTOCOL_COMMAND_READ_SETTING_DETAIL               0x11
 #define RCDEVICE_PROTOCOL_COMMAND_WRITE_SETTING                     0x13
+
+#define CADDX_PROTOCOL_HEADER                                       0x55
+#define CADDX_PROTOCOL_TAIL                                         0xAA
+
+
+typedef enum {
+    RUNCAM = 0,
+    CADDX_V2 = 1,
+} camProvider_e;
+
+typedef struct camConfig_s {
+    camProvider_e provider;
+} camConfig_t;
+
+PG_DECLARE(camConfig_t, camConfig);
+
+
+//extern camConfig_t *camConfig;
 
 // Feature Flag sets, it's a uint16_t flag
 typedef enum {
@@ -70,6 +89,21 @@ typedef enum {
     RCDEVICE_PROTOCOL_CAM_CTRL_UNKNOWN_CAMERA_OPERATION = 0xFF
 } rcdevice_camera_control_opeation_e;
 
+typedef enum {
+    CADDX_PROTOCOL_CAM_CTRL_PHOTO                    = 0x02,
+    CADDX_PROTOCOL_CAM_CTRL_RECORD                   = 0x03,
+    CADDX_PROTOCOL_CAM_CTRL_KEY                      = 0x13,
+    CADDX_PROTOCOL_CAM_CTRL_UNKNOWN_CAMERA_COMMAND   = 0xFF
+} caddx_device_camera_control_command_e;
+
+typedef enum {
+    CADDX_PROTOCOL_CAM_CTRL_START_RECORDING          = 0x01,
+    CADDX_PROTOCOL_CAM_CTRL_STOP_RECORDING           = 0x02,
+    CADDX_PROTOCOL_CAM_CTRL_TAKE_A_PHOTO             = 0x01,
+	CADDX_PROTOCOL_5KEY_INSTRUCTION                  = 0x13,
+    CADDX_PROTOCOL_CAM_CTRL_UNKNOWN_CAMERA_OPERATION = 0xFF
+} caddx_device_camera_control_operation_e;
+
 // Operation Of 5 Key OSD Cable Simulation
 typedef enum {
     RCDEVICE_PROTOCOL_5KEY_SIMULATION_NONE  = 0x00,
@@ -79,6 +113,17 @@ typedef enum {
     RCDEVICE_PROTOCOL_5KEY_SIMULATION_UP    = 0x04,
     RCDEVICE_PROTOCOL_5KEY_SIMULATION_DOWN  = 0x05
 } rcdevice_5key_simulation_operation_e;
+
+// Operation Of 5 Key OSD Cable Simulation
+typedef enum {
+    CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_NONE  = 0x00,
+    CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_SET   = 0x01,
+    CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_LEFT  = 0x04,
+    CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_RIGHT = 0x05,
+    CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_UP    = 0x02,
+    CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_DOWN  = 0x03
+} caddxdevice_5key_simulation_operation_e;
+
 
 // Operation of RCDEVICE_PROTOCOL_COMMAND_5KEY_CONNECTION
 typedef enum {
@@ -99,10 +144,23 @@ typedef enum {
 } rcdeviceCamSimulationKeyEvent_e;
 
 typedef enum {
+    CADDXDEVICE_CAM_KEY_NONE,
+    CADDXDEVICE_CAM_KEY_ENTER,
+    CADDXDEVICE_CAM_KEY_LEFT,
+    CADDXDEVICE_CAM_KEY_UP,
+    CADDXDEVICE_CAM_KEY_RIGHT,
+    CADDXDEVICE_CAM_KEY_DOWN,
+    CADDXDEVICE_CAM_KEY_CONNECTION_CLOSE,
+    CADDXDEVICE_CAM_KEY_CONNECTION_OPEN,
+    CADDXDEVICE_CAM_KEY_RELEASE,
+} caddxdeviceCamSimulationKeyEvent_e;
+
+typedef enum {
     RCDEVICE_PROTOCOL_RCSPLIT_VERSION = 0x00, // this is used to indicate the
                                               // device that using rcsplit
                                               // firmware version that <= 1.1.0
     RCDEVICE_PROTOCOL_VERSION_1_0 = 0x01,
+	CADDXDEVICE_PROTOCOL_TURTLEV2 = 0x02,
     RCDEVICE_PROTOCOL_UNKNOWN
 } rcdevice_protocol_version_e;
 
@@ -192,16 +250,21 @@ typedef struct runcamDeviceWriteSettingResponse_s {
     uint8_t needUpdateMenuItems;
 } runcamDeviceWriteSettingResponse_t;
 
+
+
 bool runcamDeviceInit(runcamDevice_t *device);
+void caddxDeviceSendPacket(runcamDevice_t *device, uint8_t command, uint8_t paramData);
 
 // camera button simulation
 bool runcamDeviceSimulateCameraButton(runcamDevice_t *device, uint8_t operation);
+bool caddxDeviceSimulateCameraButton(runcamDevice_t *device, uint8_t command, uint8_t operation);
 
 // 5 key osd cable simulation
 bool runcamDeviceOpen5KeyOSDCableConnection(runcamDevice_t *device);
 bool runcamDeviceClose5KeyOSDCableConnection(runcamDevice_t *device);
 bool runcamDeviceSimulate5KeyOSDCableButtonPress(runcamDevice_t *device, uint8_t operation);
 bool runcamDeviceSimulate5KeyOSDCableButtonRelease(runcamDevice_t *device);
+bool caddxDeviceSimulate5KeyOSDCableButtonPress(runcamDevice_t *device, uint8_t operation);
 
 // Device Setting Access
 bool runcamDeviceGetSettingDetail(runcamDevice_t *device, uint8_t settingID, runcamDeviceSettingDetail_t *outSettingDetail);

--- a/src/main/io/rcdevice.h
+++ b/src/main/io/rcdevice.h
@@ -100,7 +100,7 @@ typedef enum {
     CADDX_PROTOCOL_CAM_CTRL_START_RECORDING          = 0x01,
     CADDX_PROTOCOL_CAM_CTRL_STOP_RECORDING           = 0x02,
     CADDX_PROTOCOL_CAM_CTRL_TAKE_A_PHOTO             = 0x01,
-	CADDX_PROTOCOL_5KEY_INSTRUCTION                  = 0x13,
+    CADDX_PROTOCOL_5KEY_INSTRUCTION                  = 0x13,
     CADDX_PROTOCOL_CAM_CTRL_UNKNOWN_CAMERA_OPERATION = 0xFF
 } caddx_device_camera_control_operation_e;
 

--- a/src/main/io/rcdevice_cam.c
+++ b/src/main/io/rcdevice_cam.c
@@ -306,23 +306,23 @@ static bool caddxdeviceSend5KeyOSDCableSimualtionEvent(caddxdeviceCamSimulationK
         beeper(BEEPER_CAM_CONNECTION_CLOSE);
         break;
     case CADDXDEVICE_CAM_KEY_ENTER:
-	      caddxDeviceSendPacket(camDevice, CADDX_PROTOCOL_5KEY_INSTRUCTION, RCDEVICE_PROTOCOL_5KEY_SIMULATION_SET);
+	      caddxDeviceSendPacket(camDevice, CADDX_PROTOCOL_5KEY_INSTRUCTION, CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_SET);
         reqResult = true;
 		break;
     case CADDXDEVICE_CAM_KEY_LEFT:
-	      caddxDeviceSendPacket(camDevice, CADDX_PROTOCOL_5KEY_INSTRUCTION, RCDEVICE_PROTOCOL_5KEY_SIMULATION_LEFT);
+	      caddxDeviceSendPacket(camDevice, CADDX_PROTOCOL_5KEY_INSTRUCTION, CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_LEFT);
         reqResult = true;
 		break;
     case CADDXDEVICE_CAM_KEY_UP:
-	      caddxDeviceSendPacket(camDevice, CADDX_PROTOCOL_5KEY_INSTRUCTION, RCDEVICE_PROTOCOL_5KEY_SIMULATION_UP);
+	      caddxDeviceSendPacket(camDevice, CADDX_PROTOCOL_5KEY_INSTRUCTION, CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_UP);
         reqResult = true;
 		break;
     case CADDXDEVICE_CAM_KEY_RIGHT:
-	      caddxDeviceSendPacket(camDevice, CADDX_PROTOCOL_5KEY_INSTRUCTION, RCDEVICE_PROTOCOL_5KEY_SIMULATION_RIGHT);
+	      caddxDeviceSendPacket(camDevice, CADDX_PROTOCOL_5KEY_INSTRUCTION, CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_RIGHT);
         reqResult = true;
 		break;
     case CADDXDEVICE_CAM_KEY_DOWN:
-	      caddxDeviceSendPacket(camDevice, CADDX_PROTOCOL_5KEY_INSTRUCTION, RCDEVICE_PROTOCOL_5KEY_SIMULATION_DOWN);
+	      caddxDeviceSendPacket(camDevice, CADDX_PROTOCOL_5KEY_INSTRUCTION, CADDXDEVICE_PROTOCOL_5KEY_SIMULATION_DOWN);
         reqResult = true;
 		break;
     case CADDXDEVICE_CAM_KEY_RELEASE:


### PR DESCRIPTION
This ads the protocol used by Caddx for their Turtle series, based on this document: https://github.com/betaflight/betaflight/files/2419338/Uart_Turtletv2.docx

Works with Caddx Turtle v2, and maybe also with v1 with v2 software, but I don't have one so can not verify.

Functions: 
- Start/stop recording from radio switch. 
- Photo by switch (but not during recording so not so useful)
- Camera settings through radio similar to Runcam

The code is an ad to the Runcam code, and since I don't have a Runcam - I have not been able to verify that Runcam control still works - however - I have used a serial monitor to verify and Runcam communication seems to work from what I can see.