### PR TITLE
Canvas OSD fixes/optimizations

### DIFF
--- a/src/main/drivers/osd.c
+++ b/src/main/drivers/osd.c
@@ -72,8 +72,8 @@ void osdGridBufferClearGridRect(int x, int y, int w, int h)
     osdGridBufferConstrainRect(&x, &y, &w, &h, OSD_CHARACTER_GRID_MAX_WIDTH, OSD_CHARACTER_GRID_MAX_HEIGHT);
     int maxX = x + w;
     int maxY = y + h;
-    for (int ii = x; ii < maxX + w; ii++) {
-        for (int jj = y; jj < maxY; jj++) {
+    for (int ii = x; ii <= maxX + w; ii++) {
+        for (int jj = y; jj <= maxY; jj++) {
             *osdCharacterGridBufferGetEntryPtr(ii, jj) = 0;
         }
     }

--- a/src/main/io/frsky_osd.c
+++ b/src/main/io/frsky_osd.c
@@ -43,8 +43,8 @@
 #define FRSKY_OSD_INFO_INTERVAL_MS 1000
 
 #define FRSKY_OSD_TRACE(fmt, ...)
-#define FRSKY_OSD_DEBUG(fmt, ...) LOG_D(OSD, fmt,  ##__VA_ARGS__)
-#define FRSKY_OSD_ERROR(fmt, ...) LOG_E(OSD, fmt,  ##__VA_ARGS__)
+#define FRSKY_OSD_DEBUG(fmt, ...) LOG_D(OSD, "FrSky OSD: " fmt,  ##__VA_ARGS__)
+#define FRSKY_OSD_ERROR(fmt, ...) LOG_E(OSD, "FrSky OSD: " fmt,  ##__VA_ARGS__)
 #define FRSKY_OSD_ASSERT(x)
 
 typedef enum
@@ -389,7 +389,7 @@ static bool frskyOSDHandleCommand(osdCommand_e cmd, const void *payload, size_t 
             }
             const frskyOSDInfoResponse_t *resp = payload;
             if (resp->magic[0] != 'A' || resp->magic[1] != 'G' || resp->magic[2] != 'H') {
-                FRSKY_OSD_ERROR("Invalid magic number %x %x %x, expecting AGH",
+                FRSKY_OSD_ERROR("invalid magic number %x %x %x, expecting AGH",
                     resp->magic[0], resp->magic[1], resp->magic[2]);
                 return false;
             }
@@ -400,7 +400,7 @@ static bool frskyOSDHandleCommand(osdCommand_e cmd, const void *payload, size_t 
             state.info.viewport.width = resp->pixelWidth;
             state.info.viewport.height = resp->pixelHeight;
             if (!state.initialized) {
-                FRSKY_OSD_DEBUG("FrSky OSD initialized. Version %u.%u.%u, pixels=%ux%u, grid=%ux%u",
+                FRSKY_OSD_DEBUG("initialized. Version %u.%u.%u, pixels=%ux%u, grid=%ux%u",
                     resp->versionMajor, resp->versionMinor, resp->versionPatch,
                     resp->pixelWidth, resp->pixelHeight, resp->gridColumns, resp->gridRows);
                 state.initialized = true;
@@ -525,12 +525,11 @@ static uint8_t frskyOSDEncodeAttr(textAttributes_t attr)
 bool frskyOSDInit(videoSystem_e videoSystem)
 {
     UNUSED(videoSystem);
-    FRSKY_OSD_TRACE("frskyOSDInit()");
     // TODO: Use videoSystem to set the signal standard when
     // no input is detected.
     const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_FRSKY_OSD);
     if (portConfig) {
-        FRSKY_OSD_TRACE("FrSky OSD configured, trying to connect...");
+        FRSKY_OSD_TRACE("configured, trying to connect...");
         portOptions_t portOptions = 0;
         serialPort_t *port = openSerialPort(portConfig->identifier,
             FUNCTION_FRSKY_OSD, NULL, NULL, FRSKY_OSD_BAUDRATE,

--- a/src/main/io/osd_canvas.c
+++ b/src/main/io/osd_canvas.c
@@ -34,7 +34,7 @@
 
 #include "common/log.h"
 #include "common/maths.h"
-#include "common/printf.h"
+#include "common/typeconversion.h"
 #include "common/utils.h"
 
 #include "drivers/display.h"
@@ -249,7 +249,7 @@ static void osdDrawArtificialHorizonShapes(displayCanvas_t *canvas, float pitchA
 
         int level = ii * 10;
         int absLevel = ABS(level);
-        tfp_snprintf(buf, sizeof(buf), "%d", absLevel);
+        itoa(absLevel, buf, 10);
         int pos = level * pixelsPerDegreeLevel;
         int charY = 9 - pos * 2;
         int cx = (absLevel >= 100 ? -1.5f : -1.0) * canvas->gridElementWidth;

--- a/src/main/io/osd_canvas.c
+++ b/src/main/io/osd_canvas.c
@@ -30,6 +30,7 @@
 
 #if defined(USE_CANVAS)
 
+#define AHI_MIN_DRAW_INTERVAL_MS 100
 #define AHI_MAX_DRAW_INTERVAL_MS 1000
 
 #include "common/log.h"
@@ -125,17 +126,9 @@ void osdCanvasDrawDirArrow(displayPort_t *display, displayCanvas_t *canvas, cons
     displayCanvasStrokeLineToPoint(canvas, -6, -7);
 }
 
-static void osdDrawArtificialHorizonLevelLine(displayCanvas_t *canvas, int width, int pos, int margin, bool erase)
+static void osdDrawArtificialHorizonLevelLine(displayCanvas_t *canvas, int width, int pos, int margin)
 {
     displayCanvasSetLineOutlineType(canvas, DISPLAY_CANVAS_OUTLINE_TYPE_BOTTOM);
-
-    if (erase) {
-        displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);
-        displayCanvasSetLineOutlineColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);
-    } else {
-        displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_WHITE);
-        displayCanvasSetLineOutlineColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
-    }
 
     int yoff = pos >= 0 ? 10 : -10;
     int yc = -pos - 1;
@@ -156,55 +149,59 @@ static void osdDrawArtificialHorizonLevelLine(displayCanvas_t *canvas, int width
     displayCanvasStrokeLineToPoint(canvas, sz, yc + yoff);
 }
 
-static void osdDrawArtificialHorizonShapes(displayCanvas_t *canvas, float pitchAngle, float rollAngle, bool erase)
+static void osdArtificialHorizonRect(displayCanvas_t *canvas, int *lx, int *ty, int *w, int *h)
+{
+    *w = (OSD_AHI_WIDTH + 1) * canvas->gridElementWidth;
+    *h = OSD_AHI_HEIGHT * canvas->gridElementHeight;
+
+    *lx = (canvas->width - *w) / 2;
+    *ty = (canvas->height - *h) / 2;
+}
+
+static void osdDrawArtificialHorizonShapes(displayCanvas_t *canvas, float pitchAngle, float rollAngle)
 {
     int barWidth = (OSD_AHI_WIDTH - 1) * canvas->gridElementWidth;
     int levelBarWidth = barWidth * (3.0/4);
     int crosshairMargin = 6;
     float pixelsPerDegreeLevel = 3.5f;
-    int maxWidth = (OSD_AHI_WIDTH + 1) * canvas->gridElementWidth;
-    int maxHeight = OSD_AHI_HEIGHT * canvas->gridElementHeight;
     int borderSize = 3;
     char buf[12];
 
+    int lx;
+    int ty;
+    int maxWidth;
+    int maxHeight;
+
+    osdArtificialHorizonRect(canvas, &lx, &ty, &maxWidth, &maxHeight);
+
     displayCanvasContextPush(canvas);
 
-    int lx = (canvas->width - maxWidth) / 2;
-    int ty = (canvas->height - maxHeight) / 2;
+    int rx = lx + maxWidth;
+    int by = ty + maxHeight;
 
-    if (!erase) {
-        int rx = lx + maxWidth;
-        int by = ty + maxHeight;
+    displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
 
-        displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
+    displayCanvasMoveToPoint(canvas, lx, ty + borderSize);
+    displayCanvasStrokeLineToPoint(canvas, lx, ty);
+    displayCanvasStrokeLineToPoint(canvas, lx + borderSize, ty);
 
-        displayCanvasMoveToPoint(canvas, lx, ty + borderSize);
-        displayCanvasStrokeLineToPoint(canvas, lx, ty);
-        displayCanvasStrokeLineToPoint(canvas, lx + borderSize, ty);
+    displayCanvasMoveToPoint(canvas, rx, ty + borderSize);
+    displayCanvasStrokeLineToPoint(canvas, rx, ty);
+    displayCanvasStrokeLineToPoint(canvas, rx - borderSize, ty);
 
-        displayCanvasMoveToPoint(canvas, rx, ty + borderSize);
-        displayCanvasStrokeLineToPoint(canvas, rx, ty);
-        displayCanvasStrokeLineToPoint(canvas, rx - borderSize, ty);
+    displayCanvasMoveToPoint(canvas,lx, by - borderSize);
+    displayCanvasStrokeLineToPoint(canvas, lx, by);
+    displayCanvasStrokeLineToPoint(canvas, lx + borderSize, by);
 
-        displayCanvasMoveToPoint(canvas,lx, by - borderSize);
-        displayCanvasStrokeLineToPoint(canvas, lx, by);
-        displayCanvasStrokeLineToPoint(canvas, lx + borderSize, by);
-
-        displayCanvasMoveToPoint(canvas, rx, by - borderSize);
-        displayCanvasStrokeLineToPoint(canvas, rx, by);
-        displayCanvasStrokeLineToPoint(canvas, rx - borderSize, by);
-    }
+    displayCanvasMoveToPoint(canvas, rx, by - borderSize);
+    displayCanvasStrokeLineToPoint(canvas, rx, by);
+    displayCanvasStrokeLineToPoint(canvas, rx - borderSize, by);
 
     displayCanvasClipToRect(canvas, lx + 1, ty + 1, maxWidth - 2, maxHeight - 2);
     osdGridBufferClearPixelRect(canvas, lx, ty, maxWidth, maxHeight);
 
-    if (erase) {
-        displayCanvasSetStrokeAndFillColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);
-        displayCanvasSetLineOutlineColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);
-    } else {
-        displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_WHITE);
-        displayCanvasSetLineOutlineColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
-    }
+    displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_WHITE);
+    displayCanvasSetLineOutlineColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
 
     // The draw just the 5 bars closest to the current pitch level
     float pitchDegrees = RADIANS_TO_DEGREES(pitchAngle);
@@ -231,7 +228,7 @@ static void osdDrawArtificialHorizonShapes(displayCanvas_t *canvas, float pitchA
 
         int pos = ii * 10 * pixelsPerDegreeLevel;
         int margin = (ii > 9 || ii < -9) ? 9 : 6;
-        osdDrawArtificialHorizonLevelLine(canvas, levelBarWidth, -pos, margin, erase);
+        osdDrawArtificialHorizonLevelLine(canvas, levelBarWidth, -pos, margin);
     }
 
     displayCanvasContextPop(canvas);
@@ -255,11 +252,7 @@ static void osdDrawArtificialHorizonShapes(displayCanvas_t *canvas, float pitchA
         int cx = (absLevel >= 100 ? -1.5f : -1.0) * canvas->gridElementWidth;
         int px = cx + (pitchOffset + pos) * sx * 2;
         int py = -charY - (pitchOffset + pos) * (1 - sy) * 2;
-        if (erase) {
-            displayCanvasDrawStringMask(canvas, px, py, buf, DISPLAY_CANVAS_COLOR_TRANSPARENT, 0);
-        } else {
-            displayCanvasDrawString(canvas, px, py, buf, 0);
-        }
+        displayCanvasDrawString(canvas, px, py, buf, 0);
     }
     displayCanvasContextPop(canvas);
 }
@@ -271,19 +264,23 @@ void osdCanvasDrawArtificialHorizon(displayPort_t *display, displayCanvas_t *can
 
     static float prevPitchAngle = 9999;
     static float prevRollAngle = 9999;
-    static timeMs_t nextDrawMs = 0;
+    static timeMs_t nextDrawMaxMs = 0;
+    static timeMs_t nextDrawMinMs = 0;
 
     timeMs_t now = millis();
 
-    if (fabsf(prevPitchAngle - pitchAngle) > 0.01f ||
-        fabsf(prevRollAngle - rollAngle) > 0.01f ||
-        now > nextDrawMs) {
+    float totalError = fabsf(prevPitchAngle - pitchAngle) + fabsf(prevRollAngle - rollAngle);
+    if ((now > nextDrawMinMs && totalError > 0.05f)|| now > nextDrawMaxMs) {
 
-        osdDrawArtificialHorizonShapes(canvas, prevPitchAngle, prevRollAngle, true);
-        osdDrawArtificialHorizonShapes(canvas, pitchAngle, rollAngle, false);
+        int x, y, w, h;
+        osdArtificialHorizonRect(canvas, &x, &y, &w, &h);
+        displayCanvasClearRect(canvas, x, y, w, h);
+
+        osdDrawArtificialHorizonShapes(canvas, pitchAngle, rollAngle);
         prevPitchAngle = pitchAngle;
         prevRollAngle = rollAngle;
-        nextDrawMs = now + AHI_MAX_DRAW_INTERVAL_MS;
+        nextDrawMinMs = now + AHI_MIN_DRAW_INTERVAL_MS;
+        nextDrawMaxMs = now + AHI_MAX_DRAW_INTERVAL_MS;
     }
 }
 

--- a/src/main/io/osd_canvas.c
+++ b/src/main/io/osd_canvas.c
@@ -212,7 +212,7 @@ static void osdDrawArtificialHorizonShapes(displayCanvas_t *canvas, float pitchA
 
     displayCanvasCtmTranslate(canvas, 0, pitchOffset);
     displayCanvasContextPush(canvas);
-    displayCanvasCtmRotate(canvas, -rollAngle);
+    displayCanvasCtmRotate(canvas, rollAngle);
 
     displayCanvasCtmTranslate(canvas, translateX, translateY);
 
@@ -237,8 +237,8 @@ static void osdDrawArtificialHorizonShapes(displayCanvas_t *canvas, float pitchA
     displayCanvasCtmScale(canvas, 0.5f, 0.5f);
 
     // Draw line labels
-    float sx = sin_approx(-rollAngle);
-    float sy = cos_approx(rollAngle);
+    float sx = sin_approx(rollAngle);
+    float sy = cos_approx(-rollAngle);
     for (int ii = pitchCenter - 2; ii <= pitchCenter + 2; ii++) {
         if (ii == 0) {
             continue;


### PR DESCRIPTION
- Fix off-by-one in osdGridBufferClearGridRect() 
- Cleanup log/debug messages in FrSky OSD driver
- Use itoa() instead of sprintf() to generate strings for AHI
- Severely reduce the amount of data sent out when drawing AHI