### PR TITLE
update atomic.h gcc version for gcc 9

### DIFF
--- a/src/main/build/atomic.h
+++ b/src/main/build/atomic.h
@@ -91,7 +91,7 @@ static inline uint8_t __basepriSetRetVal(uint8_t prio)
 // ideally this would only protect memory passed as parameter (any type should work), but gcc is currently creating almost full barrier
 // this macro can be used only ONCE PER LINE, but multiple uses per block are fine
 
-#if (__GNUC__ > 8)
+#if (__GNUC__ > 9)
 #warning "Please verify that ATOMIC_BARRIER works as intended"
 // increment version number is BARRIER works
 // TODO - use flag to disable ATOMIC_BARRIER and use full barrier instead


### PR DESCRIPTION
Trivial update for latest gcc version. Working OK in simple hover test, detailed fight test later.
There will be a further gcc 9 PR for some new compiler warnings later.

Note: We might consider that this is the fifth time that such a PR has been issued. Maybe we can now trust gcc to compile this correctly.