### PR TITLE
[MIXER] Add custom mixer parameters to additionally change smix rule …

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1621,7 +1621,7 @@ static void cliServo(char *cmdline)
 
 static void printServoMix(uint8_t dumpMask, const servoMixer_t *customServoMixers, const servoMixer_t *defaultCustomServoMixers)
 {
-    const char *format = "smix %d %d %d %d %d %d";
+    const char *format = "smix %d %d %d %d %d %d %d";
     for (uint32_t i = 0; i < MAX_SERVO_RULES; i++) {
         const servoMixer_t customServoMixer = customServoMixers[i];
         if (customServoMixer.rate == 0) {
@@ -1638,6 +1638,7 @@ static void printServoMix(uint8_t dumpMask, const servoMixer_t *customServoMixer
             #ifdef USE_LOGIC_CONDITIONS
                 && customServoMixer.conditionId == customServoMixerDefault.conditionId
             #endif
+                && customServoMixer.userParamId == customServoMixerDefault.userParamId
             ;
 
             cliDefaultPrintLinef(dumpMask, equalsDefault, format,
@@ -1647,10 +1648,11 @@ static void printServoMix(uint8_t dumpMask, const servoMixer_t *customServoMixer
                 customServoMixerDefault.rate,
                 customServoMixerDefault.speed,
             #ifdef USE_LOGIC_CONDITIONS
-                customServoMixer.conditionId
+                customServoMixer.conditionId,
             #else
-                0
+                0,
             #endif
+                customServoMixerDefault.userParamId
             );
         }
         cliDumpPrintLinef(dumpMask, equalsDefault, format,
@@ -1660,10 +1662,11 @@ static void printServoMix(uint8_t dumpMask, const servoMixer_t *customServoMixer
             customServoMixer.rate,
             customServoMixer.speed,
         #ifdef USE_LOGIC_CONDITIONS
-            customServoMixer.conditionId
+            customServoMixer.conditionId,
         #else
-            0
+            0,
         #endif
+            customServoMixer.userParamId
         );
     }
 }
@@ -1680,7 +1683,7 @@ static void cliServoMix(char *cmdline)
         // erase custom mixer
         pgResetCopy(customServoMixersMutable(0), PG_SERVO_MIXER);
     } else {
-        enum {RULE = 0, TARGET, INPUT, RATE, SPEED, CONDITION, ARGS_COUNT};
+        enum {RULE = 0, TARGET, INPUT, RATE, SPEED, CONDITION, USERPARAM, ARGS_COUNT};
         char *ptr = strtok_r(cmdline, " ", &saveptr);
         while (ptr != NULL && check < ARGS_COUNT) {
             args[check++] = fastA2I(ptr);
@@ -1699,7 +1702,8 @@ static void cliServoMix(char *cmdline)
             args[INPUT] >= 0 && args[INPUT] < INPUT_SOURCE_COUNT &&
             args[RATE] >= -1000 && args[RATE] <= 1000 &&
             args[SPEED] >= 0 && args[SPEED] <= MAX_SERVO_SPEED &&
-            args[CONDITION] >= -1 && args[CONDITION] < MAX_LOGIC_CONDITIONS
+            args[CONDITION] >= -1 && args[CONDITION] < MAX_LOGIC_CONDITIONS &&
+            args[USERPARAM] >= -1 && args[USERPARAM] < MAX_MIXER_USER_PARAMS
         ) {
             customServoMixersMutable(i)->targetChannel = args[TARGET];
             customServoMixersMutable(i)->inputSource = args[INPUT];
@@ -1708,6 +1712,7 @@ static void cliServoMix(char *cmdline)
         #ifdef USE_LOGIC_CONDITIONS
             customServoMixersMutable(i)->conditionId = args[CONDITION];
         #endif
+            customServoMixersMutable(i)->userParamId = args[USERPARAM];
             cliServoMix("");
         } else {
             cliShowParseError();

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -476,6 +476,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         #else
             sbufWriteU8(dst, -1);
         #endif
+            sbufWriteU8(dst, customServoMixers(i)->userParamId);
         }
         break;
 #ifdef USE_LOGIC_CONDITIONS
@@ -1386,6 +1387,8 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         sbufWriteU16(dst, mixerConfig()->appliedMixerPreset);
         sbufWriteU8(dst, MAX_SUPPORTED_MOTORS);
         sbufWriteU8(dst, MAX_SUPPORTED_SERVOS);
+        sbufWriteU8(dst, mixerConfig()->userParam[0]);
+        sbufWriteU8(dst, mixerConfig()->userParam[1]);
         break;
 
 #if defined(USE_OSD)
@@ -1892,6 +1895,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         #else
             sbufReadU8(src);
         #endif
+            customServoMixersMutable(tmp_u8)->userParamId = sbufReadU8(src);
             loadCustomServoMixer();
         } else
             return MSP_RESULT_ERROR;
@@ -2677,6 +2681,8 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         mixerConfigMutable()->appliedMixerPreset = sbufReadU16(src);
         sbufReadU8(src); //Read and ignore MAX_SUPPORTED_MOTORS
         sbufReadU8(src); //Read and ignore MAX_SUPPORTED_SERVOS
+        mixerConfigMutable()->userParam[0] = sbufReadU8(src);
+        mixerConfigMutable()->userParam[1] = sbufReadU8(src);
         mixerUpdateStateFlags();
         break;
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -656,6 +656,14 @@ groups:
         field: fwMinThrottleDownPitchAngle
         min: 0
         max: 450
+      - name: mixer_param_0
+        field: userParam[0]
+        min: 0
+        max: 200
+      - name: mixer_param_1
+        field: userParam[1]
+        min: 0
+        max: 200
 
   - name: PG_MOTOR_3D_CONFIG
     type: flight3DConfig_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -656,11 +656,11 @@ groups:
         field: fwMinThrottleDownPitchAngle
         min: 0
         max: 450
-      - name: mixer_param_0
+      - name: mixer_param_a
         field: userParam[0]
         min: 0
         max: 200
-      - name: mixer_param_1
+      - name: mixer_param_b
         field: userParam[1]
         min: 0
         max: 200

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -37,6 +37,8 @@
 #define DSHOT_3D_DEADBAND_LOW  1047
 #define DSHOT_3D_DEADBAND_HIGH 1048
 
+#define MAX_MIXER_USER_PARAMS   2
+
 typedef enum {
     PLATFORM_MULTIROTOR     = 0,
     PLATFORM_AIRPLANE       = 1,
@@ -64,11 +66,12 @@ PG_DECLARE_ARRAY(motorMixer_t, MAX_SUPPORTED_MOTORS, primaryMotorMixer);
 
 typedef struct mixerConfig_s {
     int8_t yaw_motor_direction;
-    uint16_t yaw_jump_prevention_limit;      // make limit configurable (original fixed value was 100)
+    uint16_t yaw_jump_prevention_limit;         // make limit configurable (original fixed value was 100)
     uint8_t platformType;
     bool hasFlaps;
     int16_t appliedMixerPreset;
     uint16_t fwMinThrottleDownPitchAngle;
+    uint8_t userParam[MAX_MIXER_USER_PARAMS];   // User parameters (purpose is platform-dependent)
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -104,6 +104,7 @@ typedef struct servoMixer_s {
 #ifdef USE_LOGIC_CONDITIONS
     int8_t conditionId;
 #endif
+    int8_t userParamId;                     // Number of user-parameter multiplier
 } servoMixer_t;
 
 #define MAX_SERVO_RULES (2 * MAX_SUPPORTED_SERVOS)


### PR DESCRIPTION
Add up to 2 mixer parameters each ranging [0% ... 200%].
Add possibility to multiply a specific servo rule by a specific parameter (per-rule setup).
This will add ability to change weight of a group of servo mixer rules by a single parameter and make support for CCPM heli mixer easier:

Formula like this `S2=ColPitch + (Pitch * cos(120)+Roll * sin(120)) * PitchRollWeight` will be decomposed to 3 servo rules:

```
S2 += ColPitch
S2 += Pitch * cos(120) * PitchRollWeight  # where PitchRollWeight is a mixer_param_0
S2 += Roll * sin(120) * PitchRollWeight
```

This way Configurator won't have to recalculate mixer weights and reconfigure the mixer while still giving user a single parameter to control the weight of certain components of a servo output.

Configurator support required.

Context: https://github.com/iNavFlight/inav/pull/4701

FYI: @vltsvn, @DzikuVx 