### PR TITLE
Heading Hold Problem #3177 (After Big Angle Quad Goes Back To Original Position)

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -756,7 +756,9 @@ int16_t getHeadingHoldTarget() {
 static uint8_t getHeadingHoldState(void)
 {
     // Don't apply heading hold if overall tilt is greater than maximum angle inclination
+    static bool BigAngleDisabledMag=false;
     if (calculateCosTiltAngle() < headingHoldCosZLimit) {
+        BigAngleDisabledMag=true;
         return HEADING_HOLD_DISABLED;
     }
 
@@ -772,12 +774,15 @@ static uint8_t getHeadingHoldState(void)
     else
 #endif
     if (ABS(rcCommand[YAW]) == 0 && FLIGHT_MODE(HEADING_MODE)) {
+         if (BigAngleDisabledMag){
+              BigAngleDisabledMag=false;
+              return HEADING_HOLD_UPDATE_HEADING;
+         }
         return HEADING_HOLD_ENABLED;
     } else {
+        BigAngleDisabledMag=false;
         return HEADING_HOLD_UPDATE_HEADING;
     }
-
-    return HEADING_HOLD_UPDATE_HEADING;
 }
 
 /*

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -756,9 +756,9 @@ int16_t getHeadingHoldTarget() {
 static uint8_t getHeadingHoldState(void)
 {
     // Don't apply heading hold if overall tilt is greater than maximum angle inclination
-    static bool BigAngleDisabledMag=false;
+    static bool bigangledisabledmag = false;
     if (calculateCosTiltAngle() < headingHoldCosZLimit) {
-        BigAngleDisabledMag=true;
+        bigangledisabledmag = true;
         return HEADING_HOLD_DISABLED;
     }
 
@@ -774,13 +774,13 @@ static uint8_t getHeadingHoldState(void)
     else
 #endif
     if (ABS(rcCommand[YAW]) == 0 && FLIGHT_MODE(HEADING_MODE)) {
-         if (BigAngleDisabledMag){
-              BigAngleDisabledMag=false;
+         if (bigangledisabledmag){
+              bigangledisabledmag = false;
               return HEADING_HOLD_UPDATE_HEADING;
          }
         return HEADING_HOLD_ENABLED;
     } else {
-        BigAngleDisabledMag=false;
+        bigangledisabledmag = false;
         return HEADING_HOLD_UPDATE_HEADING;
     }
 }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -783,6 +783,7 @@ static uint8_t getHeadingHoldState(void)
         bigangledisabledmag = false;
         return HEADING_HOLD_UPDATE_HEADING;
     }
+    return HEADING_HOLD_UPDATE_HEADING;
 }
 
 /*


### PR DESCRIPTION
This change stops updating mag when tilt is greater than the maximum inclination angle and updates the mag hold position when the tilt resumes within the normal update angle.