### PR TITLE
Fix incorrect I2C definition on FOXEER 405 target

### DIFF
--- a/src/main/target/FOXEERF405/target.h
+++ b/src/main/target/FOXEERF405/target.h
@@ -116,7 +116,7 @@
 #define USE_BARO_BMP085
 
 #define USE_MAG
-#define MAG_I2C_BUS             BUS_I2C2
+#define MAG_I2C_BUS             BUS_I2C1
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883
 #define USE_MAG_IST8310


### PR DESCRIPTION
# Current Behavior
Mag's icon stays red and the calibration doesn't feed the calibration's parameters.
# Steps to Reproduce
1.Install RadioLink SE100 (or  bn-880) on FOXEER 405
2.Setup ports, configuration, etc
3.As the auto mode of mag doesn't work, force it to HMC5883 or QMC5883
4.try to calibrate
# Expected behavior
A correct calibration happens.
# Solution
Change the mag I2C BUS from BUS_I2C2 to BUS_I2C1 in target define.
# Test
Test with FOXEER 405 and RadioLink SE100, it works well.