### PR TITLE
Fix Fake GPS

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -312,7 +312,7 @@ static bool gpsFakeGPSUpdate(void)
 
         gpsSetProtocolTimeout(GPS_TIMEOUT);
 
-        gpsSetState(GPS_RECEIVING_DATA);
+        gpsSetState(GPS_RUNNING);
         return true;
     }
     return false;


### PR DESCRIPTION
Just correct the enum item name to allow build with #define USE_FAKE_GPS