### PR TITLE
increase blackbox denom range (cleanup)

### DIFF
--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -22,8 +22,8 @@
 #include "config/parameter_group.h"
 
 typedef struct blackboxConfig_s {
-    uint8_t rate_num;
-    uint8_t rate_denom;
+    uint16_t rate_num;
+    uint16_t rate_denom;
     uint8_t device;
     uint8_t invertedCardDetection;
 } blackboxConfig_t;

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -956,16 +956,23 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         break;
 
     case MSP_BLACKBOX_CONFIG:
+        sbufWriteU8(dst, 0); // API no longer supported
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
+        break;
+
+    case MSP2_BLACKBOX_CONFIG:
 #ifdef USE_BLACKBOX
         sbufWriteU8(dst, 1); //Blackbox supported
         sbufWriteU8(dst, blackboxConfig()->device);
-        sbufWriteU8(dst, blackboxConfig()->rate_num);
-        sbufWriteU8(dst, blackboxConfig()->rate_denom);
+        sbufWriteU16(dst, blackboxConfig()->rate_num);
+        sbufWriteU16(dst, blackboxConfig()->rate_denom);
 #else
         sbufWriteU8(dst, 0); // Blackbox not supported
         sbufWriteU8(dst, 0);
-        sbufWriteU8(dst, 0);
-        sbufWriteU8(dst, 0);
+        sbufWriteU16(dst, 0);
+        sbufWriteU16(dst, 0);
 #endif
         break;
 
@@ -2089,12 +2096,12 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
 #ifdef USE_BLACKBOX
-    case MSP_SET_BLACKBOX_CONFIG:
+    case MSP2_SET_BLACKBOX_CONFIG:
         // Don't allow config to be updated while Blackbox is logging
-        if ((dataSize >= 3) && blackboxMayEditConfig()) {
+        if ((dataSize >= 5) && blackboxMayEditConfig()) {
             blackboxConfigMutable()->device = sbufReadU8(src);
-            blackboxConfigMutable()->rate_num = sbufReadU8(src);
-            blackboxConfigMutable()->rate_denom = sbufReadU8(src);
+            blackboxConfigMutable()->rate_num = sbufReadU16(src);
+            blackboxConfigMutable()->rate_denom = sbufReadU16(src);
         } else
             return MSP_RESULT_ERROR;
         break;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -148,7 +148,7 @@ groups:
         field: gyro_soft_notch_cutoff_2
         condition: USE_GYRO_NOTCH_2
         min: 1
-        max: 500 
+        max: 500
       - name: gyro_stage2_lowpass_hz
         field: gyro_stage2_lowpass_hz
         condition: USE_GYRO_BIQUAD_RC_FIR2
@@ -396,11 +396,11 @@ groups:
       - name: blackbox_rate_num
         field: rate_num
         min: 1
-        max: 255
+        max: 65535
       - name: blackbox_rate_denom
         field: rate_denom
         min: 1
-        max: 255
+        max: 65535
       - name: blackbox_device
         field: device
         table: blackbox_device
@@ -1323,32 +1323,32 @@ groups:
         field: mc.braking_speed_threshold
         condition: USE_MR_BRAKING_MODE
         min: 0
-        max: 1000   
+        max: 1000
       - name: nav_mc_braking_disengage_speed
         field: mc.braking_disengage_speed
         condition: USE_MR_BRAKING_MODE
         min: 0
-        max: 1000  
+        max: 1000
       - name: nav_mc_braking_timeout
         field: mc.braking_timeout
         condition: USE_MR_BRAKING_MODE
         min: 100
-        max: 5000 
+        max: 5000
       - name: nav_mc_braking_boost_factor
         field: mc.braking_boost_factor
         condition: USE_MR_BRAKING_MODE
         min: 0
-        max: 200  
+        max: 200
       - name: nav_mc_braking_boost_timeout
         field: mc.braking_boost_timeout
         condition: USE_MR_BRAKING_MODE
         min: 0
-        max: 5000  
+        max: 5000
       - name: nav_mc_braking_boost_speed_threshold
         field: mc.braking_boost_speed_threshold
         condition: USE_MR_BRAKING_MODE
         min: 100
-        max: 1000  
+        max: 1000
       - name: nav_mc_braking_boost_disengage_speed
         field: mc.braking_boost_disengage_speed
         condition: USE_MR_BRAKING_MODE
@@ -1358,7 +1358,7 @@ groups:
         field: mc.braking_bank_angle
         condition: USE_MR_BRAKING_MODE
         min: 15
-        max: 60  
+        max: 60
       - name: nav_fw_cruise_thr
         field: fw.cruise_throttle
         min: 1000
@@ -1768,4 +1768,3 @@ groups:
         min: 0
         max: 255
         type: uint8_t
-

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -60,7 +60,7 @@
 #define MSP_PROTOCOL_VERSION                0   // Same version over MSPv1 & MSPv2 - message format didn't change and it backward compatible
 
 #define API_VERSION_MAJOR                   2   // increment when major changes are made
-#define API_VERSION_MINOR                   2   // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   3   // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 

--- a/src/main/msp/msp_protocol_v2_inav.h
+++ b/src/main/msp/msp_protocol_v2_inav.h
@@ -45,3 +45,6 @@
 #define MSP2_INAV_SELECT_BATTERY_PROFILE        0x2018
 
 #define MSP2_INAV_DEBUG                         0x2019
+
+#define MSP2_BLACKBOX_CONFIG                    0x201A
+#define MSP2_SET_BLACKBOX_CONFIG                0x201B


### PR DESCRIPTION
Attempt to add larger values of `blackbox_rate_denom` in order to provide slower logging rates (Issue #4058)

This replaces #4103 (without the local bogus branch merges ....)

* Change `blackbox_rate_denom` and `blackbox_rate_num` to `uint16_t`
* Update PG version
* Deprecate `MSP_BLACKBOX_CONFIG` and `MSP_SET_BLACKBOX_CONFIG`, add `MSP2_BLACKBOX_CONFIG` / `MSP2_SET_BLACKBOX_CONFIG`, update MSP API version.

## Outstanding issues

For reasons I don't understand, the maximum denom setting is looptime dependent and exceeding the maximum results in truncated / useless logs. Currently and empirically this patch limits the max demon to

```
 4096*1000 / gyroConfig()->looptime;
```
 i.e.

| Loop Time | `blackbox_rate_denom` |
| --------- | --------------------- |
| 2000 | 2048 |
| 1000 | 4096 |
|  500 | 8192 |
| 250 | 16384 |
| 125 | 32768 |

Assistance / advice on a better solution is requested.

It will also be necessary to update the Configurator if / when this is merged.
