### PR TITLE
Update local Docker build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,23 @@
-FROM ubuntu:xenial
-LABEL maintainer Andy Schwarz <flyandi@yahoo.com>
+FROM ubuntu:bionic
 
 # Configuration
 VOLUME /home/src/
 WORKDIR /home/src/
+ARG TOOLCHAIN_VERSION_SHORT
+ENV TOOLCHAIN_VERSION_SHORT ${TOOLCHAIN_VERSION_SHORT:-"8-2018q4"}
+ARG TOOLCHAIN_VERSION_LONG
+ENV TOOLCHAIN_VERSION_LONG ${TOOLCHAIN_VERSION_LONG:-"8-2018-q4-major"}
 
 # Essentials
 RUN mkdir -p /home/src && \
     apt-get update && \
-    apt-get install -y software-properties-common python-software-properties ruby make git gcc wget curl bzip2 lib32ncurses5 lib32z1
+    apt-get install -y software-properties-common ruby make git gcc wget curl bzip2
 
 # Toolchain
-ENV TOOLCHAIN=
-ENV TOOLCHAIN_ID=
-RUN wget -P /tmp https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2
+RUN wget -P /tmp "https://developer.arm.com/-/media/Files/downloads/gnu-rm/$TOOLCHAIN_VERSION_SHORT/gcc-arm-none-eabi-$TOOLCHAIN_VERSION_LONG-linux.tar.bz2"
 RUN mkdir -p /opt && \
 	cd /opt && \
-    tar xvjf /tmp/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -C /opt && \
-	chmod -R -w /opt/gcc-arm-none-eabi-6-2017-q2-update
+    tar xvjf "/tmp/gcc-arm-none-eabi-$TOOLCHAIN_VERSION_LONG-linux.tar.bz2" -C /opt && \
+	chmod -R -w "/opt/gcc-arm-none-eabi-$TOOLCHAIN_VERSION_LONG"
 
-ENV PATH="/opt/gcc-arm-none-eabi-6-2017-q2-update/bin:${PATH}"
+ENV PATH="/opt/gcc-arm-none-eabi-$TOOLCHAIN_VERSION_LONG/bin:$PATH"

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,12 @@
-echo "Building target" $1
-docker run --rm -v `pwd`:/home/src/ flyandi/docker-inav make TARGET=$1
+if [ -z "$1" ]; then
+  echo "Usage syntax: ./build.sh <TARGET>"
+  exit 1
+fi
+
+if [ -z "$(docker images -q inav-build)" ]; then
+  echo -e "*** Building image\n"
+  docker build -t inav-build .
+fi
+
+echo -e "*** Building target $1\n"
+docker run --rm -v "$(pwd)":/home/src/ inav-build make TARGET="$1"

--- a/docs/development/Building in Docker.md
+++ b/docs/development/Building in Docker.md
@@ -5,7 +5,7 @@ Building in Docker is remarkably easy.
 ## Build a container with toolchain
 
 ```
-docker build -t inav .
+docker build -t inav-build .
 ```
 
 ## Building firmware with Docker on Ubuntu
@@ -19,6 +19,6 @@ sh build.sh SPRACINGF3
 
 Path in Docker on Windows works in a _strange_ way, so you have to provide full path for `docker run` command. For example:
 
-`docker run --rm -v //c/Users/pspyc/Documents/Projects/inav:/home/src/ flyandi/docker-inav make TARGET=AIRBOTF4`
+`docker run --rm -v //c/Users/pspyc/Documents/Projects/inav:/home/src/ inav-build make TARGET=AIRBOTF4`
 
 So, `c:\Users\pspyc\Documents\Projects\inav` becomes `//c/Users/pspyc/Documents/Projects/inav`


### PR DESCRIPTION
Relying on a 3rd party build image might be dangerous in the long run, especially since it hasn't been maintained in two years. A better alternative would be setting up automatic builds for this repo's Dockerfile directly via Docker Hub or enforcing the use of local images; this PR implements the latter for the time to come.

The Dockerfile was also updated to include the more recent version of the ARM toolchain required by the Makefile.