### PR TITLE
Fix timer DMA on F7

### DIFF
--- a/src/main/drivers/light_ws2811strip.c
+++ b/src/main/drivers/light_ws2811strip.c
@@ -47,7 +47,8 @@
 #define WS2811_BIT_COMPARE_1 ((WS2811_PERIOD * 2) / 3)
 #define WS2811_BIT_COMPARE_0 (WS2811_PERIOD / 3)
 
-static uint16_t ledStripDMABuffer[WS2811_DMA_BUFFER_SIZE];
+static timerDMASafeType_t ledStripDMABuffer[WS2811_DMA_BUFFER_SIZE];
+
 static IO_t ws2811IO = IO_NONE;
 static TCH_t * ws2811TCH = NULL;
 static bool ws2811Initialised = false;

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -70,7 +70,7 @@ typedef struct {
 
 #ifdef USE_DSHOT
     // DSHOT parameters
-    uint16_t dmaBuffer[DSHOT_DMA_BUFFER_SIZE];
+    timerDMASafeType_t dmaBuffer[DSHOT_DMA_BUFFER_SIZE];
 #endif
 } pwmOutputPort_t;
 
@@ -239,7 +239,7 @@ static void pwmWriteDshot(uint8_t index, uint16_t value)
     motors[index]->value = value;
 }
 
-static void loadDmaBufferDshot(uint16_t *dmaBuffer, uint16_t packet)
+static void loadDmaBufferDshot(timerDMASafeType_t *dmaBuffer, uint16_t packet)
 {
     for (int i = 0; i < 16; i++) {
         dmaBuffer[i] = (packet & 0x8000) ? DSHOT_MOTOR_BIT_1 : DSHOT_MOTOR_BIT_0;  // MSB first

--- a/src/main/drivers/timer_def_stm32f3xx.h
+++ b/src/main/drivers/timer_def_stm32f3xx.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#define timerDMASafeType_t  uint16_t
+
 #define DEF_TIM_DMAMAP__D(dma, channel)         DMA_TAG(dma, 0, channel)
 #define DEF_TIM_DMAMAP__NONE                    DMA_NONE
 

--- a/src/main/drivers/timer_def_stm32f4xx.h
+++ b/src/main/drivers/timer_def_stm32f4xx.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#define timerDMASafeType_t  uint16_t
+
 #define DEF_TIM_DMAMAP__D(dma, stream, channel)         DMA_TAG(dma, stream, channel)
 #define DEF_TIM_DMAMAP__NONE                            DMA_NONE
 

--- a/src/main/drivers/timer_def_stm32f7xx.h
+++ b/src/main/drivers/timer_def_stm32f7xx.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#define timerDMASafeType_t  uint32_t
+
 // Mappings for STDLIB defines
 // #define DEF_TIM_CHNL_CH1    TIM_CHANNEL_1
 // #define DEF_TIM_CHNL_CH1N   TIM_CHANNEL_1


### PR DESCRIPTION
It appeared that F7 DMA doesn't handle 16-bit M2P transfers properly (or F7 timers don't like being fed 16-bit data). Fixes #4643