### PR TITLE
Add support for emergency arming

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -314,31 +314,16 @@ static bool emergencyArmingIsTriggered(void)
         emergencyArming.start >= millis() - EMERGENCY_ARMING_TIME_WINDOW_MS;
 }
 
-static bool emergencyArmingCanOverrideArmingPrevention(void)
+static bool emergencyArmingCanOverrideArmingDisabled(void)
 {
     uint32_t armingPrevention = armingFlags & ARMING_DISABLED_ALL_FLAGS;
-
-    // This flag is to require a switch flip if it's turned on while arming
-    // is disabled (otherwise craft could arm suddenly if the arming prevention
-    // reasons stop happening - e.g. THR high)
-    armingPrevention &= ~ARMING_DISABLED_ARM_SWITCH;
-
-    // Always override not level, unsafe navigation and compass not calibrated
-    armingPrevention &= ~ARMING_DISABLED_NOT_LEVEL;
-    armingPrevention &= ~ARMING_DISABLED_NAVIGATION_UNSAFE;
-    armingPrevention &= ~ARMING_DISABLED_COMPASS_NOT_CALIBRATED;
-
-    // In the event of a hardware failure, check wether the essential
-    // hardware is working. In that case, go ahead
-    if (getHwGyroStatus() == HW_SENSOR_OK && getHwAccelerometerStatus() == HW_SENSOR_OK) {
-        armingPrevention &= ~ARMING_DISABLED_HARDWARE_FAILURE;
-    }
+    armingPrevention &= ~ARMING_DISABLED_EMERGENCY_OVERRIDE;
     return armingPrevention == 0;
 }
 
 static bool emergencyArmingIsEnabled(void)
 {
-    return emergencyArmingIsTriggered() && emergencyArmingCanOverrideArmingPrevention();
+    return emergencyArmingIsTriggered() && emergencyArmingCanOverrideArmingDisabled();
 }
 
 void annexCode(void)

--- a/src/main/fc/fc_core.h
+++ b/src/main/fc/fc_core.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #include "common/time.h"
 
 typedef enum disarmReason_e {
@@ -37,6 +39,8 @@ void handleInflightCalibrationStickPosition(void);
 void disarm(disarmReason_t disarmReason);
 void tryArm(void);
 disarmReason_t getDisarmReason(void);
+
+void emergencyArmingUpdate(bool armingSwitchIsOn);
 
 bool isCalibrating(void);
 float getFlightTime(void);

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -179,7 +179,9 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
     rcSticks = stTmp;
 
     // perform actions
-    if (IS_RC_MODE_ACTIVE(BOXARM)) {
+    bool armingSwitchIsActive = IS_RC_MODE_ACTIVE(BOXARM);
+    emergencyArmingUpdate(armingSwitchIsActive);
+    if (armingSwitchIsActive) {
         rcDisarmTimeMs = currentTimeMs;
         tryArm();
     } else {

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -52,8 +52,21 @@ typedef enum {
                                                        ARMING_DISABLED_BOXKILLSWITCH | ARMING_DISABLED_RC_LINK | ARMING_DISABLED_THROTTLE | ARMING_DISABLED_CLI |
                                                        ARMING_DISABLED_CMS_MENU | ARMING_DISABLED_OSD_MENU | ARMING_DISABLED_ROLLPITCH_NOT_CENTERED |
                                                        ARMING_DISABLED_SERVO_AUTOTRIM | ARMING_DISABLED_OOM | ARMING_DISABLED_INVALID_SETTING |
-                                                       ARMING_DISABLED_PWM_OUTPUT_ERROR)
+                                                       ARMING_DISABLED_PWM_OUTPUT_ERROR),
 } armingFlag_e;
+
+// Arming blockers that can be overriden by emergency arming.
+// Keep in mind that this feature is intended to allow arming in
+// situations where we might just need the motors to spin so the
+// aircraft can move (even unpredictably) and get unstuck (e.g.
+// crashed into a high tree).
+#define ARMING_DISABLED_EMERGENCY_OVERRIDE  (ARMING_DISABLED_NOT_LEVEL \
+                                            | ARMING_DISABLED_NAVIGATION_UNSAFE \
+                                            | ARMING_DISABLED_COMPASS_NOT_CALIBRATED \
+                                            | ARMING_DISABLED_ACCELEROMETER_NOT_CALIBRATED \
+                                            | ARMING_DISABLED_ARM_SWITCH \
+                                            | ARMING_DISABLED_HARDWARE_FAILURE)
+
 
 extern uint32_t armingFlags;
 


### PR DESCRIPTION
Enabling and disabling the arming switch 10 times during a 10s
window will override checks for level, navigation unsafe, compass
not calibrated and some hardware failures (it will only enforce
gyro and acc to be working).

FLASH +224, RAM +24

Fixes #4489 and #4515