### PR TITLE
Use ubuntu xenial on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 env:
 # Specify the main Mafile supported goals.
   - GOAL=test


### PR DESCRIPTION
Since ubuntu 14.04 will be EOL on April 2019, want to run a quick test if Ubuntu 16 speeds up the builds.