### PR TITLE
Add GPS bearing to S.Port/F.Port telemetry

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -76,6 +76,7 @@ enum
     FSSP_DATAID_CELLS      = 0x0300 ,
     FSSP_DATAID_CELLS_LAST = 0x030F ,
     FSSP_DATAID_HEADING    = 0x0840 ,
+    FSSP_DATAID_FPV        = 0x0450 ,
     FSSP_DATAID_PITCH      = 0x0430 ,
     FSSP_DATAID_ROLL       = 0x0440 ,
     FSSP_DATAID_ACCX       = 0x0700 ,
@@ -106,6 +107,7 @@ const uint16_t frSkyDataIdTable[] = {
     //FSSP_DATAID_CELLS     ,
     //FSSP_DATAID_CELLS_LAST,
     FSSP_DATAID_HEADING   ,
+    FSSP_DATAID_FPV       ,
     FSSP_DATAID_PITCH     ,
     FSSP_DATAID_ROLL      ,
     FSSP_DATAID_ACCX      ,
@@ -511,6 +513,12 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
             case FSSP_DATAID_GPS_ALT    :
                 if (smartPortShouldSendGPSData()) {
                     smartPortSendPackage(id, gpsSol.llh.alt); // cm
+                    *clearToSend = false;
+                }
+                break;
+            case FSSP_DATAID_FPV       :
+                if (smartPortShouldSendGPSData()) {
+                    smartPortSendPackage(id, gpsSol.groundCourse); // given in 10*deg
                     *clearToSend = false;
                 }
                 break;


### PR DESCRIPTION
This replaces #5005 

> S.Port & F.Port telemetry's Hdg sensor is actually the model's orientation. This PR adds a new sensor 0450 which is the GPS heading. The heading along with the model's orientation (yaw) can be used to calculate the flight path vector (FPV).

> Instead of confusing existing scripts that are expecting the Hdg sensor to be yaw, the existing Hdg sensor was left as-is (albeit technically incorrect as it's not the heading, but the model's orientation).

> Anyway, this just adds the GPS heading telemetry sensor so the flight path vector can be calculated on S.Port & F.Port telemetry (it's already possible on Crossfire via the Yaw and Hdg sensors)

@teckel12 