### PR TITLE
Reduce flash usage by 3.7K by changing CMS data structures

### DIFF
--- a/src/main/cms/cms_menu_battery.c
+++ b/src/main/cms/cms_menu_battery.c
@@ -109,8 +109,7 @@ static const OSD_Entry menuBattSettingsEntries[]=
     OSD_SETTING_ENTRY("CAP WARN", SETTING_BATTERY_CAPACITY_WARNING),
     OSD_SETTING_ENTRY("CAP CRIT", SETTING_BATTERY_CAPACITY_CRITICAL),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuBattSettings = {
@@ -134,8 +133,7 @@ static OSD_Entry menuBatteryEntries[]=
     OSD_UINT8_CALLBACK_ENTRY("PROF", cmsx_onBatteryProfileIndexChange, (&(const OSD_UINT8_t){ &battDispProfileIndex, 1, MAX_BATTERY_PROFILE_COUNT, 1})),
     OSD_SUBMENU_ENTRY("SETTINGS", &cmsx_menuBattSettings),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY
+    OSD_BACK_AND_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuBattery = {

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -86,8 +86,7 @@ static const OSD_Entry cmsx_menuBlackboxEntries[] =
     OSD_FUNC_CALL_ENTRY("ERASE FLASH", cmsx_EraseFlash),
 #endif // USE_FLASHFS
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 const CMS_Menu cmsx_menuBlackbox = {

--- a/src/main/cms/cms_menu_builtin.c
+++ b/src/main/cms/cms_menu_builtin.c
@@ -86,8 +86,7 @@ static const OSD_Entry menuInfoEntries[] = {
     OSD_STRING_ENTRY("GITREV", infoGitRev),
     OSD_STRING_ENTRY("TARGET", infoTargetName),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu menuInfo = {
@@ -128,8 +127,7 @@ static const OSD_Entry menuFeaturesEntries[] =
     OSD_SUBMENU_ENTRY("LED STRIP", &cmsx_menuLedstrip),
 #endif // LED_STRIP
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu menuFeatures = {

--- a/src/main/cms/cms_menu_builtin.c
+++ b/src/main/cms/cms_menu_builtin.c
@@ -158,8 +158,8 @@ static const OSD_Entry menuMainEntries[] =
     OSD_SUBMENU_ENTRY("FC+FW INFO", &menuInfo),
     OSD_SUBMENU_ENTRY("MISC", &cmsx_menuMisc),
 
-    {"SAVE+REBOOT", OME_OSD_Exit, {.func = cmsMenuExit}, (void*)CMS_EXIT_SAVEREBOOT, 0},
-    {"EXIT",        OME_OSD_Exit, {.func = cmsMenuExit}, (void*)CMS_EXIT, 0},
+    {"SAVE+REBOOT", {.func = cmsMenuExit}, (void*)CMS_EXIT_SAVEREBOOT, OME_OSD_Exit, 0},
+    {"EXIT"       , {.func = cmsMenuExit}, (void*)CMS_EXIT, OME_OSD_Exit, 0},
 #ifdef CMS_MENU_DEBUG
     OSD_SUBMENU_ENTRY("ERR SAMPLE", &menuInfoEntries[0]),
 #endif

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -142,8 +142,7 @@ static const OSD_Entry cmsx_menuPidEntries[] =
     OSD_UINT8_ENTRY("YAW   I", (&(const OSD_UINT8_t){ &cmsx_pidYaw[1],   0, 200, 1 })),
     OSD_UINT8_ENTRY("YAW   D", (&(const OSD_UINT8_t){ &cmsx_pidYaw[2],   0, 200, 1 })),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuPid = {
@@ -198,8 +197,7 @@ static const OSD_Entry cmsx_menuPidAltMagEntries[] =
 
     OSD_UINT8_ENTRY("MAG P", (&(const OSD_UINT8_t){ &cmsx_pidHead[0], 0, 255, 1 })),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuPidAltMag = {
@@ -248,8 +246,7 @@ static const OSD_Entry cmsx_menuPidGpsnavEntries[] =
     OSD_UINT8_ENTRY("POSR I", (&(const OSD_UINT8_t){ &cmsx_pidVelXY[1], 0, 255, 1 })),
     OSD_UINT8_ENTRY("POSR D", (&(const OSD_UINT8_t){ &cmsx_pidVelXY[2], 0, 255, 1 })),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuPidGpsnav = {
@@ -277,8 +274,7 @@ static const OSD_Entry cmsx_menuManualRateProfileEntries[] =
     OSD_SETTING_ENTRY("MANU RC EXPO", SETTING_MANUAL_RC_EXPO),
     OSD_SETTING_ENTRY("MANU RC YAW EXP", SETTING_MANUAL_RC_YAW_EXPO),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuManualRateProfile = {
@@ -317,8 +313,7 @@ static const OSD_Entry cmsx_menuRateProfileEntries[] =
     OSD_SETTING_ENTRY("THRPID ATT", SETTING_TPA_RATE),
     OSD_SETTING_ENTRY_STEP("TPA BRKPT", SETTING_TPA_BREAKPOINT, 10),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuRateProfile = {
@@ -376,8 +371,7 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
     { "HORZN STR",   OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_horizonStrength,     0, 200, 1 }    , 0 },
     { "HORZN TRS",   OME_UINT8, NULL, &(OSD_UINT8_t){ &cmsx_horizonTransition,   0, 200, 1 }    , 0 },
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuProfileOther = {
@@ -404,8 +398,7 @@ static const OSD_Entry cmsx_menuFilterPerProfileEntries[] =
     OSD_SETTING_ENTRY("YAW P LIM", SETTING_YAW_P_LIMIT),
     OSD_SETTING_ENTRY("YAW LPF", SETTING_YAW_LPF_HZ),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuFilterPerProfile = {
@@ -426,8 +419,7 @@ static const OSD_Entry cmsx_menuGyroEntries[] =
     OSD_SETTING_ENTRY("GYRO SYNC", SETTING_GYRO_SYNC),
     OSD_SETTING_ENTRY("GYRO LPF", SETTING_GYRO_HARDWARE_LPF),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuGyro = {
@@ -466,8 +458,7 @@ static const OSD_Entry cmsx_menuImuEntries[] =
     {"FILT GLB",  OME_Submenu, cmsMenuChange,                 &cmsx_menuFilterGlobal,                                      0},
 #endif
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 const CMS_Menu cmsx_menuImu = {

--- a/src/main/cms/cms_menu_ledstrip.c
+++ b/src/main/cms/cms_menu_ledstrip.c
@@ -60,8 +60,7 @@ static const OSD_Entry cmsx_menuLedstripEntries[] =
     OSD_LABEL_ENTRY("-- LED STRIP --"),
     OSD_BOOL_FUNC_ENTRY("ENABLED", cmsx_FeatureLedStrip_Enabled),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 const CMS_Menu cmsx_menuLedstrip = {

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -67,8 +67,7 @@ static const OSD_Entry cmsx_menuRcEntries[] =
     OSD_INT16_RO_ENTRY("AUX3", &rcData[AUX3]),
     OSD_INT16_RO_ENTRY("AUX4", &rcData[AUX4]),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuRcPreview = {
@@ -94,8 +93,7 @@ static const OSD_Entry menuMiscEntries[]=
 
     OSD_SUBMENU_ENTRY("RC PREV", &cmsx_menuRcPreview),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 const CMS_Menu cmsx_menuMisc = {

--- a/src/main/cms/cms_menu_navigation.c
+++ b/src/main/cms/cms_menu_navigation.c
@@ -52,8 +52,7 @@ static const OSD_Entry cmsx_menuNavSettingsEntries[] =
     OSD_SETTING_ENTRY("MID THR FOR AH", SETTING_NAV_USE_MIDTHR_FOR_ALTHOLD),
     OSD_SETTING_ENTRY("MC HOVER THR", SETTING_NAV_MC_HOVER_THR),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
  };
 
 static const CMS_Menu cmsx_menuNavSettings = {
@@ -83,8 +82,7 @@ static const CMS_Menu cmsx_menuNavSettings = {
     OSD_SETTING_ENTRY("RTH ABORT THRES", SETTING_NAV_RTH_ABORT_THRESHOLD),
     OSD_SETTING_ENTRY("EMERG LANDING SPEED", SETTING_NAV_EMERG_LANDING_SPEED),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
  };
 
 static const CMS_Menu cmsx_menuRTH = {
@@ -111,8 +109,7 @@ static const OSD_Entry cmsx_menuFixedWingEntries[] =
     OSD_SETTING_ENTRY("PITCH TO THR RATIO", SETTING_NAV_FW_PITCH2THR),
     OSD_SETTING_ENTRY("LOITER RADIUS", SETTING_NAV_FW_LOITER_RADIUS),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuFixedWing = {
@@ -134,8 +131,7 @@ static const OSD_Entry cmsx_menuNavigationEntries[] =
     OSD_SUBMENU_ENTRY("RTH", &cmsx_menuRTH),
     OSD_SUBMENU_ENTRY("FIXED WING", &cmsx_menuFixedWing),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 const CMS_Menu cmsx_menuNavigation = {

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -57,8 +57,7 @@ static const OSD_Entry cmsx_menuAlarmsEntries[] = {
     OSD_SETTING_ENTRY("MAX DIST", SETTING_OSD_DIST_ALARM),
     OSD_SETTING_ENTRY("MAX NEG ALT", SETTING_OSD_NEG_ALT_ALARM),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuAlarms = {
@@ -101,8 +100,7 @@ static const OSD_Entry menuOsdElemActionsEntries[] = {
     OSD_UINT8_CALLBACK_ENTRY("COLUMN", cmsx_osdElementOnChange, (&(const OSD_UINT8_t){ &osdCurrentElementColumn, 0, OSD_Y(OSD_POS_MAX), 1 })),
     OSD_FUNC_CALL_ENTRY("PREVIEW", osdElementPreview),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const OSD_Entry menuOsdFixedElemActionsEntries[] = {
@@ -110,8 +108,7 @@ static const OSD_Entry menuOsdFixedElemActionsEntries[] = {
     OSD_BOOL_CALLBACK_ENTRY("ENABLED", cmsx_osdElementOnChange, &osdCurrentElementVisible),
     OSD_FUNC_CALL_ENTRY("PREVIEW", osdElementPreview),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static CMS_Menu cmsx_menuOsdElementActions = {
@@ -261,15 +258,14 @@ static const OSD_Entry menuOsdElemsEntries[] =
     OSD_ELEMENT_ENTRY("SENSOR 7 TEMP", OSD_TEMP_SENSOR_7_TEMPERATURE),
 #endif
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 #if defined(USE_GPS) && defined(USE_BARO) && defined(USE_PITOT) && defined(USE_TEMPERATURE_SENSOR)
-// All CMS OSD elements should be enabled in this case. The menu has 3 extra
-// elements (label, back and end), but there's an OSD element that we intentionally
+// All CMS OSD elements should be enabled in this case. The menu has 2 extra
+// elements (label, back+end), but there's an OSD element that we intentionally
 // don't show here (OSD_DEBUG).
-_Static_assert(ARRAYLEN(menuOsdElemsEntries) - 3 + 1 == OSD_ITEM_COUNT, "missing OSD elements in CMS");
+_Static_assert(ARRAYLEN(menuOsdElemsEntries) - 2 + 1 == OSD_ITEM_COUNT, "missing OSD elements in CMS");
 #endif
 
 const CMS_Menu menuOsdElements = {
@@ -301,8 +297,7 @@ static const OSD_Entry cmsx_menuOsdLayoutEntries[] =
 #endif
 #endif
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 const CMS_Menu cmsx_menuOsdLayout = {
@@ -344,9 +339,7 @@ static const OSD_Entry menuOsdSettingsEntries[] = {
     OSD_SETTING_ENTRY("RIGHT SCROLL", SETTING_OSD_RIGHT_SIDEBAR_SCROLL),
     OSD_SETTING_ENTRY("SCROLL ARROWS", SETTING_OSD_SIDEBAR_SCROLL_ARROWS),
 
-
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu cmsx_menuOsdSettings = {
@@ -367,8 +360,7 @@ static const OSD_Entry menuOsdEntries[] = {
     OSD_SUBMENU_ENTRY("SETTINGS", &cmsx_menuOsdSettings),
     OSD_SUBMENU_ENTRY("ALARMS", &cmsx_menuAlarms),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -35,7 +35,7 @@
 
 #include "io/osd.h"
 
-#define OSD_ITEM_ENTRY(label, item_id)      ((OSD_Entry){ label, OME_Submenu, {.itemId  = item_id}, &cmsx_menuOsdElementActions, 0 })
+#define OSD_ITEM_ENTRY(label, item_id)      ((OSD_Entry){ label, {.itemId  = item_id}, &cmsx_menuOsdElementActions, OME_Submenu, 0 })
 
 static int osdCurrentLayout = -1;
 static int osdCurrentItem = -1;

--- a/src/main/cms/cms_menu_vtx.c
+++ b/src/main/cms/cms_menu_vtx.c
@@ -128,8 +128,7 @@ static const OSD_Entry cmsx_menuVtxEntries[] =
     OSD_BOOL_ENTRY("LOW POWER", &masterConfig.vtx_power),
 #endif // USE_RTC6705
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 const CMS_Menu cmsx_menuVtx = {

--- a/src/main/cms/cms_menu_vtx_ffpv.c
+++ b/src/main/cms/cms_menu_vtx_ffpv.c
@@ -173,8 +173,7 @@ static const OSD_Entry ffpvCmsMenuCommenceEntries[] =
     OSD_LABEL_ENTRY("CONFIRM"),
     OSD_FUNC_CALL_ENTRY("YES", ffpvCmsCommence),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu ffpvCmsMenuCommence = {
@@ -199,8 +198,7 @@ static const OSD_Entry ffpvMenuEntries[] =
     OSD_TAB_CALLBACK_ENTRY("POWER", ffpvCmsConfigPower, &ffpvCmsEntPower),
     OSD_SUBMENU_ENTRY("SET", &ffpvCmsMenuCommence),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 const CMS_Menu cmsx_menuVtxFFPV = {

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -364,8 +364,7 @@ static const OSD_Entry saCmsMenuStatsEntries[] = {
     OSD_UINT16_RO_ENTRY("CRCERR", &saStat.crc),
     OSD_UINT16_RO_ENTRY("OOOERR", &saStat.ooopresp),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu saCmsMenuStats = {
@@ -547,8 +546,7 @@ static const OSD_Entry saCmsMenuPORFreqEntries[] =
     OSD_UINT16_ENTRY("NEW FREQ", (&(const OSD_UINT16_t){ &saCmsORFreqNew, 5000, 5900, 1 })),
     OSD_FUNC_CALL_ENTRY("SET", saCmsSetPORFreq),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu saCmsMenuPORFreq =
@@ -571,8 +569,7 @@ static const OSD_Entry saCmsMenuUserFreqEntries[] =
     OSD_UINT16_ENTRY("NEW FREQ", (&(const OSD_UINT16_t){ &saCmsUserFreqNew, 5000, 5900, 1 })),
     OSD_FUNC_CALL_ENTRY("SET", saCmsConfigUserFreq),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu saCmsMenuUserFreq =
@@ -601,8 +598,7 @@ static const OSD_Entry saCmsMenuConfigEntries[] =
     OSD_SUBMENU_ENTRY("STATX", &saCmsMenuStats),
 #endif /* USE_EXTENDED_CMS_MENUS */
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu saCmsMenuConfig = {
@@ -621,8 +617,7 @@ static const OSD_Entry saCmsMenuCommenceEntries[] =
     OSD_LABEL_ENTRY("CONFIRM"),
     OSD_FUNC_CALL_ENTRY("YES", saCmsCommence),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu saCmsMenuCommence = {
@@ -651,8 +646,7 @@ static const OSD_Entry saCmsMenuFreqModeEntries[] =
     OSD_SUBMENU_ENTRY("SET", &saCmsMenuCommence),
     OSD_SUBMENU_ENTRY("CONFIG", &saCmsMenuConfig),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 #pragma GCC diagnostic pop
 
@@ -668,8 +662,7 @@ static const OSD_Entry saCmsMenuChanModeEntries[] =
     OSD_SUBMENU_ENTRY("SET", &saCmsMenuCommence),
     OSD_SUBMENU_ENTRY("CONFIG", &saCmsMenuConfig),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const OSD_Entry saCmsMenuOfflineEntries[] =
@@ -681,8 +674,7 @@ static const OSD_Entry saCmsMenuOfflineEntries[] =
     OSD_SUBMENU_ENTRY("STATX", &saCmsMenuStats),
 #endif /* USE_EXTENDED_CMS_MENUS */
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 CMS_Menu cmsx_menuVtxSmartAudio; // Forward

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -593,10 +593,10 @@ static const OSD_Entry saCmsMenuConfigEntries[] =
 {
     OSD_LABEL_ENTRY("- SA CONFIG -"),
 
-    { "OP MODEL",  OME_TAB,  {.func = saCmsConfigOpmodelByGvar}, &(const OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, DYNAMIC },
-    { "FSEL MODE", OME_TAB,  {.func = saCmsConfigFreqModeByGvar}, &saCmsEntFselMode, DYNAMIC },
+    { "OP MODEL",  {.func = saCmsConfigOpmodelByGvar}, &(const OSD_TAB_t){ &saCmsOpmodel, 2, saCmsOpmodelNames }, OME_TAB, DYNAMIC },
+    { "FSEL MODE", {.func = saCmsConfigFreqModeByGvar}, &saCmsEntFselMode, OME_TAB, DYNAMIC },
     OSD_TAB_CALLBACK_ENTRY("PIT FMODE", saCmsConfigPitFModeByGvar, &saCmsEntPitFMode),
-    { "POR FREQ",  OME_Submenu, {.menufunc = saCmsORFreqGetString}, (void *)&saCmsMenuPORFreq, OPTSTRING },
+    { "POR FREQ",  {.menufunc = saCmsORFreqGetString}, (void *)&saCmsMenuPORFreq, OME_Submenu, OPTSTRING },
 #ifdef USE_EXTENDED_CMS_MENUS
     OSD_SUBMENU_ENTRY("STATX", &saCmsMenuStats),
 #endif /* USE_EXTENDED_CMS_MENUS */
@@ -646,7 +646,7 @@ static const OSD_Entry saCmsMenuFreqModeEntries[] =
     OSD_LABEL_ENTRY("- SMARTAUDIO -"),
 
     OSD_LABEL_FUNC_DYN_ENTRY("", saCmsDrawStatusString),
-    { "FREQ",   OME_Submenu, {.menufunc = saCmsUserFreqGetString},  &saCmsMenuUserFreq, OPTSTRING },
+    { "FREQ", {.menufunc = saCmsUserFreqGetString},  &saCmsMenuUserFreq, OME_Submenu, OPTSTRING },
     OSD_TAB_CALLBACK_ENTRY("POWER", saCmsConfigPowerByGvar, &saCmsEntPower),
     OSD_SUBMENU_ENTRY("SET", &saCmsMenuCommence),
     OSD_SUBMENU_ENTRY("CONFIG", &saCmsMenuConfig),

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -211,8 +211,7 @@ static const OSD_Entry trampCmsMenuCommenceEntries[] =
     OSD_LABEL_ENTRY("CONFIRM"),
     OSD_FUNC_CALL_ENTRY("YES", trampCmsCommence),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 static const CMS_Menu trampCmsMenuCommence = {
@@ -239,8 +238,7 @@ static const OSD_Entry trampMenuEntries[] =
     OSD_INT16_RO_ENTRY("T(C)", &trampData.temperature),
     OSD_SUBMENU_ENTRY("SET", &trampCmsMenuCommence),
 
-    OSD_BACK_ENTRY,
-    OSD_END_ENTRY,
+    OSD_BACK_AND_END_ENTRY,
 };
 
 const CMS_Menu cmsx_menuVtxTramp = {

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -60,7 +60,6 @@ typedef char * (*CMSMenuOptFuncPtr)(void);
 typedef struct
 {
     const char * const text;
-    const OSD_MenuElement type;
     union
     {
         const CMSEntryFuncPtr func;
@@ -68,6 +67,7 @@ typedef struct
         int itemId;
     };
     const void * const data;
+    const uint8_t type; // from OSD_MenuElement
     uint8_t flags;
 } __attribute__((packed)) OSD_Entry;
 
@@ -78,29 +78,30 @@ typedef struct
 #define OPTSTRING      (1 << 3)  // (Temporary) Flag for OME_Submenu, indicating func should be called to get a string to display.
 #define READONLY       (1 << 4)  // Indicates that the value is read-only and p->data points directly to it - applies to [U]INT(8|16)
 
-#define OSD_LABEL_ENTRY(label)                  ((OSD_Entry){ label, OME_Label, {.func = NULL}, NULL, 0 })
-#define OSD_LABEL_DATA_ENTRY(label, data)       ((OSD_Entry){ label, OME_Label, {.func = NULL}, data, 0 })
-#define OSD_LABEL_DATA_DYN_ENTRY(label, data)   ((OSD_Entry){ label, OME_Label, {.func = NULL}, data, DYNAMIC })
-#define OSD_LABEL_FUNC_DYN_ENTRY(label, fn)     ((OSD_Entry){ label, OME_LabelFunc, {.func = NULL}, fn, DYNAMIC })
-#define OSD_BACK_ENTRY                          ((OSD_Entry){ "BACK", OME_Back, {.func = NULL}, NULL, 0 })
-#define OSD_SUBMENU_ENTRY(label, menu)          ((OSD_Entry){ label, OME_Submenu, {.func = NULL}, menu, 0 })
-#define OSD_FUNC_CALL_ENTRY(label, fn)          ((OSD_Entry){ label, OME_Funcall, {.func = fn}, NULL, 0 })
-#define OSD_BOOL_ENTRY(label, val)              ((OSD_Entry){ label, OME_Bool, {.func = NULL}, val, 0 })
-#define OSD_BOOL_CALLBACK_ENTRY(label, cb, val) ((OSD_Entry){ label, OME_Bool, {.func = cb}, val, 0 })
-#define OSD_BOOL_FUNC_ENTRY(label, fn)          ((OSD_Entry){ label, OME_BoolFunc, {.func = NULL}, fn, 0 })
-#define OSD_UINT8_ENTRY(label, val)             ((OSD_Entry){ label, OME_UINT8, {.func = NULL}, val, 0 })
-#define OSD_UINT8_CALLBACK_ENTRY(label, cb, val)((OSD_Entry){ label, OME_UINT8, {.func = cb}, val, 0 })
-#define OSD_UINT16_ENTRY(label, val)            ((OSD_Entry){ label, OME_UINT16, {.func = NULL}, val, 0 })
-#define OSD_UINT16_DYN_ENTRY(label, val)        ((OSD_Entry){ label, OME_UINT16, {.func = NULL}, val, DYNAMIC })
-#define OSD_UINT16_RO_ENTRY(label, val)         ((OSD_Entry){ label, OME_UINT16, {.func = NULL}, val, DYNAMIC | READONLY })
-#define OSD_INT16_DYN_ENTRY(label, val)         ((OSD_Entry){ label, OME_INT16, {.func = NULL}, val, DYNAMIC })
-#define OSD_INT16_RO_ENTRY(label, val)          ((OSD_Entry){ label, OME_INT16, {.func = NULL}, val, DYNAMIC | READONLY })
-#define OSD_STRING_ENTRY(label, str)            ((OSD_Entry){ label, OME_String, {.func = NULL}, str, 0 })
-#define OSD_TAB_ENTRY(label, val)               ((OSD_Entry){ label, OME_TAB, {.func = NULL}, val, 0 })
-#define OSD_TAB_DYN_ENTRY(label, val)           ((OSD_Entry){ label, OME_TAB, {.func = NULL}, val, DYNAMIC })
-#define OSD_TAB_CALLBACK_ENTRY(label, cb, val)  ((OSD_Entry){ label, OME_TAB, {.func = cb}, val, 0 })
+#define OSD_LABEL_ENTRY(label)                  ((OSD_Entry){ label, {.func = NULL}, NULL, OME_Label, 0 })
+#define OSD_LABEL_DATA_ENTRY(label, data)       ((OSD_Entry){ label, {.func = NULL}, data, OME_Label, 0 })
+#define OSD_LABEL_DATA_DYN_ENTRY(label, data)   ((OSD_Entry){ label, {.func = NULL}, data, OME_Label, DYNAMIC })
+#define OSD_LABEL_FUNC_DYN_ENTRY(label, fn)     ((OSD_Entry){ label, {.func = NULL}, fn, OME_LabelFunc, DYNAMIC })
+#define OSD_BACK_ENTRY                          ((OSD_Entry){ "BACK", {.func = NULL}, NULL, OME_Back, 0 })
+#define OSD_BACK_AND_END_ENTRY                  ((OSD_Entry){ "BACK", {.func = NULL}, NULL, OME_BACK_AND_END, 0 })
+#define OSD_SUBMENU_ENTRY(label, menu)          ((OSD_Entry){ label, {.func = NULL}, menu, OME_Submenu, 0 })
+#define OSD_FUNC_CALL_ENTRY(label, fn)          ((OSD_Entry){ label, {.func = fn}, NULL, OME_Funcall, 0 })
+#define OSD_BOOL_ENTRY(label, val)              ((OSD_Entry){ label, {.func = NULL}, val, OME_Bool, 0 })
+#define OSD_BOOL_CALLBACK_ENTRY(label, cb, val) ((OSD_Entry){ label, {.func = cb}, val, OME_Bool, 0 })
+#define OSD_BOOL_FUNC_ENTRY(label, fn)          ((OSD_Entry){ label, {.func = NULL}, fn, OME_BoolFunc, 0 })
+#define OSD_UINT8_ENTRY(label, val)             ((OSD_Entry){ label, {.func = NULL}, val, OME_UINT8, 0 })
+#define OSD_UINT8_CALLBACK_ENTRY(label, cb, val)((OSD_Entry){ label, {.func = cb}, val, OME_UINT8, 0 })
+#define OSD_UINT16_ENTRY(label, val)            ((OSD_Entry){ label, {.func = NULL}, val, OME_UINT16, 0 })
+#define OSD_UINT16_DYN_ENTRY(label, val)        ((OSD_Entry){ label, {.func = NULL}, val, OME_UINT16, DYNAMIC })
+#define OSD_UINT16_RO_ENTRY(label, val)         ((OSD_Entry){ label, {.func = NULL}, val, OME_UINT16, DYNAMIC | READONLY })
+#define OSD_INT16_DYN_ENTRY(label, val)         ((OSD_Entry){ label, {.func = NULL}, val, OME_INT16, DYNAMIC })
+#define OSD_INT16_RO_ENTRY(label, val)          ((OSD_Entry){ label, {.func = NULL}, val, OME_INT16, DYNAMIC | READONLY })
+#define OSD_STRING_ENTRY(label, str)            ((OSD_Entry){ label, {.func = NULL}, str, OME_String, 0 })
+#define OSD_TAB_ENTRY(label, val)               ((OSD_Entry){ label, {.func = NULL}, val, OME_TAB, 0 })
+#define OSD_TAB_DYN_ENTRY(label, val)           ((OSD_Entry){ label, {.func = NULL}, val, OME_TAB, DYNAMIC })
+#define OSD_TAB_CALLBACK_ENTRY(label, cb, val)  ((OSD_Entry){ label, {.func = cb}, val, OME_TAB, 0 })
 
-#define OSD_END_ENTRY                           ((OSD_Entry){ NULL, OME_END, {.func = NULL}, NULL, 0 })
+#define OSD_END_ENTRY                           ((OSD_Entry){ NULL, {.func = NULL}, NULL, OME_END, 0 })
 
 // Data type for OME_Setting. Uses upper 4 bits
 // of flags, leaving 16 data types.
@@ -185,7 +186,7 @@ typedef struct OSD_SETTING_s {
     const uint8_t step;
 } __attribute__((packed)) OSD_SETTING_t;
 
-#define OSD_SETTING_ENTRY_STEP_TYPE(name, setting, step, type)  { name, OME_Setting, NULL, &(const OSD_SETTING_t){ setting, step }, type }
+#define OSD_SETTING_ENTRY_STEP_TYPE(name, setting, step, type)  { name, NULL, &(const OSD_SETTING_t){ setting, step }, OME_Setting, type }
 #define OSD_SETTING_ENTRY_TYPE(name, setting, type)             OSD_SETTING_ENTRY_STEP_TYPE(name, setting, 0, type)
 #define OSD_SETTING_ENTRY_STEP(name, setting, step)             OSD_SETTING_ENTRY_STEP_TYPE(name, setting, step, 0)
 #define OSD_SETTING_ENTRY(name, setting)                        OSD_SETTING_ENTRY_STEP(name, setting, 0)

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -69,7 +69,7 @@ typedef struct
     };
     const void * const data;
     uint8_t flags;
-} OSD_Entry;
+} __attribute__((packed)) OSD_Entry;
 
 // Bits in flags
 #define PRINT_VALUE    (1 << 0)  // Value has been changed, need to redraw

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -46,6 +46,7 @@ typedef enum
     //wlasciwosci elementow
     OME_TAB,
     OME_END,
+    OME_BACK_AND_END,
 
     // Debug aid
     OME_MENU,


### PR DESCRIPTION
After discussing CMS space optimisations with @hydra, the following changes were identified as potential flash savers:

- Packing OSD_Entry struct. It's not used in performance critical code, so it shouldn't impact flight characteristics.
- Reworking the fields in OSD_Entry so they're naturally aligned (reduces the code needed to deal with the packed struct)
- Combine OSD_Back and OSD_END into a single OSD_BACK_AND_END item, saving an OSD_Entry per menu.

Tested and ready to merge. Could probably wait for 2.2.