### PR TITLE
 Printf: Implement size checked and va_list variants

### DIFF
--- a/src/main/common/log.c
+++ b/src/main/common/log.c
@@ -116,7 +116,7 @@ static void logPrint(const char *buf, size_t size)
 static size_t logFormatPrefix(char *buf, const timeMs_t timeMs)
 {
     // Write timestamp
-    return tfp_sprintf(buf, LOG_PREFIX, timeMs / 1000, timeMs % 1000);
+    return tfp_sprintf(buf, LOG_PREFIX, (int)(timeMs / 1000), (int)(timeMs % 1000));
 }
 
 static bool logHasOutput(void)

--- a/src/main/common/printf.h
+++ b/src/main/common/printf.h
@@ -109,13 +109,14 @@ regs Kusti, 23.10.2004
 
 void init_printf(void *putp, void (*putf) (void *, char));
 
-int tfp_printf(const char *fmt, ...);
-int tfp_sprintf(char *s, const char *fmt, ...);
+int tfp_printf(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+int tfp_sprintf(char *s, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+int tfp_snprintf(char *s, int size, const char *fmt, ...) __attribute__ ((format (printf, 3, 4)));
+int tfp_vsprintf(char *s, const char *fmt, va_list va) __attribute__ ((format (printf, 2, 0)));
+int tfp_vsnprintf(char *s, int size, const char *fmt, va_list va) __attribute__ ((format (printf, 3, 0)));
 
 int tfp_format(void *putp, void (*putf) (void *, char), const char *fmt, va_list va);
-
-#define printf tfp_printf
-#define sprintf tfp_sprintf
+int tfp_nformat(void *putp, int n, void (*putf) (void *, char), const char *fmt, va_list va);
 
 void printfSupportInit(void);
 struct serialPort_s;

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -877,7 +877,7 @@ static void cliSerialPassthrough(char *cmdline)
             tfp_printf("Port %d could not be opened.\r\n", id);
             return;
         }
-        tfp_printf("Port %d opened, baud = %d.\r\n", id, baud);
+        tfp_printf("Port %d opened, baud = %u.\r\n", id, (unsigned)baud);
     } else {
         passThroughPort = passThroughPortUsage->serialPort;
         // If the user supplied a mode, override the port's mode, otherwise

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -864,7 +864,7 @@ static void cliSerialPassthrough(char *cmdline)
     serialPortUsage_t *passThroughPortUsage = findSerialPortUsageByIdentifier(id);
     if (!passThroughPortUsage || passThroughPortUsage->serialPort == NULL) {
         if (!baud) {
-            printf("Port %d is closed, must specify baud.\r\n", id);
+            tfp_printf("Port %d is closed, must specify baud.\r\n", id);
             return;
         }
         if (!mode)
@@ -874,29 +874,29 @@ static void cliSerialPassthrough(char *cmdline)
                                          baud, mode,
                                          SERIAL_NOT_INVERTED);
         if (!passThroughPort) {
-            printf("Port %d could not be opened.\r\n", id);
+            tfp_printf("Port %d could not be opened.\r\n", id);
             return;
         }
-        printf("Port %d opened, baud = %d.\r\n", id, baud);
+        tfp_printf("Port %d opened, baud = %d.\r\n", id, baud);
     } else {
         passThroughPort = passThroughPortUsage->serialPort;
         // If the user supplied a mode, override the port's mode, otherwise
         // leave the mode unchanged. serialPassthrough() handles one-way ports.
-        printf("Port %d already open.\r\n", id);
+        tfp_printf("Port %d already open.\r\n", id);
         if (mode && passThroughPort->mode != mode) {
-            printf("Adjusting mode from %d to %d.\r\n",
+            tfp_printf("Adjusting mode from %d to %d.\r\n",
                    passThroughPort->mode, mode);
             serialSetMode(passThroughPort, mode);
         }
         // If this port has a rx callback associated we need to remove it now.
         // Otherwise no data will be pushed in the serial port buffer!
         if (passThroughPort->rxCallback) {
-            printf("Removing rxCallback\r\n");
+            tfp_printf("Removing rxCallback\r\n");
             passThroughPort->rxCallback = 0;
         }
     }
 
-    printf("Forwarding data to %d, power cycle to exit.\r\n", id);
+    tfp_printf("Forwarding data to %d, power cycle to exit.\r\n", id);
 
     serialPassthrough(cliPort, passThroughPort, NULL, NULL);
 }

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -367,7 +367,7 @@ static void showStatusPage(void)
 
     if (feature(FEATURE_CURRENT_METER)) {
         i2c_OLED_set_line(rowIndex++);
-        tfp_sprintf(lineBuffer, "mAh: %d", getMAhDrawn());
+        tfp_sprintf(lineBuffer, "mAh: %d", (int)getMAhDrawn());
         padLineBufferToChar(12);
         i2c_OLED_send_string(lineBuffer);
 
@@ -392,7 +392,7 @@ static void showStatusPage(void)
         i2c_OLED_set_line(rowIndex++);
         i2c_OLED_send_string(lineBuffer);
 
-        tfp_sprintf(lineBuffer, "La/Lo: %d/%d", gpsSol.llh.lat / GPS_DEGREES_DIVIDER, gpsSol.llh.lon / GPS_DEGREES_DIVIDER);
+        tfp_sprintf(lineBuffer, "La/Lo: %d/%d", (int)(gpsSol.llh.lat / GPS_DEGREES_DIVIDER), (int)(gpsSol.llh.lon / GPS_DEGREES_DIVIDER));
         padLineBuffer();
         i2c_OLED_set_line(rowIndex++);
         i2c_OLED_send_string(lineBuffer);
@@ -412,7 +412,7 @@ static void showStatusPage(void)
 #ifdef USE_BARO
     if (sensors(SENSOR_BARO)) {
         int32_t alt = baroCalculateAltitude();
-        tfp_sprintf(lineBuffer, "Alt: %d", alt / 100);
+        tfp_sprintf(lineBuffer, "Alt: %d", (int)(alt / 100));
         padHalfLineBuffer();
         i2c_OLED_set_xy(HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex);
         i2c_OLED_send_string(lineBuffer);

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -338,7 +338,7 @@ void generateLedConfig(ledConfig_t *ledConfig, char *ledConfigBuffer, size_t buf
     *fptr = 0;
 
     // TODO - check buffer length
-    sprintf(ledConfigBuffer, "%u,%u:%s:%s:%u", ledGetX(ledConfig), ledGetY(ledConfig), directions, baseFunctionOverlays, ledGetColor(ledConfig));
+    tfp_sprintf(ledConfigBuffer, "%u,%u:%s:%s:%u", ledGetX(ledConfig), ledGetY(ledConfig), directions, baseFunctionOverlays, ledGetColor(ledConfig));
 }
 
 typedef enum {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -324,10 +324,10 @@ static void osdFormatDistanceSymbol(char *buff, int32_t dist)
         centifeet = CENTIMETERS_TO_CENTIFEET(dist);
         if (abs(centifeet) < FEET_PER_MILE * 100 / 2) {
             // Show feet when dist < 0.5mi
-            tfp_sprintf(buff, "%d%c", centifeet / 100, SYM_FT);
+            tfp_sprintf(buff, "%d%c", (int)(centifeet / 100), SYM_FT);
         } else {
             // Show miles when dist >= 0.5mi
-            tfp_sprintf(buff, "%d.%02d%c", centifeet / (100*FEET_PER_MILE),
+            tfp_sprintf(buff, "%d.%02d%c", (int)(centifeet / (100*FEET_PER_MILE)),
             (abs(centifeet) % (100 * FEET_PER_MILE)) / FEET_PER_MILE, SYM_MI);
         }
         break;
@@ -336,10 +336,10 @@ static void osdFormatDistanceSymbol(char *buff, int32_t dist)
      case OSD_UNIT_METRIC:
         if (abs(dist) < METERS_PER_KILOMETER * 100) {
             // Show meters when dist < 1km
-            tfp_sprintf(buff, "%d%c", dist / 100, SYM_M);
+            tfp_sprintf(buff, "%d%c", (int)(dist / 100), SYM_M);
         } else {
             // Show kilometers when dist >= 1km
-            tfp_sprintf(buff, "%d.%02d%c", dist / (100*METERS_PER_KILOMETER),
+            tfp_sprintf(buff, "%d.%02d%c", (int)(dist / (100*METERS_PER_KILOMETER)),
                 (abs(dist) % (100 * METERS_PER_KILOMETER)) / METERS_PER_KILOMETER, SYM_KM);
          }
          break;
@@ -374,10 +374,10 @@ static void osdFormatVelocityStr(char* buff, int32_t vel, bool _3D)
     case OSD_UNIT_UK:
         FALLTHROUGH;
     case OSD_UNIT_IMPERIAL:
-        tfp_sprintf(buff, "%3d%c", osdConvertVelocityToUnit(vel), (_3D ? SYM_3D_MPH : SYM_MPH));
+        tfp_sprintf(buff, "%3d%c", (int)osdConvertVelocityToUnit(vel), (_3D ? SYM_3D_MPH : SYM_MPH));
         break;
     case OSD_UNIT_METRIC:
-        tfp_sprintf(buff, "%3d%c", osdConvertVelocityToUnit(vel), (_3D ? SYM_3D_KMH : SYM_KMH));
+        tfp_sprintf(buff, "%3d%c", (int)osdConvertVelocityToUnit(vel), (_3D ? SYM_3D_KMH : SYM_KMH));
         break;
     }
 }
@@ -457,13 +457,13 @@ static void osdFormatAltitudeStr(char *buff, int32_t alt)
     switch ((osd_unit_e)osdConfig()->units) {
         case OSD_UNIT_IMPERIAL:
             value = CENTIMETERS_TO_FEET(alt);
-            tfp_sprintf(buff, "%d%c", value, SYM_FT);
+            tfp_sprintf(buff, "%d%c", (int)value, SYM_FT);
             break;
         case OSD_UNIT_UK:
             FALLTHROUGH;
         case OSD_UNIT_METRIC:
             value = CENTIMETERS_TO_METERS(alt);
-            tfp_sprintf(buff, "%d%c", value, SYM_M);
+            tfp_sprintf(buff, "%d%c", (int)value, SYM_M);
             break;
     }
 }
@@ -478,7 +478,7 @@ static void osdFormatTime(char *buff, uint32_t seconds, char sym_m, char sym_h)
         value = seconds / 60;
     }
     buff[0] = sym;
-    tfp_sprintf(buff + 1, "%02d:%02d", value / 60, value % 60);
+    tfp_sprintf(buff + 1, "%02d:%02d", (int)(value / 60), (int)(value % 60));
 }
 
 static inline void osdFormatOnTime(char *buff)
@@ -572,11 +572,11 @@ static void osdFormatCoordinate(char *buff, char sym, int32_t val)
     int32_t integerPart = val / GPS_DEGREES_DIVIDER;
     // Latitude maximum integer width is 3 (-90) while
     // longitude maximum integer width is 4 (-180).
-    int integerDigits = tfp_sprintf(buff + 1, (integerPart == 0 && val < 0) ? "-%d" : "%d", integerPart);
+    int integerDigits = tfp_sprintf(buff + 1, (integerPart == 0 && val < 0) ? "-%d" : "%d", (int)integerPart);
     // We can show up to 7 digits in decimalPart.
     int32_t decimalPart = abs(val % GPS_DEGREES_DIVIDER);
     STATIC_ASSERT(GPS_DEGREES_DIVIDER == 1e7, adjust_max_decimal_digits);
-    int decimalDigits = tfp_sprintf(buff + 1 + integerDigits, "%07d", decimalPart);
+    int decimalDigits = tfp_sprintf(buff + 1 + integerDigits, "%07d", (int)decimalPart);
     // Embbed the decimal separator
     buff[1 + integerDigits - 1] += SYM_ZERO_HALF_TRAILING_DOT - '0';
     buff[1 + integerDigits] += SYM_ZERO_HALF_LEADING_DOT - '0';
@@ -1247,7 +1247,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_MAH_DRAWN:
         buff[0] = SYM_MAH;
-        tfp_sprintf(buff + 1, "%-4d", getMAhDrawn());
+        tfp_sprintf(buff + 1, "%-4d", (int)getMAhDrawn());
         osdUpdateBatteryCapacityOrVoltageTextAttributes(&elemAttr);
         break;
 
@@ -2043,11 +2043,11 @@ static bool osdDrawSingleElement(uint8_t item)
             const navigationPIDControllers_t *nav_pids = getNavigationPIDControllers();
             strcpy(buff, "POSO ");
             // display requested velocity cm/s
-            tfp_sprintf(buff + 5, "%4d", lrintf(nav_pids->pos[X].output_constrained * 100));
+            tfp_sprintf(buff + 5, "%4d", (int)lrintf(nav_pids->pos[X].output_constrained * 100));
             buff[9] = ' ';
-            tfp_sprintf(buff + 10, "%4d", lrintf(nav_pids->pos[Y].output_constrained * 100));
+            tfp_sprintf(buff + 10, "%4d", (int)lrintf(nav_pids->pos[Y].output_constrained * 100));
             buff[14] = ' ';
-            tfp_sprintf(buff + 15, "%4d", lrintf(nav_pids->pos[Z].output_constrained * 100));
+            tfp_sprintf(buff + 15, "%4d", (int)lrintf(nav_pids->pos[Z].output_constrained * 100));
             buff[19] = '\0';
             break;
         }
@@ -2265,7 +2265,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 }
             }
             if (value > 0 && value <= 999) {
-                tfp_sprintf(buff, "%3d", value);
+                tfp_sprintf(buff, "%3d", (int)value);
             } else {
                 buff[0] = buff[1] = buff[2] = '-';
             }
@@ -2309,10 +2309,10 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_DEBUG:
         {
             // Longest representable string is -32768, hence 6 characters
-            tfp_sprintf(buff, "[0]=%6d [1]=%6d", debug[0], debug[1]);
+            tfp_sprintf(buff, "[0]=%6d [1]=%6d", (int)debug[0], (int)debug[1]);
             displayWrite(osdDisplayPort, elemPosX, elemPosY, buff);
             elemPosY++;
-            tfp_sprintf(buff, "[2]=%6d [3]=%6d", debug[2], debug[3]);
+            tfp_sprintf(buff, "[2]=%6d [3]=%6d", (int)debug[2], (int)debug[3]);
             break;
         }
 
@@ -2766,10 +2766,10 @@ void osdInit(displayPort_t *osdDisplayPortToUse)
     if (statsConfig()->stats_enabled) {
         displayWrite(osdDisplayPort, STATS_LABEL_X_POS, ++y, "ODOMETER:");
         if (osdConfig()->units == OSD_UNIT_IMPERIAL) {
-            tfp_sprintf(string_buffer, "%5d", statsConfig()->stats_total_dist / METERS_PER_MILE);
+            tfp_sprintf(string_buffer, "%5d", (int)(statsConfig()->stats_total_dist / METERS_PER_MILE));
             string_buffer[5] = SYM_MI;
         } else {
-            tfp_sprintf(string_buffer, "%5d", statsConfig()->stats_total_dist / METERS_PER_KILOMETER);
+            tfp_sprintf(string_buffer, "%5d", (int)(statsConfig()->stats_total_dist / METERS_PER_KILOMETER));
             string_buffer[5] = SYM_KM;
         }
         string_buffer[6] = '\0';
@@ -2777,7 +2777,7 @@ void osdInit(displayPort_t *osdDisplayPortToUse)
 
         displayWrite(osdDisplayPort, STATS_LABEL_X_POS, ++y, "TOTAL TIME:");
         uint32_t tot_mins = statsConfig()->stats_total_time / 60;
-        tfp_sprintf(string_buffer, "%2d:%02dHM", tot_mins / 60, tot_mins % 60);
+        tfp_sprintf(string_buffer, "%2d:%02dHM", (int)(tot_mins / 60), (int)(tot_mins % 60));
         displayWrite(osdDisplayPort, STATS_VALUE_X_POS-5, y,  string_buffer);
 
 #ifdef USE_ADC
@@ -2902,7 +2902,7 @@ static void osdShowStats(void)
 
         if (osdConfig()->stats_energy_unit == OSD_STATS_ENERGY_UNIT_MAH) {
             displayWrite(osdDisplayPort, statNameX, top, "USED MAH         :");
-            tfp_sprintf(buff, "%d%c", getMAhDrawn(), SYM_MAH);
+            tfp_sprintf(buff, "%d%c", (int)getMAhDrawn(), SYM_MAH);
         } else {
             displayWrite(osdDisplayPort, statNameX, top, "USED WH          :");
             osdFormatCentiNumber(buff, getMWhDrawn() / 10, 0, 2, 0, 3);
@@ -2914,7 +2914,7 @@ static void osdShowStats(void)
         if (totalDistance > 0) {
             displayWrite(osdDisplayPort, statNameX, top, "AVG EFFICIENCY   :");
             if (osdConfig()->stats_energy_unit == OSD_STATS_ENERGY_UNIT_MAH)
-                tfp_sprintf(buff, "%d%c%c", getMAhDrawn() * 100000 / totalDistance,
+                tfp_sprintf(buff, "%d%c%c", (int)(getMAhDrawn() * 100000 / totalDistance),
                     SYM_MAH_KM_0, SYM_MAH_KM_1);
             else {
                 osdFormatCentiNumber(buff, getMWhDrawn() * 10000 / totalDistance, 0, 2, 0, 3);

--- a/src/main/sensors/temperature.c
+++ b/src/main/sensors/temperature.c
@@ -162,7 +162,7 @@ bool getSensorTemperature(uint8_t temperatureUpdateSensorIndex, int16_t *tempera
 void tempSensorAddressToString(uint64_t address, char *hex_address)
 {
     if (address < 8)
-        tfp_sprintf(hex_address, "%d", address);
+        tfp_sprintf(hex_address, "%d", (int)address);
     else {
         uint32_t *address32 = (uint32_t *)&address;
         tfp_sprintf(hex_address, "%08lx%08lx", address32[1], address32[0]);


### PR DESCRIPTION
Printf: Implement size checked and va_list variants
tfp_snprintf(), tfp_vsprintf() and tfp_vsnprintf

Mark all the functions as accepting a format string.

Also, drop the #define's for printf() and snprintf() and call
them explicitely, since #defining printf messes up with
__attribute__ ((format (printf, X, Y)))

All: Fix warnings reported by -Wformat