### PR TITLE
remove RX_PWM from documentation

### DIFF
--- a/docs/Board - Airbot F4 and Flip32 F4.md
+++ b/docs/Board - Airbot F4 and Flip32 F4.md
@@ -24,7 +24,7 @@
 
 ## Radio Receivers
 
-This board does not support Parallel PWM receiver connection. Only SerialRX, PPM and MSP receivers are supported.
+SerialRX, PPM and MSP receivers are supported.
 
 SerialRX and PPM receivers should be connected to dedicated _PPM SBUS_ connector above _Motor 1_. MSP receivers should be connected to one of UARTs configured as MSP.
 
@@ -77,7 +77,7 @@ LED strip is enabled on Motor 5 pin (PA1)
 
 ## SoftwareSerial
 
-This board allows for single **SoftwareSerial** port on small soldering pads located next to UART3 pins. 
+This board allows for single **SoftwareSerial** port on small soldering pads located next to UART3 pins.
 
 | Pad   | SoftwareSerial Role   |
 | ----  | ----                  |

--- a/docs/Board - BeeRotor F4.md
+++ b/docs/Board - BeeRotor F4.md
@@ -25,7 +25,7 @@
 
 ## Radio Receivers
 
-This board does not support Parallel PWM receiver connection. Only SerialRX, PPM and MSP receivers are supported.
+SerialRX, PPM and MSP receivers are supported.
 
 SerialRX and PPM receivers should be connected to dedicated _PPM SBUS_ pin on the _RX_ connector. MSP receivers should be connected to one of UARTs configured as MSP.
 

--- a/docs/Board - MatekF405.md
+++ b/docs/Board - MatekF405.md
@@ -34,7 +34,7 @@ Due to differences on the board (I2C - see below), there are two firmware varian
 * Current Sensor: Yes (AIO, CTR), otherwise FCHUB-6S option
 * Integrated Power Distribution Board: Yes (AIO, CTR), otherwise FCHUB-6S option
 * Integrated Voltage Regulator: 5V 2A & 9V 2A (AIO), 5V 2A (CTR), otherwise FCHUB-6S option
-* 6 PWM / DSHOT capable outputs (iNav does not implement DSHOT)
+* 6 PWM / DSHOT capable outputs
 * WS2812 Led Strip : Yes
 * Beeper: Yes
 * RSSI: Yes
@@ -108,5 +108,3 @@ Rcgroups Thread Matek F405: https://www.rcgroups.com/forums/showthread.php?28892
 Rcgroups Thread Matek F405-AIO: https://www.rcgroups.com/forums/showthread.php?2912273-Matek-Flight-Controller-F405-AIO
 
 This board doesn't have hardware inverters for UART pins. This page explains getting SmartPort telemetry working on F4 board:  https://github.com/iNavFlight/inav/blob/master/docs/Telemetry.md
-
-

--- a/docs/Board - Omnibus F4.md
+++ b/docs/Board - Omnibus F4.md
@@ -86,7 +86,7 @@ More target options:
 
 ## Radio Receivers
 
-This board does not support Parallel PWM receiver connection. Only SerialRX, PPM and MSP receivers are supported.
+SerialRX, PPM and MSP receivers are supported.
 
 SerialRX and PPM receivers should be connected to dedicated _PPM SBUS_ connector above _Motor 1_. MSP receivers should be connected to one of UARTs configured as MSP.
 

--- a/docs/Board - Omnibus F7.md
+++ b/docs/Board - Omnibus F7.md
@@ -20,7 +20,7 @@
 
 ## Radio Receivers
 
-This board does not support Parallel PWM receiver connection. Only SerialRX, PPM and MSP receivers are supported.
+SerialRX, PPM and MSP receivers are supported.
 
 SerialRX and PPM receivers should be connected to dedicated _PPM SBUS_ connector. For SerialRX use UART2
 

--- a/docs/Board - SPRacingF3.md
+++ b/docs/Board - SPRacingF3.md
@@ -43,21 +43,6 @@ http://seriouslypro.com/spracingf3#manual
 
 ### IO_1
 
-The 8 pin IO_1 connector has the following pinouts when used in RX_PARALLEL_PWM mode.
-
-| Pin | Function       | Notes                                        |
-| --- | -------------- | -------------------------------------------- |
-| 1   | Ground         |                                              |
-| 2   | VCC_IN         | Voltage as-supplied by BEC.                  |
-| 3   | RC_CH1         | |
-| 4   | RC_CH2         | |
-| 5   | RC_CH5         | |
-| 6   | RC_CH6         | |
-| 7   | LED_STRIP      | Enable `feature LED_STRIP`                   |
-| 8   | VCC            | 3.3v output for LOW CURRENT application only |
-
-When RX_PPM/RX_SERIAL is used the IO_1 pinout is as follows.
-
 | Pin | Function       | Notes                                        |
 | --- | -------------- | -------------------------------------------- |
 | 1   | Ground         |                                              |
@@ -70,21 +55,6 @@ When RX_PPM/RX_SERIAL is used the IO_1 pinout is as follows.
 | 8   | VCC            | 3.3v output for LOW CURRENT application only |
 
 ### IO_2
-
-The 8 pin IO_2 connector has the following pinouts when used in RX_PARALLEL_PWM mode.
-
-| Pin | Function          | Notes                                        |
-| --- | ----------------- | -------------------------------------------- |
-| 1   | Ground            |                                              |
-| 2   | VCC_IN            | Voltage as-supplied by BEC.                  |
-| 3   | RC_CH3            |                                              |
-| 4   | RC_CH4            |                                              |
-| 5   | RC_CH7/HC-SR04_TRIG |                                              |
-| 6   | RC_CH8/HC-SR04_ECHO |                                              |
-| 7   | ADC_1             | Current Sensor                               |
-| 8   | ADC_2             | RSSI                                         |
-
-When RX_PPM/RX_SERIAL is used the IO_2 pinout is as follows.
 
 | Pin | Function                  | Notes                                        |
 | --- | ------------------------- | -------------------------------------------- |

--- a/docs/LedStrip.md
+++ b/docs/LedStrip.md
@@ -26,7 +26,7 @@ but only the first 32 are used.
 
 WS2812 LEDs require an 800khz signal and precise timings and thus requires the use of a dedicated hardware timer.
 
-Note: Not all WS2812 ICs use the same timings, some batches use different timings.  
+Note: Not all WS2812 ICs use the same timings, some batches use different timings.
 
 It could be possible to be able to specify the timings required via CLI if users request it.
 
@@ -52,9 +52,6 @@ from another BEC.  Just ensure that the GROUND is the same for all BEC outputs a
 | --------------------- | ---- | --------- | -------|
 | ChebuzzF3/F3Discovery | PB8  | Data In   | PB8    |
 | Sparky                | PWM5 | Data In   | PA6    |
-
-Additionally, since RC5 is also used for Parallel PWM RC input on both the Chebuzz and STM32F3Discovery targets, led strips
-can not be used at the same time at Parallel PWM.
 
 If you have LEDs that are intermittent, flicker or show the wrong colors then drop the VIN to less than 4.7v, e.g. by using an inline
 diode on the VIN to the LED strip. The problem occurs because of the difference in voltage between the data signal and the power
@@ -186,7 +183,7 @@ This mode binds the LED color to RSSI level.
 | Orange     |    40%   |
 | Red        |    20%   |
 | Deep pink  |     0%   |
-    
+
 When RSSI is below 50% is reached, LEDs will blink slowly, and they will blink fast when under 20%.
 
 
@@ -202,7 +199,7 @@ This mode binds the LED color to remaining battery capacity.
 | Orange     |    40%   |
 | Red        |    20%   |
 | Deep pink  |     0%   |
-    
+
 When Warning or Critial voltage is reached, LEDs will blink slowly or fast.
 Note: this mode requires a current sensor. If you don't have the actual device you can set up a virtual current sensor (see [Battery](Battery.md)).
 
@@ -242,7 +239,7 @@ This mode flashes LEDs that correspond to roll and pitch stick positions.  i.e. 
 | Mode | Direction | LED Color |
 |------------|--------|---------------------|
 |Orientation | North  | WHITE			|
-|Orientation | East   | DARK VIOLET	|  
+|Orientation | East   | DARK VIOLET	|
 |Orientation | South  | RED			|
 |Orientation | West   | DEEP PINK		|
 |Orientation | Up     | BLUE			|
@@ -297,7 +294,7 @@ the same time.  Thrust should normally be combined with Color or Mode/Orientatio
 
 #### Thrust ring state
 
-This mode is allows you to use one or multiple led rings (e.g. NeoPixel ring) for an afterburner effect.  The light pattern rotates clockwise as throttle increases. 
+This mode is allows you to use one or multiple led rings (e.g. NeoPixel ring) for an afterburner effect.  The light pattern rotates clockwise as throttle increases.
 
 A better effect is acheived when LEDs configured for thrust ring have no other functions.
 
@@ -305,7 +302,7 @@ LED direction and X/Y positions are irrelevant for thrust ring LED state.  The o
 
 Each LED of the ring can be a different color. The color can be selected between the 16 colors availables.
 
-For example, led 0 is set as a `R`ing thrust state led in color 13 as follow. 
+For example, led 0 is set as a `R`ing thrust state led in color 13 as follow.
 
 ```
 led 0 2,2::R:13
@@ -321,7 +318,7 @@ x,y position and directions are ignored when using this mode.
 
 Other modes will override or combine with the color mode.
 
-For example, to set led 0 to always use color 10 you would issue this command. 
+For example, to set led 0 to always use color 10 you would issue this command.
 
 ```
 led 0 0,0::C:10
@@ -419,7 +416,7 @@ Mode 6 use these functions:
 | 5        | gps: no satellites |
 | 6        | gps: no fix        |
 | 7        | gps: 3D fix        |
- 
+
 The ColorIndex is picked from the colors array ("palette").
 
 Examples (using the default colors):
@@ -521,13 +518,13 @@ Which translates into the following positions:
 
 ```
      6             3
-      \           / 
-       \   5-4   / 
+      \           /
+       \   5-4   /
       7 \ FRONT / 2
-        | 12-15 | 
+        | 12-15 |
       8 /  BACK \ 1
        /  10-11  \
-      /           \ 
+      /           \
      9             0
 ```
 
@@ -535,7 +532,7 @@ LEDs 0,3,6 and 9 should be placed underneath the quad, facing downwards.
 LEDs 1-2, 4-5, 7-8 and 10-11 should be positioned so the face east/north/west/south, respectively.
 LEDs 12-13 should be placed facing down, in the middle
 LEDs 14-15 should be placed facing up, in the middle
- 
+
 ### Exmple 28 LED config
 
 ```
@@ -577,12 +574,12 @@ led 27 2,9:S:FWT:0
 ```
        16-18  9-11
 19-21 \           / 6-8
-       \  12-15  / 
+       \  12-15  /
         \ FRONT /
         /  BACK \
        /         \
 22-24 /           \ 3-5
-       25-27   0-2  
+       25-27   0-2
 ```
 
 All LEDs should face outwards from the chassis in this configuration.

--- a/docs/Rssi.md
+++ b/docs/Rssi.md
@@ -41,5 +41,3 @@ Under CLI :
 
 
 FrSky D4R-II and X8R supported.
-
-The feature can not be used when RX_PARALLEL_PWM is enabled.

--- a/docs/Rx.md
+++ b/docs/Rx.md
@@ -2,16 +2,10 @@
 
 A receiver is used to receive radio control signals from your transmitter and convert them into signals that the flight controller can understand.
 
-There are 3 basic types of receivers:
+There are 2 basic types of receivers:
 
-1. Parallel PWM Receivers
-2. PPM Receivers
-3. Serial Receivers
-
-## Parallel PWM Receivers
-
-8 channel support, 1 channel per input pin.  On some platforms using parallel input will disable the use of serial ports
-and SoftSerial making it hard to use telemetry or GPS features.
+1. PPM Receivers
+2. Serial Receivers
 
 ## PPM Receivers
 
@@ -128,7 +122,7 @@ SUMH is a legacy Graupner protocol.  Graupner have issued a firmware updates for
 
 10 channels via serial currently supported.
 
-IBUS is the FlySky digital serial protocol and is available with the FS-IA6B, FS-X6B and FS-IA10 receivers. 
+IBUS is the FlySky digital serial protocol and is available with the FS-IA6B, FS-X6B and FS-IA10 receivers.
 The Turnigy TGY-IA6B and TGY-IA10 are the same devices with a different label, therefore they also work.
 
 IBUS can provide up to 120Hz refresh rate, more than double compared to standard 50Hz of PPM.
@@ -160,7 +154,6 @@ There are 3 features that control receiver mode:
 ```
 RX_PPM
 RX_SERIAL
-RX_PARALLEL_PWM
 RX_MSP
 ```
 

--- a/docs/Rx.md
+++ b/docs/Rx.md
@@ -43,7 +43,7 @@ http://www.lemon-rx.com/shop/index.php?route=product/product&product_id=118
 
 #### Spektrum pesudo RSSI
 
-As of iNav 1.6, a pseudo RSSI, based on satellite fade count is supported and reported as normal iNav RSSI (0-1023 range). In order to use this feature, the following is necessary:
+As of iNav 1.6, a pseudo RSSI, based on satellite fade count is supported and reported as normal iNav RSSI (0-1023 range). In order to use this feature, the following is necessary:obj/inav_2.2.2_SPRACINGF3EVO.hex
 
 * Bind the satellite receiver using a physical RX; the bind function provided by the flight controller is not sufficient.
 * The CLI variable `rssi_channel` is set to channel 9:
@@ -57,7 +57,7 @@ This pseudo-RSSI should work on all makes of Spektrum satellite RX; it is tested
 16 channels via serial currently supported.  See below how to set up your transmitter.
 
 * You probably need an inverter between the receiver output and the flight controller. However, some flight controllers have this built in and doesn't need one.
-* Some OpenLRS receivers produce a non-inverted SBUS signal. It is possible to switch SBUS inversion off using CLI command `set sbus_inversion = OFF` when using an F3 based flight controller.
+* Some OpenLRS receivers produce obj/inav_2.2.2_SPRACINGF3EVO.hexa non-inverted SBUS signal. It is possible to switch SBUS inversion off using CLI command `set sbus_inversion = OFF` when using an F3 based flight controller.
 * Softserial ports cannot be used with SBUS because it runs at too high of a bitrate (1Mbps).  Refer to the chapter specific to your board to determine which port(s) may be used.
 * You will need to configure the channel mapping in the GUI (Receiver tab) or CLI (`map` command). Note that channels above 8 are mapped "straight", with no remapping.
 
@@ -141,7 +141,7 @@ The flash is avaliable here: https://github.com/benb0jangles/FlySky-i6-Mod-
 ```
 After flash "10ch Timer Mod i6 Updater", it is passible to get RSSI signal on selected Aux channel from FS-i6 Err sensor.
 
-It is possible to use IBUS RX and IBUS telemetry on only one port of the hardware UART. More information in Telemetry.md.
+It is possible to use IBUS RX and IBUS telemetry on only one port of the hardware UART. More information in Telemetry.md.obj/inav_2.2.2_SPRACINGF3EVO.hex
 
 ## MultiWii serial protocol (MSP)
 
@@ -149,15 +149,15 @@ Allows you to use MSP commands as the RC input.  Only 8 channel support to maint
 
 ## Configuration
 
-There are 3 features that control receiver mode:
+The receiver type can be set from the configurator or CLI.
 
 ```
-RX_PPM
-RX_SERIAL
-RX_MSP
+# get receiver_type
+receiver_type = NONE
+Allowed values: NONE, PWM, PPM, SERIAL, MSP, SPI, UIB
 ```
 
-Only one receiver feature can be enabled at a time.
+Note that `PWM` is a synonym for `NONE`. 
 
 ### RX signal-loss detection
 


### PR DESCRIPTION
As RX_PWM was (mainly) removed from the code base some time ago, this PR updates the documentation.

Note there are still at least two places where RX PWM is referenced / user visible:
* Feature list (easy, set to "")
* settings `rxReceiverType_e` list. 

