### PR TITLE
fix osd rpm warnings

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -889,10 +889,10 @@ static void osdFormatRpm(char *buff, uint32_t rpm)
     buff[1] = SYM_THR;
     if (rpm) {
         if (rpm >= 1000) {
-            tfp_sprintf(buff + 2, "%2dk", rpm / 1000);
+            tfp_sprintf(buff + 2, "%2luk", rpm / 1000);
         }
         else {
-            tfp_sprintf(buff + 2, "%3d", rpm);
+            tfp_sprintf(buff + 2, "%3lu", rpm);
         }
     }
     else {


### PR DESCRIPTION
Trivial fix for GCC 9.2.0 compilation warnings:
```
%% osd.c 
./src/main/io/osd.c: In function 'osdFormatRpm':
./src/main/io/osd.c:892:35: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
  892 |             tfp_sprintf(buff + 2, "%2dk", rpm / 1000);
      |                                   ^~~~~~  ~~~~~~~~~~
      |                                               |
      |                                               long unsigned int
./src/main/io/osd.c:895:35: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  895 |             tfp_sprintf(buff + 2, "%3d", rpm);
      |                                   ^~~~~  ~~~
      |                                          |
      |                                          uint32_t {aka long unsigned int}
```
Please ignore if it's too trivial / late / causes problems with older compilers.