### PR TITLE
Fixes to timer DMA and DSHOT code

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -266,8 +266,11 @@ static uint16_t prepareDshotPacket(const uint16_t value, bool requestTelemetry)
     return packet;
 }
 
-void pwmCompleteDshotUpdate(uint8_t motorCount, timeUs_t currentTimeUs)
+void pwmCompleteDshotUpdate(uint8_t motorCount)
 {
+    // Get latest REAL time
+    timeUs_t currentTimeUs = micros();
+
     // Enforce motor update rate
     if (!isProtocolDshot || (dshotMotorUpdateIntervalUs == 0) || ((currentTimeUs - dshotMotorLastUpdateUs) <= dshotMotorUpdateIntervalUs)) {
         return;

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -34,7 +34,7 @@ typedef enum {
 
 void pwmWriteMotor(uint8_t index, uint16_t value);
 void pwmShutdownPulsesForAllMotors(uint8_t motorCount);
-void pwmCompleteDshotUpdate(uint8_t motorCount, timeUs_t currentTimeUs);
+void pwmCompleteDshotUpdate(uint8_t motorCount);
 bool isMotorProtocolDshot(void);
 
 void pwmWriteServo(uint8_t index, uint16_t value);

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -784,7 +784,7 @@ void taskRunRealtimeCallbacks(timeUs_t currentTimeUs)
 #endif
 
 #ifdef USE_DSHOT
-    pwmCompleteDshotUpdate(getMotorCount(), currentTimeUs);
+    pwmCompleteDshotUpdate(getMotorCount());
 #endif
 }
 


### PR DESCRIPTION
Fixes a race condition to timer DMA.
Ensures that current DMA transaction is always terminated before starting a new one. 
Ensures that DSHOT scheduler doesn't use stale time - prevents long SD-card file system operations from breaking DSHOT scheduling and triggering a DMA race condition.

Fixes https://github.com/iNavFlight/inav/issues/4197