### PR TITLE
[GYRO] Clean up gyro hardware definitions; Implement gyro sync sanity check

### DIFF
--- a/src/main/target/KAKUTEF7/target.c
+++ b/src/main/target/KAKUTEF7/target.c
@@ -28,8 +28,6 @@
 #include "drivers/timer.h"
 #include "drivers/bus.h"
 
-BUSDEV_REGISTER_SPI_TAG(busdev_icm20689,     DEVHW_ICM20689,      ICM20689_SPI_BUS,    ICM20689_CS_PIN,     ICM20689_EXTI_PIN,       0,  DEVFLAGS_NONE);
-
 const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM1, CH3, PE13, TIM_USE_PPM,                                               0, 1), // PPM, DMA2_ST6
 

--- a/src/main/target/KAKUTEF7/target.h
+++ b/src/main/target/KAKUTEF7/target.h
@@ -45,7 +45,7 @@
 #define GYRO_ICM20689_ALIGN      CW270_DEG
 #define ACC_ICM20689_ALIGN       CW270_DEG
 
-#define ICM20689_EXTI_PIN            PE1
+#define GYRO_INT_EXTI            PE1
 #define ICM20689_CS_PIN          SPI4_NSS_PIN
 #define ICM20689_SPI_BUS         BUS_SPI4
 

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -37,7 +37,7 @@
 
 // MPU6000 interrupts
 #define USE_EXTI
-#define MPU6000_EXTI_PIN        PC4
+#define GYRO_INT_EXTI           PC4
 #define USE_MPU_DATA_READY_SIGNAL
 
 #define MPU6000_CS_PIN          PA4

--- a/src/main/target/SPRACINGF7DUAL/target.h
+++ b/src/main/target/SPRACINGF7DUAL/target.h
@@ -40,7 +40,6 @@
 #define GYRO_1_EXTI_PIN         PC13
 #define GYRO_2_EXTI_PIN         PC14
 #define GYRO_INT_EXTI           GYRO_1_EXTI_PIN
-#define MPU_INT_EXTI
 
 #define USE_MPU_DATA_READY_SIGNAL
 #define ENSURE_MPU_DATA_READY_IS_LOW

--- a/src/main/target/YUPIF4/target.h
+++ b/src/main/target/YUPIF4/target.h
@@ -55,8 +55,6 @@
 
 #define USE_GYRO_MPU6500
 #define USE_ACC_MPU6500
-#define ICM20689_CS_PIN         SPI1_NSS_PIN
-#define ICM20689_EXTI_PIN       PC4
 
 #define USE_ACC
 #define USE_ACC_SPI_MPU6500

--- a/src/main/target/YUPIF7/target.h
+++ b/src/main/target/YUPIF7/target.h
@@ -42,8 +42,6 @@
 
 #define USE_GYRO_MPU6500
 #define USE_ACC_MPU6500
-#define ICM20689_CS_PIN         SPI1_NSS_PIN
-#define ICM20689_EXTI_PIN       PC4
 
 #define USE_ACC
 #define USE_ACC_SPI_MPU6500

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -63,6 +63,10 @@
         #endif
     #endif
 
+    #if defined(USE_GYRO_ICM20689)
+        BUSDEV_REGISTER_SPI(busdev_icm20689,    DEVHW_ICM20689,     ICM20689_SPI_BUS,   ICM20689_CS_PIN,    GYRO_INT_EXTI,  DEVFLAGS_NONE);
+    #endif
+
     #if defined(USE_GYRO_BMI160)
         #if defined(BMI160_SPI_BUS)
         BUSDEV_REGISTER_SPI(busdev_bmi160,      DEVHW_BMI160,       BMI160_SPI_BUS,     BMI160_CS_PIN,      GYRO_INT_EXTI,  DEVFLAGS_NONE);


### PR DESCRIPTION
If a board doesn't have gyro sync interrupt connected, but we enable gyro sync every gyro update will be wasting up to 100us on busy-waiting until gyro watchdog triggers the update regardless of the interrupt. This causes 10% of CPU time at 1kHz loop and 20% of CPU time at 2kHz loop to be wasted.

This PR creates a gyro sync sanity check - if we miss more than 100 consecutive gyro sync interrupts - we assume that gyro sync is not working and disable it altogether to free up CPU time wasted on busy-waiting.

Also minor gyro definitions cleanup.