### PR TITLE
Old param in docs and CLI error spacing

### DIFF
--- a/docs/Battery.md
+++ b/docs/Battery.md
@@ -295,7 +295,7 @@ set battery_capacity_critical = 150
 
 ## Remaining flight time and flight distance estimation
 
-The estimated remaining flight time and flight distance estimations can be displayed on the OSD (for fixed wing only for the moment). They are calculated from the GPS distance from home, remaining battery capacity and average power draw. They are taking into account the requested altitude change and heading to home change after altitude change following the switch to RTH. They are also taking into account the estimated wind if `osd_use_wind_compensation` is set to `ON`. When the timer and distance indicator reach 0 they will blink and you need to go home in a straight line manually or by engaging RTH. You should be left with at least `rth_energy_margin`% of battery left when arriving home if the cruise speed and power are set correctly (see bellow).
+The estimated remaining flight time and flight distance estimations can be displayed on the OSD (for fixed wing only for the moment). They are calculated from the GPS distance from home, remaining battery capacity and average power draw. They are taking into account the requested altitude change and heading to home change after altitude change following the switch to RTH. They are also taking into account the estimated wind if `osd_estimations_wind_compensation` is set to `ON`. When the timer and distance indicator reach 0 they will blink and you need to go home in a straight line manually or by engaging RTH. You should be left with at least `rth_energy_margin`% of battery left when arriving home if the cruise speed and power are set correctly (see bellow).
 
 To use this feature the following conditions need to be met:
 - The `VBAT`, `CURRENT_METER` and `GPS` features need to be enabled

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2293,7 +2293,7 @@ static void cliSet(char *cmdline)
                     cliPrintf("%s set to ", name);
                     cliPrintVar(val, 0);
                 } else {
-                    cliPrint("Invalid value.");
+                    cliPrint("Invalid value. ");
                     cliPrintVarRange(val);
                     cliPrintLinefeed();
                 }


### PR DESCRIPTION
Just two minuscule things I found while setting up a new model.

I left the commits separate for history clarity, but they could be squashed together on merge after all.