### PR TITLE
Matek F411 and F405 SoftSerial docs update

### DIFF
--- a/docs/Board - Matek F411 Wing.md
+++ b/docs/Board - Matek F411 Wing.md
@@ -23,7 +23,7 @@
 * `MATEKF411` if you want to control LEDs and have SS1 TX on ST1 pad.
 * `MATEKF411_FD_SFTSRL` if you need the softserial to be full-duplex (TX = ST1 pad, RX = LED pad), at the cost of losing the LED output.
 * `MATEKF411_RSSI` if you want to have analog RSSI input on ST1 pad. SS1 TX will be available on the LED pad.
-* `MATEKF411_SFTSRL2`if you want to use two softserials (TX only) at the same time. Eg. Smart Audio + S. Port,  Smart Audio + LTM
+* `MATEKF411_SFTSRL2`if you want to use two softserials (TX only) at the same time. Eg. Smart Audio + S. Port,  Smart Audio + LTM. (SS1 TX will be on ST1 pad and SS2 TX will be on LED pad).
 
 ## Where to buy:
 

--- a/docs/Board - MatekF405.md
+++ b/docs/Board - MatekF405.md
@@ -75,8 +75,22 @@ I2C requires that the WS2812 led strip is moved to S5, thus WS2812 is not usable
 Soft serial is available as an alternative to a hardware UART on RX4/TX4 and TX2. By default this is NOT inverted. In order to use this feature:
 
 * Enable soft serial
-* Do not assign any function to hardware UART4 or UART2-TX
-* Assign the desired function to the soft-serial port
+* Do not assign any function to hardware UART4
+* Assign the desired function to the soft-serial ports
+* UART4 TX/RX pads will be used as SoftSerial 1 TX/RX pads
+* UART2 TX pad will be used as SoftSerial 2 TX pad
+
+RX2 and SBUS pads can be used as normal for receiver-only UART. If you need a full duplex UART (IE: TBS Crossfire) and SoftSerial, then use UART 1, 3 or 5 for Full Duplex.
+
+#### Common scenarios for SoftSerial on this boards:
+You need to wire a FrSky receiver (SBUS and SmartPort) to the Flight controller
+* Connect SBUS from Receiver to SBUS pin on the Flight Controller
+* Connect SmartPort from Receiver to TX2 pad on the Flight Controller
+* Enable SoftSerial and set UART2 for Serial RX and SoftSerial 2 for SmartPort Telemetry
+
+You need to wire a SmartAudio or Trump VTX to the Flight controller
+* Connect SmartAudio/Tramp from VTX to the TX4 pad on the Flight Controller
+* Enable SoftSerial and set SoftSerial 1 for SmartAudio or Tramp
 
 ### USB
 


### PR DESCRIPTION
Some clarification about use of SoftSerial ports on this two boards.