### PR TITLE
OSD: Add support for uploading 64 byte fonts

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -658,7 +658,7 @@ void max7456ReadNvm(uint16_t char_address, osdCharacter_t *chr)
 
     max7456WaitUntilNoBusy();
 
-    for (unsigned ii = 0; ii < sizeof(chr->data); ii++) {
+    for (unsigned ii = 0; ii < OSD_CHAR_VISIBLE_BYTES; ii++) {
         busWrite(state.dev, MAX7456ADD_CMAL, ii);
         busRead(state.dev, MAX7456ADD_CMDO, &chr->data[ii]);
     }
@@ -699,7 +699,7 @@ void max7456WriteNvm(uint16_t char_address, const osdCharacter_t *chr)
         or_val = addr_h << 6;
     }
 
-    for (unsigned x = 0; x < sizeof(chr->data); x++) {
+    for (unsigned x = 0; x < OSD_CHAR_VISIBLE_BYTES; x++) {
         bufPtr = max7456PrepareBuffer(spiBuff, bufPtr, MAX7456ADD_CMAL, x | or_val); //set start address low
         bufPtr = max7456PrepareBuffer(spiBuff, bufPtr, MAX7456ADD_CMDI, chr->data[x]);
     }

--- a/src/main/drivers/osd.h
+++ b/src/main/drivers/osd.h
@@ -25,7 +25,10 @@
 #define OSD_CHAR_WIDTH 12
 #define OSD_CHAR_HEIGHT 18
 #define OSD_CHAR_BITS_PER_PIXEL 2
-#define OSD_CHAR_BYTES (OSD_CHAR_WIDTH * OSD_CHAR_HEIGHT * OSD_CHAR_BITS_PER_PIXEL / 8)
+#define OSD_CHAR_VISIBLE_BYTES (OSD_CHAR_WIDTH * OSD_CHAR_HEIGHT * OSD_CHAR_BITS_PER_PIXEL / 8)
+// Only the first 54 bytes of a character represent visible data. However, some OSD drivers
+// accept 64 bytes and use the extra 10 bytes for metadata.
+#define OSD_CHAR_BYTES 64
 
 #define OSD_CHARACTER_COLOR_BLACK 0
 #define OSD_CHARACTER_COLOR_TRANSPARENT 1


### PR DESCRIPTION
Although visible data is only 54 bytes, some drivers can accept
64 bytes and use the remaining 10 for metadata. MAX7456 driver
ignores the extra 10 bytes.