### PR TITLE
Fixed mavlink telemetry flight mode info

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -477,7 +477,7 @@ void mavlinkSendHUDAndHeartbeat(void)
     if (flm != FLM_MANUAL) {
         mavModes |= MAV_MODE_FLAG_STABILIZE_ENABLED;
     }
-    else if (flm == FLM_POSITION_HOLD || flm == FLM_RTH || flm == FLM_MISSION) {
+    if (flm == FLM_POSITION_HOLD || flm == FLM_RTH || flm == FLM_MISSION) {
         mavModes |= MAV_MODE_FLAG_GUIDED_ENABLED;
     }
 


### PR DESCRIPTION
This fix allowing to set MAV_MODE_FLAG_GUIDED_ENABLED depend on current flight mode. 