### PR TITLE
[PG] Avoid keeping 2 copies of each PG in RAM

### DIFF
--- a/src/main/config/parameter_group.h
+++ b/src/main/config/parameter_group.h
@@ -22,6 +22,8 @@
 
 #include "build/build_config.h"
 
+#define PG_MAX_SIZE 2048
+
 typedef uint16_t pgn_t;
 
 // parameter group registry flags
@@ -45,7 +47,6 @@ typedef struct pgRegistry_s {
     pgn_t pgn;             // The parameter group number, the top 4 bits are reserved for version
     uint16_t size;         // Size of the group in RAM, the top 4 bits are reserved for flags
     uint8_t *address;      // Address of the group in RAM.
-    uint8_t *copy;         // Address of the copy in RAM.
     uint8_t **ptr;         // The pointer to update after loading the record into ram.
     union {
         void *ptr;         // Pointer to init template
@@ -101,22 +102,37 @@ extern const uint8_t __pg_resetdata_end[];
     } while (0)                                                          \
     /**/
 
+#ifdef UNIT_TEST
+# define _PG_PROFILE_CURRENT_DECL(_type, _name)                  \
+    _type *_name ## _ProfileCurrent = &_name ## _Storage[0];
+# define _PG_DEFAULT_DECL(_type, _name)
+# define _PG_DEFAULT_I(_type, _name, _png)
+#else
+# define _PG_PROFILE_CURRENT_DECL(_type, _name)  \
+    _type *_name ## _ProfileCurrent;
+# define _PG_DEFAULT_DECL(_type, _name) \
+    _type* _name ## Default(void *blob);
+# define _PG_DEFAULT_I(_type, _name, _pgn) \
+    _type* _name ## Default(void *blob) { pgResetCopy(blob, _pgn); return (_type*)blob; }
+#endif
+
+
 // Declare system config
 #define PG_DECLARE(_type, _name)                                        \
     extern _type _name ## _System;                                      \
-    extern _type _name ## _Copy;                                        \
     static inline const _type* _name(void) { return &_name ## _System; }\
     static inline _type* _name ## Mutable(void) { return &_name ## _System; }\
+    _PG_DEFAULT_DECL(_type, _name);                                     \
     struct _dummy                                                       \
     /**/
 
 // Declare system config array
 #define PG_DECLARE_ARRAY(_type, _size, _name)                           \
     extern _type _name ## _SystemArray[_size];                          \
-    extern _type _name ## _CopyArray[_size];                            \
     static inline const _type* _name(int _index) { return &_name ## _SystemArray[_index]; } \
     static inline _type* _name ## Mutable(int _index) { return &_name ## _SystemArray[_index]; } \
     static inline _type (* _name ## _array(void))[_size] { return &_name ## _SystemArray; } \
+    _PG_DEFAULT_DECL(_type, _name);                                     \
     struct _dummy                                                       \
     /**/
 
@@ -129,17 +145,20 @@ extern const uint8_t __pg_resetdata_end[];
     /**/
 
 
+#define _PG_ASSERT_MAX_SIZE(_type, _name, _count) unsigned char __pg_ ## _name ## _too_big[sizeof(_type) * _count <= PG_MAX_SIZE ? 0 : -1]
+
+
 // Register system config
 #define PG_REGISTER_I(_type, _name, _pgn, _version, _reset)             \
     _type _name ## _System;                                             \
-    _type _name ## _Copy;                                               \
+    _PG_ASSERT_MAX_SIZE(_type, _name, 1);                               \
+    _PG_DEFAULT_I(_type, _name, _pgn);                                  \
     /* Force external linkage for g++. Catch multi registration */      \
     extern const pgRegistry_t _name ## _Registry;                       \
     const pgRegistry_t _name ##_Registry PG_REGISTER_ATTRIBUTES = {     \
         .pgn = _pgn | (_version << 12),                                 \
         .size = sizeof(_type) | PGR_SIZE_SYSTEM_FLAG,                   \
         .address = (uint8_t*)&_name ## _System,                         \
-        .copy = (uint8_t*)&_name ## _Copy,                              \
         .ptr = 0,                                                       \
         _reset,                                                         \
     }                                                                   \
@@ -162,13 +181,13 @@ extern const uint8_t __pg_resetdata_end[];
 // Register system config array
 #define PG_REGISTER_ARRAY_I(_type, _size, _name, _pgn, _version, _reset)  \
     _type _name ## _SystemArray[_size];                                 \
-    _type _name ## _CopyArray[_size];                                   \
+    _PG_ASSERT_MAX_SIZE(_type, _name, _size);                           \
+    _PG_DEFAULT_I(_type, _name, _pgn);                                  \
     extern const pgRegistry_t _name ##_Registry;                        \
     const pgRegistry_t _name ## _Registry PG_REGISTER_ATTRIBUTES = {    \
         .pgn = _pgn | (_version << 12),                                 \
         .size = (sizeof(_type) * _size) | PGR_SIZE_SYSTEM_FLAG,         \
         .address = (uint8_t*)&_name ## _SystemArray,                    \
-        .copy = (uint8_t*)&_name ## _CopyArray,                         \
         .ptr = 0,                                                       \
         _reset,                                                         \
     }                                                                   \
@@ -191,25 +210,16 @@ extern const uint8_t __pg_resetdata_end[];
     /**/
 #endif
 
-#ifdef UNIT_TEST
-# define _PG_PROFILE_CURRENT_DECL(_type, _name)                  \
-    _type *_name ## _ProfileCurrent = &_name ## _Storage[0];
-#else
-# define _PG_PROFILE_CURRENT_DECL(_type, _name)  \
-    _type *_name ## _ProfileCurrent;
-#endif
-
 // register profile config
 #define PG_REGISTER_PROFILE_I(_type, _name, _pgn, _version, _reset)     \
     STATIC_UNIT_TESTED _type _name ## _Storage[MAX_PROFILE_COUNT];      \
-    STATIC_UNIT_TESTED _type _name ## _CopyStorage[MAX_PROFILE_COUNT];  \
+    _PG_ASSERT_MAX_SIZE(_type, _name, MAX_PROFILE_COUNT);               \
     _PG_PROFILE_CURRENT_DECL(_type, _name)                              \
     extern const pgRegistry_t _name ## _Registry;                       \
     const pgRegistry_t _name ## _Registry PG_REGISTER_ATTRIBUTES = {    \
         .pgn = _pgn | (_version << 12),                                 \
         .size = sizeof(_type) | PGR_SIZE_PROFILE_FLAG,                  \
         .address = (uint8_t*)&_name ## _Storage,                        \
-        .copy = (uint8_t*)&_name ## _CopyStorage,                       \
         .ptr = (uint8_t **)&_name ## _ProfileCurrent,                   \
         _reset,                                                         \
     }                                                                   \

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -247,10 +247,10 @@ void *settingGetValuePointer(const setting_t *val)
     return pg->address + getValueOffset(val);
 }
 
-const void * settingGetCopyValuePointer(const setting_t *val)
+const void * settingGetDefaultValuePointer(void *pgBlob, const setting_t *val)
 {
-    const pgRegistry_t *pg = pgFind(settingGetPgn(val));
-    return pg->copy + getValueOffset(val);
+	pgResetCopy(pgBlob, settingGetPgn(val));
+	return ((uint8_t *)pgBlob) + getValueOffset(val);
 }
 
 setting_min_t settingGetMin(const setting_t *val)

--- a/src/main/fc/settings.h
+++ b/src/main/fc/settings.h
@@ -92,11 +92,9 @@ pgn_t settingGetPgn(const setting_t *val);
 // Returns a pointer to the actual value stored by
 // the setting_t. The returned value might be modified.
 void * settingGetValuePointer(const setting_t *val);
-// Returns a pointer to the backed up copy of the value. Note that
-// this will contain random garbage unless a copy of the parameter
-// group for the value has been manually performed. Currently, this
-// is only used by cli.c during config dumps.
-const void * settingGetCopyValuePointer(const setting_t *val);
+// Returns a pointer to the default value. Note that
+// pgBlob must be at least PG_MAX_SIZE.
+const void * settingGetDefaultValuePointer(void *pgBlob, const setting_t *val);
 // Returns the minimum valid value for the given setting_t. setting_min_t
 // depends on the target and build options, but will always be a signed
 // integer (e.g. intxx_t,)


### PR DESCRIPTION
Instead, keep a single copy in RAM and regenerate the default values
on the stack as needed. Since we only need to retrieve the default
values during dump/diff, the lost in performance is mostly irrelevant.

This saves around 5.2K of RAM and ~500 bytes of FLASH