### PR TITLE
Fixed value option in mixer

### DIFF
--- a/docs/Mixer.md
+++ b/docs/Mixer.md
@@ -50,6 +50,7 @@ Each servo mixing rule has the following parameters:
 * Input: the input for the mixing rule, see a summary of the input types table bellow.
 * Weight: percentage of the input to forward to the servo. Range [-1000, 1000]. Mixing rule output = input * weight. If the output of a set of mixing rules is lower/higher than the defined servo min/max the output is clipped (the servo will never travel farther than the set min/max).
 * Speed: maximum rate of change of the mixing rule output. Used to limit the servo speed. 1 corresponds to maximum 10µs/s output rate of change. Set to 0 for no speed limit. For example: 10 = full sweep (1000 to 2000) in 10s, 100 = full sweep in 1s.
+* Fixed value: a constant µs value the output will be set to if the selected input source is "Fixed Value".
 
 | CLI input ID | Mixer input | Description |
 |----|--------------------------|------------------------------------------------------------------------------|
@@ -65,8 +66,8 @@ Each servo mixing rule has the following parameters:
 | 9  | RC channel 6             | Raw RC channel 6 |
 | 10 | RC channel 7             | Raw RC channel 7 |
 | 11 | RC channel 8             | Raw RC channel 8 |
-| 12 | GIMBAL PITCH             | Scaled pitch attitude of the aircraft [-90°, 90°] => [-500, 500] |
-| 13 | GIMBAL ROLL              | Scaled roll attitude of the aircraft [-180°, 180°] => [-500, 500] |
+| 12 | GIMBAL PITCH             | Scaled pitch attitude of the aircraft [-90°, 90°] => [-500, +500] from middle value |
+| 13 | GIMBAL ROLL              | Scaled roll attitude of the aircraft [-180°, 180°] => [-500, +500] from middle value |
 | 14 | FEATURE FLAPS            | This input value is equal to the `flaperon_throw_offset` setting when the `FLAPERON` flight mode is enabled, 0 otherwise |
 | 15 | RC channel 9             | Raw RC channel 9 |
 | 16 | RC channel 10            | Raw RC channel 10 |
@@ -76,18 +77,19 @@ Each servo mixing rule has the following parameters:
 | 20 | RC channel 14            | Raw RC channel 14 |
 | 21 | RC channel 15            | Raw RC channel 15 |
 | 22 | RC channel 16            | Raw RC channel 16 |
-| 23 | Stabilized ROLL+         | Clipped between 0 and 1000 |       
+| 23 | Stabilized ROLL+         | Clipped between 0 and 1000 |
 | 24 | Stabilized ROLL-         | Clipped between -1000 and 0 |
 | 25 | Stabilized PITCH+        | Clipped between 0 and 1000 |
 | 26 | Stabilized PITCH-        | Clipped between -1000 and 0 |
 | 27 | Stabilized YAW+          | Clipped between 0 and 1000 |
 | 28 | Stabilized YAW-          | Clipped between -1000 and 0 |
-| 29 | One                      | Constant value of 500 |
+| 29 | One                      | Constant value of +500 from middle value |
+| 30 | Fixed Value              | A configurable constant µs value [1000, 2000] |
 
 The `smix reset` command removes all the existing motor mixing rules.
 
 The `smix` command is used to list, create or modify rules. To list the currently defined rules run the `smix` command without parameters.
 
-To create or modify rules use the `smix` command with the following syntax: `smix <n> <servo_index> <input_id> <weight> <speed> <logic_condition_id>`. `<n>` is representing the index of the servo mixing rule to create or modify (integer). To disable a mixing rule set the weight to 0.
+To create or modify rules use the `smix` command with the following syntax: `smix <n> <servo_index> <input_id> <weight> <speed> <fixed_value> <logic_condition_id>`. `<n>` is representing the index of the servo mixing rule to create or modify (integer). To disable a mixing rule set the weight to 0.
 
-`logic_condition_id` default value is `-1` for rules that should be always executed. 
+`logic_condition_id` default value is `-1` for rules that should be always executed.

--- a/src/main/cms/cms_menu_mixer_servo.c
+++ b/src/main/cms/cms_menu_mixer_servo.c
@@ -155,6 +155,7 @@ static void loadServoMixerSettings(void)
     tmpServoMixer.inputSource = customServoMixers(currentServoMixerIndex)->inputSource;
     tmpServoMixer.rate = customServoMixers(currentServoMixerIndex)->rate;
     tmpServoMixer.speed = customServoMixers(currentServoMixerIndex)->speed;
+    tmpServoMixer.fixedValue = customServoMixers(currentServoMixerIndex)->fixedValue;
 }
 
 static void saveServoMixerSettings(void)
@@ -163,6 +164,7 @@ static void saveServoMixerSettings(void)
     customServoMixersMutable(currentServoMixerIndex)->inputSource = tmpServoMixer.inputSource;
     customServoMixersMutable(currentServoMixerIndex)->rate = tmpServoMixer.rate;
     customServoMixersMutable(currentServoMixerIndex)->speed = tmpServoMixer.speed;
+    customServoMixersMutable(currentServoMixerIndex)->fixedValue = tmpServoMixer.fixedValue;
 
 }
 
@@ -204,6 +206,7 @@ static const OSD_Entry cmsx_menuServoMixerEntries[] =
        OSD_TAB_DYN_ENTRY("INPUT", (&(const OSD_TAB_t){ &tmpServoMixer.inputSource, SERVO_MIXER_INPUT_CMS_NAMES_COUNT - 1, servoMixerInputCmsNames})),
        OSD_INT16_DYN_ENTRY("WEIGHT", (&(const OSD_INT16_t){&tmpServoMixer.rate, 0, 1000, 1})),
        OSD_UINT8_DYN_ENTRY("SPEED", (&(const OSD_UINT8_t){&tmpServoMixer.speed, 0, 255, 1})),
+       OSD_UINT16_DYN_ENTRY("FIXVAL", (&(const OSD_UINT16_t){&tmpServoMixer.fixedValue, 1000, 2000, 1})),
        OSD_BACK_AND_END_ENTRY
 };
 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1577,7 +1577,7 @@ static void cliServo(char *cmdline)
 
 static void printServoMix(uint8_t dumpMask, const servoMixer_t *customServoMixers, const servoMixer_t *defaultCustomServoMixers)
 {
-    const char *format = "smix %d %d %d %d %d %d";
+    const char *format = "smix %d %d %d %d %d %d %d";
     for (uint32_t i = 0; i < MAX_SERVO_RULES; i++) {
         const servoMixer_t customServoMixer = customServoMixers[i];
         if (customServoMixer.rate == 0) {
@@ -1591,6 +1591,7 @@ static void printServoMix(uint8_t dumpMask, const servoMixer_t *customServoMixer
                 && customServoMixer.inputSource == customServoMixerDefault.inputSource
                 && customServoMixer.rate == customServoMixerDefault.rate
                 && customServoMixer.speed == customServoMixerDefault.speed
+                && customServoMixer.fixedValue == customServoMixerDefault.fixedValue
             #ifdef USE_LOGIC_CONDITIONS
                 && customServoMixer.conditionId == customServoMixerDefault.conditionId
             #endif
@@ -1602,6 +1603,7 @@ static void printServoMix(uint8_t dumpMask, const servoMixer_t *customServoMixer
                 customServoMixerDefault.inputSource,
                 customServoMixerDefault.rate,
                 customServoMixerDefault.speed,
+                customServoMixerDefault.fixedValue,
             #ifdef USE_LOGIC_CONDITIONS
                 customServoMixer.conditionId
             #else
@@ -1615,6 +1617,7 @@ static void printServoMix(uint8_t dumpMask, const servoMixer_t *customServoMixer
             customServoMixer.inputSource,
             customServoMixer.rate,
             customServoMixer.speed,
+            customServoMixer.fixedValue,
         #ifdef USE_LOGIC_CONDITIONS
             customServoMixer.conditionId
         #else
@@ -1636,7 +1639,7 @@ static void cliServoMix(char *cmdline)
         // erase custom mixer
         pgResetCopy(customServoMixersMutable(0), PG_SERVO_MIXER);
     } else {
-        enum {RULE = 0, TARGET, INPUT, RATE, SPEED, CONDITION, ARGS_COUNT};
+        enum {RULE = 0, TARGET, INPUT, RATE, SPEED, FIXED_VALUE, CONDITION, ARGS_COUNT};
         char *ptr = strtok_r(cmdline, " ", &saveptr);
         args[CONDITION] = -1;
         while (ptr != NULL && check < ARGS_COUNT) {
@@ -1656,12 +1659,14 @@ static void cliServoMix(char *cmdline)
             args[INPUT] >= 0 && args[INPUT] < INPUT_SOURCE_COUNT &&
             args[RATE] >= -1000 && args[RATE] <= 1000 &&
             args[SPEED] >= 0 && args[SPEED] <= MAX_SERVO_SPEED &&
+            args[FIXED_VALUE] >= 1000 && args[FIXED_VALUE] <= 2000 &&
             args[CONDITION] >= -1 && args[CONDITION] < MAX_LOGIC_CONDITIONS
         ) {
             customServoMixersMutable(i)->targetChannel = args[TARGET];
             customServoMixersMutable(i)->inputSource = args[INPUT];
             customServoMixersMutable(i)->rate = args[RATE];
             customServoMixersMutable(i)->speed = args[SPEED];
+            customServoMixersMutable(i)->fixedValue = args[FIXED_VALUE];
         #ifdef USE_LOGIC_CONDITIONS
             customServoMixersMutable(i)->conditionId = args[CONDITION];
         #endif
@@ -3153,7 +3158,7 @@ const clicmd_t cmdTable[] = {
 #endif
     CLI_COMMAND_DEF("set", "change setting", "[<name>=<value>]", cliSet),
     CLI_COMMAND_DEF("smix", "servo mixer",
-        "<rule> <servo> <source> <rate> <speed> <conditionId>\r\n"
+        "<rule> <servo> <source> <rate> <speed> <fixed value> <logic condition id>\r\n"
         "\treset\r\n", cliServoMix),
 #ifdef USE_SDCARD
     CLI_COMMAND_DEF("sd_info", "sdcard info", NULL, cliSdInfo),

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1630,7 +1630,7 @@ static void printServoMix(uint8_t dumpMask, const servoMixer_t *customServoMixer
 static void cliServoMix(char *cmdline)
 {
     char * saveptr;
-    int args[6], check = 0;
+    int args[7], check = 0;
     uint8_t len = strlen(cmdline);
 
     if (len == 0) {
@@ -1641,13 +1641,14 @@ static void cliServoMix(char *cmdline)
     } else {
         enum {RULE = 0, TARGET, INPUT, RATE, SPEED, FIXED_VALUE, CONDITION, ARGS_COUNT};
         char *ptr = strtok_r(cmdline, " ", &saveptr);
+        args[FIXED_VALUE] = 1500;
         args[CONDITION] = -1;
         while (ptr != NULL && check < ARGS_COUNT) {
             args[check++] = fastA2I(ptr);
             ptr = strtok_r(NULL, " ", &saveptr);
         }
 
-        if (ptr != NULL || (check < ARGS_COUNT - 1)) {
+        if (ptr != NULL || (check < ARGS_COUNT - 2) || (check > ARGS_COUNT)) {
             cliShowParseError();
             return;
         }
@@ -3158,7 +3159,7 @@ const clicmd_t cmdTable[] = {
 #endif
     CLI_COMMAND_DEF("set", "change setting", "[<name>=<value>]", cliSet),
     CLI_COMMAND_DEF("smix", "servo mixer",
-        "<rule> <servo> <source> <rate> <speed> <fixed value> <logic condition id>\r\n"
+        "<rule> <servo> <source> <rate> <speed> [<fixed value> <logic condition id>]\r\n"
         "\treset\r\n", cliServoMix),
 #ifdef USE_SDCARD
     CLI_COMMAND_DEF("sd_info", "sdcard info", NULL, cliSdInfo),

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -471,6 +471,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
             sbufWriteU8(dst, customServoMixers(i)->inputSource);
             sbufWriteU16(dst, customServoMixers(i)->rate);
             sbufWriteU8(dst, customServoMixers(i)->speed);
+            sbufWriteU16(dst, customServoMixers(i)->fixedValue);
         #ifdef USE_LOGIC_CONDITIONS
             sbufWriteU8(dst, customServoMixers(i)->conditionId);
         #else
@@ -1886,11 +1887,12 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP2_INAV_SET_SERVO_MIXER:
         sbufReadU8Safe(&tmp_u8, src);
-        if ((dataSize == 7) && (tmp_u8 < MAX_SERVO_RULES)) {
+        if ((dataSize == 9) && (tmp_u8 < MAX_SERVO_RULES)) {
             customServoMixersMutable(tmp_u8)->targetChannel = sbufReadU8(src);
             customServoMixersMutable(tmp_u8)->inputSource = sbufReadU8(src);
             customServoMixersMutable(tmp_u8)->rate = sbufReadU16(src);
             customServoMixersMutable(tmp_u8)->speed = sbufReadU8(src);
+            customServoMixersMutable(tmp_u8)->fixedValue = sbufReadU16(src);
         #ifdef USE_LOGIC_CONDITIONS
             customServoMixersMutable(tmp_u8)->conditionId = sbufReadU8(src);
         #else

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -62,7 +62,7 @@ PG_RESET_TEMPLATE(servoConfig_t, servoConfig,
     .tri_unarmed_servo = 1
 );
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(servoMixer_t, MAX_SERVO_RULES, customServoMixers, PG_SERVO_MIXER, 1);
+PG_REGISTER_ARRAY_WITH_RESET_FN(servoMixer_t, MAX_SERVO_RULES, customServoMixers, PG_SERVO_MIXER, 2);
 
 void pgResetFn_customServoMixers(servoMixer_t *instance)
 {
@@ -71,7 +71,8 @@ void pgResetFn_customServoMixers(servoMixer_t *instance)
             .targetChannel = 0,
             .inputSource = 0,
             .rate = 0,
-            .speed = 0
+            .speed = 0,
+            .fixedValue = 1500
 #ifdef USE_LOGIC_CONDITIONS
             ,.conditionId = -1
 #endif
@@ -317,6 +318,11 @@ void servoMixer(float dT)
 
         const uint8_t target = currentServoMixer[i].targetChannel;
         const uint8_t from = currentServoMixer[i].inputSource;
+
+        if (from == INPUT_FIXED_VALUE) {
+            // Must be [-500:+500], so center it around middle value (data - middle = input)
+            input[INPUT_FIXED_VALUE] = constrain(currentServoMixer[i].fixedValue - 1500, -500, 500);
+        }
 
         /*
          * Apply mixer speed limit. 1 [one] speed unit is defined as 10us/s:

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -54,6 +54,7 @@ typedef enum {
     INPUT_STABILIZED_YAW_PLUS       = 27,
     INPUT_STABILIZED_YAW_MINUS      = 28,
     INPUT_LOGIC_ONE                 = 29,
+    INPUT_FIXED_VALUE               = 30,
 
     INPUT_SOURCE_COUNT
 } inputSource_e;
@@ -101,6 +102,7 @@ typedef struct servoMixer_s {
     uint8_t inputSource;                    // input channel for this rule
     int16_t rate;                           // range [-1000;+1000] ; can be used to adjust a rate 0-1000% and a direction
     uint8_t speed;                          // reduces the speed of the rule, 0=unlimited speed
+    uint16_t fixedValue;                    // range [1000;2000] ; used to output a fixed value
 #ifdef USE_LOGIC_CONDITIONS
     int8_t conditionId;
 #endif


### PR DESCRIPTION
Follow up to #4833, adds the option to have a mixer rule output a constant configurable value between 1000 and 2000 µs.

---

+ [X] Configurator PR: iNavFlight/inav-configurator#795
+ [X] Bench testing