### PR TITLE
Multicopter Manual Input Pauses RTH Operation Issue #4994

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1194,7 +1194,7 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_RTH_HEAD_HOME(navigatio
             return NAV_FSM_EVENT_SWITCH_TO_EMERGENCY_LANDING;
         }
         else {
-            setDesiredPosition(tmpHomePos, 0, NAV_POS_UPDATE_Z);
+            setDesiredPosition(tmpHomePos, 0, NAV_POS_UPDATE_Z | NAV_POS_UPDATE_XY);
             return NAV_FSM_EVENT_NONE;
         }
     }


### PR DESCRIPTION
Addresses multicopter issue ##4994, with operator input causing RTH to stop at its current location rather than returning to home during the NAV_STATE_RTH_HEAD_HOME operation.