### PR TITLE
Fixed inverted axis in MAG3110 according to datasheet

### DIFF
--- a/src/main/drivers/compass/compass_mag3110.c
+++ b/src/main/drivers/compass/compass_mag3110.c
@@ -97,7 +97,7 @@ static bool mag3110Read(magDev_t * mag)
 
     mag->magADCRaw[X] = (int16_t)(buf[0] << 8 | buf[1]);
     mag->magADCRaw[Y] = (int16_t)(buf[2] << 8 | buf[3]);
-    mag->magADCRaw[Z] = (int16_t)(buf[4] << 8 | buf[5]);
+    mag->magADCRaw[Z] = -(int16_t)(buf[4] << 8 | buf[5]);  // Z is down, not up in this sensor
 
     return true;
 }

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -174,7 +174,7 @@
     #if !defined(MAG3110_I2C_BUS)
         #define MAG3110_I2C_BUS MAG_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_mag3110,     DEVHW_MAG3110,      MAG3110_I2C_BUS,    0x0C,               NONE,           DEVFLAGS_NONE);
+    BUSDEV_REGISTER_I2C(busdev_mag3110,     DEVHW_MAG3110,      MAG3110_I2C_BUS,    0x0E,               NONE,           DEVFLAGS_NONE);
 #endif
 
 #if defined(USE_MAG_LIS3MDL)


### PR DESCRIPTION
The z-axis is inverted in MAG3110 according to datasheet. The value has to be inverted to compensate for this. Don't know why a silicon manufacturer of a magnetometer does not know how the Cartesian coordinate system is defined. Tested on MAMBAF405.
If this patch is not applied the sensor will drift massively once pitched/rolled a bit, although the heading is correct when not pitched/rolled.