### PR TITLE
Enable DShot and ESC-telemetry for KAKUTEF7

### DIFF
--- a/src/main/target/KAKUTEF7/target.h
+++ b/src/main/target/KAKUTEF7/target.h
@@ -165,4 +165,7 @@
 #define TARGET_IO_PORTD 0xffff
 #define TARGET_IO_PORTE 0xffff
 
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+
 #define MAX_PWM_OUTPUT_PORTS       6


### PR DESCRIPTION
Tested on my Kakute F7 mini, I am sure that it will be work on Kakute F7 also.
For now on my setup doesn't work current sensor via ESC telemetry, but this is probably because ESC, it not working on Betaflight too.