### PR TITLE
Fix rssi_source = auto

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -364,7 +364,7 @@ void rxUpdateRSSISource(void)
         }
     }
 
-    if (rxConfig()->rssi_source == RSSI_SOURCE_RX_PROTOCOL) {
+    if (rxConfig()->rssi_source == RSSI_SOURCE_RX_PROTOCOL || rxConfig()->rssi_source == RSSI_SOURCE_AUTO) {
         activeRssiSource = RSSI_SOURCE_RX_PROTOCOL;
         return;
     }


### PR DESCRIPTION
Fix rssi_source = auto so that when `FEATURE_RSSI_ADC` is disabled and `rssi_channel` is set to 0 the RSSI is taken automatically from the RX protocol