### PR TITLE
Fixed IBUS protocol for AFHDS 3 and new AFHDS 2a receivers.

### DIFF
--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -46,7 +46,9 @@
 #include "telemetry/ibus.h"
 #include "telemetry/ibus_shared.h"
 
-#define IBUS_MAX_CHANNEL 14
+#define IBUS_MAX_CHANNEL 18
+//In AFHDS there is 18 channels encoded in 14 slots (each slot is 2 byte long)
+#define IBUS_MAX_SLOTS 14
 #define IBUS_BUFFSIZE 32
 #define IBUS_MODEL_IA6B 0
 #define IBUS_MODEL_IA6 1
@@ -139,7 +141,7 @@ static bool isChecksumOkIa6(void)
     uint16_t chksum, rxsum;
     chksum = ibusChecksum;
     rxsum = ibus[ibusFrameSize - 2] + (ibus[ibusFrameSize - 1] << 8);
-    for (i = 0, offset = ibusChannelOffset; i < IBUS_MAX_CHANNEL; i++, offset += 2) {
+    for (i = 0, offset = ibusChannelOffset; i < IBUS_MAX_SLOTS; i++, offset += 2) {
         chksum += ibus[offset] + (ibus[offset + 1] << 8);
     }
     return chksum == rxsum;
@@ -165,9 +167,13 @@ static bool checksumIsOk(void) {
 static void updateChannelData(void) {
     uint8_t i;
     uint8_t offset;
-
-    for (i = 0, offset = ibusChannelOffset; i < IBUS_MAX_CHANNEL; i++, offset += 2) {
-        ibusChannelData[i] = ibus[offset] + (ibus[offset + 1] << 8);
+    
+    for (i = 0, offset = ibusChannelOffset; i < IBUS_MAX_SLOTS; i++, offset += 2) {
+        ibusChannelData[i] = ibus[offset] + ((ibus[offset + 1] & 0x0F) << 8);
+    }
+    //latest IBUS recievers are using prviously not used 4 bits on every channel to incresse total channel count
+    for (i = IBUS_MAX_SLOTS, offset = ibusChannelOffset + 1; i < IBUS_MAX_CHANNEL; i++, offset += 6) {
+        ibusChannelData[i] = ((ibus[offset] & 0xF0) >> 4) | (ibus[offset + 2] & 0xF0) | ((ibus[offset + 4] & 0xF0) << 4);
     }
 }
 


### PR DESCRIPTION
New FlySky receivers (AFHDS 3 and latest AFHDS 2a) are using 4 bits free bits in every channel to pass additional data, thus increase total passed channels to 18.
Missing logic has been implemented - it is still compatible with 14 channels receivers.
The fix is critical because if new channels are being send in the frame they are causing invalid value recognition.
Please see BF pull request:
https://github.com/betaflight/betaflight/pull/8749