### PR TITLE
Added S5 and S6 motor/servo to FIREWORKSV2 and variants

### DIFF
--- a/src/main/target/FIREWORKSV2/target.c
+++ b/src/main/target/FIREWORKSV2/target.c
@@ -48,7 +48,9 @@ const timerHardware_t timerHardware[] = {
 
     DEF_TIM(TIM2, CH4, PA3, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,    1, 1), // S3_OUT    D(1,6)
     DEF_TIM(TIM3, CH2, PB5, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,    1, 0), // S4_OUT    D(1,5)
-
+    DEF_TIM(TIM3, CH3, PC8, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,    0, 0), // S5_OUT    D(1,7)
+    DEF_TIM(TIM3, CH4, PC9, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,    0, 0), // S6_OUT    D(1,8)
+	
     DEF_TIM(TIM4, CH1, PB6, TIM_USE_LED,                            0, 0), // LED strip D(1,0)
 
     DEF_TIM(TIM1, CH2, PA9, TIM_USE_ANY,                            0, 0), // SS1

--- a/src/main/target/FIREWORKSV2/target.h
+++ b/src/main/target/FIREWORKSV2/target.h
@@ -182,11 +182,11 @@
 #define MAX7456_SPI_BUS         BUS_SPI3
 #define MAX7456_CS_PIN          PA15
 
-#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
-#define M25P16_CS_PIN           PB12
-#define M25P16_SPI_BUS          BUS_SPI2
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
+#define M25P16_CS_PIN           PB12
+#define M25P16_SPI_BUS          BUS_SPI2
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 
 #define USE_ADC
 #define ADC_CHANNEL_1_PIN               PC1
@@ -223,8 +223,8 @@
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 // Number of available PWM outputs
-#define MAX_PWM_OUTPUT_PORTS    4
-#define TARGET_MOTOR_COUNT      4
+#define MAX_PWM_OUTPUT_PORTS    8
+#define TARGET_MOTOR_COUNT      6
 
 #define TARGET_IO_PORTA         0xffff
 #define TARGET_IO_PORTB         0xffff


### PR DESCRIPTION
Referenced to https://github.com/iNavFlight/inav/issues/4421, now this target is abble to use motor or servo on S5/S6 PIN for Airplane.