### PR TITLE
[F411] Increase main clock speed to 96MHz

### DIFF
--- a/src/main/target/system_stm32f4xx.c
+++ b/src/main/target/system_stm32f4xx.c
@@ -413,11 +413,11 @@ uint32_t hse_value = HSE_VALUE;
 #endif /* STM32F401xx */
 
 #if defined(STM32F410xx) || defined(STM32F411xE)
-#define PLL_N      336
+#define PLL_N      192
 /* SYSCLK = PLL_VCO / PLL_P */
-#define PLL_P      4
+#define PLL_P      2
 /* USB OTG FS, SDIO and RNG Clock =  PLL_VCO / PLLQ */
-#define PLL_Q      7
+#define PLL_Q      4
 #endif /* STM32F410xx || STM32F411xE */
 
 /******************************************************************************/


### PR DESCRIPTION
96MHz is still below the 100MHz maximum while still allowing to
configure a 48MHz clock for USB