### PR TITLE
Check the correct bit in VM0 to detect screen size

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -290,7 +290,7 @@ uint16_t max7456GetScreenSize(void)
     // deal with a zero returned from here.
     // TODO: Inspect all callers, make sure they can handle zero and
     // change this function to return zero before initialization.
-    if (state.isInitialized && (state.registers.vm0 & VIDEO_LINES_NTSC)) {
+    if (state.isInitialized && ((state.registers.vm0 & VIDEO_MODE_PAL) == 0)) {
         return VIDEO_BUFFER_CHARS_NTSC;
     }
     return VIDEO_BUFFER_CHARS_PAL;


### PR DESCRIPTION
Check VM0 against VIDEO_MODE_PAL (bit 6 = 1). Previous check was
a typo that always returned true.

Fixes #4268