### PR TITLE
[WIP] Cylindrical geofence

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -202,6 +202,7 @@ A shorter form is also supported to enable and disable functions using `serial <
 |  nav_rth_abort_threshold  | 50000 | RTH sanity checking feature will notice if distance to home is increasing during RTH and once amount of increase exceeds the threshold defined by this parameter, instead of continuing RTH machine will enter emergency landing, self-level and go down safely. Default is 500m which is safe enough for both multirotor machines and airplanes. [cm] |
 |  geofence_radius  | 0 | Radius of the cylinder centered on the home point out of which the aircraft will enter F/S. A value of 0 disables horizontal geofencing. [m] |
 |  geofence_height  | 0 | Height of the cylinder centered on the home point out of which the aircraft will enter F/S. A value of 0 disables vertical geofencing. [m] |
+|  geofence_buffer  | 10 | A threshold to let the pilot disengage F/S after having crossed the geofence boundaries. Represents the distance towards the home point that can be flown without re-triggering F/S. [m] |
 |  nav_mc_bank_angle  | 30 | Maximum banking angle (deg) that multicopter navigation is allowed to set. Machine must be able to satisfy this angle without loosing altitude |
 |  nav_mc_hover_thr  | 1500 | Multicopter hover throttle hint for altitude controller. Should be set to approximate throttle value when drone is hovering. |
 |  nav_mc_auto_disarm_delay  | 2000 |  |

--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -200,6 +200,8 @@ A shorter form is also supported to enable and disable functions using `serial <
 |  nav_rth_altitude  | 1000 | Used in EXTRA, FIXED and AT_LEAST rth alt modes [cm] (Default 1000 means 10 meters) |
 |  nav_rth_home_altitude  | 0 | Aircraft will climb/descend to this altitude after reaching home if landing is not enabled. Set to 0 to stay at `nav_rth_altitude` (default) [cm] |
 |  nav_rth_abort_threshold  | 50000 | RTH sanity checking feature will notice if distance to home is increasing during RTH and once amount of increase exceeds the threshold defined by this parameter, instead of continuing RTH machine will enter emergency landing, self-level and go down safely. Default is 500m which is safe enough for both multirotor machines and airplanes. [cm] |
+|  geofence_radius  | 0 | Radius of the cylinder centered on the home point out of which the aircraft will enter F/S. A value of 0 disables horizontal geofencing. [m] |
+|  geofence_height  | 0 | Height of the cylinder centered on the home point out of which the aircraft will enter F/S. A value of 0 disables vertical geofencing. [m] |
 |  nav_mc_bank_angle  | 30 | Maximum banking angle (deg) that multicopter navigation is allowed to set. Machine must be able to satisfy this angle without loosing altitude |
 |  nav_mc_hover_thr  | 1500 | Multicopter hover throttle hint for altitude controller. Should be set to approximate throttle value when drone is hovering. |
 |  nav_mc_auto_disarm_delay  | 2000 |  |

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1210,6 +1210,8 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         sbufWriteU16(dst, navConfig()->general.land_slowdown_minalt);
         sbufWriteU16(dst, navConfig()->general.land_slowdown_maxalt);
         sbufWriteU16(dst, navConfig()->general.emerg_descent_rate);
+        sbufWriteU32(dst, navConfig()->general.geofence_radius);
+        sbufWriteU32(dst, navConfig()->general.geofence_height);
         break;
 
     case MSP_FW_CONFIG:
@@ -2128,6 +2130,8 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             navConfigMutable()->general.land_slowdown_minalt = sbufReadU16(src);
             navConfigMutable()->general.land_slowdown_maxalt = sbufReadU16(src);
             navConfigMutable()->general.emerg_descent_rate = sbufReadU16(src);
+            navConfigMutable()->general.geofence_radius = sbufReadU32(src);
+            navConfigMutable()->general.geofence_height = sbufReadU32(src);
         } else
             return MSP_RESULT_ERROR;
         break;

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1210,8 +1210,6 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         sbufWriteU16(dst, navConfig()->general.land_slowdown_minalt);
         sbufWriteU16(dst, navConfig()->general.land_slowdown_maxalt);
         sbufWriteU16(dst, navConfig()->general.emerg_descent_rate);
-        sbufWriteU32(dst, navConfig()->general.geofence_radius);
-        sbufWriteU32(dst, navConfig()->general.geofence_height);
         break;
 
     case MSP_FW_CONFIG:
@@ -2130,8 +2128,6 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             navConfigMutable()->general.land_slowdown_minalt = sbufReadU16(src);
             navConfigMutable()->general.land_slowdown_maxalt = sbufReadU16(src);
             navConfigMutable()->general.emerg_descent_rate = sbufReadU16(src);
-            navConfigMutable()->general.geofence_radius = sbufReadU32(src);
-            navConfigMutable()->general.geofence_height = sbufReadU32(src);
         } else
             return MSP_RESULT_ERROR;
         break;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1366,6 +1366,12 @@ groups:
       - name: nav_rth_home_altitude
         field: general.rth_home_altitude
         max: 65000
+      - name: geofence_radius
+        field: general.geofence_radius
+        max: 4294967295
+      - name: geofence_height
+        field: general.geofence_radius
+        max: 4294967295
 
       - name: nav_mc_bank_angle
         field: mc.max_bank_angle

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1372,6 +1372,9 @@ groups:
       - name: geofence_height
         field: general.geofence_radius
         max: 4294967295
+      - name: geofence_buffer
+        field: general.geofence_buffer
+        max: 100
 
       - name: nav_mc_bank_angle
         field: mc.max_bank_angle

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3091,11 +3091,19 @@ void updateFlightBehaviorModifiers(void)
 
 void processGeofenceStatus(void)
 {
-    // No need to update status if F/S has already been enforced
-    if (getStateOfForcedRTH() == RTH_IDLE) {
+    static bool geofenceTriggered = false;
+
+    if (!geofenceTriggered) {
         if ((navConfig()->general.geofence_radius > 0 && GPS_distanceToHome > navConfig()->general.geofence_radius) || (navConfig()->general.geofence_height > 0 && posControl.actualState.abs.pos.z > navConfig()->general.geofence_height * 100)) {
-            activateForcedRTH();
+            geofenceTriggered = true;
+            // No need to update status if F/S has already been enforced
+            if (getStateOfForcedRTH() == RTH_IDLE) {
+                    activateForcedRTH();
+            }
         }
+    // Only re-enable geofence if the aircraft gets back inside it
+    } else if (GPS_distanceToHome < navConfig()->general.geofence_radius && posControl.actualState.abs.pos.z < navConfig()->general.geofence_height * 100) {
+        geofenceTriggered = false;
     }
 }
 

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -171,8 +171,9 @@ typedef struct navConfig_s {
         uint16_t min_rth_distance;              // 0 Disables. Minimal distance for RTH in cm, otherwise it will just autoland
         uint16_t rth_abort_threshold;           // Initiate emergency landing if during RTH we get this much [cm] away from home
         uint16_t max_terrain_follow_altitude;   // Max altitude to be used in SURFACE TRACKING mode
-        uint16_t geofence_radius;               // cylindrical geofence radius (m)
-        uint16_t geofence_height;               // cylindrical geofence height (m)
+        uint32_t geofence_radius;               // cylindrical geofence radius (m)
+        uint32_t geofence_height;               // cylindrical geofence height (m)
+        uint16_t geofence_buffer;               // minimum distance inwards from limit to re-enable geofence (m)
     } general;
 
     struct {

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -32,7 +32,7 @@
 
 /* GPS Home location data */
 extern gpsLocation_t        GPS_home;
-extern uint32_t             GPS_distanceToHome;        // distance to home point in meters 
+extern uint32_t             GPS_distanceToHome;        // distance to home point in meters
 extern int16_t              GPS_directionToHome;       // direction to home point in degrees
 
 extern bool autoThrottleManuallyIncreased;
@@ -171,6 +171,8 @@ typedef struct navConfig_s {
         uint16_t min_rth_distance;              // 0 Disables. Minimal distance for RTH in cm, otherwise it will just autoland
         uint16_t rth_abort_threshold;           // Initiate emergency landing if during RTH we get this much [cm] away from home
         uint16_t max_terrain_follow_altitude;   // Max altitude to be used in SURFACE TRACKING mode
+        uint16_t geofence_radius;               // cylindrical geofence radius (m)
+        uint16_t geofence_height;               // cylindrical geofence height (m)
     } general;
 
     struct {


### PR DESCRIPTION
This PR enables the definition of a cylindrical geofence with both horizontal (distance from home) and vertical (altitude from home) boundaries, partially implementing #62.

New settings:
+ `geofence_radius`
+ `geofence_height`
+ `geofence_buffer`

Behavior:
1. Aircraft exceeds horizontal (`geofence_radius`, _red line below)_, vertical (`geofence_height`) or both boundaries.
2. RTH is engaged.
    - Pilot lets the aircraft fly home.
      + Usual RTH behavior.
    - Pilot moves the sticks and disengages RTH, thus proceeding outside the geofence.
      + Geofence gets disabled until the aircraft comes back inside the boundaries plus `geofence_buffer` meters _(blue line below is the buffer size, green the resulting boundary)_. This gives some more room to disengage RTH and get back on track, especially with MRs.

![geofence](https://user-images.githubusercontent.com/3594528/58982855-ba9ac600-87d5-11e9-8b54-8a8e082a7d6c.png)

---

+ [ ] Field tested
+ [X] ~~Configurator PR~~ Should this feature be configurable via CLI only?
