### PR TITLE
Fixed wrong address of MAG3110

### DIFF
--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -174,7 +174,7 @@
     #if !defined(MAG3110_I2C_BUS)
         #define MAG3110_I2C_BUS MAG_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_mag3110,     DEVHW_MAG3110,      MAG3110_I2C_BUS,    0x0C,               NONE,           DEVFLAGS_NONE);
+    BUSDEV_REGISTER_I2C(busdev_mag3110,     DEVHW_MAG3110,      MAG3110_I2C_BUS,    0x0E,               NONE,           DEVFLAGS_NONE);
 #endif
 
 #if defined(USE_MAG_LIS3MDL)


### PR DESCRIPTION
The address in common_hardware.c for the MAG3110 was wrong. Probably a copy&paste error from the sensor above. The address has to be 0x0E and not 0x0C. Tested on MAMBAF405.