### PR TITLE
[GF/LF] Fix PG resets for global functions and logic functions

### DIFF
--- a/src/main/common/global_functions.c
+++ b/src/main/common/global_functions.c
@@ -38,7 +38,7 @@
 
 #include "common/axis.h"
 
-PG_REGISTER_ARRAY(globalFunction_t, MAX_GLOBAL_FUNCTIONS, globalFunctions, PG_GLOBAL_FUNCTIONS, 0);
+PG_REGISTER_ARRAY_WITH_RESET_FN(globalFunction_t, MAX_GLOBAL_FUNCTIONS, globalFunctions, PG_GLOBAL_FUNCTIONS, 0);
 
 EXTENDED_FASTRAM uint64_t globalFunctionsFlags = 0;
 EXTENDED_FASTRAM globalFunctionState_t globalFunctionsStates[MAX_GLOBAL_FUNCTIONS];

--- a/src/main/common/logic_condition.c
+++ b/src/main/common/logic_condition.c
@@ -42,25 +42,6 @@
 
 PG_REGISTER_ARRAY(logicCondition_t, MAX_LOGIC_CONDITIONS, logicConditions, PG_LOGIC_CONDITIONS, 0);
 
-void pgResetFn_logicConditions(logicCondition_t *instance)
-{
-    for (int i = 0; i < MAX_LOGIC_CONDITIONS; i++) {
-        RESET_CONFIG(logicCondition_t, &instance[i],
-            .enabled = 0,
-            .operation = LOGIC_CONDITION_TRUE,
-            .operandA = {
-                .type = LOGIC_CONDITION_OPERAND_TYPE_VALUE,
-                .value = 0
-            },
-            .operandB = {
-                .type = LOGIC_CONDITION_OPERAND_TYPE_VALUE,
-                .value = 0
-            },
-            .flags = 0
-        );
-    }
-}
-
 logicConditionState_t logicConditionStates[MAX_LOGIC_CONDITIONS];
 
 static int logicConditionCompute(


### PR DESCRIPTION
- globalFunction_t needs to be registered with a reset fn, otherwise
it's never called.
- logicCondition_t is reset to all zeroes, so it doesn't need a reset
fn at all, it can be just deleted.