### PR TITLE
[BUS] Lazy allocate device scratchpad memory

### DIFF
--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -27,6 +27,8 @@
 #include "platform.h"
 #include "build/debug.h"
 
+#include "common/memory.h"
+
 #include "drivers/bus.h"
 #include "drivers/io.h"
 
@@ -199,16 +201,25 @@ void busSetSpeed(const busDevice_t * dev, busSpeed_e speed)
 
 uint32_t busDeviceReadScratchpad(const busDevice_t * dev)
 {
-    return dev->scratchpad[0];
+    uint32_t * mem = busDeviceGetScratchpadMemory(dev);
+    return (mem != NULL) ? mem[0] : 0;
 }
 
 void busDeviceWriteScratchpad(busDevice_t * dev, uint32_t value)
 {
-    dev->scratchpad[0] = value;
+    uint32_t * mem = busDeviceGetScratchpadMemory(dev);
+
+    if (mem != NULL) {
+        mem[0] = value;
+    }
 }
 
 void * busDeviceGetScratchpadMemory(const busDevice_t * dev)
 {
+    if (dev->scratchpad == NULL) {
+        ((busDevice_t *)dev)->scratchpad = memAllocate(BUS_SCRATCHPAD_MEMORY_SIZE, OWNER_SYSTEM);
+    }
+
     return (void *)dev->scratchpad;
 }
 

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -192,9 +192,9 @@ typedef struct busDevice_s {
 #endif
     } busdev;
     IO_t irqPin;                    // Device IRQ pin. Bus system will only assign IO_t object to this var. Initialization is up to device driver
-    uint32_t scratchpad[BUS_SCRATCHPAD_MEMORY_SIZE / sizeof(uint32_t)];     // Memory where device driver can store persistent data. Zeroed out when initializing the device
-                                                                            // for the first time. Useful when once device is shared between several sensors
-                                                                            // (like MPU/ICM acc-gyro sensors)
+    uint32_t * scratchpad;          // Memory where device driver can store persistent data. Zeroed out when initializing the device
+                                    // for the first time. Useful when once device is shared between several sensors
+                                    // (like MPU/ICM acc-gyro sensors)
 } busDevice_t;
 
 #ifdef __APPLE__


### PR DESCRIPTION
Save some RAM by allocating 20-byte scratchpad buffer only when device needs it.
Further improvement would be to allow device to specify size of required scratchpad buffer.