### PR TITLE
Fix detection of NTSC signal after 1.5s

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -335,10 +335,13 @@ static void max7456ReInit(void)
             break;
         default:
             busRead(state.dev, MAX7456ADD_STAT, &statVal);
-            if (VIN_IS_PAL(statVal) || millis() > MAX_SYNC_WAIT_MS) {
+            if (VIN_IS_PAL(statVal)) {
                 vm0Mode = VIDEO_MODE_PAL;
             } else if (VIN_IS_NTSC_alt(statVal)) {
                 vm0Mode = VIDEO_MODE_NTSC;
+            } else if ( millis() > MAX_SYNC_WAIT_MS) {
+                // Detection timed out, default to PAL
+                vm0Mode = VIDEO_MODE_PAL;
             } else {
                 // No signal detected yet, wait for detection timeout
                 return;


### PR DESCRIPTION
Due to a logic error during refactor, signal was always being stored
internally as PAL when more than 1.5s had elapsed since boot. The
MAX7456 kept reporting that the signal was actually NTSC, causing the
reinitialization sequence to trigger and the OSD to blink once every
second, but since the data cached in RAM was always stored as PAL
this continued forever.

Fixes #4183