### PR TITLE
fix for decimal value of battery voltage (in cli-status and oled display)

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2326,7 +2326,7 @@ static void cliStatus(char *cmdline)
     rtcGetDateTime(&dt);
     dateTimeFormatLocal(buf, &dt);
     cliPrintLinef("Current Time: %s", buf);
-    cliPrintLinef("Voltage: %d.%dV (%dS battery - %s)", getBatteryVoltage() / 100, getBatteryVoltage() % 100, getBatteryCellCount(), getBatteryStateString());
+    cliPrintLinef("Voltage: %d.%02dV (%dS battery - %s)", getBatteryVoltage() / 100, getBatteryVoltage() % 100, getBatteryCellCount(), getBatteryStateString());
     cliPrintf("CPU Clock=%dMHz", (SystemCoreClock / 1000000));
 
     const uint32_t detectedSensorsMask = sensorsMask();

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -357,7 +357,7 @@ static void showStatusPage(void)
 
     if (feature(FEATURE_VBAT)) {
         i2c_OLED_set_line(rowIndex++);
-        tfp_sprintf(lineBuffer, "V: %d.%1d ", getBatteryVoltage() / 100, getBatteryVoltage() % 100);
+        tfp_sprintf(lineBuffer, "V: %d.%02d ", getBatteryVoltage() / 100, getBatteryVoltage() % 100);
         padLineBufferToChar(12);
         i2c_OLED_send_string(lineBuffer);
 
@@ -387,7 +387,7 @@ static void showStatusPage(void)
         i2c_OLED_set_xy(HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
         i2c_OLED_send_string(lineBuffer);
 
-        tfp_sprintf(lineBuffer, "HDOP: %d.%1d", gpsSol.hdop / 100, gpsSol.hdop % 100);
+        tfp_sprintf(lineBuffer, "HDOP: %d.%02d", gpsSol.hdop / 100, gpsSol.hdop % 100);
         padLineBuffer();
         i2c_OLED_set_line(rowIndex++);
         i2c_OLED_send_string(lineBuffer);


### PR DESCRIPTION
Battery voltage is in hundredths of a volt.

With the actual code, a value of 1209 is represented as 12.9 instead of 12.09 because of:
snprintf(buf_i, sizeof(buf_i), "%d.%1d", value / 100, value % 100).

Padding with starting zero with "%d.%02d" fix the anomaly.