### PR TITLE
fixed craft name spaces bug

### DIFF
--- a/src/main/io/osd_dji_hd.c
+++ b/src/main/io/osd_dji_hd.c
@@ -402,8 +402,8 @@ static mspResult_e djiProcessMspCommand(mspPacket_t *cmd, mspPacket_t *reply, ms
                 int len = strlen(name);
                 if (len > 12) len = 12;
                 sbufWriteData(dst, name, len);
-           }
-	   break;
+            }
+	    break;
 
         case DJI_MSP_STATUS:
         case DJI_MSP_STATUS_EX:

--- a/src/main/io/osd_dji_hd.c
+++ b/src/main/io/osd_dji_hd.c
@@ -397,10 +397,13 @@ static mspResult_e djiProcessMspCommand(mspPacket_t *cmd, mspPacket_t *reply, ms
             break;
 
         case DJI_MSP_NAME:
-            for (const char * name = systemConfig()->name; *name; name++) {
-                sbufWriteU8(dst, *name++);
-            }
-            break;
+            {
+                const char * name = systemConfig()->name;
+                int len = strlen(name);
+                if (len > 12) len = 12;
+                sbufWriteData(dst, name, len);
+           }
+	   break;
 
         case DJI_MSP_STATUS:
         case DJI_MSP_STATUS_EX:


### PR DESCRIPTION
Fixed bug where the craft name seems to ignore every other character on DJI Goggles.

Bug verified [here](https://www.rcgroups.com/forums/showthread.php?3371977-DJI-Digital-FPV-System-Owners/page246).