### PR TITLE
Convert all NAV Controllers to PIDFF and allow to set MC POS_Z I

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1026,11 +1026,6 @@ groups:
         condition: USE_NAV
         min: 0
         max: 255
-      - name: nav_mc_pos_z_d
-        field: bank_mc.pid[PID_POS_Z].D
-        condition: USE_NAV
-        min: 0
-        max: 255
       - name: nav_mc_vel_z_p
         field: bank_mc.pid[PID_VEL_Z].P
         condition: USE_NAV

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1735,14 +1735,6 @@ void navPidInit(pidController_t *pid, float _kP, float _kI, float _kD, float _kF
 }
 
 /*-----------------------------------------------------------
- * Float point P-controller implementation
- *-----------------------------------------------------------*/
-void navPInit(pController_t *p, float _kP)
-{
-    p->param.kP = _kP;
-}
-
-/*-----------------------------------------------------------
  * Detects if thrust vector is facing downwards
  *-----------------------------------------------------------*/
 bool isThrustFacingDownwards(void)
@@ -3033,22 +3025,39 @@ void navigationUsePIDs(void)
 
     // Initialize position hold P-controller
     for (int axis = 0; axis < 2; axis++) {
-        navPInit(&posControl.pids.pos[axis], (float)pidProfile()->bank_mc.pid[PID_POS_XY].P / 100.0f);
+        navPidInit(
+            &posControl.pids.pos[axis], 
+            (float)pidProfile()->bank_mc.pid[PID_POS_XY].P / 100.0f,
+            (float)pidProfile()->bank_mc.pid[PID_POS_XY].I / 100.0f,
+            (float)pidProfile()->bank_mc.pid[PID_POS_XY].D / 100.0f,
+            (float)pidProfile()->bank_mc.pid[PID_POS_XY].FF / 100.0f
+        );
 
-        navPidInit(&posControl.pids.vel[axis], (float)pidProfile()->bank_mc.pid[PID_VEL_XY].P / 20.0f,
-                                               (float)pidProfile()->bank_mc.pid[PID_VEL_XY].I / 100.0f,
-                                               (float)pidProfile()->bank_mc.pid[PID_VEL_XY].D / 100.0f,
-                                               (float)pidProfile()->bank_mc.pid[PID_VEL_XY].FF / 100.0f
+        navPidInit(
+            &posControl.pids.vel[axis],
+            (float)pidProfile()->bank_mc.pid[PID_VEL_XY].P / 20.0f,
+            (float)pidProfile()->bank_mc.pid[PID_VEL_XY].I / 100.0f,
+            (float)pidProfile()->bank_mc.pid[PID_VEL_XY].D / 100.0f,
+            (float)pidProfile()->bank_mc.pid[PID_VEL_XY].FF / 100.0f
         );
     }
 
     // Initialize altitude hold PID-controllers (pos_z, vel_z, acc_z
-    navPInit(&posControl.pids.pos[Z], (float)pidProfile()->bank_mc.pid[PID_POS_Z].P / 100.0f);
+    navPidInit(
+        &posControl.pids.pos[Z], 
+        (float)pidProfile()->bank_mc.pid[PID_POS_Z].P / 100.0f,
+        (float)pidProfile()->bank_mc.pid[PID_POS_Z].I / 100.0f,
+        (float)pidProfile()->bank_mc.pid[PID_POS_Z].D / 100.0f,
+        (float)pidProfile()->bank_mc.pid[PID_POS_Z].FF / 100.0f
+    );
 
-    navPidInit(&posControl.pids.vel[Z], (float)pidProfile()->bank_mc.pid[PID_VEL_Z].P / 66.7f,
-                                        (float)pidProfile()->bank_mc.pid[PID_VEL_Z].I / 20.0f,
-                                        (float)pidProfile()->bank_mc.pid[PID_VEL_Z].D / 100.0f,
-                                        0.0f);
+    navPidInit(
+        &posControl.pids.vel[Z],
+        (float)pidProfile()->bank_mc.pid[PID_VEL_Z].P / 66.7f,
+        (float)pidProfile()->bank_mc.pid[PID_VEL_Z].I / 20.0f,
+        (float)pidProfile()->bank_mc.pid[PID_VEL_Z].D / 100.0f,
+        (float)pidProfile()->bank_mc.pid[PID_VEL_Z].FF / 100.0f
+    );
 
     // Initialize surface tracking PID
     navPidInit(&posControl.pids.surface, 2.0f,
@@ -3061,12 +3070,12 @@ void navigationUsePIDs(void)
     navPidInit(&posControl.pids.fw_nav, (float)pidProfile()->bank_fw.pid[PID_POS_XY].P / 100.0f,
                                         (float)pidProfile()->bank_fw.pid[PID_POS_XY].I / 100.0f,
                                         (float)pidProfile()->bank_fw.pid[PID_POS_XY].D / 100.0f,
-                                        0.0f);
+                                        (float)pidProfile()->bank_fw.pid[PID_POS_XY].FF / 100.0f);
 
     navPidInit(&posControl.pids.fw_alt, (float)pidProfile()->bank_fw.pid[PID_POS_Z].P / 10.0f,
                                         (float)pidProfile()->bank_fw.pid[PID_POS_Z].I / 10.0f,
                                         (float)pidProfile()->bank_fw.pid[PID_POS_Z].D / 10.0f,
-                                        0.0f);
+                                        (float)pidProfile()->bank_fw.pid[PID_POS_Z].FF / 10.0f);
 }
 
 void navigationInit(void)

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -246,10 +246,6 @@ typedef struct {
 } pidControllerParam_t;
 
 typedef struct {
-    float kP;
-} pControllerParam_t;
-
-typedef struct {
     bool reset;
     pidControllerParam_t param;
     pt1Filter_t dterm_filter_state;     // last derivative for low-pass filter
@@ -263,14 +259,9 @@ typedef struct {
     float output_constrained;           // controller output constrained
 } pidController_t;
 
-typedef struct {
-    pControllerParam_t param;
-    float output_constrained;
-} pController_t;
-
 typedef struct navigationPIDControllers_s {
     /* Multicopter PIDs */
-    pController_t   pos[XYZ_AXIS_COUNT];
+    pidController_t pos[XYZ_AXIS_COUNT];
     pidController_t vel[XYZ_AXIS_COUNT];
     pidController_t surface;
 

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -358,7 +358,6 @@ float navPidApply2(pidController_t *pid, const float setpoint, const float measu
 float navPidApply3(pidController_t *pid, const float setpoint, const float measurement, const float dt, const float outMin, const float outMax, const pidControllerFlags_e pidFlags, const float gainScaler);
 void navPidReset(pidController_t *pid);
 void navPidInit(pidController_t *pid, float _kP, float _kI, float _kD, float _kFF);
-void navPInit(pController_t *p, float _kP);
 
 bool isThrustFacingDownwards(void);
 uint32_t calculateDistanceToDestination(const fpVector3_t * destinationPos);


### PR DESCRIPTION
In this PR:

- all NAV controllers converted to PIDFF with ability to read bank settings 
- not used PIDFF values are not user configurable and thus always `0`
- MC POS_Z has now working `I` component without breaking the possibility to compute altitude from climb rate