### PR TITLE
TASK_VTXCTRL revert to 5Hz

### DIFF
--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -538,7 +538,7 @@ cfTask_t cfTasks[TASK_COUNT] = {
     [TASK_VTXCTRL] = {
         .taskName = "VTXCTRL",
         .taskFunc = vtxUpdate,
-        .desiredPeriod = TASK_PERIOD_HZ(50),          // 50Hz @20msec
+        .desiredPeriod = TASK_PERIOD_HZ(5),          // 5Hz @200msec
         .staticPriority = TASK_PRIORITY_IDLE,
     },
 #endif


### PR DESCRIPTION
Fix flaky SA by restoring the old task frequency.
5Hz should be plenty for a slow and low priority task as VTX control is.