### PR TITLE
Enforce board alignment setting limits in updateBoardAlignment()

### DIFF
--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -29,7 +29,15 @@
 
 #include "drivers/sensor.h"
 
+#if defined(UNIT_TEST)
+// Unit tests can't include settings. Provide some dummy limits.
+#define SETTING_ALIGN_BOARD_ROLL_MIN -1800
+#define SETTING_ALIGN_BOARD_ROLL_MAX 3600
+#define SETTING_ALIGN_BOARD_PITCH_MIN -1800
+#define SETTING_ALIGN_BOARD_PITCH_MAX 3600
+#else
 #include "fc/settings.h"
+#endif
 
 #include "boardalignment.h"
 

--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -29,6 +29,8 @@
 
 #include "drivers/sensor.h"
 
+#include "fc/settings.h"
+
 #include "boardalignment.h"
 
 static bool standardBoardAlignment = true;     // board orientation correction
@@ -64,8 +66,11 @@ void updateBoardAlignment(int16_t roll, int16_t pitch)
     const float sinAlignYaw = sin_approx(DECIDEGREES_TO_RADIANS(boardAlignment()->yawDeciDegrees));
     const float cosAlignYaw = cos_approx(DECIDEGREES_TO_RADIANS(boardAlignment()->yawDeciDegrees));
 
-    boardAlignmentMutable()->rollDeciDegrees += -sinAlignYaw * pitch + cosAlignYaw * roll;
-    boardAlignmentMutable()->pitchDeciDegrees += cosAlignYaw * pitch + sinAlignYaw * roll;
+    int16_t rollDeciDegrees = boardAlignment()->rollDeciDegrees + -sinAlignYaw * pitch + cosAlignYaw * roll;
+    int16_t pitchDeciDegrees = boardAlignment()->pitchDeciDegrees + cosAlignYaw * pitch + sinAlignYaw * roll;
+
+    boardAlignmentMutable()->rollDeciDegrees = constrain(rollDeciDegrees, SETTING_ALIGN_BOARD_ROLL_MIN, SETTING_ALIGN_BOARD_ROLL_MAX);
+    boardAlignmentMutable()->pitchDeciDegrees = constrain(pitchDeciDegrees, SETTING_ALIGN_BOARD_PITCH_MIN, SETTING_ALIGN_BOARD_PITCH_MAX);
 
     initBoardAlignment();
 }


### PR DESCRIPTION
Otherwise RC adjusments are able to change pitch and roll out of
their valid ranges.