### PR TITLE
Update EZUHF RSSI doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: "\U0001F41B Bug report"
 about: Report an issue to help make INAV better
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: "\U0001F680Feature request"
 about: Suggest a new feature for INAV
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,6 +1,9 @@
 ---
-name: "\U00002753Question"
+name: "❓Question"
 about: Have a question?
+title: ''
+labels: ''
+assignees: ''
 
 ---
 
@@ -16,3 +19,5 @@ You can also read public documentations or watch video tutorials:
 * [Official Wiki](https://github.com/iNavFlight/inav/wiki)
 * [Video series by Painless360](https://www.youtube.com/playlist?list=PLYsWjANuAm4qdXEGFSeUhOZ10-H8YTSnH)
 * [Video series by Paweł Spychalski](https://www.youtube.com/playlist?list=PLOUQ8o2_nCLloACrA6f1_daCjhqY2x0fB)
+* [How to setup INAV on a flying wing](https://www.youtube.com/playlist?list=PLOUQ8o2_nCLn_lCX7UB2OPLzR4w5G4el3)
+* [How to setup INAV on a 5" quad](https://www.youtube.com/playlist?list=PLOUQ8o2_nCLl9M6Vm-ZNLMCr6_9yNVHQG)

--- a/docs/Rssi.md
+++ b/docs/Rssi.md
@@ -17,10 +17,11 @@ e.g. if you used channel 9 then you would set:
 ```
 set rssi_channel = 9
 ```
-Note: Some systems such as EZUHF invert the RSSI ( 0 = Full signal / 100 = Lost signal). To correct this problem you can invert the channel input so you will get a correct reading by using command:
+Note: Some systems such as EZUHF invert the RSSI ( 0 = Full signal / 100 = Lost signal). To correct this problem you can invert the RSSI scale so you will get a correct reading by using these commands:
 
 ```
-set rssi_ppm_invert = 1
+set rssi_min = 100
+set rssi_max = 0
 ```
 Default is set to "0" for normal operation ( 100 = Full signal / 0 = Lost signal).
 


### PR DESCRIPTION
The old rssi_ppm_invert doesn't exist any more. Use rssi_min and rssi_max to invert rssi for EZUHF.