### PR TITLE
Added DSHOT to SPRACINGF7DUAL target

### DIFF
--- a/src/main/target/SPRACINGF7DUAL/target.h
+++ b/src/main/target/SPRACINGF7DUAL/target.h
@@ -216,3 +216,5 @@
 #define TARGET_IO_PORTD         (BIT(2))
 
 #define MAX_PWM_OUTPUT_PORTS    8
+
+#define USE_DSHOT


### PR DESCRIPTION
I added DSHOT to the SP Racing F7 Dual target. I have test flown and haven't had any issues as of yet.