### PR TITLE
[CANVAS] Fix home direction arrow orientation

### DIFF
--- a/src/main/io/osd_canvas.c
+++ b/src/main/io/osd_canvas.c
@@ -116,7 +116,7 @@ void osdCanvasDrawDirArrow(displayPort_t *display, displayCanvas_t *canvas, cons
     displayCanvasSetFillColor(canvas, DISPLAY_CANVAS_COLOR_WHITE);
     displayCanvasSetStrokeColor(canvas, DISPLAY_CANVAS_COLOR_BLACK);
 
-    displayCanvasCtmRotate(canvas, -DEGREES_TO_RADIANS(degrees));
+    displayCanvasCtmRotate(canvas, -DEGREES_TO_RADIANS(180 + degrees));
     displayCanvasCtmTranslate(canvas, px + canvas->gridElementWidth / 2, py + canvas->gridElementHeight / 2);
     displayCanvasFillStrokeTriangle(canvas, 0, 6, 5, -6, -5, -6);
     displayCanvasSetFillColor(canvas, DISPLAY_CANVAS_COLOR_TRANSPARENT);


### PR DESCRIPTION
Arrow as rotating in the correct direction, but it was drawn
inverted 180 degrees (i.e. it pointed up when it should point down).

Kudos to @fmartinezo for the heads up