### PR TITLE
Add support for protocol-based RSSI

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -125,6 +125,9 @@ tables:
   - name: nav_extra_arming_safety
     values: ["OFF", "ON", "ALLOW_BYPASS"]
     enum: navExtraArmingSafety_e
+  - name: rssi_source
+    values: ["NONE", "AUTO", "ADC", "CHANNEL", "PROTOCOL", "MSP"]
+    enum: rssiSource_e
 
 groups:
   - name: PG_GYRO_CONFIG
@@ -368,6 +371,9 @@ groups:
         field: maxcheck
         min: PWM_RANGE_MIN
         max: PWM_RANGE_MAX
+      - name: rssi_source
+        field: rssi_source
+        table: rssi_source
       - name: rssi_channel
         min: 0
         max: MAX_SUPPORTED_RC_CHANNEL_COUNT

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -231,7 +231,10 @@ STATIC_UNIT_TESTED uint8_t crsfFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
 
             // Inject link quality into channel 17
             const crsfPayloadLinkStatistics_t* linkStats = (crsfPayloadLinkStatistics_t*)&crsfFrame.frame.payload;
+
             crsfChannelData[16] = scaleRange(constrain(linkStats->uplinkLQ, 0, 100), 0, 100, 191, 1791);    // will map to [1000;2000] range
+
+            lqTrackerSet(rxRuntimeConfig->lqTracker, scaleRange(constrain(linkStats->uplinkLQ, 0, 100), 0, 100, 0, RSSI_MAX_VALUE));
 
             // This is not RC channels frame, update channel value but don't indicate frame completion
             return RX_FRAME_PENDING;

--- a/src/main/rx/eleres.c
+++ b/src/main/rx/eleres.c
@@ -368,7 +368,7 @@ static void telemetryRX(void)
 }
 
 //because we shared SPI bus I can't read data in real IRQ, so need to probe this pin from main idle
-rx_spi_received_e eleresDataReceived(uint8_t *payload)
+rx_spi_received_e eleresDataReceived(uint8_t *payload, uint16_t *linkQuality)
 {
     UNUSED(payload);
 
@@ -380,8 +380,13 @@ rx_spi_received_e eleresDataReceived(uint8_t *payload)
         statusRegisters[0] = rfmSpiRead(0x03);
         statusRegisters[1] = rfmSpiRead(0x04);
         //only if RC frame received
-        if (statusRegisters[0] & RF22B_RX_PACKET_RECEIVED_INTERRUPT)
+        if (statusRegisters[0] & RF22B_RX_PACKET_RECEIVED_INTERRUPT) {
             return RX_SPI_RECEIVED_DATA;
+        }
+    }
+
+    if (linkQuality) {
+        *linkQuality = eleresRssi();
     }
 
     eleresSetRcDataFromPayload(NULL,NULL);
@@ -724,7 +729,7 @@ uint8_t eleresBind(void)
     channelHoppingTime = 33;
     RED_LED_OFF;
     while (timeout--) {
-        eleresDataReceived(NULL);
+        eleresDataReceived(NULL, NULL);
         eleresSetRcDataFromPayload(NULL,NULL);
         if (rfRxBuffer[0]==0x42) {
             for (i=0; i<4; i++) {

--- a/src/main/rx/eleres.h
+++ b/src/main/rx/eleres.h
@@ -5,7 +5,7 @@
 void eleresSetRcDataFromPayload(uint16_t *rcData, const uint8_t *payload);
 uint8_t eleresBind(void);
 uint16_t eleresRssi(void);
-rx_spi_received_e eleresDataReceived(uint8_t *payload);
+rx_spi_received_e eleresDataReceived(uint8_t *payload, uint16_t *linkQuality);
 void eleresInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
 
 typedef struct

--- a/src/main/rx/nrf24_cx10.c
+++ b/src/main/rx/nrf24_cx10.c
@@ -196,7 +196,7 @@ static bool cx10ReadPayloadIfAvailable(uint8_t *payload)
  * This is called periodically by the scheduler.
  * Returns RX_SPI_RECEIVED_DATA if a data packet was received.
  */
-rx_spi_received_e cx10Nrf24DataReceived(uint8_t *payload)
+rx_spi_received_e cx10Nrf24DataReceived(uint8_t *payload, uint16_t *linkQuality)
 {
     static uint8_t ackCount;
     rx_spi_received_e ret = RX_SPI_RECEIVED_NONE;

--- a/src/main/rx/nrf24_h8_3d.c
+++ b/src/main/rx/nrf24_h8_3d.c
@@ -218,7 +218,7 @@ static bool h8_3dCrcOK(uint16_t crc, const uint8_t *payload)
  * This is called periodically by the scheduler.
  * Returns NRF24L01_RECEIVED_DATA if a data packet was received.
  */
-rx_spi_received_e h8_3dNrf24DataReceived(uint8_t *payload)
+rx_spi_received_e h8_3dNrf24DataReceived(uint8_t *payload, uint16_t *linkQuality)
 {
     rx_spi_received_e ret = RX_SPI_RECEIVED_NONE;
     bool payloadReceived = false;

--- a/src/main/rx/nrf24_inav.c
+++ b/src/main/rx/nrf24_inav.c
@@ -361,7 +361,7 @@ static void writeBindAckPayload(uint8_t *payload)
  * This is called periodically by the scheduler.
  * Returns RX_SPI_RECEIVED_DATA if a data packet was received.
  */
-rx_spi_received_e inavNrf24DataReceived(uint8_t *payload)
+rx_spi_received_e inavNrf24DataReceived(uint8_t *payload, uint16_t *linkQuality)
 {
     rx_spi_received_e ret = RX_SPI_RECEIVED_NONE;
     timeUs_t timeNowUs;

--- a/src/main/rx/nrf24_syma.c
+++ b/src/main/rx/nrf24_syma.c
@@ -227,7 +227,7 @@ static void setSymaXHoppingChannels(uint32_t addr)
  * This is called periodically by the scheduler.
  * Returns RX_SPI_RECEIVED_DATA if a data packet was received.
  */
-rx_spi_received_e symaNrf24DataReceived(uint8_t *payload)
+rx_spi_received_e symaNrf24DataReceived(uint8_t *payload, uint16_t *linkQuality)
 {
     rx_spi_received_e ret = RX_SPI_RECEIVED_NONE;
 

--- a/src/main/rx/nrf24_v202.c
+++ b/src/main/rx/nrf24_v202.c
@@ -217,7 +217,7 @@ static rx_spi_received_e readrx(uint8_t *packet)
  * This is called periodically by the scheduler.
  * Returns RX_SPI_RECEIVED_DATA if a data packet was received.
  */
-rx_spi_received_e v202Nrf24DataReceived(uint8_t *packet)
+rx_spi_received_e v202Nrf24DataReceived(uint8_t *packet, uint16_t *linkQuality)
 {
     return readrx(packet);
 }

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -137,6 +137,13 @@ typedef uint8_t (*rcFrameStatusFnPtr)(rxRuntimeConfig_t *rxRuntimeConfig);
 typedef bool (*rcProcessFrameFnPtr)(const rxRuntimeConfig_t *rxRuntimeConfig);
 typedef uint16_t (*rcGetLinkQualityPtr)(const rxRuntimeConfig_t *rxRuntimeConfig);
 
+typedef struct rxLinkQualityTracker_s {
+    timeMs_t lastUpdatedMs;
+    uint32_t lqAccumulator;
+    uint32_t lqCount;
+    uint32_t lqValue;
+} rxLinkQualityTracker_e;
+
 typedef struct rxRuntimeConfig_s {
     uint8_t channelCount;                  // number of rc channels as reported by current input driver
     timeUs_t rxRefreshRate;
@@ -145,7 +152,7 @@ typedef struct rxRuntimeConfig_s {
     rcReadRawDataFnPtr rcReadRawFn;
     rcFrameStatusFnPtr rcFrameStatusFn;
     rcProcessFrameFnPtr rcProcessFrameFn;
-    rcGetLinkQualityPtr rcGetLinkQuality;   // Function to get link quality as calculated by protocol driver
+    rxLinkQualityTracker_e * lqTracker;     // Pointer to a 
     uint16_t *channelData;
     void *frameData;
 } rxRuntimeConfig_t;
@@ -166,6 +173,11 @@ typedef enum {
 } rssiSource_e;
 
 extern rxRuntimeConfig_t rxRuntimeConfig; //!!TODO remove this extern, only needed once for channelCount
+
+void lqTrackerReset(rxLinkQualityTracker_e * lqTracker);
+void lqTrackerAccumulate(rxLinkQualityTracker_e * lqTracker, uint16_t rawValue);
+void lqTrackerSet(rxLinkQualityTracker_e * lqTracker, uint16_t rawValue);
+uint16_t lqTrackerGet(rxLinkQualityTracker_e * lqTracker);
 
 void rxInit(void);
 void rxUpdateRSSISource(void);

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -50,10 +50,11 @@
 #define RSSI_MAX_VALUE 1023
 
 typedef enum {
-    RX_FRAME_PENDING = 0,               // No new data available from receiver
-    RX_FRAME_COMPLETE = (1 << 0),       // There is new data available
-    RX_FRAME_FAILSAFE = (1 << 1),       // Receiver detected loss of RC link. Only valid when RX_FRAME_COMPLETE is set as well
+    RX_FRAME_PENDING = 0,                       // No new data available from receiver
+    RX_FRAME_COMPLETE = (1 << 0),               // There is new data available
+    RX_FRAME_FAILSAFE = (1 << 1),               // Receiver detected loss of RC link. Only valid when RX_FRAME_COMPLETE is set as well
     RX_FRAME_PROCESSING_REQUIRED = (1 << 2),
+    RX_FRAME_DROPPED = (1 << 3),                // Receiver detected dropped frame. Not loss of link yet.
 } rxFrameState_e;
 
 typedef enum {
@@ -123,6 +124,7 @@ typedef struct rxConfig_s {
     uint16_t rx_max_usec;
     uint8_t rcFilterFrequency;              // RC filter cutoff frequency (smoothness vs response sharpness)
     uint16_t mspOverrideChannels;           // Channels to override with MSP RC when BOXMSPRCOVERRIDE is active
+    uint8_t rssi_source;
 } rxConfig_t;
 
 PG_DECLARE(rxConfig_t, rxConfig);
@@ -133,6 +135,7 @@ typedef struct rxRuntimeConfig_s rxRuntimeConfig_t;
 typedef uint16_t (*rcReadRawDataFnPtr)(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan); // used by receiver driver to return channel data
 typedef uint8_t (*rcFrameStatusFnPtr)(rxRuntimeConfig_t *rxRuntimeConfig);
 typedef bool (*rcProcessFrameFnPtr)(const rxRuntimeConfig_t *rxRuntimeConfig);
+typedef uint16_t (*rcGetLinkQualityPtr)(const rxRuntimeConfig_t *rxRuntimeConfig);
 
 typedef struct rxRuntimeConfig_s {
     uint8_t channelCount;                  // number of rc channels as reported by current input driver
@@ -142,6 +145,7 @@ typedef struct rxRuntimeConfig_s {
     rcReadRawDataFnPtr rcReadRawFn;
     rcFrameStatusFnPtr rcFrameStatusFn;
     rcProcessFrameFnPtr rcProcessFrameFn;
+    rcGetLinkQualityPtr rcGetLinkQuality;   // Function to get link quality as calculated by protocol driver
     uint16_t *channelData;
     void *frameData;
 } rxRuntimeConfig_t;
@@ -154,6 +158,7 @@ typedef struct rcChannel_s {
 
 typedef enum {
     RSSI_SOURCE_NONE = 0,
+    RSSI_SOURCE_AUTO,
     RSSI_SOURCE_ADC,
     RSSI_SOURCE_RX_CHANNEL,
     RSSI_SOURCE_RX_PROTOCOL,
@@ -173,9 +178,6 @@ bool isRxPulseValid(uint16_t pulseDuration);
 uint8_t calculateChannelRemapping(const uint8_t *channelMap, uint8_t channelMapEntryCount, uint8_t channelToRemap);
 void parseRcChannels(const char *input);
 
-// filtered = true indicates that newRssi comes from a source which already does
-// filtering and no further filtering should be performed in the value.
-void setRSSI(uint16_t newRssi, rssiSource_e source, bool filtered);
 void setRSSIFromMSP(uint8_t newMspRssi);
 void updateRSSI(timeUs_t currentTimeUs);
 // Returns RSSI in [0, RSSI_MAX_VALUE] range.

--- a/src/main/rx/rx_spi.c
+++ b/src/main/rx/rx_spi.c
@@ -42,7 +42,6 @@
 #include "rx/nrf24_inav.h"
 
 
-static uint16_t rxSpiProtocolLinkQuality = 0;
 static uint16_t rxSpiRcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 STATIC_UNIT_TESTED uint8_t rxSpiPayload[RX_SPI_MAX_PAYLOAD_SIZE];
 STATIC_UNIT_TESTED uint8_t rxSpiNewPacketAvailable; // set true when a new packet is received
@@ -128,19 +127,14 @@ STATIC_UNIT_TESTED bool rxSpiSetProtocol(rx_spi_protocol_e protocol)
  */
 static uint8_t rxSpiFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
 {
-    UNUSED(rxRuntimeConfig);
+    uint16_t linkQuality = 0;
 
-    if (protocolDataReceived(&rxSpiPayload[0], &rxSpiProtocolLinkQuality) == RX_SPI_RECEIVED_DATA) {
+    if (protocolDataReceived(&rxSpiPayload[0], &linkQuality) == RX_SPI_RECEIVED_DATA) {
+        lqTrackerSet(rxRuntimeConfig->lqTracker, linkQuality);
         rxSpiNewPacketAvailable = true;
         return RX_FRAME_COMPLETE;
     }
     return RX_FRAME_PENDING;
-}
-
-static uint16_t rxSpiGetLinkQuality(const rxRuntimeConfig_t *rxRuntimeConfig)
-{
-    UNUSED(rxRuntimeConfig);
-    return rxSpiProtocolLinkQuality;
 }
 
 /*
@@ -155,11 +149,12 @@ bool rxSpiInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
         protocolInit(rxConfig, rxRuntimeConfig);
         ret = true;
     }
+
     rxRuntimeConfig->rxRefreshRate = 10000;
     rxSpiNewPacketAvailable = false;
     rxRuntimeConfig->rcReadRawFn = rxSpiReadRawRC;
     rxRuntimeConfig->rcFrameStatusFn = rxSpiFrameStatus;
-    rxRuntimeConfig->rcGetLinkQuality = rxSpiGetLinkQuality;
+
     return ret;
 }
 #endif

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -65,8 +65,6 @@
 #define SBUS_DIGITAL_CHANNEL_MIN 173
 #define SBUS_DIGITAL_CHANNEL_MAX 1812
 
-#define SBUS_LQ_INTERVAL_MS      200
-
 
 enum {
     DEBUG_SBUS_INTERFRAME_TIME = 0,
@@ -100,10 +98,6 @@ typedef struct sbusFrameData_s {
     uint8_t buffer[SBUS_FRAME_SIZE];
     uint8_t position;
     timeUs_t lastActivityTimeUs;
-    uint16_t lqValue;
-    uint32_t lqTotalFrames;
-    uint32_t lqGoodFrames;
-    timeMs_t lqLastUpdateMs;
 } sbusFrameData_t;
 
 STATIC_ASSERT(SBUS_FRAME_SIZE == sizeof(sbusFrame_t), SBUS_FRAME_SIZE_doesnt_match_sbusFrame_t);
@@ -179,15 +173,6 @@ static uint8_t sbusFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
 {
     sbusFrameData_t *sbusFrameData = rxRuntimeConfig->frameData;
 
-    // Re-calculate "virtual link quality"
-    const timeMs_t currentTimeMs = millis();
-    if ((currentTimeMs - sbusFrameData->lqLastUpdateMs) > SBUS_LQ_INTERVAL_MS) {
-        sbusFrameData->lqValue = (sbusFrameData->lqTotalFrames > 0) ? RSSI_MAX_VALUE * sbusFrameData->lqGoodFrames / sbusFrameData->lqTotalFrames : 0;
-        sbusFrameData->lqTotalFrames = 0;
-        sbusFrameData->lqGoodFrames = 0;
-        sbusFrameData->lqLastUpdateMs = currentTimeMs;
-    }
-
     if (!sbusFrameData->frameDone) {
         return RX_FRAME_PENDING;
     }
@@ -200,28 +185,16 @@ static uint8_t sbusFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
 
     // Calculate "virtual link quality based on packet loss metric"
     if (retValue & RX_FRAME_COMPLETE) {
-        sbusFrameData->lqTotalFrames++;
-        sbusFrameData->lqGoodFrames += ((retValue & RX_FRAME_DROPPED) || (retValue & RX_FRAME_FAILSAFE)) ? 0 : 1;
+        lqTrackerAccumulate(rxRuntimeConfig->lqTracker, ((retValue & RX_FRAME_DROPPED) || (retValue & RX_FRAME_FAILSAFE)) ? 0 : RSSI_MAX_VALUE);
     }
 
     return retValue;
-}
-
-static uint16_t sbusGetLinkQuality(const rxRuntimeConfig_t *rxRuntimeConfig)
-{
-    sbusFrameData_t *sbusFrameData = rxRuntimeConfig->frameData;
-    return sbusFrameData->lqValue;
 }
 
 bool sbusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     static uint16_t sbusChannelData[SBUS_MAX_CHANNEL];
     static sbusFrameData_t sbusFrameData;
-
-    sbusFrameData.lqValue = 0;
-    sbusFrameData.lqTotalFrames = 0;
-    sbusFrameData.lqGoodFrames = 0;
-    sbusFrameData.lqLastUpdateMs = 0;
 
     rxRuntimeConfig->channelData = sbusChannelData;
     rxRuntimeConfig->frameData = &sbusFrameData;
@@ -232,7 +205,6 @@ bool sbusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
     rxRuntimeConfig->rxRefreshRate = 11000;
 
     rxRuntimeConfig->rcFrameStatusFn = sbusFrameStatus;
-    rxRuntimeConfig->rcGetLinkQuality = sbusGetLinkQuality;
 
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {

--- a/src/main/rx/sbus_channels.c
+++ b/src/main/rx/sbus_channels.c
@@ -74,6 +74,11 @@ uint8_t sbusChannelsDecode(rxRuntimeConfig_t *rxRuntimeConfig, const sbusChannel
         return RX_FRAME_COMPLETE | RX_FRAME_FAILSAFE;
     }
 
+    if (channels->flags & SBUS_FLAG_SIGNAL_LOSS) {
+        // The received data is a repeat of the last valid data so can be considered complete.
+        return RX_FRAME_COMPLETE | RX_FRAME_DROPPED;
+    }
+
     return RX_FRAME_COMPLETE;
 }
 


### PR DESCRIPTION
If a protocol (or protocol driver) provides a digital RSSI or Link Quality metric, it can be used as RSSI input with a new `rssi_source` setting. Default behavior is to auto-select ADC or RX channel, based on features enabled, but it can be overridden.

`set rssi_source = PROTOCOL` is supported for FPORT (native RSSI) and SBUS (virtual LQ metric based on lost frames).

Fixes #4938.

Tested on L9R and works great.