### PR TITLE
[FC] Add back MOTOR_STOP for multirotors

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -305,16 +305,6 @@ void validateAndFixConfig(void)
     gyroConfigMutable()->gyroSync = false;
 #endif
 
-    /*
-     * MOTOR_STOP is no longer allowed on Multirotors and Tricopters
-     */
-    if (
-        feature(FEATURE_MOTOR_STOP) &&
-        (mixerConfig()->platformType == PLATFORM_MULTIROTOR || mixerConfig()->platformType == PLATFORM_TRICOPTER)
-    ) {
-        featureClear(FEATURE_MOTOR_STOP);
-    }
-
     // Call target-specific validation function
     validateAndFixTargetConfig();
 

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -445,6 +445,19 @@ void processRx(timeUs_t currentTimeUs)
 
     const throttleStatus_e throttleStatus = calculateThrottleStatus();
 
+    // When armed and motors aren't spinning, do beeps periodically
+    if (ARMING_FLAG(ARMED) && feature(FEATURE_MOTOR_STOP) && !STATE(FIXED_WING)) {
+        static bool armedBeeperOn = false;
+
+        if (throttleStatus == THROTTLE_LOW) {
+            beeper(BEEPER_ARMED);
+            armedBeeperOn = true;
+        } else if (armedBeeperOn) {
+            beeperSilence();
+            armedBeeperOn = false;
+        }
+    }
+
     processRcStickPositions(throttleStatus);
 
     updateActivatedModes();


### PR DESCRIPTION
Based on the poll in Telegram 43% of users think that `MOTOR_STOP` should stay on multirotors:
![image](https://user-images.githubusercontent.com/11059099/56828983-d5872b80-6862-11e9-9bf4-96ca5a9244b5.png)

We did, however, remove support for stick arming, so `MOTOR_STOP` behavior **will not disarm** the quad if throttle is kept low for too long. While quad is armed it will beep indefinitely if the throttle is low to warn about the danger.