### PR TITLE
Reduce LEDSTRIP timer clock to match CPU clock

### DIFF
--- a/src/main/drivers/light_ws2811strip.h
+++ b/src/main/drivers/light_ws2811strip.h
@@ -26,7 +26,7 @@
 
 #define WS2811_DMA_BUFFER_SIZE (WS2811_DATA_BUFFER_SIZE + WS2811_DELAY_BUFFER_LENGTH)   // number of bytes needed is #LEDs * 24 bytes + 42 trailing bytes)
 
-#define WS2811_TIMER_HZ         24000000
+#define WS2811_TIMER_HZ         2400000
 #define WS2811_CARRIER_HZ       800000
 
 void ws2811LedStripInit(void);


### PR DESCRIPTION
LEDSTRIP timer frequency has value to of 24MHz. On F3 (timer clock 72MHz) this yields prescaler of 3 and everything works normally.

However on F405 (timer clock either 168 or 84 MHz) this may yield a non-integer prescaler of 3.5 on certain timers. 
INAV 2.1 used truncation and yielded LEDSTRIP carrier frequency of 933KHz.
INAV 2.2 uses proper rounding and generates LEDSTRIP carrier of 700KHz.

WS2811 expects carrier of 800KHz and based on individual chip tolerances may work (or not work) with different frequency.

This PR lowers timer frequency to 2.4MHz and ensures that integer prescaler is calculated for the following timer clocks: 72 MHz (F3); 84, 168 (F405), 108, 216 (F722).
On F411 operating at 84MHz CPU clock on certain timers this will generate a prescaler of 17.5 (rounded up to 18), but this will yield carrier frequency of 778kHz which should be close enough.

Fixes #4783