### PR TITLE
Fix simple Dterm diferentiator

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -539,7 +539,7 @@ static void FAST_CODE pidApplyFixedWingRateController(pidState_t *pidState, flig
 static void FAST_CODE pidApplyMulticopterRateController(pidState_t *pidState, flight_dynamics_index_t axis)
 {
     const float rateError = pidState->rateTarget - pidState->gyroRate;
-    static float previousDeltaFiltered = 0.0f;
+    static float previousDeltaFiltered[FLIGHT_DYNAMICS_INDEX_COUNT] = {0.0f, 0.0f, 0.0f};
 
     // Calculate new P-term
     float newPTerm = rateError * pidState->kP;
@@ -580,8 +580,8 @@ static void FAST_CODE pidApplyMulticopterRateController(pidState_t *pidState, fl
             firFilterUpdate(&pidState->gyroRateFilter, deltaFiltered);
             newDTerm = firFilterApply(&pidState->gyroRateFilter);
         } else {
-            newDTerm = deltaFiltered - previousDeltaFiltered; //Simple differentiator to replace Dterm FIR
-            previousDeltaFiltered = deltaFiltered;
+            newDTerm = deltaFiltered - previousDeltaFiltered[axis]; //Simple differentiator to replace Dterm FIR
+            previousDeltaFiltered[axis] = deltaFiltered;
         }
 
         // Calculate derivative

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -539,6 +539,7 @@ static void FAST_CODE pidApplyFixedWingRateController(pidState_t *pidState, flig
 static void FAST_CODE pidApplyMulticopterRateController(pidState_t *pidState, flight_dynamics_index_t axis)
 {
     const float rateError = pidState->rateTarget - pidState->gyroRate;
+    static float previousDeltaFiltered = 0.0f;
 
     // Calculate new P-term
     float newPTerm = rateError * pidState->kP;
@@ -579,7 +580,8 @@ static void FAST_CODE pidApplyMulticopterRateController(pidState_t *pidState, fl
             firFilterUpdate(&pidState->gyroRateFilter, deltaFiltered);
             newDTerm = firFilterApply(&pidState->gyroRateFilter);
         } else {
-            newDTerm = deltaFiltered;
+            newDTerm = deltaFiltered - previousDeltaFiltered; //Simple differentiator to replace Dterm FIR
+            previousDeltaFiltered = deltaFiltered;
         }
 
         // Calculate derivative


### PR DESCRIPTION
FIR has to be inited and buffer initialized in case user changes FIR from OFF to ON. Other option is to have dummy function pointers or listeners in MSP and CLI to init it before PID loop is executed. Let's assume this is fine for now