### PR TITLE
Change VTX power level via switch

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: "\U0001F41B Bug report"
 about: Report an issue to help make INAV better
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: "\U0001F680Feature request"
 about: Suggest a new feature for INAV
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,6 +1,9 @@
 ---
-name: "\U00002753Question"
+name: "❓Question"
 about: Have a question?
+title: ''
+labels: ''
+assignees: ''
 
 ---
 
@@ -16,3 +19,5 @@ You can also read public documentations or watch video tutorials:
 * [Official Wiki](https://github.com/iNavFlight/inav/wiki)
 * [Video series by Painless360](https://www.youtube.com/playlist?list=PLYsWjANuAm4qdXEGFSeUhOZ10-H8YTSnH)
 * [Video series by Paweł Spychalski](https://www.youtube.com/playlist?list=PLOUQ8o2_nCLloACrA6f1_daCjhqY2x0fB)
+* [How to setup INAV on a flying wing](https://www.youtube.com/playlist?list=PLOUQ8o2_nCLn_lCX7UB2OPLzR4w5G4el3)
+* [How to setup INAV on a 5" quad](https://www.youtube.com/playlist?list=PLOUQ8o2_nCLl9M6Vm-ZNLMCr6_9yNVHQG)

--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -264,10 +264,10 @@ static const adjustmentConfig_t defaultAdjustmentConfigs[ADJUSTMENT_FUNCTION_COU
         .adjustmentFunction = ADJUSTMENT_FW_MIN_THROTTLE_DOWN_PITCH_ANGLE,
         .mode = ADJUSTMENT_MODE_STEP,
         .data = { .stepConfig = { .step = 5 }}
-	}, {
-		.adjustmentFunction = ADJUSTMENT_VTX_POWER_LEVEL,
-		.mode = ADJUSTMENT_MODE_STEP,
-		.data = { .stepConfig = { .step = 1 }}  
+    }, {
+        .adjustmentFunction = ADJUSTMENT_VTX_POWER_LEVEL,
+        .mode = ADJUSTMENT_MODE_STEP,
+        .data = { .stepConfig = { .step = 1 }}  
 #ifdef USE_INFLIGHT_PROFILE_ADJUSTMENT
     }, {
         .adjustmentFunction = ADJUSTMENT_PROFILE,
@@ -548,9 +548,9 @@ static void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t 
         case ADJUSTMENT_FW_MIN_THROTTLE_DOWN_PITCH_ANGLE:
             applyAdjustmentU16(ADJUSTMENT_FW_MIN_THROTTLE_DOWN_PITCH_ANGLE, &mixerConfigMutable()->fwMinThrottleDownPitchAngle, delta, 0, FW_MIN_THROTTLE_DOWN_PITCH_ANGLE_MAX);
             break;
-		case ADJUSTMENT_VTX_POWER_LEVEL:
-			applyAdjustmentU8(ADJUSTMENT_VTX_POWER_LEVEL, &vtxSettingsConfigMutable()->power, delta, VTX_SETTINGS_MIN_POWER, VTX_SETTINGS_MAX_POWER);
-			break;
+        case ADJUSTMENT_VTX_POWER_LEVEL:
+            applyAdjustmentU8(ADJUSTMENT_VTX_POWER_LEVEL, &vtxSettingsConfigMutable()->power, delta, VTX_SETTINGS_MIN_POWER, VTX_SETTINGS_MAX_POWER);
+            break;
         default:
             break;
     };

--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -33,6 +33,7 @@
 #include "config/parameter_group_ids.h"
 
 #include "drivers/time.h"
+#include "drivers/vtx_common.h"
 
 #include "fc/config.h"
 #include "fc/controlrate_profile.h"
@@ -45,6 +46,7 @@
 #include "flight/pid.h"
 
 #include "io/beeper.h"
+#include "io/vtx.h"
 
 #include "sensors/boardalignment.h"
 
@@ -262,6 +264,10 @@ static const adjustmentConfig_t defaultAdjustmentConfigs[ADJUSTMENT_FUNCTION_COU
         .adjustmentFunction = ADJUSTMENT_FW_MIN_THROTTLE_DOWN_PITCH_ANGLE,
         .mode = ADJUSTMENT_MODE_STEP,
         .data = { .stepConfig = { .step = 5 }}
+	}, {
+		.adjustmentFunction = ADJUSTMENT_VTX_POWER_LEVEL,
+		.mode = ADJUSTMENT_MODE_STEP,
+		.data = { .stepConfig = { .step = 1 }}  
 #ifdef USE_INFLIGHT_PROFILE_ADJUSTMENT
     }, {
         .adjustmentFunction = ADJUSTMENT_PROFILE,
@@ -542,6 +548,9 @@ static void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t 
         case ADJUSTMENT_FW_MIN_THROTTLE_DOWN_PITCH_ANGLE:
             applyAdjustmentU16(ADJUSTMENT_FW_MIN_THROTTLE_DOWN_PITCH_ANGLE, &mixerConfigMutable()->fwMinThrottleDownPitchAngle, delta, 0, FW_MIN_THROTTLE_DOWN_PITCH_ANGLE_MAX);
             break;
+		case ADJUSTMENT_VTX_POWER_LEVEL:
+			applyAdjustmentU8(ADJUSTMENT_VTX_POWER_LEVEL, &vtxSettingsConfigMutable()->power, delta, VTX_SETTINGS_MIN_POWER, VTX_SETTINGS_MAX_POWER);
+			break;
         default:
             break;
     };

--- a/src/main/fc/rc_adjustments.h
+++ b/src/main/fc/rc_adjustments.h
@@ -74,8 +74,9 @@ typedef enum {
     ADJUSTMENT_VEL_Z_I                  = 46,
     ADJUSTMENT_VEL_Z_D                  = 47,
     ADJUSTMENT_FW_MIN_THROTTLE_DOWN_PITCH_ANGLE = 48,
+    ADJUSTMENT_VTX_POWER_LEVEL = 49,
 #ifdef USE_INFLIGHT_PROFILE_ADJUSTMENT
-    ADJUSTMENT_PROFILE                  = 49,
+    ADJUSTMENT_PROFILE                  = 50,
 #endif
     ADJUSTMENT_FUNCTION_COUNT // must be last
 } adjustmentFunction_e;


### PR DESCRIPTION
Hi, 
this PR allow user to change VTX power during the flight.
I used "Adjustments" mechanism to avoid huge modification to iNav's code.

I'm not sure in "rc_adjustments.c" if it's correct to use "VTX_SETTINGS_MIN_POWER" and "VTX_SETTINGS_MAX_POWER" to constrain the variable which sets the power level.

My advice is to use a 3-pos switch or a potentiometer and set the same channel in "Range Channel" and "Adjustment Channel".

I tested it only on my Eachine Smartaudio VTX.

Note: i have PR ready for inav-configurator to add this feature. I'll wait for this to get accepted before proposing that.

EDIT: iNav Configurator PR [#775](https://github.com/iNavFlight/inav-configurator/pull/775)