### PR TITLE
Per-device setting to access I2C bus directly

### DIFF
--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -134,7 +134,7 @@ typedef enum {
 
 typedef enum {
     DEVFLAGS_NONE                       = 0,
-    DEVFLAGS_USE_RAW_REGISTERS          = (1 << 0),     // Don't manipulate MSB for R/W selection
+    DEVFLAGS_USE_RAW_REGISTERS          = (1 << 0),     // Don't manipulate MSB for R/W selection (SPI), allow using 0xFF register to raw i2c reads/writes
     DEVFLAGS_USE_MANUAL_DEVICE_SELECT   = (1 << 1),     // (SPI only) Don't automatically select/deselect device
     DEVFLAGS_SPI_MODE_0                 = (1 << 2),     // (SPI only) Use CPOL=0/CPHA=0 (if unset MODE3 is used - CPOL=1/CPHA=1)
 } deviceFlags_e;

--- a/src/main/drivers/bus_busdev_i2c.c
+++ b/src/main/drivers/bus_busdev_i2c.c
@@ -28,21 +28,25 @@
 
 bool i2cBusWriteBuffer(const busDevice_t * dev, uint8_t reg, const uint8_t * data, uint8_t length)
 {
-    return i2cWriteBuffer(dev->busdev.i2c.i2cBus, dev->busdev.i2c.address, reg, length, data);
+    const bool allowRawAccess = (dev->flags & DEVFLAGS_USE_RAW_REGISTERS);
+    return i2cWriteBuffer(dev->busdev.i2c.i2cBus, dev->busdev.i2c.address, reg, length, data, allowRawAccess);
 }
 
 bool i2cBusWriteRegister(const busDevice_t * dev, uint8_t reg, uint8_t data)
 {
-    return i2cWrite(dev->busdev.i2c.i2cBus, dev->busdev.i2c.address, reg, data);
+    const bool allowRawAccess = (dev->flags & DEVFLAGS_USE_RAW_REGISTERS);
+    return i2cWrite(dev->busdev.i2c.i2cBus, dev->busdev.i2c.address, reg, data, allowRawAccess);
 }
 
 bool i2cBusReadBuffer(const busDevice_t * dev, uint8_t reg, uint8_t * data, uint8_t length)
 {
-    return i2cRead(dev->busdev.i2c.i2cBus, dev->busdev.i2c.address, reg, length, data);
+    const bool allowRawAccess = (dev->flags & DEVFLAGS_USE_RAW_REGISTERS);
+    return i2cRead(dev->busdev.i2c.i2cBus, dev->busdev.i2c.address, reg, length, data, allowRawAccess);
 }
 
 bool i2cBusReadRegister(const busDevice_t * dev, uint8_t reg, uint8_t * data)
 {
-    return i2cRead(dev->busdev.i2c.i2cBus, dev->busdev.i2c.address, reg, 1, data);
+    const bool allowRawAccess = (dev->flags & DEVFLAGS_USE_RAW_REGISTERS);
+    return i2cRead(dev->busdev.i2c.i2cBus, dev->busdev.i2c.address, reg, 1, data, allowRawAccess);
 }
 #endif

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -61,8 +61,8 @@ typedef struct i2cDevice_s {
 
 void i2cSetSpeed(uint8_t speed);
 void i2cInit(I2CDevice device);
-bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, const uint8_t *data);
-bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data);
-bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf);
+bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, const uint8_t *data, bool allowRawAccess);
+bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t data, bool allowRawAccess);
+bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf, bool allowRawAccess);
 
 uint16_t i2cGetErrorCounter(void);

--- a/src/main/drivers/bus_i2c_hal.c
+++ b/src/main/drivers/bus_i2c_hal.c
@@ -170,7 +170,7 @@ static bool i2cHandleHardwareFailure(I2CDevice device)
     return false;
 }
 
-bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, const uint8_t *data)
+bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_, const uint8_t *data, bool allowRawAccess)
 {
     if (device == I2CINVALID)
         return false;
@@ -183,10 +183,12 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
 
     HAL_StatusTypeDef status;
 
-    if (reg_ == 0xFF)
+    if (reg_ == 0xFF && allowRawAccess) {
         status = HAL_I2C_Master_Transmit(&i2cHandle[device].Handle, addr_ << 1, (uint8_t *)data, len_, I2C_DEFAULT_TIMEOUT);
-    else
+    }
+    else {
         status = HAL_I2C_Mem_Write(&i2cHandle[device].Handle,addr_ << 1, reg_, I2C_MEMADD_SIZE_8BIT, (uint8_t *)data, len_, I2C_DEFAULT_TIMEOUT);
+    }
 
     if (status != HAL_OK)
         return i2cHandleHardwareFailure(device);
@@ -194,12 +196,12 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len_,
     return true;
 }
 
-bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data)
+bool i2cWrite(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t data, bool allowRawAccess)
 {
-    return i2cWriteBuffer(device, addr_, reg_, 1, &data);
+    return i2cWriteBuffer(device, addr_, reg_, 1, &data, allowRawAccess);
 }
 
-bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf, bool allowRawAccess)
 {
     if (device == I2CINVALID)
         return false;
@@ -212,10 +214,12 @@ bool i2cRead(I2CDevice device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t
 
     HAL_StatusTypeDef status;
 
-    if (reg_ == 0xFF)
+    if (reg_ == 0xFF && allowRawAccess) {
         status = HAL_I2C_Master_Receive(&i2cHandle[device].Handle,addr_ << 1,buf, len, I2C_DEFAULT_TIMEOUT);
-    else
+    }
+    else {
         status = HAL_I2C_Mem_Read(&i2cHandle[device].Handle,addr_ << 1, reg_, I2C_MEMADD_SIZE_8BIT,buf, len, I2C_DEFAULT_TIMEOUT);
+    }
 
     if (status != HAL_OK)
         return i2cHandleHardwareFailure(device);

--- a/src/main/drivers/bus_i2c_stm32f40x.c
+++ b/src/main/drivers/bus_i2c_stm32f40x.c
@@ -124,6 +124,7 @@ typedef struct i2cBusState_s {
     uint32_t        timeout;
 
     /* Active transfer */
+    bool                        allowRawAccess;
     uint8_t                     addr;   // device address
     i2cTransferDirection_t      rw;     // direction
     uint8_t                     reg;    // register
@@ -193,7 +194,7 @@ static void i2cStateMachine(i2cBusState_t * i2cBusState, const uint32_t currentT
             if (I2C_CheckEvent(I2Cx, I2C_EVENT_MASTER_MODE_SELECT) != ERROR) {
                 if (i2cBusState->rw == I2C_TXN_READ) {
                     // Special case - no register address
-                    if (i2cBusState->reg == 0xFF) {
+                    if (i2cBusState->reg == 0xFF && i2cBusState->allowRawAccess) {
                         i2cBusState->state = I2C_STATE_R_RESTART_ADDR;
                     }
                     else {
@@ -397,7 +398,7 @@ static void i2cStateMachine(i2cBusState_t * i2cBusState, const uint32_t currentT
         case I2C_STATE_W_ADDR_WAIT:
             if (I2C_CheckEvent(I2Cx, I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED) != ERROR) {
                 // Special no-address case, skip address byte transmission
-                if (i2cBusState->reg == 0xFF) {
+                if (i2cBusState->reg == 0xFF && i2cBusState->allowRawAccess) {
                     i2cBusState->state = I2C_STATE_W_TRANSFER;
                 }
                 else {
@@ -543,7 +544,7 @@ static void i2cWaitForCompletion(I2CDevice device)
     } while (busState[device].state != I2C_STATE_STOPPED);
 }
 
-bool i2cWriteBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, const uint8_t * data)
+bool i2cWriteBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, const uint8_t * data, bool allowRawAccess)
 {
     // Don't try to access the non-initialized device
     if (!busState[device].initialized)
@@ -557,6 +558,7 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, co
     busState[device].buf = CONST_CAST(uint8_t*, data);
     busState[device].txnOk = false;
     busState[device].state = I2C_STATE_STARTING;
+    busState[device].allowRawAccess = allowRawAccess;
 
     // Inject I2C_EVENT_START
     i2cWaitForCompletion(device);
@@ -564,12 +566,12 @@ bool i2cWriteBuffer(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, co
     return busState[device].txnOk;
 }
 
-bool i2cWrite(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t data)
+bool i2cWrite(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t data, bool allowRawAccess)
 {
-    return i2cWriteBuffer(device, addr, reg, 1, &data);
+    return i2cWriteBuffer(device, addr, reg, 1, &data, allowRawAccess);
 }
 
-bool i2cRead(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t* buf)
+bool i2cRead(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t* buf, bool allowRawAccess)
 {
     // Don't try to access the non-initialized device
     if (!busState[device].initialized)
@@ -583,6 +585,7 @@ bool i2cRead(I2CDevice device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t* 
     busState[device].buf = buf;
     busState[device].txnOk = false;
     busState[device].state = I2C_STATE_STARTING;
+    busState[device].allowRawAccess = allowRawAccess;
 
     // Inject I2C_EVENT_START
     i2cWaitForCompletion(device);

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -235,7 +235,7 @@
 #endif
 
 #if defined(USE_PITOT_MS4525) && defined(MS4525_I2C_BUS)
-    BUSDEV_REGISTER_I2C(busdev_ms5425,      DEVHW_MS4525,       MS4525_I2C_BUS,     0x28,               NONE,           DEVFLAGS_NONE);
+    BUSDEV_REGISTER_I2C(busdev_ms5425,      DEVHW_MS4525,       MS4525_I2C_BUS,     0x28,               NONE,           DEVFLAGS_USE_RAW_REGISTERS);    // Requires 0xFF to passthrough
 #endif
 
 


### PR DESCRIPTION
Some I2C devices require direct access without register write cycle. Others require register number. 

Previously code was handling this using 0xFF register address, however VL53L0X makes use of 0xFF register number as well which made it incompatible with i.e. MS4525 pitot sensor.

This PR implements a busDevice flag `DEVFLAGS_USE_RAW_REGISTERS` that will allow using register 0xFF to access bus directly. 

Should fix https://github.com/iNavFlight/inav/issues/4138