### PR TITLE
CLI: ignore spaces between cmd and setting name for get/set

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2546,6 +2546,8 @@ static void cliGet(char *cmdline)
     int matchedCommands = 0;
     char name[SETTING_MAX_NAME_LENGTH];
 
+    while(*cmdline == ' ') ++cmdline; // ignore spaces
+
     for (uint32_t i = 0; i < SETTINGS_TABLE_COUNT; i++) {
         val = settingGet(i);
         if (settingNameContains(val, name, cmdline)) {
@@ -2573,6 +2575,8 @@ static void cliSet(char *cmdline)
     const setting_t *val;
     char *eqptr = NULL;
     char name[SETTING_MAX_NAME_LENGTH];
+
+    while(*cmdline == ' ') ++cmdline; // ignore spaces
 
     len = strlen(cmdline);
 


### PR DESCRIPTION
Closes https://github.com/iNavFlight/inav-configurator/issues/515