### PR TITLE
Add KakuteF4V2 tricopter build configuration/target

### DIFF
--- a/src/main/target/KAKUTEF4/KAKUTEF4V2TRI.mk
+++ b/src/main/target/KAKUTEF4/KAKUTEF4V2TRI.mk
@@ -1,0 +1,1 @@
+#KAKUTEF4V2TRI.mk file

--- a/src/main/target/KAKUTEF4/target.c
+++ b/src/main/target/KAKUTEF4/target.c
@@ -29,6 +29,7 @@
 #include "drivers/timer.h"
 
 const timerHardware_t timerHardware[] = {
+#if !defined(KAKUTEF4V2TRI)
     DEF_TIM(TIM8, CH2, PC7, TIM_USE_PPM,   0, 0), // PPM IN
 
     DEF_TIM(TIM3, CH3, PB0, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0), // S1_OUT - DMA1_ST7
@@ -42,6 +43,16 @@ const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM5, CH1, PA0, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0, 0), // S5_OUT - DMA1_ST2
     DEF_TIM(TIM8, CH3, PC8, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0, 1), // S6_OUT - DMA2_ST4
     DEF_TIM(TIM5, CH2, PA1, TIM_USE_LED,                         0, 0), // LED_STRIP - DMA1_ST4
+#endif
+#else
+	// Timer definition for tricopter on KakuteF4V2
+	// Swaps function of M4 and LED pads
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MC_MOTOR, 0, 0), // S1_OUT - DMA1_ST7
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MC_MOTOR, 0, 0), // S2_OUT - DMA1_ST2
+    DEF_TIM(TIM2, CH4, PA3, TIM_USE_MC_MOTOR, 0, 1), // S3_OUT - DMA1_ST6
+    DEF_TIM(TIM8, CH3, PC8, TIM_USE_MC_SERVO, 0, 0), // S4_OUT - DMA2_ST2     LED pad on KakuteF4V2 used for tricopter tail servo
+	
+	DEF_TIM(TIM5, CH3, PA2, TIM_USE_LED,      0, 0), // LED_STRIP - DMA1_ST0  M4 pad on KakuteF4V2
 #endif
 };
 

--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -31,8 +31,6 @@
 #   define USBD_PRODUCT_STRING "KakuteF4-V1"
 #endif
 
-#define USE_TARGET_CONFIG
-
 #define LED0                    PB5
 #define LED1                    PB4
 #define LED2                    PB6
@@ -149,14 +147,8 @@
 #define USE_LED_STRIP
 #if !defined(KAKUTEF4V2TRI)
 #define WS2811_PIN                      PC8
-#define WS2811_DMA_HANDLER_IDENTIFER    DMA2_ST4_HANDLER
-#define WS2811_DMA_STREAM               DMA2_Stream4
-#define WS2811_DMA_CHANNEL              DMA_Channel_7
 #else
 #define WS2811_PIN                      PA2
-#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST0_HANDLER
-#define WS2811_DMA_STREAM               DMA1_Stream0
-#define WS2811_DMA_CHANNEL              DMA_Channel_6
 #endif
 
 #define VBAT_ADC_CHANNEL            ADC_CHN_1

--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -23,13 +23,15 @@
  */
 
 #pragma once
-#if defined(KAKUTEF4V2)
+#if defined(KAKUTEF4V2) || defined(KAKUTEF4V2TRI)
 #   define TARGET_BOARD_IDENTIFIER "KTV2"
 #   define USBD_PRODUCT_STRING "KakuteF4-V2"
 #else
 #   define TARGET_BOARD_IDENTIFIER "KTV1"
 #   define USBD_PRODUCT_STRING "KakuteF4-V1"
 #endif
+
+#define USE_TARGET_CONFIG
 
 #define LED0                    PB5
 #define LED1                    PB4
@@ -53,7 +55,7 @@
 #define USE_ACC_MPU6500
 #define ACC_MPU6500_ALIGN       CW270_DEG
 
-#ifdef KAKUTEF4V2
+#if defined(KAKUTEF4V2) || defined(KAKUTEF4V2TRI)
 #   define USE_I2C
 #   define USE_I2C_DEVICE_1
 #   define I2C1_SCL                PB8        // SCL pad
@@ -68,8 +70,6 @@
 #   define USE_MAG_IST8310
 #   define USE_MAG_IST8308
 #   define USE_MAG_LIS3MDL
-
-#   define TEMPERATURE_I2C_BUS     BUS_I2C1
 
 #   define USE_BARO
 #   define BARO_I2C_BUS            BUS_I2C1
@@ -108,7 +108,7 @@
 #define UART6_RX_PIN            PC7
 #define UART6_TX_PIN            PC6
 
-#ifdef KAKUTEF4V2
+#if defined(KAKUTEF4V2) || defined(KAKUTEF4V2TRI)
 #   define USE_UART4
 #   define UART4_RX_PIN            PA1
 #   define UART4_TX_PIN            PA0
@@ -147,10 +147,17 @@
 #define ADC_CHANNEL_3_PIN           PC1
 
 #define USE_LED_STRIP
+#if !defined(KAKUTEF4V2TRI)
 #define WS2811_PIN                      PC8
 #define WS2811_DMA_HANDLER_IDENTIFER    DMA2_ST4_HANDLER
 #define WS2811_DMA_STREAM               DMA2_Stream4
 #define WS2811_DMA_CHANNEL              DMA_Channel_7
+#else
+#define WS2811_PIN                      PA2
+#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_ST0_HANDLER
+#define WS2811_DMA_STREAM               DMA1_Stream0
+#define WS2811_DMA_CHANNEL              DMA_Channel_6
+#endif
 
 #define VBAT_ADC_CHANNEL            ADC_CHN_1
 #define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
@@ -170,10 +177,10 @@
 #define TARGET_IO_PORTD        (BIT(2))
 
 #define USE_DSHOT
-#define USE_SERIALSHOT
+#define USE_SERIAL_SHOT
 #define USE_ESC_SENSOR
 
-#ifdef KAKUTEF4V2
+#if defined(KAKUTEF4V2) || defined(KAKUTEF4V2TRI)
 #   define MAX_PWM_OUTPUT_PORTS       4
 #else
 #   define MAX_PWM_OUTPUT_PORTS       6


### PR DESCRIPTION
The KakuteF4V2 is being used on the RCExplorer Tricopters, but the iNav target needs to be custom built for tricopter use.

This PR creates a new target, KAKUTEF4V2TRI, which has the M4 output pad function and the LED pad function swapped.  This allows the tricopter tail servo to be connected to a separate timer from the motor outputs, allowing separate motor/servo output protocols.

The new target hex file has been installed and tested on my RCE TricopterLR.  Motor and servo (connected to LED pad) outputs look correct via logic analyzer trace, and operate correctly as evidenced by correct motor and servo responses (currently using DShot300 for motors with 370 Hz servo).

The LED output (on the M4 pad) looks correct via logic analyzer trace, but I have no LEDs to physically test with.