### PR TITLE
F7xx clock fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ LINKER_DIR      := $(ROOT)/src/main/target/link
 
 # default xtal value for F4 targets
 HSE_VALUE       = 8000000
+MHZ_VALUE      ?=
 
 # used for turning on features like VCP and SDCARD
 FEATURES        =
@@ -166,6 +167,10 @@ TARGET_FLAGS    := $(TARGET_FLAGS) -D$(TARGET_MCU) -D$(TARGET)
 
 ifneq ($(HSE_VALUE),)
 DEVICE_FLAGS    := $(DEVICE_FLAGS) -DHSE_VALUE=$(HSE_VALUE)
+endif
+
+ifneq ($(MHZ_VALUE),)
+DEVICE_FLAGS    := $(DEVICE_FLAGS) -DMHZ_VALUE=$(MHZ_VALUE)
 endif
 
 ifneq ($(BASE_TARGET), $(TARGET))

--- a/src/main/drivers/rcc.c
+++ b/src/main/drivers/rcc.c
@@ -2,62 +2,55 @@
 #include "platform.h"
 #include "rcc.h"
 
+#define RCC_BIT_CMD(ptr, mask, state)       do { if (state != DISABLE) { ptr |= mask; } else { ptr &= ~mask; } } while(0)
+
+
 void RCC_ClockCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
 {
     int tag = periphTag >> 5;
     uint32_t mask = 1 << (periphTag & 0x1f);
-#if defined(USE_HAL_DRIVER)
-    (void)tag;
-    (void)mask;
-    (void)NewState;
-#else
+
     switch (tag) {
 #if defined(STM32F3)
     case RCC_AHB:
-        RCC_AHBPeriphClockCmd(mask, NewState);
+        RCC_BIT_CMD(RCC->AHBENR, mask, NewState);
         break;
 #endif
     case RCC_APB2:
-        RCC_APB2PeriphClockCmd(mask, NewState);
+        RCC_BIT_CMD(RCC->APB2ENR, mask, NewState);
         break;
     case RCC_APB1:
-        RCC_APB1PeriphClockCmd(mask, NewState);
+        RCC_BIT_CMD(RCC->APB1ENR, mask, NewState);
         break;
-#if defined(STM32F4)
+#if defined(STM32F4) || defined(STM32F7)
     case RCC_AHB1:
-        RCC_AHB1PeriphClockCmd(mask, NewState);
+        RCC_BIT_CMD(RCC->AHB1ENR, mask, NewState);
         break;
 #endif
     }
-#endif
 }
 
 void RCC_ResetCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
 {
     int tag = periphTag >> 5;
     uint32_t mask = 1 << (periphTag & 0x1f);
-#if defined(USE_HAL_DRIVER)
-    (void)tag;
-    (void)mask;
-    (void)NewState;
-#else
+
     switch (tag) {
 #if defined(STM32F3)
     case RCC_AHB:
-        RCC_AHBPeriphResetCmd(mask, NewState);
+        RCC_BIT_CMD(RCC->AHBRSTR, mask, NewState);
         break;
 #endif
     case RCC_APB2:
-        RCC_APB2PeriphResetCmd(mask, NewState);
+        RCC_BIT_CMD(RCC->APB2RSTR, mask, NewState);
         break;
     case RCC_APB1:
-        RCC_APB1PeriphResetCmd(mask, NewState);
+        RCC_BIT_CMD(RCC->APB1RSTR, mask, NewState);
         break;
-#if defined(STM32F4)
+#if defined(STM32F4) || defined(STM32F7)
     case RCC_AHB1:
-        RCC_AHB1PeriphResetCmd(mask, NewState);
+        RCC_BIT_CMD(RCC->AHB1RSTR, mask, NewState);
         break;
 #endif
     }
-#endif
 }

--- a/src/main/drivers/system_stm32f7xx.c
+++ b/src/main/drivers/system_stm32f7xx.c
@@ -68,89 +68,19 @@ void enableGPIOPowerUsageAndNoiseReductions(void)
     __HAL_RCC_DMA2_CLK_ENABLE();
     __HAL_RCC_USB_OTG_HS_CLK_ENABLE();
     __HAL_RCC_USB_OTG_HS_ULPI_CLK_ENABLE();
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    __HAL_RCC_GPIOD_CLK_ENABLE();
-    __HAL_RCC_GPIOE_CLK_ENABLE();
-    __HAL_RCC_GPIOF_CLK_ENABLE();
-    __HAL_RCC_GPIOG_CLK_ENABLE();
-    __HAL_RCC_GPIOH_CLK_ENABLE();
-    __HAL_RCC_GPIOI_CLK_ENABLE();
-#ifndef STM32F722xx
-    __HAL_RCC_DMA2D_CLK_ENABLE();
-    __HAL_RCC_GPIOJ_CLK_ENABLE();
-    __HAL_RCC_GPIOK_CLK_ENABLE();
-#endif
 
     //APB1
-    __HAL_RCC_TIM2_CLK_ENABLE();
-    __HAL_RCC_TIM3_CLK_ENABLE();
-    __HAL_RCC_TIM4_CLK_ENABLE();
-    __HAL_RCC_TIM5_CLK_ENABLE();
-    __HAL_RCC_TIM6_CLK_ENABLE();
-    __HAL_RCC_TIM7_CLK_ENABLE();
-    __HAL_RCC_TIM12_CLK_ENABLE();
-    __HAL_RCC_TIM13_CLK_ENABLE();
-    __HAL_RCC_TIM14_CLK_ENABLE();
-    __HAL_RCC_LPTIM1_CLK_ENABLE();
-    __HAL_RCC_SPI2_CLK_ENABLE();
-    __HAL_RCC_SPI3_CLK_ENABLE();
     __HAL_RCC_USART2_CLK_ENABLE();
     __HAL_RCC_USART3_CLK_ENABLE();
     __HAL_RCC_UART4_CLK_ENABLE();
     __HAL_RCC_UART5_CLK_ENABLE();
-    __HAL_RCC_I2C1_CLK_ENABLE();
-    __HAL_RCC_I2C2_CLK_ENABLE();
-    __HAL_RCC_I2C3_CLK_ENABLE();
-    __HAL_RCC_CAN1_CLK_ENABLE();
-    __HAL_RCC_DAC_CLK_ENABLE();
     __HAL_RCC_UART7_CLK_ENABLE();
     __HAL_RCC_UART8_CLK_ENABLE();
-#ifndef STM32F722xx
-    __HAL_RCC_I2C4_CLK_ENABLE();
-    __HAL_RCC_CAN2_CLK_ENABLE();
-    __HAL_RCC_CEC_CLK_ENABLE();
-#endif
 
     //APB2
-    __HAL_RCC_TIM1_CLK_ENABLE();
-    __HAL_RCC_TIM8_CLK_ENABLE();
     __HAL_RCC_USART1_CLK_ENABLE();
     __HAL_RCC_USART6_CLK_ENABLE();
-    __HAL_RCC_ADC1_CLK_ENABLE();
-    __HAL_RCC_ADC2_CLK_ENABLE();
-    __HAL_RCC_ADC3_CLK_ENABLE();
     __HAL_RCC_SDMMC1_CLK_ENABLE();
-    __HAL_RCC_SPI1_CLK_ENABLE();
-    __HAL_RCC_SPI4_CLK_ENABLE();
-    __HAL_RCC_TIM9_CLK_ENABLE();
-    __HAL_RCC_TIM10_CLK_ENABLE();
-    __HAL_RCC_TIM11_CLK_ENABLE();
-    __HAL_RCC_SPI5_CLK_ENABLE();
-    __HAL_RCC_SAI1_CLK_ENABLE();
-    __HAL_RCC_SAI2_CLK_ENABLE();
-#ifndef STM32F722xx
-    __HAL_RCC_SPI6_CLK_ENABLE();
-#endif
-//
-//    GPIO_InitTypeDef GPIO_InitStructure;
-//    GPIO_StructInit(&GPIO_InitStructure);
-//    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP; // default is un-pulled input
-//
-//    GPIO_InitStructure.GPIO_Pin  = GPIO_Pin_All;
-//    GPIO_InitStructure.GPIO_Pin &= ~(GPIO_Pin_11 | GPIO_Pin_12); // leave USB D+/D- alone
-//
-//    GPIO_InitStructure.GPIO_Pin &= ~(GPIO_Pin_13 | GPIO_Pin_14); // leave JTAG pins alone
-//    GPIO_Init(GPIOA, &GPIO_InitStructure);
-//
-//    GPIO_InitStructure.GPIO_Pin  = GPIO_Pin_All;
-//    GPIO_Init(GPIOB, &GPIO_InitStructure);
-//
-//    GPIO_InitStructure.GPIO_Pin  = GPIO_Pin_All;
-//    GPIO_Init(GPIOC, &GPIO_InitStructure);
-//    GPIO_Init(GPIOD, &GPIO_InitStructure);
-//    GPIO_Init(GPIOE, &GPIO_InitStructure);
 }
 
 bool isMPUSoftReset(void)

--- a/src/main/target/system_stm32f7xx.c
+++ b/src/main/target/system_stm32f7xx.c
@@ -74,10 +74,22 @@
   #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
 #endif /* HSI_VALUE */
 
+#if !defined(MHZ_VALUE)
+  #define MHZ_VALUE     216
+#endif
+
+#if MHZ_VALUE == 216
+  #define PLL_N     432
+  #define PLL_Q     9
+#elif MHZ_VALUE == 168
+  #define PLL_N     336
+  #define PLL_Q     7
+#else
+  #error "Unsupported MHZ_VALUE!"
+#endif
+
 #define PLL_M     8
-#define PLL_N     432
 #define PLL_P     RCC_PLLP_DIV2 /* 2 */
-#define PLL_Q     9
 
 #define PLL_SAIN  384
 #define PLL_SAIQ  7
@@ -298,7 +310,7 @@ void SystemInit(void)
   /* Configure the system clock to 216 MHz */
   SystemClock_Config();
 
-  if (SystemCoreClock != 216000000)
+  if (SystemCoreClock != MHZ_VALUE * 1000000)
   {
       while (1)
       {


### PR DESCRIPTION
- Fix non-working RCC on F7xx
- Remove default enabling of all periphs clock - allow drivers to enable only necessary (except UARTs that don't support that)
- Create MHZ_VALUE to allow certain F7xx targets to be downclocked to 168MHz