### PR TITLE
Switch back to 32-bit DMA on F4

### DIFF
--- a/src/main/drivers/timer_def_stm32f4xx.h
+++ b/src/main/drivers/timer_def_stm32f4xx.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define timerDMASafeType_t  uint16_t
+#define timerDMASafeType_t  uint32_t
 
 #define DEF_TIM_DMAMAP__D(dma, stream, channel)         DMA_TAG(dma, stream, channel)
 #define DEF_TIM_DMAMAP__NONE                            DMA_NONE


### PR DESCRIPTION
During today's test I've figured out that 16-bit DMA doesn't work with some timers.

This fixes broken DSHOT on REVO and on other F4 targets using `TIM2` and `TIM5` (they have a 32-bit counter):

![image](https://user-images.githubusercontent.com/11059099/57574083-a95ad580-7432-11e9-8e90-29904bce96cb.png)
