### PR TITLE
Scaling of throttle to limit maximum power

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -139,7 +139,7 @@ static void cliBootlog(char *cmdline);
 // sync this with features_e
 static const char * const featureNames[] = {
     "THR_VBAT_COMP", "VBAT", "TX_PROF_SEL", "BAT_PROF_AUTOSWITCH", "MOTOR_STOP",
-    "", "SOFTSERIAL", "GPS", "",
+    "THR_SCALING", "SOFTSERIAL", "GPS", "",
     "", "TELEMETRY", "CURRENT_METER", "3D", "RX_PARALLEL_PWM",
     "RX_MSP", "RSSI_ADC", "LED_STRIP", "DASHBOARD", "",
     "BLACKBOX", "", "TRANSPONDER", "AIRMODE",

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -190,7 +190,7 @@ void validateAndFixConfig(void)
 #endif
 
     // Disable unused features
-    featureClear(FEATURE_UNUSED_3 | FEATURE_UNUSED_4 | FEATURE_UNUSED_5 | FEATURE_UNUSED_6 | FEATURE_UNUSED_7 | FEATURE_UNUSED_8 | FEATURE_UNUSED_9 );
+    featureClear(FEATURE_UNUSED_3 | FEATURE_UNUSED_4 | FEATURE_UNUSED_5 | FEATURE_UNUSED_6 | FEATURE_UNUSED_7 | FEATURE_UNUSED_8 | FEATURE_UNUSED_9 | FEATURE_UNUSED_10);
 
 #if defined(DISABLE_RX_PWM_FEATURE) || !defined(USE_RX_PWM)
     if (rxConfig()->receiverType == RX_TYPE_PWM) {

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -41,7 +41,7 @@ typedef enum {
     FEATURE_TX_PROF_SEL = 1 << 2,       // Profile selection by TX stick command
     FEATURE_BAT_PROFILE_AUTOSWITCH = 1 << 3,
     FEATURE_MOTOR_STOP = 1 << 4,
-    NOT_USED_10 = 1 << 5,               // was FEATURE_SERVO_TILT
+    FEATURE_THR_SCALING = 1 << 5,  // was FEATURE_SERVO_TILT
     FEATURE_SOFTSERIAL = 1 << 6,
     FEATURE_GPS = 1 << 7,
     FEATURE_UNUSED_3 = 1 << 8,          // was FEATURE_FAILSAFE

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -440,6 +440,10 @@ groups:
       - name: motor_pwm_protocol
         field: motorPwmProtocol
         table: motor_pwm_protocol
+      - name: throttle_full_bat_limit
+        field: throttleFullBatLimit
+        min: PWM_RANGE_MIN
+        max: PWM_RANGE_MAX
 
   - name: PG_FAILSAFE_CONFIG
     type: failsafeConfig_t

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -91,6 +91,7 @@ typedef struct motorConfig_s {
     uint16_t motorAccelTimeMs;              // Time limit for motor to accelerate from 0 to 100% throttle [ms]
     uint16_t motorDecelTimeMs;              // Time limit for motor to decelerate from 0 to 100% throttle [ms]
     uint16_t digitalIdleOffsetValue;
+    uint16_t throttleFullBatLimit;          // Max throttle when battery is full. Used for throttle VBat scaling
 } motorConfig_t;
 
 PG_DECLARE(motorConfig_t, motorConfig);


### PR DESCRIPTION
This allows to limit the max throttle used when the battery is full but without reducing the `max_throttle` setting which allows the VBat throttle compensation feature to still use up to `max_throttle`

Typical usage would be to use higher voltage batteries than what the motor/prop could take at max throttle. For example using 5S LiIon in a plane made for 4S LiPo. The max voltage is 21V that could be too much power for the motor at max throttle but the min voltage is 13.75V (2.75V/cell) which is bellow the minimum 4S LiPo voltage. So with this patch it is possible to limit the full throttle when the battery is 21V to 80% (16.8/21*100) but with VBat throttle compensation the plane would feel like it has a full 4S LiPo during the whole flight. This is assuming power linear with ESC command but it is possible to adjust the curve to make it linear with #4187 