### PR TITLE
Experimental mitigation for IMU horizon drift on fixed wings

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -801,6 +801,10 @@ groups:
       - name: small_angle
         min: 0
         max: 180
+      - name: imu_acc_ignore_rate
+        field: acc_ignore_rate
+        min: 0
+        max: 15
 
   - name: PG_ARMING_CONFIG
     type: armingConfig_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -804,7 +804,11 @@ groups:
       - name: imu_acc_ignore_rate
         field: acc_ignore_rate
         min: 0
-        max: 15
+        max: 20
+      - name: imu_acc_ignore_slope
+        field: acc_ignore_slope
+        min: 0
+        max: 5
 
   - name: PG_ARMING_CONFIG
     type: armingConfig_t

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -94,7 +94,7 @@ STATIC_FASTRAM pt1Filter_t rotRateFilter;
 
 STATIC_FASTRAM bool gpsHeadingInitialized;
 
-PG_REGISTER_WITH_RESET_TEMPLATE(imuConfig_t, imuConfig, PG_IMU_CONFIG, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(imuConfig_t, imuConfig, PG_IMU_CONFIG, 1);
 
 PG_RESET_TEMPLATE(imuConfig_t, imuConfig,
     .dcm_kp_acc = 2500,             // 0.25 * 10000
@@ -102,7 +102,7 @@ PG_RESET_TEMPLATE(imuConfig_t, imuConfig,
     .dcm_kp_mag = 10000,            // 1.00 * 10000
     .dcm_ki_mag = 0,                // 0.00 * 10000
     .small_angle = 25,
-    .acc_ignore_rate = 0
+    .acc_ignore_rate = 0            
 );
 
 STATIC_UNIT_TESTED void imuComputeRotationMatrix(void)

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -48,6 +48,7 @@ typedef struct imuConfig_s {
     uint16_t dcm_ki_mag;                    // DCM filter integral gain ( x 10000) for magnetometer and GPS heading
     uint8_t small_angle;
     uint8_t acc_ignore_rate;
+    uint8_t acc_ignore_slope;
 } imuConfig_t;
 
 PG_DECLARE(imuConfig_t, imuConfig);

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -47,6 +47,7 @@ typedef struct imuConfig_s {
     uint16_t dcm_kp_mag;                    // DCM filter proportional gain ( x 10000) for magnetometer and GPS heading
     uint16_t dcm_ki_mag;                    // DCM filter integral gain ( x 10000) for magnetometer and GPS heading
     uint8_t small_angle;
+    uint8_t acc_ignore_rate;
 } imuConfig_t;
 
 PG_DECLARE(imuConfig_t, imuConfig);


### PR DESCRIPTION
Experiment: if rotation rate on a FIXED_WING is higher than a threshold - centrifugal force messes up too much and we should not use measured accel for AHRS comp

```
     Centrifugal acceleration AccelC = Omega^2 * R = Speed^2 / R
         Omega = Speed / R
     For a banked turn R = Speed^2 / (G * tan(Roll))
         Omega = G * tan(Roll) / Speed 
```

Knowing the typical airspeed is around ~20 m/s we can calculate roll angles that yield certain angular rate:
```
         1 deg   =>  0.49 deg/s
         2 deg   =>  0.98 deg/s
         5 deg   =>  2.45 deg/s
        10 deg   =>  4.96 deg/s
```
Therefore for a typical plane a sustained angular rate of ~2.45 deg/s will yield a banking error of ~5 deg. Since we can't do proper centrifugal compensation at the moment we pass the magnitude of angular rate through an  LPF with a low cutoff and if it's larger than our threshold - invalidate accelerometer.

This PR adds a new CLI parameter `imu_acc_ignore_rate` defining a collective rotation rate [deg/s] - a threshold after which accelerometer is no longer trusted for IMU compensation. Zero means disabled (default). Enabling and setting to too low values will disable accelerometer even for slight maneuvers and may cause issues by itself. I'd recommend against setting lower than 3-5 deg/s.

For those who dare - start with max value (15 deg/s) and reduce until horizon drift is acceptable.