### PR TITLE
Reinstated MSP_SET_BOX

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -405,7 +405,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         }
         break;
 
-        case MSP2_INAV_STATUS:
+    case MSP2_INAV_STATUS:
         {
             // Preserves full arming flags and box modes
             boxBitmask_t mspBoxModeFlags;
@@ -2827,6 +2827,17 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             return MSP_RESULT_ERROR;
         break;
 #endif
+    case MSP_SET_BOX:
+        {
+            boxBitmask_t inputMask;
+            memset(&inputMask, 0, sizeof(inputMask));
+            //copy over all provided bytes, up to the size of a boxBitmask_t
+            memcpy(&inputMask, sbufConstPtr(src), dataSize <= sizeof(inputMask) ? dataSize : sizeof(inputMask));
+            unpackBoxModeFlags(&inputMask);
+            mspRcModeUpdate(&inputMask);
+        }
+        //if (!setMspModeActivation(sbufConstPtr(src), dataSize)) return MSP_RESULT_ERROR;
+        break;
 
     default:
         return MSP_RESULT_ERROR;

--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -365,6 +365,20 @@ void packBoxModeFlags(boxBitmask_t * mspBoxModeFlags)
     }
 }
 
+void unpackBoxModeFlags(boxBitmask_t *mspBoxModeFlags) 
+{
+    boxBitmask_t newMask; //temporary to hold the results of unpacking
+    memset(&newMask, 0, sizeof(boxBitmask_t));
+    
+    for (int i = 0; i < activeBoxIdCount; ++i) {
+        if(bitArrayGet(mspBoxModeFlags->bits, i)) {
+            bitArraySet(newMask.bits, activeBoxIds[i]);
+        }
+    }
+    //shove the resulsts of unpacking back into the input structure
+    *mspBoxModeFlags = newMask;
+}
+
 uint16_t packSensorStatus(void)
 {
     // Sensor bits

--- a/src/main/fc/fc_msp_box.h
+++ b/src/main/fc/fc_msp_box.h
@@ -32,6 +32,7 @@ const box_t *findBoxByPermanentId(uint8_t permanentId);
 
 struct boxBitmask_s;
 void packBoxModeFlags(struct boxBitmask_s * mspBoxModeFlags);
+void unpackBoxModeFlags(boxBitmask_t * mspBoxModeFlags);
 uint16_t packSensorStatus(void);
 struct sbuf_s;
 bool serializeBoxNamesReply(struct sbuf_s *dst);

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -41,6 +41,7 @@ static bool isUsingNAVModes = false;
 #endif
 
 boxBitmask_t rcModeActivationMask; // one bit per mode defined in boxId_e
+boxBitmask_t mspRcModeActivationMask;
 
 // TODO(alberto): It looks like we can now safely remove this assert, since everything
 // but BB is able to handle more than 32 boxes and all the definitions use
@@ -130,6 +131,11 @@ void rcModeUpdate(boxBitmask_t *newState)
     rcModeActivationMask = *newState;
 }
 
+void mspRcModeUpdate(boxBitmask_t *newState)
+{
+    mspRcModeActivationMask = *newState;
+}
+
 bool isModeActivationConditionPresent(boxId_e modeId)
 {
     for (int index = 0; index < MAX_MODE_ACTIVATION_CONDITION_COUNT; index++) {
@@ -175,7 +181,7 @@ void updateActivatedModes(void)
 
     // Now see which modes should be enabled
     for (int modeIndex = 0; modeIndex < CHECKBOX_ITEM_COUNT; modeIndex++) {
-        // only modes with conditions specified are considered
+        // first see if there is a rc-based condition for the mode
         if (specifiedConditionCountPerMode[modeIndex] > 0) {
             // For AND logic, the specified condition count and valid condition count must be the same.
             // For OR logic, the valid condition count must be greater than zero.
@@ -192,6 +198,9 @@ void updateActivatedModes(void)
                     bitArraySet(newMask.bits, modeIndex);
                 }
             }
+        //if no rc-based condition, activate based on MSP requested modes
+        } else if(bitArrayGet(mspRcModeActivationMask.bits, modeIndex)) {
+            bitArraySet(newMask.bits, modeIndex);
         }
     }
 

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -118,6 +118,7 @@ PG_DECLARE(modeActivationOperatorConfig_t, modeActivationOperatorConfig);
 
 bool IS_RC_MODE_ACTIVE(boxId_e boxId);
 void rcModeUpdate(boxBitmask_t *newState);
+void mspRcModeUpdate(boxBitmask_t *newState);
 
 bool isModeActivationConditionPresent(boxId_e modeId);
 

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -60,7 +60,7 @@
 #define MSP_PROTOCOL_VERSION                0   // Same version over MSPv1 & MSPv2 - message format didn't change and it backward compatible
 
 #define API_VERSION_MAJOR                   2   // increment when major changes are made
-#define API_VERSION_MINOR                   3   // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   4   // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 


### PR DESCRIPTION
Ref #5023 
This allows a MSP client to directly request flight modes. Without this, a MSP client would have to know the FC configuration and the RC ranges (possibly multiple) needed to activate a specific mode. By using this interface, a client can simply request any mode not tied to a RC range. 

The requested modes are represented with a bitmask. The meaning of the bits is the same as for the MSP_ACTIVEBOXES message. Specifically, the bits map to the Modes as delivered in the MSP_BOXNAMES message. 