### PR TITLE
Enable DSHOT on KAKUTEF7

### DIFF
--- a/src/main/target/KAKUTEF7/target.h
+++ b/src/main/target/KAKUTEF7/target.h
@@ -33,6 +33,9 @@
 #define BEEPER              PD15
 #define BEEPER_INVERTED
 
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+
 #define USE_ACC
 #define USE_GYRO
 


### PR DESCRIPTION
Tested on the bench then a brief indoor flight on 7 inch quad.