### PR TITLE
Landing direction

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -408,6 +408,7 @@ A shorter form is also supported to enable and disable functions using `serial <
 | fw_p_level | 20 | Fixed-wing attitude stabilisation P-gain                      |
 | fw_i_level | 5 | Fixed-wing attitude stabilisation low-pass filter cutoff      |
 | fw_d_level | 75 | Fixed-wing attitude stabilisation HORIZON transition point    |
+|  nav_land_direction  | 0 | Predefined landing direction in deg (1-360), 0-not use, <0-can change by homeReset |
 |  max_angle_inclination_rll  | 300 | Maximum inclination in level (angle) mode (ROLL axis). 100=10° |
 |  max_angle_inclination_pit  | 300 | Maximum inclination in level (angle) mode (PITCH axis). 100=10° |
 |  fw_iterm_limit_stick_position  | 0.5 | Iterm is not allowed to grow when stick position is above threshold. This solves the problem of bounceback or followthrough when full stick deflection is applied on poorely tuned fixed wings. In other words, stabilization is partialy disabled when pilot is actively controlling the aircraft and active when sticks are not touched. `0` mean stick is in center position, `1` means it is fully deflected to either side |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1058,6 +1058,11 @@ groups:
         min: HEADING_HOLD_RATE_LIMIT_MIN
         max: HEADING_HOLD_RATE_LIMIT_MAX
 
+      - name: nav_land_direction
+        field: land_direction
+        condition: USE_NAV
+        min: -360
+        max: 360
       - name: nav_mc_pos_z_p
         field: bank_mc.pid[PID_POS_Z].P
         condition: USE_NAV

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -214,6 +214,8 @@ PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
 
         .heading_hold_rate_limit = HEADING_HOLD_RATE_LIMIT_DEFAULT,
 
+        .land_direction = 0,
+
         .max_angle_inclination[FD_ROLL] = 300,    // 30 degrees
         .max_angle_inclination[FD_PITCH] = 300,    // 30 degrees
         .pidSumLimit = PID_SUM_LIMIT_DEFAULT,

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -129,7 +129,7 @@ static EXTENDED_FASTRAM float dBoostFactor;
 static EXTENDED_FASTRAM float dBoostMaxAtAlleceleration;
 #endif
 
-PG_REGISTER_PROFILE_WITH_RESET_TEMPLATE(pidProfile_t, pidProfile, PG_PID_PROFILE, 9);
+PG_REGISTER_PROFILE_WITH_RESET_TEMPLATE(pidProfile_t, pidProfile, PG_PID_PROFILE, 10);
 
 PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
         .bank_mc = {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -119,6 +119,8 @@ typedef struct pidProfile_s {
 
     int16_t max_angle_inclination[ANGLE_INDEX_COUNT];       // Max possible inclination (roll and pitch axis separately
 
+    int16_t land_direction;                 // predefined landing direction in deg, 0-not use, <0-can change by homeReset
+
     float dterm_setpoint_weight;
     uint16_t pidSumLimit;
 

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1952,7 +1952,7 @@ void updateActualHeading(bool headingValid, int32_t newHeading)
             int32_t fakeToRealYawOffset = newHeading - posControl.actualState.yaw;
             posControl.rthState.homePosition.yaw += fakeToRealYawOffset;
         } else {
-            posControl.rthState.homePosition.yaw += fakeToRealYawOffset;
+            posControl.rthState.homePosition.yaw = DEGREES_TO_CENTIDEGREES(ABS(pidProfile()->land_direction) % 360);
         }
         if (posControl.rthState.homePosition.yaw < 0) {
             posControl.rthState.homePosition.yaw += DEGREES_TO_CENTIDEGREES(360);

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -65,6 +65,13 @@ typedef enum {
     NAV_HOME_VALID_ALL = NAV_HOME_VALID_XY | NAV_HOME_VALID_Z | NAV_HOME_VALID_HEADING,
 } navigationHomeFlags_t;
 
+typedef enum {
+    NAV_HOME_MIN_RTH = 0, //actual yaw, always
+    NAV_HOME_DISARM = 1, //actual yaw, navigationActualStateHomeValidity
+    NAV_HOME_RESET = 2, //actual yaw, navigationActualStateHomeValidity
+    NAV_HOME_WP = 3, //0 always
+} navigationHomeReason_t;
+
 typedef struct navigationFlags_s {
     bool horizontalPositionDataNew;
     bool verticalPositionDataNew;
@@ -382,7 +389,7 @@ bool isLandingDetected(void);
 
 navigationFSMStateFlags_t navGetCurrentStateFlags(void);
 
-void setHomePosition(const fpVector3_t * pos, int32_t yaw, navSetWaypointFlags_t useMask, navigationHomeFlags_t homeFlags);
+void setHomePosition(const fpVector3_t * pos, int32_t yaw, navSetWaypointFlags_t useMask, navigationHomeFlags_t homeFlags, navigationHomeReason_t reason);
 void setDesiredPosition(const fpVector3_t * pos, int32_t yaw, navSetWaypointFlags_t useMask);
 void setDesiredSurfaceOffset(float surfaceOffset);
 void setDesiredPositionToFarAwayTarget(int32_t yaw, int32_t distance, navSetWaypointFlags_t useMask);


### PR DESCRIPTION
This is second part of https://github.com/iNavFlight/inav/pull/4961
For airplane it defined direction to land with aproach. https://github.com/iNavFlight/inav/issues/1814 https://github.com/iNavFlight/inav/issues/3670 https://github.com/iNavFlight/inav/issues/4070
For multirotors it defined head direction when landing.
When 0 (default) it is disabled and work as before.