### PR TITLE
Relative Mission Waypoints

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1287,11 +1287,13 @@ static void cliWaypoints(char *cmdline)
     } else if (sl_strcasecmp(cmdline, "reset") == 0) {
         resetWaypointList();
     } else if (sl_strcasecmp(cmdline, "load") == 0) {
-        loadNonVolatileWaypointList();
+        loadNonVolatileWaypointList(false);
     } else if (sl_strcasecmp(cmdline, "save") == 0) {
         posControl.waypointListValid = false;
         for (int i = 0; i < NAV_MAX_WAYPOINTS; i++) {
-            if (!(posControl.waypointList[i].action == NAV_WP_ACTION_WAYPOINT || posControl.waypointList[i].action == NAV_WP_ACTION_RTH)) break;
+            if (!(posControl.waypointList[i].action == NAV_WP_ACTION_WAYPOINT
+               || posControl.waypointList[i].action == NAV_WP_ACTION_RTH
+               || posControl.waypointList[i].action == NAV_WP_ACTION_RELATIVE)) break;
             if (posControl.waypointList[i].flag == NAV_WP_FLAG_LAST) {
                 posControl.waypointCount = i + 1;
                 posControl.waypointListValid = true;
@@ -1343,7 +1345,10 @@ static void cliWaypoints(char *cmdline)
             }
             if (validArgumentCount < 4) {
                 cliShowParseError();
-            } else if (!(action == 0 || action == NAV_WP_ACTION_WAYPOINT || action == NAV_WP_ACTION_RTH) || (p1 < 0) || !(flag == 0 || flag == NAV_WP_FLAG_LAST)) {
+            } else if (!(action == 0 || action == NAV_WP_ACTION_WAYPOINT || action == NAV_WP_ACTION_RTH || action == NAV_WP_ACTION_RELATIVE)
+                    || (p1 < 0) 
+                    || !(flag == 0 || flag == NAV_WP_FLAG_LAST)
+                    || (action == NAV_WP_ACTION_RELATIVE && (lat < 0 || lat * 100 > navConfig()->general.waypoint_safe_distance || lon < 0 || lon > 359))) {
                 cliShowParseError();
             } else {
                 posControl.waypointList[i].action = action;

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2596,7 +2596,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #ifdef NAV_NON_VOLATILE_WAYPOINT_STORAGE
     case MSP_WP_MISSION_LOAD:
         sbufReadU8Safe(NULL, src);    // Mission ID (reserved)
-        if ((dataSize != 1) || (!loadNonVolatileWaypointList()))
+        if ((dataSize != 1) || (!loadNonVolatileWaypointList(true)))
             return MSP_RESULT_ERROR;
         break;
 

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -249,7 +249,7 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
 
     // Load waypoint list
     if (rcSticks == THR_LO + YAW_CE + PIT_HI + ROL_HI) {
-        const bool success = loadNonVolatileWaypointList();
+        const bool success = loadNonVolatileWaypointList(true);
         beeper(success ? BEEPER_ACTION_SUCCESS : BEEPER_ACTION_FAIL);
     }
 #endif

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -213,7 +213,8 @@ typedef struct gpsOrigin_s {
 
 typedef enum {
     NAV_WP_ACTION_WAYPOINT = 0x01,
-    NAV_WP_ACTION_RTH      = 0x04
+    NAV_WP_ACTION_RTH      = 0x04,
+    NAV_WP_ACTION_RELATIVE = 0x09
 } navWaypointActions_e;
 
 typedef enum {
@@ -384,7 +385,7 @@ bool isWaypointListValid(void);
 void getWaypoint(uint8_t wpNumber, navWaypoint_t * wpData);
 void setWaypoint(uint8_t wpNumber, const navWaypoint_t * wpData);
 void resetWaypointList(void);
-bool loadNonVolatileWaypointList(void);
+bool loadNonVolatileWaypointList(bool checkRelativeCalculate);
 bool saveNonVolatileWaypointList(void);
 
 float RTHAltitude();


### PR DESCRIPTION
Implement https://github.com/iNavFlight/inav/issues/3968
Tested in fly on quadx and regular airplane.
```
wp 0 9 25 0 1500 0 0
wp 1 9 19 113 1500 0 0
wp 2 9 19 157 1500 0 0
wp 3 9 19 203 1500 0 0
wp 4 9 19 247 1500 0 0
wp 5 9 19 293 1500 0 0
wp 6 9 19 337 1500 0 0
wp 7 9 19 23 1500 0 0
wp 8 9 19 67 1500 0 0
wp 9 9 25 180 1500 0 0
wp 10 4 0 0 1000 1 165
```
When is not GPS fix (not enough pos estimator) and when try load from EEPROM to FC by sticks or via MSP (inav-configurator, mission planer etc) this will fail.
Load with CLI ignore GPS fix so it can be edit in CLI
![wp](https://user-images.githubusercontent.com/23119651/56083441-5b4bb580-5e25-11e9-95e6-319dadf5ce9b.png)
.