### PR TITLE
I2C: Reduce timeout on F7 from 10s to 10ms

### DIFF
--- a/src/main/drivers/bus_i2c_hal.c
+++ b/src/main/drivers/bus_i2c_hal.c
@@ -82,7 +82,11 @@ static i2cDevice_t i2cHardwareMap[] = {
 
 static volatile uint16_t i2cErrorCount = 0;
 
-#define I2C_DEFAULT_TIMEOUT     10000
+// Note that I2C_TIMEOUT is in us, while the HAL
+// functions expect the timeout to be in ticks.
+// Since we're setting up the ticks a 1khz, each
+// tick equals 1ms.
+#define I2C_DEFAULT_TIMEOUT     (I2C_TIMEOUT / 1000)
 
 typedef struct i2cState_s {
     volatile bool initialised;


### PR DESCRIPTION
F3 and F4 are already using a 10ms timeout

References #4751