### PR TITLE
Save space on F3

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -43,3 +43,11 @@
 #define FAST_CODE
 #define NOINLINE
 #endif
+
+#ifdef STM32F3
+#undef USE_WIND_ESTIMATOR
+#undef USE_SERIALRX_SUMD
+#undef USE_SERIALRX_SUMH
+#undef USE_SERIALRX_XBUS
+#undef USE_SERIALRX_JETIEXBUS
+#endif


### PR DESCRIPTION
As F3 are EOL, we have to disable not used features

```
#undef USE_WIND_ESTIMATOR
#undef USE_SERIALRX_SUMD
#undef USE_SERIALRX_SUMH
#undef USE_SERIALRX_XBUS
#undef USE_SERIALRX_JETIEXBUS
```