### PR TITLE
Add softserial on UART2 for WINGFC/FF_F35 targets

### DIFF
--- a/src/main/target/FF_F35_LIGHTNING/target.c
+++ b/src/main/target/FF_F35_LIGHTNING/target.c
@@ -30,6 +30,9 @@ const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 1, 0),
     DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 1, 0),
 
+    DEF_TIM(TIM5,  CH3, PA2,  TIM_USE_ANY, 0, 0),
+    DEF_TIM(TIM5,  CH4, PA3,  TIM_USE_ANY, 0, 0),
+
 #ifdef WINGFC
     DEF_TIM(TIM2,  CH4, PB11, TIM_USE_PPM, 0, 0), // UART3 RX
 #else

--- a/src/main/target/FF_F35_LIGHTNING/target.h
+++ b/src/main/target/FF_F35_LIGHTNING/target.h
@@ -87,7 +87,11 @@
 #define UART6_RX_PIN            PC7
 #define UART6_TX_PIN            PC6
 
-#define SERIAL_PORT_COUNT       7 //VCP, UART1, UART2, UART3, UART4, UART5, UART6
+#define USE_SOFTSERIAL1
+#define SOFTSERIAL_1_RX_PIN     PA3     // shared with UART2 RX
+#define SOFTSERIAL_1_TX_PIN     PA2     // shared with UART2 TX
+
+#define SERIAL_PORT_COUNT       8       //VCP, UART1, UART2, UART3, UART4, UART5, UART6
 
 #define USE_SPI
 #define USE_SPI_DEVICE_1

--- a/src/main/target/FF_F35_LIGHTNING/target.mk
+++ b/src/main/target/FF_F35_LIGHTNING/target.mk
@@ -11,6 +11,7 @@ TARGET_SRC = \
              drivers/compass/compass_ist8310.c \
              drivers/compass/compass_mag3110.c \
              drivers/rangefinder/rangefinder_hcsr04.c \
+             drivers/serial_softserial.c \
              drivers/serial_usb_vcp.c \
              drivers/max7456.c
 


### PR DESCRIPTION
Related to #4540 