### PR TITLE
Stats saving improvements

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -77,6 +77,8 @@
 
 #include "navigation/navigation.h"
 
+static bool configIsDirty; /* someone indicated that the config is modified and it is not yet saved */
+
 #ifndef DEFAULT_FEATURES
 #define DEFAULT_FEATURES 0
 #endif
@@ -401,6 +403,7 @@ void writeEEPROM(void)
     suspendRxSignal();
 
     writeConfigToEEPROM();
+    configIsDirty = false;
 
     resumeRxSignal();
 }
@@ -424,6 +427,16 @@ void saveConfigAndNotify(void)
     writeEEPROM();
     readEEPROM();
     beeperConfirmationBeeps(1);
+}
+
+void setConfigDirty(void)
+{
+    configIsDirty = true;
+}
+
+bool isConfigDirty(void)
+{
+    return configIsDirty;
 }
 
 uint8_t getConfigProfile(void)

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -122,6 +122,9 @@ void saveConfigAndNotify(void);
 void validateAndFixConfig(void);
 void validateAndFixTargetConfig(void);
 
+void setConfigDirty(void);
+bool isConfigDirty(void);
+
 uint8_t getConfigProfile(void);
 bool setConfigProfile(uint8_t profileIndex);
 void setConfigProfileAndWriteEEPROM(uint8_t profileIndex);

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -634,6 +634,8 @@ void processRx(timeUs_t currentTimeUs)
     }
 #endif
 
+    /* allow the stats collector to do periodic tasks */
+    statsOnLoop();
 }
 
 // Function for loop trigger

--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -545,6 +545,8 @@ static void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t 
         default:
             break;
     };
+
+    setConfigDirty();
 }
 
 #ifdef USE_INFLIGHT_PROFILE_ADJUSTMENT
@@ -565,6 +567,8 @@ static void applySelectAdjustment(uint8_t adjustmentFunction, uint8_t position)
     if (applied) {
         beeperConfirmationBeeps(position + 1);
     }
+
+    setConfigDirty();
 }
 #endif
 

--- a/src/main/fc/stats.h
+++ b/src/main/fc/stats.h
@@ -14,10 +14,12 @@ typedef struct statsConfig_s {
 uint32_t getFlyingEnergy();
 void statsOnArm(void);
 void statsOnDisarm(void);
+void statsOnLoop(void);
 
 #else
 
 #define statsOnArm()    do {} while (0)
 #define statsOnDisarm() do {} while (0)
+#define statsOnLoop()   do {} while (0)
 
 #endif


### PR DESCRIPTION
Stats saving improvements:

- small delay on disarm, allowing the disarming actually complete
  before executing long lasting flash write operation

- don't save stats if rc-adjustments were done during the flight
  and there are some changes that we don't want to automatically
  get saved to flash

Fixes #3842
Fixes #3348