### PR TITLE
Fix BETAFLIGHTF4 target motor 1

### DIFF
--- a/src/main/target/BETAFLIGHTF4/target.c
+++ b/src/main/target/BETAFLIGHTF4/target.c
@@ -27,10 +27,10 @@ const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM4, CH3, PB8,  TIM_USE_PPM,                               0, 0), // PPM
 
     // Motors
-    DEF_TIM(TIM1,  CH2, PB0,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR,      0, 0), // S1_OUT D2_ST6
-    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,      0, 0), // S2_OUT D1_ST2
-    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,      0, 0), // S3_OUT D1_ST6
-    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,      0, 0), // S4_OUT D1_ST1
+    DEF_TIM(TIM1,  CH2N, PB0,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR,      0, 0), // S1_OUT D2_ST6
+    DEF_TIM(TIM3,  CH4,  PB1,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,      0, 0), // S2_OUT D1_ST2
+    DEF_TIM(TIM8,  CH4,  PC9,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,      0, 0), // S3_OUT D1_ST6
+    DEF_TIM(TIM8,  CH3,  PC8,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,      0, 0), // S4_OUT D1_ST1
 
     // LED strip
     DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_LED,                              0, 0), // D1_ST0


### PR DESCRIPTION
Fixes #4295

Motor 1 timer definition haven't been migrated correctly from 2.0.1