### PR TITLE
Fix FAILSAFE and NAV co-existence

### DIFF
--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -135,7 +135,6 @@ typedef struct failsafeState_s {
     bool suspended;                         // Failsafe is temporary suspended. This happens when we temporary suspend RX system due to EEPROM write/read
     bool active;                            // Failsafe is active (on RC link loss)
     bool controlling;                       // Failsafe is driving the sticks instead of pilot
-    bool bypassNavigation;
     timeMs_t rxDataFailurePeriod;
     timeMs_t rxDataRecoveryPeriod;
     timeMs_t validRxDataReceivedAt;
@@ -144,6 +143,7 @@ typedef struct failsafeState_s {
     timeMs_t landingShouldBeFinishedAt;
     timeMs_t receivingRxDataPeriod;         // period for the required period of valid rxData
     timeMs_t receivingRxDataPeriodPreset;   // preset for the required period of valid rxData
+    failsafeProcedure_e activeProcedure;
     failsafePhase_e phase;
     failsafeRxLinkState_e rxLinkState;
     int16_t lastGoodRcCommand[4];


### PR DESCRIPTION
When different failsafe procedures are used and chosen at run-time (see https://github.com/iNavFlight/inav/issues/4822 for context) failsafe subsystem may consider different failsafe procedures for different checks and cause misbehavior when both NAV and FAILSAFE are involved.

This PR ensures that failsafe procedure is selected when entering failsafe and is consistently used across the whole failsafe sequence.