### PR TITLE
[OSD] Fix position of the symbol in remaining capacity indicator

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1294,8 +1294,8 @@ static bool osdDrawSingleElement(uint8_t item)
         else // currentBatteryProfile->capacity.unit == BAT_CAPACITY_UNIT_MWH
             osdFormatCentiNumber(buff + 1, getBatteryRemainingCapacity() / 10, 0, 2, 0, 3);
 
-        buff[3] = currentBatteryProfile->capacity.unit == BAT_CAPACITY_UNIT_MAH ? SYM_MAH : SYM_WH;
-        buff[4] = '\0';
+        buff[4] = currentBatteryProfile->capacity.unit == BAT_CAPACITY_UNIT_MAH ? SYM_MAH : SYM_WH;
+        buff[5] = '\0';
 
         if ((getBatteryState() != BATTERY_NOT_PRESENT) && batteryUsesCapacityThresholds() && (getBatteryRemainingCapacity() <= currentBatteryProfile->capacity.warning - currentBatteryProfile->capacity.critical))
             TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);


### PR DESCRIPTION
Symbol and end of string null marker were off by one, overwriting
the last character.