### PR TITLE
Enable RANGEFINDER_HCSR04_I2C for all targets with flash > 256k

### DIFF
--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -74,6 +74,7 @@
 #define USE_RANGEFINDER_MSP
 #define USE_RANGEFINDER_BENEWAKE
 #define USE_RANGEFINDER_VL53L0X
+#define USE_RANGEFINDER_HCSR04_I2C
 
 // Allow default optic flow boards
 #define USE_OPFLOW

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -232,7 +232,7 @@
     #endif
 #endif
 
-#if defined(USE_RANGEFINDER_HCSR04_I2C)
+#if defined(USE_RANGEFINDER_HCSR04_I2C) && (defined(HCSR04_I2C_BUS) || defined(RANGEFINDER_I2C_BUS))
     #if !defined(HCSR04_I2C_BUS)
         #define HCSR04_I2C_BUS RANGEFINDER_I2C_BUS
     #endif


### PR DESCRIPTION
Fixes #4542 