### PR TITLE
Fix USB disconnect pulse, clean up some comments

### DIFF
--- a/src/main/drivers/usb_io.c
+++ b/src/main/drivers/usb_io.c
@@ -69,11 +69,11 @@ void usbGenerateDisconnectPulse(void)
     IO_t usbPin = IOGetByTag(IO_TAG(PA12));
     IOConfigGPIO(usbPin, IOCFG_OUT_OD);
 
-    IOHi(usbPin);
+    IOLo(usbPin);
 
     delay(200);
 
-    IOLo(usbPin);
+    IOHi(usbPin);
 }
 
 #endif

--- a/src/main/vcp/hw_config.c
+++ b/src/main/vcp/hw_config.c
@@ -86,20 +86,20 @@ void Set_System(void)
 #endif /* STM32L1XX_XD */
 
     /*Pull down PA12 to create USB Disconnect Pulse*/     // HJI
-#if defined(STM32F303xC)                                    // HJI
+#if defined(STM32F303xC)                                  // HJI
     RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOA, ENABLE);   // HJI
 
-    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_12;          // HJI
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_12;            // HJI
     GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;     // HJI
-    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;        // HJI
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;         // HJI
     GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;        // HJI
-    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;     // HJI
+    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;      // HJI
 #else
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE); // HJI
 
-    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_12;// HJI
-    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;// HJI
-    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_OD;// HJI
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_12;            // HJI
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;     // HJI
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_OD;      // HJI
 #endif
 
     GPIO_Init(GPIOA, &GPIO_InitStructure);                // HJI


### PR DESCRIPTION
In source file usb_io.c, the usbGenerateDisconnectPulse function generates the usb disconnect pulse backwards, it should pull PA12 low for 200 mSec and then release it, rather than pull PA12 high for 200 mSec and release.  Also cleaned up some other USB disconnect comments in hw_config.c.

Tested with KakuteF4V2 on Windows 7 hosted configurator, now works as expected.