### PR TITLE
OSD new icons for the Gforce

### DIFF
--- a/src/main/drivers/osd_symbols.h
+++ b/src/main/drivers/osd_symbols.h
@@ -197,6 +197,11 @@
 
 #define SYM_AH_V_START            0xE0 // 224 to 229 Vertical AHI
 
+#define SYM_GFORCE                0xE6 // 230 Gforce (all axis)
+#define SYM_GFORCE_X              0xE7 // 231 Gforce X
+#define SYM_GFORCE_Y              0xE8 // 232 Gforce Y
+#define SYM_GFORCE_Z              0xE9 // 233 Gforce Z
+
 #define SYM_BARO_TEMP             0xF0 // 240
 #define SYM_IMU_TEMP              0xF1 // 241
 #define SYM_TEMP                  0xF2 // 242

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2356,7 +2356,8 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_GFORCE:
         {
-            osdFormatCentiNumber(buff, GForce, 0, 2, 0, 3);
+            buff[0] = SYM_GFORCE;
+            osdFormatCentiNumber(buff + 1, GForce, 0, 2, 0, 3);
             if (GForce > osdConfig()->gforce_alarm * 100) {
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
             }
@@ -2368,7 +2369,8 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_GFORCE_Z:
         {
             float GForceValue = GForceAxis[item - OSD_GFORCE_X];
-            osdFormatCentiNumber(buff, GForceValue, 0, 2, 0, 4);
+            buff[0] = SYM_GFORCE_X + item - OSD_GFORCE_X;
+            osdFormatCentiNumber(buff + 1, GForceValue, 0, 2, 0, 4);
             if ((GForceValue < osdConfig()->gforce_axis_alarm_min * 100) || (GForceValue > osdConfig()->gforce_axis_alarm_max * 100)) {
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
             }


### PR DESCRIPTION
... icons placed before the datas, "g" alone would be an unit, but "g+(axis_symbol)" not really, so it goes before the values.