### PR TITLE
OSD improvements

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -44,6 +44,7 @@ COMMON_SRC = \
             drivers/io.c \
             drivers/io_pca9685.c \
             drivers/light_led.c \
+            drivers/osd.c \
             drivers/resource.c \
             drivers/rx_nrf24l01.c \
             drivers/rx_spi.c \

--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -285,11 +285,16 @@ void displayCommitTransaction(displayPort_t *instance)
 
 bool displayGetCanvas(displayCanvas_t *canvas, const displayPort_t *instance)
 {
+#if defined(USE_CANVAS)
     if (canvas && instance->vTable->getCanvas && instance->vTable->getCanvas(canvas, instance)) {
         canvas->gridElementWidth = canvas->width / instance->cols;
         canvas->gridElementHeight = canvas->height / instance->rows;
         return true;
     }
+#else
+    UNUSED(canvas);
+    UNUSED(instance);
+#endif
     return false;
 }
 

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -44,8 +44,6 @@ enum VIDEO_TYPES { AUTO = 0, PAL, NTSC };
 #define MAX7456_MODE_BLINK    (1 << 4)
 #define MAX7456_MODE_SOLID_BG (1 << 5)
 
-extern uint16_t max7456ScreenBuffer[MAX7456_BUFFER_CHARS_PAL] ALIGNED(4);
-
 void max7456Init(const videoSystem_e videoSystem);
 void max7456Update(void);
 void max7456ReadNvm(uint16_t char_address, osdCharacter_t *chr);

--- a/src/main/drivers/osd.c
+++ b/src/main/drivers/osd.c
@@ -1,0 +1,43 @@
+/*
+ * This file is part of INAV.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+#include "drivers/osd.h"
+
+uint16_t osdCharacterGridBuffer[OSD_CHARACTER_GRID_BUFFER_SIZE] ALIGNED(4);
+
+void osdCharacterGridBufferClear(void)
+{
+    uint32_t *ptr = (uint32_t *)osdCharacterGridBuffer;
+    uint32_t *end = (uint32_t *)(ARRAYEND(osdCharacterGridBuffer));
+    for (; ptr < end; ptr++) {
+        *ptr = 0;
+    }
+}
+
+uint16_t *osdCharacterGridBufferGetEntryPtr(unsigned x, unsigned y)
+{
+    unsigned pos = y * OSD_CHARACTER_GRID_MAX_WIDTH + x;
+    return &osdCharacterGridBuffer[pos];
+}

--- a/src/main/drivers/osd.h
+++ b/src/main/drivers/osd.h
@@ -22,6 +22,8 @@
 
 #include <stdint.h>
 
+#include "common/utils.h"
+
 #define OSD_CHAR_WIDTH 12
 #define OSD_CHAR_HEIGHT 18
 #define OSD_CHAR_BITS_PER_PIXEL 2
@@ -57,3 +59,13 @@ typedef enum {
 typedef struct osdCharacter_s {
     uint8_t data[OSD_CHAR_BYTES];
 } osdCharacter_t;
+
+#define OSD_CHARACTER_GRID_MAX_WIDTH 30
+#define OSD_CHARACTER_GRID_MAX_HEIGHT 16
+#define OSD_CHARACTER_GRID_BUFFER_SIZE (OSD_CHARACTER_GRID_MAX_WIDTH * OSD_CHARACTER_GRID_MAX_HEIGHT)
+
+extern uint16_t osdCharacterGridBuffer[OSD_CHARACTER_GRID_BUFFER_SIZE] ALIGNED(4);
+
+// Sets all buffer entries to 0
+void osdCharacterGridBufferClear(void);
+uint16_t *osdCharacterGridBufferGetEntryPtr(unsigned x, unsigned y);

--- a/src/main/drivers/osd.h
+++ b/src/main/drivers/osd.h
@@ -38,6 +38,7 @@
 
 // 3 is unused but it's interpreted as transparent by all drivers
 
+typedef struct displayCanvas_s displayCanvas_t;
 
 // Video Character Display parameters
 
@@ -68,4 +69,6 @@ extern uint16_t osdCharacterGridBuffer[OSD_CHARACTER_GRID_BUFFER_SIZE] ALIGNED(4
 
 // Sets all buffer entries to 0
 void osdCharacterGridBufferClear(void);
+void osdGridBufferClearGridRect(int x, int y, int w, int h);
+void osdGridBufferClearPixelRect(displayCanvas_t *canvas, int x, int y, int w, int h);
 uint16_t *osdCharacterGridBufferGetEntryPtr(unsigned x, unsigned y);

--- a/src/main/io/frsky_osd.c
+++ b/src/main/io/frsky_osd.c
@@ -804,13 +804,13 @@ void frskyOSDSetStrokeWidth(unsigned width)
 void frskyOSDSetLineOutlineType(frskyOSDLineOutlineType_e outlineType)
 {
     uint8_t type = outlineType;
-    frskyOSDSendAsyncCommand(OSD_CMD_DRAWING_SET_STROKE_WIDTH, &type, sizeof(type));
+    frskyOSDSendAsyncCommand(OSD_CMD_DRAWING_SET_LINE_OUTLINE_TYPE, &type, sizeof(type));
 }
 
 void frskyOSDSetLineOutlineColor(frskyOSDColor_e outlineColor)
 {
     uint8_t color = outlineColor;
-    frskyOSDSendAsyncCommand(OSD_CMD_DRAWING_SET_STROKE_WIDTH, &color, sizeof(color));
+    frskyOSDSendAsyncCommand(OSD_CMD_DRAWING_SET_LINE_OUTLINE_COLOR, &color, sizeof(color));
 }
 
 void frskyOSDClipToRect(int x, int y, int w, int h)

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -893,7 +893,9 @@ static void osdFormatRpm(char *buff, uint32_t rpm)
     buff[1] = SYM_THR;
     if (rpm) {
         if (rpm >= 1000) {
-            tfp_sprintf(buff + 2, "%2luK", rpm / 1000);
+            osdFormatCentiNumber(buff + 2, rpm / 10, 0, 1, 1, 2);
+            buff[4] = 'K';
+            buff[5] = '\0';
         }
         else {
             tfp_sprintf(buff + 2, "%3lu", rpm);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2188,49 +2188,14 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_HEADING_GRAPH:
         {
-            static const uint8_t graph[] = {
-                SYM_HEADING_LINE,
-                SYM_HEADING_E,
-                SYM_HEADING_LINE,
-                SYM_HEADING_DIVIDED_LINE,
-                SYM_HEADING_LINE,
-                SYM_HEADING_S,
-                SYM_HEADING_LINE,
-                SYM_HEADING_DIVIDED_LINE,
-                SYM_HEADING_LINE,
-                SYM_HEADING_W,
-                SYM_HEADING_LINE,
-                SYM_HEADING_DIVIDED_LINE,
-                SYM_HEADING_LINE,
-                SYM_HEADING_N,
-                SYM_HEADING_LINE,
-                SYM_HEADING_DIVIDED_LINE,
-                SYM_HEADING_LINE,
-                SYM_HEADING_E,
-                SYM_HEADING_LINE,
-                SYM_HEADING_DIVIDED_LINE,
-                SYM_HEADING_LINE,
-                SYM_HEADING_S,
-                SYM_HEADING_LINE,
-                SYM_HEADING_DIVIDED_LINE,
-                SYM_HEADING_LINE,
-                SYM_HEADING_W,
-                SYM_HEADING_LINE,
-            };
             if (osdIsHeadingValid()) {
-                int16_t h = DECIDEGREES_TO_DEGREES(osdGetHeading());
-                if (h >= 180) {
-                    h -= 360;
-                }
-                int hh = h * 4;
-                hh = hh + 720 + 45;
-                hh = hh / 90;
-                memcpy_fn(buff, graph + hh + 1, 9);
+                osdDrawHeadingGraph(osdDisplayPort, osdGetDisplayPortCanvas(), OSD_DRAW_POINT_GRID(elemPosX, elemPosY), osdGetHeading());
+                return true;
             } else {
                 buff[0] = buff[2] = buff[4] = buff[6] = buff[8] = SYM_HEADING_LINE;
                 buff[1] = buff[3] = buff[5] = buff[7] = SYM_HEADING_DIVIDED_LINE;
+                buff[OSD_HEADING_GRAPH_WIDTH] = '\0';
             }
-            buff[9] = '\0';
             break;
         }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -185,8 +185,12 @@ static osdMapData_t osdMapData;
 
 static displayPort_t *osdDisplayPort;
 static bool osdDisplayIsReady = false;
+#if defined(USE_CANVAS)
 static displayCanvas_t osdCanvas;
-static bool osdDisplayHasCanvas = false;
+static bool osdDisplayHasCanvas;
+#else
+#define osdDisplayHasCanvas false
+#endif
 
 #define AH_MAX_PITCH_DEFAULT 20 // Specify default maximum AHI pitch value displayed (degrees)
 #define AH_SIDEBAR_WIDTH_POS 7
@@ -2793,7 +2797,9 @@ static void osdCompleteAsyncInitialization(void)
 
     osdDisplayIsReady = true;
 
+#if defined(USE_CANVAS)
     osdDisplayHasCanvas = displayGetCanvas(&osdCanvas, osdDisplayPort);
+#endif
 
     displayBeginTransaction(osdDisplayPort, DISPLAY_TRANSACTION_OPT_RESET_DRAWING);
     displayClearScreen(osdDisplayPort);
@@ -3289,9 +3295,11 @@ displayPort_t *osdGetDisplayPort(void)
 
 displayCanvas_t *osdGetDisplayPortCanvas(void)
 {
+#if defined(USE_CANVAS)
     if (osdDisplayHasCanvas) {
         return &osdCanvas;
     }
+#endif
     return NULL;
 }
 

--- a/src/main/io/osd_canvas.c
+++ b/src/main/io/osd_canvas.c
@@ -287,4 +287,63 @@ void osdCanvasDrawArtificialHorizon(displayPort_t *display, displayCanvas_t *can
     }
 }
 
+void osdCanvasDrawHeadingGraph(displayPort_t *display, displayCanvas_t *canvas, const osdDrawPoint_t *p, int heading)
+{
+    static const uint8_t graph[] = {
+        SYM_HEADING_W,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_N,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_E,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_S,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_W,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_N,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_E,
+        SYM_HEADING_LINE,
+    };
+
+    STATIC_ASSERT(sizeof(graph) > (3599 / OSD_HEADING_GRAPH_DECIDEGREES_PER_CHAR) + OSD_HEADING_GRAPH_WIDTH + 1, graph_is_too_short);
+
+    char buf[OSD_HEADING_GRAPH_WIDTH + 1];
+    int px;
+    int py;
+
+    osdDrawPointGetPixels(&px, &py, display, canvas, p);
+    int rw = OSD_HEADING_GRAPH_WIDTH * canvas->gridElementWidth;
+    int rh = canvas->gridElementHeight;
+
+    displayCanvasClipToRect(canvas, px, py, rw, rh);
+
+    int idx = heading / OSD_HEADING_GRAPH_DECIDEGREES_PER_CHAR;
+    int offset = ((heading % OSD_HEADING_GRAPH_DECIDEGREES_PER_CHAR) * canvas->gridElementWidth) / OSD_HEADING_GRAPH_DECIDEGREES_PER_CHAR;
+    memcpy_fn(buf, graph + idx, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+    // We need a +1 because characters are 12px wide, so
+    // they can't have a 1px arrow centered. All existing fonts
+    // place the arrow at 5px, hence there's a 1px offset.
+    // TODO: Put this in font metadata and read it back.
+    displayCanvasDrawString(canvas, px - offset + 1, py, buf, DISPLAY_CANVAS_BITMAP_OPT_ERASE_TRANSPARENT);
+
+    displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
+    displayCanvasSetFillColor(canvas, DISPLAY_CANVAS_COLOR_WHITE);
+    int rmx = px + rw / 2;
+    displayCanvasFillStrokeTriangle(canvas, rmx - 2, py - 1, rmx + 2, py - 1, rmx, py + 1);
+}
+
 #endif

--- a/src/main/io/osd_canvas.c
+++ b/src/main/io/osd_canvas.c
@@ -30,6 +30,8 @@
 
 #if defined(USE_CANVAS)
 
+#define AHI_MAX_DRAW_INTERVAL_MS 1000
+
 #include "common/log.h"
 #include "common/maths.h"
 #include "common/printf.h"
@@ -37,7 +39,9 @@
 
 #include "drivers/display.h"
 #include "drivers/display_canvas.h"
+#include "drivers/osd.h"
 #include "drivers/osd_symbols.h"
+#include "drivers/time.h"
 
 #include "io/osd_common.h"
 
@@ -123,26 +127,33 @@ void osdCanvasDrawDirArrow(displayPort_t *display, displayCanvas_t *canvas, cons
 
 static void osdDrawArtificialHorizonLevelLine(displayCanvas_t *canvas, int width, int pos, int margin, bool erase)
 {
-    // Vertical strokes
-    displayCanvasFillStrokeRect(canvas, -width / 2, -pos - 1, 3, -10);
-    displayCanvasFillStrokeRect(canvas, width / 2, -pos - 1, 3, -10);
-    // Horizontal strokes
-    displayCanvasFillStrokeRect(canvas, -width / 2 + 1, -pos - 1, width / 2 - margin, 3);
-    displayCanvasFillStrokeRect(canvas, width / 2 + 1, -pos - 1, -width / 2 + margin, 3);
+    displayCanvasSetLineOutlineType(canvas, DISPLAY_CANVAS_OUTLINE_TYPE_BOTTOM);
 
-    if (!erase) {
-        // When we're not erasing the old AHI position, we need to clean up so black
-        // strokes left by the horizontal strokes.
+    if (erase) {
+        displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);
+        displayCanvasSetLineOutlineColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);
+    } else {
         displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_WHITE);
-
-        displayCanvasMoveToPoint(canvas, -width / 2, -pos - 1);
-        displayCanvasStrokeLineToPoint(canvas, -width / 2 + 3, -pos - 1);
-
-        displayCanvasMoveToPoint(canvas, width / 2, -pos - 1);
-        displayCanvasStrokeLineToPoint(canvas, width / 2 - 3, -pos - 1);
-
-        displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
+        displayCanvasSetLineOutlineColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
     }
+
+    int yoff = pos >= 0 ? 10 : -10;
+    int yc = -pos - 1;
+    int sz = width / 2;
+
+    // Horizontal strokes
+    displayCanvasMoveToPoint(canvas, -sz, yc);
+    displayCanvasStrokeLineToPoint(canvas, -margin, yc);
+    displayCanvasMoveToPoint(canvas, sz, yc);
+    displayCanvasStrokeLineToPoint(canvas, margin, yc);
+
+    // Vertical strokes
+    displayCanvasSetLineOutlineType(canvas, DISPLAY_CANVAS_OUTLINE_TYPE_LEFT);
+    displayCanvasMoveToPoint(canvas, -sz, yc);
+    displayCanvasStrokeLineToPoint(canvas, -sz, yc + yoff);
+    displayCanvasSetLineOutlineType(canvas, DISPLAY_CANVAS_OUTLINE_TYPE_RIGHT);
+    displayCanvasMoveToPoint(canvas, sz, yc);
+    displayCanvasStrokeLineToPoint(canvas, sz, yc + yoff);
 }
 
 static void osdDrawArtificialHorizonShapes(displayCanvas_t *canvas, float pitchAngle, float rollAngle, bool erase)
@@ -185,13 +196,14 @@ static void osdDrawArtificialHorizonShapes(displayCanvas_t *canvas, float pitchA
     }
 
     displayCanvasClipToRect(canvas, lx + 1, ty + 1, maxWidth - 2, maxHeight - 2);
+    osdGridBufferClearPixelRect(canvas, lx, ty, maxWidth, maxHeight);
 
     if (erase) {
-        displayCanvasSetFillColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);
-        displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);
+        displayCanvasSetStrokeAndFillColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);
+        displayCanvasSetLineOutlineColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);
     } else {
-        displayCanvasSetFillColor(canvas, DISPLAY_CANVAS_COLOR_WHITE);
-        displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
+        displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_WHITE);
+        displayCanvasSetLineOutlineColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
     }
 
     // The draw just the 5 bars closest to the current pitch level
@@ -209,62 +221,21 @@ static void osdDrawArtificialHorizonShapes(displayCanvas_t *canvas, float pitchA
 
     for (int ii = pitchCenter - 2; ii <= pitchCenter + 2; ii++) {
         if (ii == 0) {
-            displayCanvasFillStrokeRect(canvas, -barWidth / 2, -1, barWidth / 2 - crosshairMargin, 3);
-            displayCanvasFillStrokeRect(canvas, barWidth / 2, -1, -barWidth / 2 + crosshairMargin, 3);
+            displayCanvasSetLineOutlineType(canvas, DISPLAY_CANVAS_OUTLINE_TYPE_BOTTOM);
+            displayCanvasMoveToPoint(canvas, -barWidth / 2, 0);
+            displayCanvasStrokeLineToPoint(canvas, -crosshairMargin, 0);
+            displayCanvasMoveToPoint(canvas, barWidth / 2, 0);
+            displayCanvasStrokeLineToPoint(canvas, crosshairMargin, 0);
             continue;
         }
 
         int pos = ii * 10 * pixelsPerDegreeLevel;
         int margin = (ii > 9 || ii < -9) ? 9 : 6;
-        if (pos > 0) {
-            osdDrawArtificialHorizonLevelLine(canvas, levelBarWidth, -pos, margin, erase);
-        } else {
-            displayCanvasContextPush(canvas);
-            displayCanvasCtmScale(canvas, 1, -1);
-            osdDrawArtificialHorizonLevelLine(canvas, levelBarWidth, pos, margin, erase);
-            displayCanvasContextPop(canvas);
-        }
+        osdDrawArtificialHorizonLevelLine(canvas, levelBarWidth, -pos, margin, erase);
     }
 
     displayCanvasContextPop(canvas);
 
-#if 0
-
-
-
-    // The draw just the 5 bars closest to the current pitch level
-    float pitchDegrees = RADIANS_TO_DEGREES(pitchAngle);
-    float pitchCenter = roundf(pitchDegrees / 10.0f);
-    float pitchOffset = -pitchDegrees * pixelsDegreeLevel;
-    float translateX = osdCanvas.widthPixels / 2;
-    float translateY = osdCanvas.heightPixels / 2;
-
-    displayCanvasCtmTranslate(canvas, 0, pitchOffset);
-    displayCanvasContextPush(canvas);
-    displayCanvasCtmRotate(canvas, -rollAngle);
-    displayCanvasCtmTranslate(canvas, translateX, translateY);
-
-    for (int ii = pitchCenter - 2; ii <= pitchCenter + 2; ii++) {
-        if (ii == 0) {
-            displayCanvasFillStrokeRect(canvas, -width / 2, -1, width / 2 - crosshairMargin, 3);
-            displayCanvasFillStrokeRect(canvas, width / 2, -1, -width / 2 + crosshairMargin, 3);
-            continue;
-        }
-
-        int pos = ii * 10 * pixelsDegreeLevel;
-        int margin = 6;
-        if (pos > 0) {
-            osdDrawArtificialHorizonLevelLine(levelWidth, -pos, margin, erase);
-        } else {
-            displayCanvasContextPush(canvas);
-            displayCanvasCtmScale(canvas, 1, -1);
-            osdDrawArtificialHorizonLevelLine(levelWidth, pos, margin, erase);
-            displayCanvasContextPop(canvas);
-        }
-    }
-
-    displayCanvasContextPop(canvas);
-#endif
     displayCanvasCtmTranslate(canvas, translateX, translateY);
     displayCanvasCtmScale(canvas, 0.5f, 0.5f);
 
@@ -300,12 +271,19 @@ void osdCanvasDrawArtificialHorizon(displayPort_t *display, displayCanvas_t *can
 
     static float prevPitchAngle = 9999;
     static float prevRollAngle = 9999;
+    static timeMs_t nextDrawMs = 0;
 
-    if (fabsf(prevPitchAngle - pitchAngle) > 0.01f || fabsf(prevRollAngle - rollAngle) > 0.01f) {
+    timeMs_t now = millis();
+
+    if (fabsf(prevPitchAngle - pitchAngle) > 0.01f ||
+        fabsf(prevRollAngle - rollAngle) > 0.01f ||
+        now > nextDrawMs) {
+
         osdDrawArtificialHorizonShapes(canvas, prevPitchAngle, prevRollAngle, true);
         osdDrawArtificialHorizonShapes(canvas, pitchAngle, rollAngle, false);
         prevPitchAngle = pitchAngle;
         prevRollAngle = rollAngle;
+        nextDrawMs = now + AHI_MAX_DRAW_INTERVAL_MS;
     }
 }
 

--- a/src/main/io/osd_canvas.h
+++ b/src/main/io/osd_canvas.h
@@ -35,3 +35,4 @@ typedef struct osdDrawPoint_s osdDrawPoint_t;
 void osdCanvasDrawVario(displayPort_t *display, displayCanvas_t *canvas, const osdDrawPoint_t *p, float zvel);
 void osdCanvasDrawDirArrow(displayPort_t *display, displayCanvas_t *canvas, const osdDrawPoint_t *p, float degrees, bool eraseBefore);
 void osdCanvasDrawArtificialHorizon(displayPort_t *display, displayCanvas_t *canvas, const osdDrawPoint_t *p, float pitchAngle, float rollAngle);
+void osdCanvasDrawHeadingGraph(displayPort_t *display, displayCanvas_t *canvas, const osdDrawPoint_t *p, int heading);

--- a/src/main/io/osd_common.c
+++ b/src/main/io/osd_common.c
@@ -123,3 +123,19 @@ void osdDrawArtificialHorizon(displayPort_t *display, displayCanvas_t *canvas, c
     }
 #endif
 }
+
+void osdDrawHeadingGraph(displayPort_t *display, displayCanvas_t *canvas, const osdDrawPoint_t *p, int heading)
+{
+    uint8_t gx;
+    uint8_t gy;
+#if defined(USE_CANVAS)
+    if (canvas) {
+        osdCanvasDrawHeadingGraph(display, canvas, p, heading);
+    } else {
+#endif
+        osdDrawPointGetGrid(&gx, &gy, display, canvas, p);
+        osdGridDrawHeadingGraph(display, gx, gy, heading);
+#if defined(USE_CANVAS)
+    }
+#endif
+}

--- a/src/main/io/osd_common.h
+++ b/src/main/io/osd_common.h
@@ -38,6 +38,9 @@
 #define OSD_AHI_H_SYM_COUNT 9
 #define OSD_AHI_V_SYM_COUNT 6
 
+#define OSD_HEADING_GRAPH_WIDTH 9
+#define OSD_HEADING_GRAPH_DECIDEGREES_PER_CHAR 225
+
 typedef struct displayPort_s displayPort_t;
 typedef struct displayCanvas_s displayCanvas_t;
 
@@ -72,3 +75,6 @@ void osdDrawVario(displayPort_t *display, displayCanvas_t *canvas, const osdDraw
 // the arrow will be erased first (need for e.g. the home arrow, since it uses multiple symbols)
 void osdDrawDirArrow(displayPort_t *display, displayCanvas_t *canvas, const osdDrawPoint_t *p, float degrees, bool eraseBefore);
 void osdDrawArtificialHorizon(displayPort_t *display, displayCanvas_t *canvas, const osdDrawPoint_t *p, float rollAngle, float pitchAngle);
+// Draws a heading graph with heading given as 0.1 degree steps i.e. [0, 3600). It uses 9 horizontal
+// grid slots.
+void osdDrawHeadingGraph(displayPort_t *display, displayCanvas_t *canvas, const osdDrawPoint_t *p, int heading);

--- a/src/main/io/osd_grid.c
+++ b/src/main/io/osd_grid.c
@@ -153,4 +153,48 @@ void osdGridDrawArtificialHorizon(displayPort_t *display, unsigned gx, unsigned 
     }
 }
 
+void osdGridDrawHeadingGraph(displayPort_t *display, unsigned gx, unsigned gy, int heading)
+{
+    static const uint8_t graph[] = {
+        SYM_HEADING_LINE,
+        SYM_HEADING_E,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_S,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_W,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_N,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_E,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_S,
+        SYM_HEADING_LINE,
+        SYM_HEADING_DIVIDED_LINE,
+        SYM_HEADING_LINE,
+        SYM_HEADING_W,
+        SYM_HEADING_LINE,
+    };
+    char buf[OSD_HEADING_GRAPH_WIDTH + 1];
+    int16_t h = DECIDEGREES_TO_DEGREES(heading);
+    if (h >= 180) {
+        h -= 360;
+    }
+    int hh = h * 4;
+    hh = hh + 720 + 45;
+    hh = hh / 90;
+    memcpy_fn(buf, graph + hh + 1, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+    displayWrite(display, gx, gy, buf);
+}
+
 #endif

--- a/src/main/io/osd_grid.h
+++ b/src/main/io/osd_grid.h
@@ -31,3 +31,4 @@ typedef struct displayPort_s displayPort_t;
 void osdGridDrawVario(displayPort_t *display, unsigned gx, unsigned gy, float zvel);
 void osdGridDrawDirArrow(displayPort_t *display, unsigned gx, unsigned gy, float degrees);
 void osdGridDrawArtificialHorizon(displayPort_t *display, unsigned gx, unsigned gy, float pitchAngle, float rollAngle);
+void osdGridDrawHeadingGraph(displayPort_t *display, unsigned gx, unsigned gy, int heading);


### PR DESCRIPTION
- [OSD] Remove FrSky OSD dependency on MAX7456
- [FRSKYOSD] Fix constants used to set outline type and color
- [OSD] Add helper functions for clearing a rect in the grid buffer
- [OSD] Exclude some unused variables and functions when not using canvas
- [OSD] Redo pixel based AHI using outlines instead of stroked rects
- [OSD] Add a canvas based implementation for OSD_HEADING_GRAPH
- [FRSKYOSD] Poll the canvas size every 1s
- [OSD] Display 1 decimal for RPM values >= 1000
