### PR TITLE
CLI batch mode

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -135,6 +135,11 @@ static uint32_t bufferIndex = 0;
 static void cliAssert(char *cmdline);
 #endif
 
+#ifdef USE_CLI_BATCH
+static bool commandBatchActive = false;
+static bool commandBatchError = false;
+#endif
+
 // sync this with features_e
 static const char * const featureNames[] = {
     "THR_VBAT_COMP", "VBAT", "TX_PROF_SEL", "BAT_PROF_AUTOSWITCH", "MOTOR_STOP",
@@ -207,6 +212,28 @@ static void cliPrintLine(const char *str)
 {
     cliPrint(str);
     cliPrintLinefeed();
+}
+
+static void cliPrintError(const char *str)
+{
+    cliPrint("### ERROR: ");
+    cliPrint(str);
+#ifdef USE_CLI_BATCH
+    if (commandBatchActive) {
+        commandBatchError = true;
+    }
+#endif
+}
+
+static void cliPrintErrorLine(const char *str)
+{
+    cliPrint("### ERROR: ");
+    cliPrintLine(str);
+#ifdef USE_CLI_BATCH
+    if (commandBatchActive) {
+        commandBatchError = true;
+    }
+#endif
 }
 
 #ifdef CLI_MINIMAL_VERBOSITY
@@ -298,6 +325,27 @@ static void cliPrintLinef(const char *format, ...)
     va_end(va);
 }
 
+static void cliPrintErrorVa(const char *format, va_list va)
+{
+    cliPrint("### ERROR: ");
+    cliPrintfva(format, va);
+    va_end(va);
+
+#ifdef USE_CLI_BATCH
+    if (commandBatchActive) {
+        commandBatchError = true;
+    }
+#endif
+}
+
+static void cliPrintErrorLinef(const char *format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    cliPrintErrorVa(format, va);
+    cliPrintLinefeed();
+}
+
 static void printValuePointer(const setting_t *var, const void *valuePointer, uint32_t full)
 {
     int32_t value = 0;
@@ -358,7 +406,7 @@ static void printValuePointer(const setting_t *var, const void *valuePointer, ui
             cliPrintf(name);
         } else {
             settingGetName(var, buf);
-            cliPrintLinef("VALUE %d OUT OF RANGE FOR %s", (int)value, buf);
+            cliPrintErrorLinef("VALUE %d OUT OF RANGE FOR %s", (int)value, buf);
         }
         break;
     }
@@ -512,12 +560,12 @@ static void cliPrompt(void)
 
 static void cliShowParseError(void)
 {
-    cliPrintLine("Parse error");
+    cliPrintErrorLinef("Parse error");
 }
 
 static void cliShowArgumentRangeError(char *name, int min, int max)
 {
-    cliPrintLinef("%s must be between %d and %d", name, min, max);
+    cliPrintErrorLinef("%s must be between %d and %d", name, min, max);
 }
 
 static const char *nextArg(const char *currentArg)
@@ -564,11 +612,16 @@ static void cliAssert(char *cmdline)
 
     if (assertFailureLine) {
         if (assertFailureFile) {
-            cliPrintLinef("Assertion failed at line %d, file %s", assertFailureLine, assertFailureFile);
+            cliPrintErrorLinef("Assertion failed at line %d, file %s", assertFailureLine, assertFailureFile);
         }
         else {
-            cliPrintLinef("Assertion failed at line %d", assertFailureLine);
+            cliPrintErrorLinef("Assertion failed at line %d", assertFailureLine);
         }
+#ifdef USE_CLI_BATCH
+        if (commandBatchActive) {
+            commandBatchError = true;
+        }
+#endif
     }
     else {
         cliPrintLine("No assert() failed");
@@ -700,7 +753,7 @@ static void cliSerial(char *cmdline)
     currentConfig = serialFindPortConfiguration(val);
     if (!currentConfig) {
         // Invalid port ID
-        cliPrintLinef("Invalid port ID %d", val);
+        cliPrintErrorLinef("Invalid port ID %d", val);
         return;
     }
     memcpy(&portConfig, currentConfig, sizeof(portConfig));
@@ -1679,11 +1732,11 @@ static void printLogic(uint8_t dumpMask, const logicCondition_t *logicConditions
     const char *format = "logic %d %d %d %d %d %d %d %d";
     for (uint32_t i = 0; i < MAX_LOGIC_CONDITIONS; i++) {
         const logicCondition_t logic = logicConditions[i];
-        
+
         bool equalsDefault = false;
         if (defaultLogicConditions) {
             logicCondition_t defaultValue = defaultLogicConditions[i];
-            equalsDefault = 
+            equalsDefault =
                 logic.enabled == defaultValue.enabled &&
                 logic.operation == defaultValue.operation &&
                 logic.operandA.type == defaultValue.operandA.type &&
@@ -1730,9 +1783,9 @@ static void cliLogic(char *cmdline) {
             INDEX = 0,
             ENABLED,
             OPERATION,
-            OPERAND_A_TYPE, 
+            OPERAND_A_TYPE,
             OPERAND_A_VALUE,
-            OPERAND_B_TYPE, 
+            OPERAND_B_TYPE,
             OPERAND_B_VALUE,
             FLAGS,
             ARGS_COUNT
@@ -1758,7 +1811,7 @@ static void cliLogic(char *cmdline) {
             args[OPERAND_B_TYPE] >= 0 && args[OPERAND_B_TYPE] < LOGIC_CONDITION_OPERAND_TYPE_LAST &&
             args[OPERAND_B_VALUE] >= -1000000 && args[OPERAND_B_VALUE] <= 1000000 &&
             args[FLAGS] >= 0 && args[FLAGS] <= 255
-        
+
         ) {
             logicConditionsMutable(i)->enabled = args[ENABLED];
             logicConditionsMutable(i)->operation = args[OPERATION];
@@ -2115,7 +2168,7 @@ static void cliFeature(char *cmdline)
 
         for (uint32_t i = 0; ; i++) {
             if (featureNames[i] == NULL) {
-                cliPrintLine("Invalid name");
+                cliPrintErrorLine("Invalid name");
                 break;
             }
 
@@ -2124,7 +2177,7 @@ static void cliFeature(char *cmdline)
                 mask = 1 << i;
 #ifndef USE_GPS
                 if (mask & FEATURE_GPS) {
-                    cliPrintLine("unavailable");
+                    cliPrintErrorLine("unavailable");
                     break;
                 }
 #endif
@@ -2190,7 +2243,7 @@ static void cliBeeper(char *cmdline)
 
         for (uint32_t i = 0; ; i++) {
             if (i == beeperCount) {
-                cliPrintLine("Invalid name");
+                cliPrintErrorLine("Invalid name");
                 break;
             }
             if (sl_strncasecmp(cmdline, beeperNameForTableIndex(i), len) == 0) {
@@ -2495,9 +2548,53 @@ static void cliDumpBatteryProfile(uint8_t profileIndex, uint8_t dumpMask)
     dumpAllValues(BATTERY_CONFIG_VALUE, dumpMask);
 }
 
+#ifdef USE_CLI_BATCH
+static void cliPrintCommandBatchWarning(const char *warning)
+{
+    cliPrintErrorLinef("ERRORS WERE DETECTED - PLEASE REVIEW BEFORE CONTINUING");
+    if (warning) {
+        cliPrintErrorLinef(warning);
+    }
+}
+
+static void resetCommandBatch(void)
+{
+    commandBatchActive = false;
+    commandBatchError = false;
+}
+
+static void cliBatch(char *cmdline)
+{
+    if (strncasecmp(cmdline, "start", 5) == 0) {
+        if (!commandBatchActive) {
+            commandBatchActive = true;
+            commandBatchError = false;
+        }
+        cliPrintLine("Command batch started");
+    } else if (strncasecmp(cmdline, "end", 3) == 0) {
+        if (commandBatchActive && commandBatchError) {
+            cliPrintCommandBatchWarning(NULL);
+        } else {
+            cliPrintLine("Command batch ended");
+        }
+        resetCommandBatch();
+    } else {
+        cliPrintErrorLinef("Invalid option");
+    }
+}
+#endif
+
 static void cliSave(char *cmdline)
 {
     UNUSED(cmdline);
+
+#ifdef USE_CLI_BATCH
+    if (commandBatchActive && commandBatchError) {
+        cliPrintCommandBatchWarning("PLEASE FIX ERRORS THEN 'SAVE'");
+        resetCommandBatch();
+        return;
+    }
+#endif
 
     cliPrint("Saving");
     //copyCurrentProfileToProfileSlot(getConfigProfile();
@@ -2511,6 +2608,10 @@ static void cliDefaults(char *cmdline)
 
     cliPrint("Resetting to defaults");
     resetEEPROM();
+
+#ifdef USE_CLI_BATCH
+    commandBatchError = false;
+#endif
 
     if (!checkCommand(cmdline, "noreboot"))
         cliReboot();
@@ -2542,7 +2643,7 @@ static void cliGet(char *cmdline)
         return;
     }
 
-    cliPrintLine("Invalid name");
+    cliPrintErrorLine("Invalid name");
 }
 
 static void cliSet(char *cmdline)
@@ -2632,7 +2733,7 @@ static void cliSet(char *cmdline)
                     cliPrintf("%s set to ", name);
                     cliPrintVar(val, 0);
                 } else {
-                    cliPrint("Invalid value. ");
+                    cliPrintError("Invalid value. ");
                     cliPrintVarRange(val);
                     cliPrintLinefeed();
                 }
@@ -2640,7 +2741,7 @@ static void cliSet(char *cmdline)
                 return;
             }
         }
-        cliPrintLine("Invalid name");
+        cliPrintErrorLine("Invalid name");
     } else {
         // no equals, check for matching variables.
         cliGet(cmdline);
@@ -2767,7 +2868,7 @@ static void cliStatus(char *cmdline)
         unsigned invalidIndex;
         if (!settingsValidate(&invalidIndex)) {
             settingGetName(settingGet(invalidIndex), buf);
-            cliPrintLinef("Invalid setting: %s", buf);
+            cliPrintErrorLinef("Invalid setting: %s", buf);
         }
     }
 #else
@@ -2919,9 +3020,19 @@ static void printConfig(const char *cmdline, bool doDiff)
         dumpMask = dumpMask | SHOW_DEFAULTS;   // add default values as comments for changed values
     }
 
+#ifdef USE_CLI_BATCH
+    bool batchModeEnabled = false;
+#endif
+
     if ((dumpMask & DUMP_MASTER) || (dumpMask & DUMP_ALL)) {
         cliPrintHashLine("version");
         cliVersion(NULL);
+
+#ifdef USE_CLI_BATCH
+        cliPrintHashLine("start the command batch");
+        cliPrintLine("batch start");
+        batchModeEnabled = true;
+#endif
 
         if ((dumpMask & (DUMP_ALL | DO_DIFF)) == (DUMP_ALL | DO_DIFF)) {
 #ifndef CLI_MINIMAL_VERBOSITY
@@ -3023,6 +3134,9 @@ static void printConfig(const char *cmdline, bool doDiff)
             cliPrintLinef("battery_profile %d", currentBatteryProfileIndexSave + 1);
 
             cliPrintHashLine("save configuration\r\nsave");
+#ifdef USE_CLI_BATCH
+            batchModeEnabled = false;
+#endif
         } else {
             // dump just the current profiles
             cliDumpProfile(getConfigProfile(), dumpMask);
@@ -3037,6 +3151,14 @@ static void printConfig(const char *cmdline, bool doDiff)
     if (dumpMask & DUMP_BATTERY_PROFILE) {
         cliDumpBatteryProfile(getConfigBatteryProfile(), dumpMask);
     }
+
+#ifdef USE_CLI_BATCH
+    if (batchModeEnabled) {
+        cliPrintHashLine("end the command batch");
+        cliPrintLine("batch end");
+    }
+#endif
+
     // restore configs from copies
     restoreConfigs();
 }
@@ -3085,6 +3207,9 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("assert", "", NULL, cliAssert),
 #endif
     CLI_COMMAND_DEF("aux", "configure modes", NULL, cliAux),
+#ifdef USE_CLI_BATCH
+    CLI_COMMAND_DEF("batch", "start or end a batch of commands", "start | end", cliBatch),
+#endif
 #ifdef BEEPER
     CLI_COMMAND_DEF("beeper", "turn on/off beeper", "list\r\n"
             "\t<+|->[name]", cliBeeper),
@@ -3147,7 +3272,7 @@ const clicmd_t cmdTable[] = {
 #endif
     CLI_COMMAND_DEF("servo", "configure servos", NULL, cliServo),
 #ifdef USE_LOGIC_CONDITIONS
-    CLI_COMMAND_DEF("logic", "configure logic conditions", 
+    CLI_COMMAND_DEF("logic", "configure logic conditions",
         "<rule> <enabled> <operation> <operand A type> <operand A value> <operand B type> <operand B value> <flags>\r\n"
         "\treset\r\n", cliLogic),
 #endif
@@ -3275,7 +3400,7 @@ void cliProcess(void)
                 if (cmd < cmdTable + ARRAYLEN(cmdTable))
                     cmd->func(cliBuffer + strlen(cmd->name) + 1);
                 else
-                    cliPrint("Unknown command, try 'help'");
+                    cliPrintError("Unknown command, try 'help'");
                 bufferIndex = 0;
             }
 
@@ -3318,6 +3443,11 @@ void cliEnter(serialPort_t *serialPort)
     cliPrintLine("\r\nCLI");
 #endif
     cliPrompt();
+
+#ifdef USE_CLI_BATCH
+    resetCommandBatch();
+#endif
+
     ENABLE_ARMING_FLAG(ARMING_DISABLED_CLI);
 }
 

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -157,6 +157,8 @@
 
 #ifndef STM32F3 //F3 series does not have enoug RAM to support logic conditions
 #define USE_LOGIC_CONDITIONS
+
+#define USE_CLI_BATCH
 #endif
 
 //Enable DST calculations


### PR DESCRIPTION
Port of Betaflight's `batch` mode for CLI dumps. Prompts user for confirmation when saving after having pasted a config dump that has generated errors.

I tried to keep the formatting wrapper additions to a minimum while doing as little modifications as possible to the existing framework, but this resulted in slight code duplication.

- [X] Bench tested