### PR TITLE
Add Matek Serialshot protocol

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -93,6 +93,7 @@ COMMON_SRC = \
             io/beeper.c \
             io/lights.c \
             io/pwmdriver_i2c.c \
+            io/esc_serialshot.c \
             io/piniobox.c \
             io/serial.c \
             io/serial_4way.c \

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -205,15 +205,8 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
                 continue;
             }
 
-            if (pwmMotorConfig(timerHardwarePtr, pwmIOConfiguration.motorCount, init->motorPwmRate, init->pwmProtocolType, init->enablePWMOutput)) {
-                if (init->useFastPwm) {
-                    pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].flags = PWM_PF_MOTOR | PWM_PF_OUTPUT_PROTOCOL_FASTPWM | PWM_PF_OUTPUT_PROTOCOL_PWM;
-                } else if (init->pwmProtocolType == PWM_TYPE_BRUSHED) {
-                    pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].flags = PWM_PF_MOTOR | PWM_PF_MOTOR_MODE_BRUSHED | PWM_PF_OUTPUT_PROTOCOL_PWM;
-                } else {
-                    pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].flags = PWM_PF_MOTOR | PWM_PF_OUTPUT_PROTOCOL_PWM ;
-                }
-
+            if (pwmMotorConfig(timerHardwarePtr, pwmIOConfiguration.motorCount, motorConfig()->motorPwmRate, init->enablePWMOutput)) {
+                pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].flags = PWM_PF_MOTOR;
                 pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].index = pwmIOConfiguration.motorCount;
                 pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].timerHardware = timerHardwarePtr;
 
@@ -232,7 +225,7 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
             }
 
             if (pwmServoConfig(timerHardwarePtr, pwmIOConfiguration.servoCount, init->servoPwmRate, init->servoCenterPulse, init->enablePWMOutput)) {
-                pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].flags = PWM_PF_SERVO | PWM_PF_OUTPUT_PROTOCOL_PWM;
+                pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].flags = PWM_PF_SERVO;
                 pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].index = pwmIOConfiguration.servoCount;
                 pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].timerHardware = timerHardwarePtr;
 

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -57,7 +57,6 @@ typedef struct drv_pwm_config_s {
     bool useUART3;
     bool useUART6;
     bool useVbat;
-    bool useFastPwm;
     bool useSoftSerial;
     bool useLEDStrip;
 #ifdef USE_RANGEFINDER
@@ -66,8 +65,6 @@ typedef struct drv_pwm_config_s {
     bool useServoOutputs;
     uint16_t servoPwmRate;
     uint16_t servoCenterPulse;
-    uint8_t pwmProtocolType;
-    uint16_t motorPwmRate;
     rangefinderIOConfig_t rangefinderIOConfig;
 } drv_pwm_config_t;
 
@@ -75,9 +72,6 @@ typedef enum {
     PWM_PF_NONE = 0,
     PWM_PF_MOTOR = (1 << 0),
     PWM_PF_SERVO = (1 << 1),
-    PWM_PF_MOTOR_MODE_BRUSHED = (1 << 2),
-    PWM_PF_OUTPUT_PROTOCOL_PWM = (1 << 3),
-    PWM_PF_OUTPUT_PROTOCOL_FASTPWM = (1 << 4),
     PWM_PF_PPM = (1 << 5),
     PWM_PF_PWM = (1 << 6)
 } pwmPortFlags_e;

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -30,19 +30,20 @@ typedef enum {
     PWM_TYPE_DSHOT300,
     PWM_TYPE_DSHOT600,
     PWM_TYPE_DSHOT1200,
+    PWM_TYPE_SERIALSHOT,
 } motorPwmProtocolTypes_e;
 
 void pwmWriteMotor(uint8_t index, uint16_t value);
 void pwmShutdownPulsesForAllMotors(uint8_t motorCount);
-void pwmCompleteDshotUpdate(uint8_t motorCount);
-bool isMotorProtocolDshot(void);
+void pwmCompleteMotorUpdate(void);
+bool isMotorProtocolDigital(void);
 
 void pwmWriteServo(uint8_t index, uint16_t value);
 
 void pwmDisableMotors(void);
 void pwmEnableMotors(void);
 struct timerHardware_s;
-bool pwmMotorConfig(const struct timerHardware_s *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, motorPwmProtocolTypes_e proto, bool enableOutput);
+bool pwmMotorConfig(const struct timerHardware_s *timerHardware, uint8_t motorIndex, uint16_t motorPwmRate, bool enableOutput);
 bool pwmServoConfig(const struct timerHardware_s *timerHardware, uint8_t servoIndex, uint16_t servoPwmRate, uint16_t servoCenterPulse, bool enableOutput);
 void pwmWriteBeeper(bool onoffBeep);
 void beeperPwmInit(ioTag_t tag, uint16_t frequency);

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -298,6 +298,11 @@ void validateAndFixConfig(void)
         motorConfigMutable()->motorPwmRate = MIN(motorConfig()->motorPwmRate, 32000);
         break;
 #endif
+#ifdef USE_SERIALSHOT
+    case PWM_TYPE_SERIALSHOT:   // 2-4 kHz
+        motorConfigMutable()->motorPwmRate = constrain(motorConfig()->motorPwmRate, 2000, 4000);
+        break;
+#endif
     }
 #endif
 

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -722,7 +722,7 @@ void taskRunRealtimeCallbacks(timeUs_t currentTimeUs)
 #endif
 
 #ifdef USE_DSHOT
-    pwmCompleteDshotUpdate(getMotorCount());
+    pwmCompleteMotorUpdate();
 #endif
 }
 

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -317,16 +317,7 @@ void init(void)
     pwm_params.servoCenterPulse = servoConfig()->servoCenterPulse;
     pwm_params.servoPwmRate = servoConfig()->servoPwmRate;
 
-    pwm_params.pwmProtocolType = motorConfig()->motorPwmProtocol;
-#ifndef BRUSHED_MOTORS
-    pwm_params.useFastPwm = (motorConfig()->motorPwmProtocol == PWM_TYPE_ONESHOT125) ||
-                            (motorConfig()->motorPwmProtocol == PWM_TYPE_ONESHOT42) ||
-                            (motorConfig()->motorPwmProtocol == PWM_TYPE_MULTISHOT);
-#endif
-    pwm_params.motorPwmRate = motorConfig()->motorPwmRate;
-
     if (motorConfig()->motorPwmProtocol == PWM_TYPE_BRUSHED) {
-        pwm_params.useFastPwm = false;
         featureClear(FEATURE_3D);
     }
 
@@ -350,9 +341,6 @@ void init(void)
     pwmInit(&pwm_params);
 
     mixerPrepare();
-
-    if (!pwm_params.useFastPwm)
-        motorControlEnable = true;
 
     addBootlogEvent2(BOOT_EVENT_PWM_INIT_DONE, BOOT_EVENT_FLAGS_NONE);
     systemState |= SYSTEM_STATE_MOTORS_READY;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -32,7 +32,7 @@ tables:
   - name: blackbox_device
     values: ["SERIAL", "SPIFLASH", "SDCARD"]
   - name: motor_pwm_protocol
-    values: ["STANDARD", "ONESHOT125", "ONESHOT42", "MULTISHOT", "BRUSHED", "DSHOT150", "DSHOT300", "DSHOT600", "DSHOT1200"]
+    values: ["STANDARD", "ONESHOT125", "ONESHOT42", "MULTISHOT", "BRUSHED", "DSHOT150", "DSHOT300", "DSHOT600", "DSHOT1200", "SERIALSHOT"]
   - name: failsafe_procedure
     values: ["SET-THR", "DROP", "RTH", "NONE"]
   - name: current_sensor

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -175,7 +175,7 @@ void FAST_CODE NOINLINE writeMotors(void)
 
 #ifdef USE_DSHOT
         // If we use DSHOT we need to convert motorValue to DSHOT ranges
-        if (isMotorProtocolDshot()) {
+        if (isMotorProtocolDigital()) {
             const float dshotMinThrottleOffset = (DSHOT_MAX_THROTTLE - DSHOT_MIN_THROTTLE) / 10000.0f * motorConfig()->digitalIdleOffsetValue;
 
             if (feature(FEATURE_3D)) {

--- a/src/main/io/esc_serialshot.c
+++ b/src/main/io/esc_serialshot.c
@@ -1,0 +1,98 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <ctype.h>
+#include <math.h>
+
+#include "platform.h"
+
+#include "build/build_config.h"
+#include "build/debug.h"
+
+#include "common/maths.h"
+
+#include "io/serial.h"
+#include "io/esc_serialshot.h"
+
+#if defined(USE_SERIALSHOT)
+
+#define SERIALSHOT_UART_BAUD        921600
+#define THROTTLE_DATA_FRAME_SIZE    9
+
+static uint8_t txBuffer[THROTTLE_DATA_FRAME_SIZE];
+static serialPort_t * escPort = NULL;
+static serialPortConfig_t * portConfig;
+
+bool serialshotInitialize(void)
+{
+    // Avoid double initialization
+    if (escPort) {
+        return true;
+    }
+
+    portConfig = findSerialPortConfig(FUNCTION_SERIALSHOT);
+    if (!portConfig) {
+        return false;
+    }
+
+    escPort = openSerialPort(portConfig->identifier, FUNCTION_SERIALSHOT, NULL, NULL, SERIALSHOT_UART_BAUD, MODE_RXTX, SERIAL_NOT_INVERTED | SERIAL_UNIDIR);
+    if (!escPort) {
+        return false;
+    }
+
+    return true;
+}
+
+void serialshotUpdateMotor(int index, uint16_t value)
+{
+    if (index < 0 && index > 3) {
+        return;
+    }
+
+    txBuffer[index * 2 + 0] = 0xFF & (value >> 8);
+    txBuffer[index * 2 + 1] = 0xFF & (value >> 0);
+}
+
+void serialshotSendUpdate(void)
+{
+    // Skip update if previous one is not yet fully sent
+    // This helps to avoid buffer overflow and evenyually the data corruption
+    if (!isSerialTransmitBufferEmpty(escPort)) {
+        return;
+    }
+
+    // Calculate checksum
+    txBuffer[8] = 
+        txBuffer[0] + txBuffer[1] +
+        txBuffer[2] + txBuffer[3] +
+        txBuffer[4] + txBuffer[5] +
+        txBuffer[6] + txBuffer[7];
+
+    // Send data 
+    serialWriteBuf(escPort, txBuffer, THROTTLE_DATA_FRAME_SIZE);
+}
+
+#endif

--- a/src/main/io/esc_serialshot.c
+++ b/src/main/io/esc_serialshot.c
@@ -87,6 +87,11 @@ void serialshotUpdateMotor(int index, uint16_t value)
 
 void serialshotSendUpdate(void)
 {
+    // Check if the port is initialized
+    if (!escPort) {
+        return;
+    }
+
     // Skip update if previous one is not yet fully sent
     // This helps to avoid buffer overflow and evenyually the data corruption
     if (!isSerialTransmitBufferEmpty(escPort)) {

--- a/src/main/io/esc_serialshot.h
+++ b/src/main/io/esc_serialshot.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#pragma once
+
+bool serialshotInitialize(void);
+void serialshotUpdateMotor(int index, uint16_t value);
+void serialshotSendUpdate(void);

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -49,6 +49,7 @@ typedef enum {
     FUNCTION_LOG                 = (1 << 15), // 32768
     FUNCTION_RANGEFINDER         = (1 << 16), // 65536
     FUNCTION_VTX_FFPV            = (1 << 17), // 131072
+    FUNCTION_SERIALSHOT          = (1 << 18), // 262144
 } serialPortFunction_e;
 
 typedef enum {

--- a/src/main/target/MATEKF405/target.h
+++ b/src/main/target/MATEKF405/target.h
@@ -207,6 +207,7 @@
 #define TARGET_IO_PORTD         (BIT(2))
 
 #define USE_DSHOT
+#define USE_SERIALSHOT
 
 #define MAX_PWM_OUTPUT_PORTS       6
 

--- a/src/main/target/MATEKF411/target.h
+++ b/src/main/target/MATEKF411/target.h
@@ -151,6 +151,7 @@
 #define USE_SPEKTRUM_BIND
 #define BIND_PIN                PA10 //  RX1
 
+#define USE_SERIALSHOT
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define TARGET_IO_PORTA         0xffff

--- a/src/main/target/MATEKF722/target.h
+++ b/src/main/target/MATEKF722/target.h
@@ -161,3 +161,4 @@
 
 #define MAX_PWM_OUTPUT_PORTS        7
 #define USE_DSHOT
+#define USE_SERIALSHOT

--- a/src/main/target/MATEKF722SE/target.h
+++ b/src/main/target/MATEKF722SE/target.h
@@ -196,3 +196,4 @@
 
 #define MAX_PWM_OUTPUT_PORTS        8
 #define USE_DSHOT
+#define USE_SERIALSHOT

--- a/src/main/target/OMNIBUSF7NXT/target.h
+++ b/src/main/target/OMNIBUSF7NXT/target.h
@@ -174,6 +174,7 @@
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define USE_DSHOT
+#define USE_SERIALSHOT
 
 // Number of available PWM outputs
 #define MAX_PWM_OUTPUT_PORTS    6

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -33,7 +33,6 @@
 #define BEEPER                  PB4
 
 #define USE_DSHOT
-#define USE_SERIALSHOT
 
 // MPU6000 interrupts
 #define USE_EXTI

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -33,6 +33,7 @@
 #define BEEPER                  PB4
 
 #define USE_DSHOT
+#define USE_SERIALSHOT
 
 // MPU6000 interrupts
 #define USE_EXTI


### PR DESCRIPTION
Initial cut on MATEK's SerialShort protocol. 
No telemetry (we don't support ESC telemetry yet).
Not tested. May break DSHOT.