### PR TITLE
[VL53L0X] Fix infinite timeout (hang) during init

### DIFF
--- a/src/main/drivers/rangefinder/rangefinder_vl53l0x.c
+++ b/src/main/drivers/rangefinder/rangefinder_vl53l0x.c
@@ -805,6 +805,9 @@ static void vl53l0x_Init(rangefinderDev_t * rangefinder)
     uint8_t byte;
     isInitialized = false;
 
+    // During init set timeout to a higher value
+    setTimeout(500);
+
     // VL53L0X_DataInit() begin
     // Switch sensor to 2.8V mode
     byte = readReg(rangefinder->busDev, VL53L0X_REG_VHV_CONFIG_PAD_SCL_SDA__EXTSUP_HV);


### PR DESCRIPTION
During init the operation timeout for VL53L0X is zero which effectively mean "no timeout". Combined with broken support for register 0xFF (fixed by #4249) this causes VL53L0X init to hang indefinitely.

Prevents #4269 from happening.