### PR TITLE
Add ICM20601 IMU support

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6500.c
@@ -127,6 +127,7 @@ static bool mpu6500DeviceDetect(busDevice_t * dev)
         switch (tmp) {
             case MPU6500_WHO_AM_I_CONST:
             case ICM20608G_WHO_AM_I_CONST:
+            case ICM20601_WHO_AM_I_CONST:
             case ICM20602_WHO_AM_I_CONST:
             case ICM20689_WHO_AM_I_CONST:
                 // Compatible chip detected


### PR DESCRIPTION
Add ICM20601's ID to the ones recognized by the MPU6500 driver

Tested