### PR TITLE
Add SPL06-001 barometer driver

### DIFF
--- a/src/main/drivers/barometer/barometer_spl006.c
+++ b/src/main/drivers/barometer/barometer_spl006.c
@@ -1,0 +1,255 @@
+/*
+ * This file is part of iNav.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+#include "build/build_config.h"
+#include "common/utils.h"
+
+#include "drivers/time.h"
+#include "drivers/io.h"
+#include "drivers/bus.h"
+#include "drivers/barometer/barometer.h"
+#include "drivers/barometer/barometer_spl006.h"
+
+#if defined(USE_BARO_SPL006)
+
+// SPL006, address 0x76
+
+typedef struct {
+    int16_t c0;
+    int16_t c1;
+    int32_t c00;
+    int32_t c10;
+    int16_t c01;
+    int16_t c11;
+    int16_t c20;
+    int16_t c21;
+    int16_t c30;
+} spl006_coeffs_t;
+
+
+spl006_coeffs_t spl006_cal;
+// uncompensated pressure and temperature
+static int32_t spl006_pressure_raw = 0;
+static int32_t spl006_temperature_raw = 0;
+
+static int8_t spl006_samples_to_cfg_reg_value(uint8_t sample_rate)
+{
+    switch(sample_rate)
+    {
+        case 1: return 0;
+        case 2: return 1;
+        case 4: return 2;
+        case 8: return 3;
+        case 16: return 4;
+        case 32: return 5;
+        case 64: return 6;
+        case 128: return 7;
+        default: return -1; // invalid
+    }
+}
+
+static int32_t spl006_raw_value_scale_factor(uint8_t oversampling_rate)
+{
+    switch(oversampling_rate)
+    {
+        case 1: return 524288;
+        case 2: return 1572864;
+        case 4: return 3670016;
+        case 8: return 7864320;
+        case 16: return 253952;
+        case 32: return 516096;
+        case 64: return 1040384;
+        case 128: return 2088960;
+        default: return -1; // invalid
+    }
+}
+
+static bool spl006_start_temperature_measurement(baroDev_t * baro)
+{
+    return busWrite(baro->busDev, SPL006_MODE_AND_STATUS_REG, SPL006_MEAS_TEMPERATURE);
+}
+
+static bool spl006_read_temperature(baroDev_t * baro)
+{
+    uint8_t data[SPL006_TEMPERATURE_LEN];
+    int32_t spl006_temperature;
+
+    bool ack = busReadBuf(baro->busDev, SPL006_TEMPERATURE_START_REG, data, SPL006_TEMPERATURE_LEN);
+
+    if (ack) {
+        spl006_temperature = (int32_t)((data[0] & 0x80 ? 0xFF000000 : 0) | (((uint32_t)(data[0])) << 16) | (((uint32_t)(data[1])) << 8) | ((uint32_t)data[2]));
+        spl006_temperature_raw = spl006_temperature;
+    }
+
+    return ack;
+}
+
+static bool spl006_start_pressure_measurement(baroDev_t * baro)
+{
+    return busWrite(baro->busDev, SPL006_MODE_AND_STATUS_REG, SPL006_MEAS_PRESSURE);
+}
+
+static bool spl006_read_pressure(baroDev_t * baro)
+{
+    uint8_t data[SPL006_PRESSURE_LEN];
+    int32_t spl006_pressure;
+
+    bool ack = busReadBuf(baro->busDev, SPL006_PRESSURE_START_REG, data, SPL006_PRESSURE_LEN);
+
+    if (ack) {
+        spl006_pressure = (int32_t)((data[0] & 0x80 ? 0xFF000000 : 0) | (((uint32_t)(data[0])) << 16) | (((uint32_t)(data[1])) << 8) | ((uint32_t)data[2]));
+        spl006_pressure_raw = spl006_pressure;
+    }
+
+    return ack;
+}
+
+// Returns temperature in degrees centigrade
+static float spl006_compensate_temperature(int32_t temperature_raw)
+{
+    const float t_raw_sc = (float)temperature_raw / spl006_raw_value_scale_factor(SPL006_TEMPERATURE_OVERSAMPLING);
+    const float temp_comp = (float)spl006_cal.c0 / 2 + t_raw_sc * spl006_cal.c1;
+    return temp_comp;
+}
+
+// Returns pressure in Pascal
+static float spl006_compensate_pressure(int32_t pressure_raw, int32_t temperature_raw)
+{
+    const float p_raw_sc = (float)pressure_raw / spl006_raw_value_scale_factor(SPL006_PRESSURE_OVERSAMPLING);
+    const float t_raw_sc = (float)temperature_raw / spl006_raw_value_scale_factor(SPL006_TEMPERATURE_OVERSAMPLING);
+
+    const float pressure_cal = (float)spl006_cal.c00 + p_raw_sc * ((float)spl006_cal.c10 + p_raw_sc * ((float)spl006_cal.c20 + p_raw_sc * spl006_cal.c30));
+    const float p_temp_comp = t_raw_sc * ((float)spl006_cal.c01 + p_raw_sc * ((float)spl006_cal.c11 + p_raw_sc * spl006_cal.c21));
+
+    return pressure_cal + p_temp_comp;
+}
+
+bool spl006_calculate(baroDev_t * baro, int32_t * pressure, int32_t * temperature)
+{
+    UNUSED(baro);
+
+    if (pressure) {
+        *pressure = lrintf(spl006_compensate_pressure(spl006_pressure_raw, spl006_temperature_raw));
+    }
+
+    if (temperature) {
+        *temperature = lrintf(spl006_compensate_temperature(spl006_temperature_raw) * 100);
+    }
+
+    return true;
+}
+
+#define DETECTION_MAX_RETRY_COUNT   5
+static bool deviceDetect(busDevice_t * busDev)
+{
+    uint8_t chipId;
+    for (int retry = 0; retry < DETECTION_MAX_RETRY_COUNT; retry++) {
+        delay(100);
+        bool ack = busRead(busDev, SPL006_CHIP_ID_REG, &chipId);
+        if (ack && chipId == SPL006_DEFAULT_CHIP_ID) {
+            return true;
+        }
+    };
+
+    return false;
+}
+
+static bool read_calibration_coefficients(baroDev_t *baro) {
+    uint8_t sstatus;
+    if (!(busRead(baro->busDev, SPL006_MODE_AND_STATUS_REG, &sstatus) && (sstatus & SPL006_MEAS_CFG_COEFFS_RDY)))
+        return false;   // error reading status or coefficients not ready
+
+    uint8_t caldata[SPL006_CALIB_COEFFS_LEN];
+
+    if (!busReadBuf(baro->busDev, SPL006_CALIB_COEFFS_START, (uint8_t *)&caldata, SPL006_CALIB_COEFFS_LEN)) {
+        return false;
+    }
+
+    spl006_cal.c0 = (caldata[0] & 0x80 ? 0xF000 : 0) | ((uint16_t)caldata[0] << 4) | (((uint16_t)caldata[1] & 0xF0) >> 4);
+    spl006_cal.c1 = ((caldata[1] & 0x8 ? 0xF000 : 0) | ((uint16_t)caldata[1] & 0x0F) << 8) | (uint16_t)caldata[2];
+    spl006_cal.c00 = (caldata[3] & 0x80 ? 0xFFF00000 : 0) | ((uint32_t)caldata[3] << 12) | ((uint32_t)caldata[4] << 4) | (((uint32_t)caldata[5] & 0xF0) >> 4);
+    spl006_cal.c10 = (caldata[5] & 0x8 ? 0xFFF00000 : 0) | (((uint32_t)caldata[5] & 0x0F) << 16) | ((uint32_t)caldata[6] << 8) | (uint32_t)caldata[7];
+    spl006_cal.c01 = ((uint16_t)caldata[8] << 8) | ((uint16_t)caldata[9]);
+    spl006_cal.c11 = ((uint16_t)caldata[10] << 8) | (uint16_t)caldata[11];
+    spl006_cal.c20 = ((uint16_t)caldata[12] << 8) | (uint16_t)caldata[13];
+    spl006_cal.c21 = ((uint16_t)caldata[14] << 8) | (uint16_t)caldata[15];
+    spl006_cal.c30 = ((uint16_t)caldata[16] << 8) | (uint16_t)caldata[17];
+
+    return true;
+}
+
+static bool spl006_configure_measurements(baroDev_t *baro)
+{
+    uint8_t reg_value;
+
+    reg_value = SPL006_TEMP_USE_EXT_SENSOR | spl006_samples_to_cfg_reg_value(SPL006_TEMPERATURE_OVERSAMPLING);
+    if (!busWrite(baro->busDev, SPL006_TEMPERATURE_CFG_REG, reg_value)) {
+        return false;
+    }
+
+    reg_value = spl006_samples_to_cfg_reg_value(SPL006_PRESSURE_OVERSAMPLING);
+    if (!busWrite(baro->busDev, SPL006_PRESSURE_CFG_REG, reg_value)) {
+        return false;
+    }
+
+    reg_value = 0;
+    if (SPL006_TEMPERATURE_OVERSAMPLING > 8) {
+        reg_value |= SPL006_TEMPERATURE_RESULT_BIT_SHIFT;
+    }
+    if (SPL006_PRESSURE_OVERSAMPLING > 8) {
+        reg_value |= SPL006_PRESSURE_RESULT_BIT_SHIFT;
+    }
+    if (!busWrite(baro->busDev, SPL006_INT_AND_FIFO_CFG_REG, reg_value)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool spl006Detect(baroDev_t *baro)
+{
+    baro->busDev = busDeviceInit(BUSTYPE_ANY, DEVHW_SPL006, 0, OWNER_BARO);
+    if (baro->busDev == NULL) {
+        return false;
+    }
+
+    busSetSpeed(baro->busDev, BUS_SPEED_STANDARD);
+
+    if (!(deviceDetect(baro->busDev) && read_calibration_coefficients(baro) && spl006_configure_measurements(baro))) {
+        busDeviceDeInit(baro->busDev);
+        return false;
+    }
+
+    baro->ut_delay = SPL006_MEASUREMENT_TIME(SPL006_TEMPERATURE_OVERSAMPLING) * 1000;
+    baro->get_ut = spl006_read_temperature;
+    baro->start_ut = spl006_start_temperature_measurement;
+
+    baro->up_delay = SPL006_MEASUREMENT_TIME(SPL006_PRESSURE_OVERSAMPLING) * 1000;
+    baro->start_up = spl006_start_pressure_measurement;
+    baro->get_up = spl006_read_pressure;
+
+    baro->calculate = spl006_calculate;
+
+    return true;
+}
+
+#endif

--- a/src/main/drivers/barometer/barometer_spl006.h
+++ b/src/main/drivers/barometer/barometer_spl006.h
@@ -1,0 +1,69 @@
+/*
+ * This file is part of iNav.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define SPL006_I2C_ADDR                         0x76
+#define SPL006_DEFAULT_CHIP_ID                  0x10
+
+#define SPL006_PRESSURE_START_REG               0x00
+#define SPL006_PRESSURE_LEN                     3       // 24 bits, 3 bytes
+#define SPL006_PRESSURE_B2_REG                  0x00    // Pressure MSB Register
+#define SPL006_PRESSURE_B1_REG                  0x01    // Pressure middle byte Register
+#define SPL006_PRESSURE_B0_REG                  0x02    // Pressure LSB Register
+#define SPL006_TEMPERATURE_START_REG            0x03
+#define SPL006_TEMPERATURE_LEN                  3       // 24 bits, 3 bytes
+#define SPL006_TEMPERATURE_B2_REG               0x03    // Temperature MSB Register
+#define SPL006_TEMPERATURE_B1_REG               0x04    // Temperature middle byte Register
+#define SPL006_TEMPERATURE_B0_REG               0x05    // Temperature LSB Register
+#define SPL006_PRESSURE_CFG_REG                 0x06    // Pressure config
+#define SPL006_TEMPERATURE_CFG_REG              0x07    // Temperature config
+#define SPL006_MODE_AND_STATUS_REG              0x08    // Mode and status
+#define SPL006_INT_AND_FIFO_CFG_REG             0x09    // Interrupt and FIFO config
+#define SPL006_INT_STATUS_REG                   0x0A    // Interrupt and FIFO config
+#define SPL006_FIFO_STATUS_REG                  0x0B    // Interrupt and FIFO config
+#define SPL006_RST_REG                          0x0C    // Softreset Register
+#define SPL006_CHIP_ID_REG                      0x0D    // Chip ID Register
+#define SPL006_CALIB_COEFFS_START               0x10
+#define SPL006_CALIB_COEFFS_END                 0x21
+
+#define SPL006_CALIB_COEFFS_LEN                 (SPL006_CALIB_COEFFS_END - SPL006_CALIB_COEFFS_START + 1)
+
+// TEMPERATURE_CFG_REG
+#define SPL006_TEMP_USE_EXT_SENSOR              (1<<7)
+
+// MODE_AND_STATUS_REG
+#define SPL006_MEAS_PRESSURE                    (1<<0)  // measure pressure
+#define SPL006_MEAS_TEMPERATURE                 (1<<1)  // measure temperature
+
+#define SPL006_MEAS_CFG_CONTINUOUS              (1<<2)
+#define SPL006_MEAS_CFG_PRESSURE_RDY            (1<<4)
+#define SPL006_MEAS_CFG_TEMPERATURE_RDY         (1<<5)
+#define SPL006_MEAS_CFG_SENSOR_RDY              (1<<6)
+#define SPL006_MEAS_CFG_COEFFS_RDY              (1<<7)
+
+// INT_AND_FIFO_CFG_REG
+#define SPL006_PRESSURE_RESULT_BIT_SHIFT        (1<<2)  // necessary for pressure oversampling > 8
+#define SPL006_TEMPERATURE_RESULT_BIT_SHIFT     (1<<3)  // necessary for temperature oversampling > 8
+
+#define SPL006_PRESSURE_OVERSAMPLING            8       // oversampling 8
+#define SPL006_TEMPERATURE_OVERSAMPLING         8       // oversampling 8
+
+#define SPL006_MEASUREMENT_TIME(oversampling)   ((2 + lrintf(oversampling * 1.6)) + 1) // ms
+
+bool spl006Detect(baroDev_t *baro);
+

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -102,6 +102,7 @@ typedef enum {
     DEVHW_MS5611,
     DEVHW_MS5607,
     DEVHW_LPS25H,
+    DEVHW_SPL006,
 
     /* Compass chips */
     DEVHW_HMC5883,

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -16,7 +16,7 @@ tables:
     values: ["NONE", "PMW3901", "CXOF", "MSP", "FAKE"]
     enum: opticalFlowSensor_e
   - name: baro_hardware
-    values: ["NONE", "AUTO", "BMP085", "MS5611", "BMP280", "MS5607", "LPS25H", "FAKE"]
+    values: ["NONE", "AUTO", "BMP085", "MS5611", "BMP280", "MS5607", "LPS25H", "SPL006", "FAKE"]
     enum: baroSensor_e
   - name: pitot_hardware
     values: ["NONE", "AUTO", "MS4525", "ADC", "VIRTUAL", "FAKE"]

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -36,6 +36,7 @@
 #include "drivers/barometer/barometer_lps25h.h"
 #include "drivers/barometer/barometer_fake.h"
 #include "drivers/barometer/barometer_ms56xx.h"
+#include "drivers/barometer/barometer_spl006.h"
 #include "drivers/time.h"
 
 #include "fc/runtime_config.h"
@@ -122,6 +123,19 @@ bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse)
 #if defined(USE_BARO_BMP280) || defined(USE_BARO_SPI_BMP280)
         if (bmp280Detect(dev)) {
             baroHardware = BARO_BMP280;
+            break;
+        }
+#endif
+        /* If we are asked for a specific sensor - break out, otherwise - fall through and continue */
+        if (baroHardwareToUse != BARO_AUTODETECT) {
+            break;
+        }
+        FALLTHROUGH;
+
+    case BARO_SPL006:
+#if defined(USE_BARO_SPL006) || defined(USE_BARO_SPI_SPL006)
+        if (spl006Detect(dev)) {
+            baroHardware = BARO_SPL006;
             break;
         }
 #endif

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -29,7 +29,8 @@ typedef enum {
     BARO_BMP280 = 4,
     BARO_MS5607 = 5,
     BARO_LPS25H = 6,
-    BARO_FAKE = 7,
+    BARO_SPL006 = 7,
+    BARO_FAKE = 8,
     BARO_MAX = BARO_FAKE
 } baroSensor_e;
 

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -97,6 +97,17 @@
     #endif
 #endif
 
+#if defined(USE_BARO_SPL006)
+    #if defined(SPL006_SPI_BUS)
+      BUSDEV_REGISTER_SPI(busdev_spl006,      DEVHW_SPL006,       SPL006_SPI_BUS,     SPL006_CS_PIN,      NONE,           DEVFLAGS_NONE);
+    #elif defined(SPL006_I2C_BUS) || defined(BARO_I2C_BUS)
+      #if !defined(SPL006_I2C_BUS)
+        #define SPL006_I2C_BUS BARO_I2C_BUS
+      #endif
+      BUSDEV_REGISTER_I2C(busdev_spl006,      DEVHW_SPL006,       SPL006_I2C_BUS,     0x76,               NONE,           DEVFLAGS_NONE);
+    #endif
+#endif
+
 #if defined(USE_BARO_LPS25H)
     #if defined(LPS25H_SPI_BUS)
     BUSDEV_REGISTER_SPI(busdev_lps25h,      DEVHW_LPS25H,       LPS25H_SPI_BUS,     LPS25H_CS_PIN,      NONE,           DEVFLAGS_NONE);


### PR DESCRIPTION
Closes #4455 

The SPL06-001 is a precise barometer pin-to-pin compatible with the BMP280.

Configurator PR: https://github.com/iNavFlight/inav-configurator/pull/823