### PR TITLE
Use non-root user in Docker build and update docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.vagrant/
+obj/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,6 @@ RUN mkdir -p /opt && \
 	chmod -R -w "/opt/gcc-arm-none-eabi-$TOOLCHAIN_VERSION_LONG"
 
 ENV PATH="/opt/gcc-arm-none-eabi-$TOOLCHAIN_VERSION_LONG/bin:$PATH"
+
+RUN useradd inav
+USER inav

--- a/docs/development/Building in Docker.md
+++ b/docs/development/Building in Docker.md
@@ -1,24 +1,34 @@
 # Building with Docker
 
-Building in Docker is remarkably easy.
+Building with [Docker](https://www.docker.com/) is remarkably easy: an isolated container will hold all the needed compilation tools so that they won't interfere with your system and you won't need to install and manage them by yourself. You'll only need to have Docker itself [installed](https://docs.docker.com/install/).
 
-## Build a container with toolchain
+The first time that you'll run a build it will take a little more time than following executions since it will be building its base image first. Once this initial process is completed, the firmware will be always built immediately.
+
+If you want to start from scratch - _even if that's rarely needed_ - delete the `inav-build` image on your system (`docker image rm inav-build`).
+
+## Linux
+
+In the repo's root, run:
 
 ```
-docker build -t inav-build .
+./build.sh <TARGET>
 ```
 
-## Building firmware with Docker on Ubuntu
+Where `<TARGET>` must be replaced with the name of the target that you want to build. For example:
 
-Build specified target
 ```
-sh build.sh SPRACINGF3
+./build.sh MATEKF405SE
 ```
 
-## Building firmware with Docker on Windows 10
+## Windows 10
 
-Path in Docker on Windows works in a _strange_ way, so you have to provide full path for `docker run` command. For example:
+Docker on Windows requires full paths for mounting volumes in `docker run` commands. For example: `c:\Users\pspyc\Documents\Projects\inav` becomes `//c/Users/pspyc/Documents/Projects/inav` .
 
-`docker run --rm -v //c/Users/pspyc/Documents/Projects/inav:/home/src/ inav-build make TARGET=AIRBOTF4`
+You'll have to manually execute the same steps that the build script does:
 
-So, `c:\Users\pspyc\Documents\Projects\inav` becomes `//c/Users/pspyc/Documents/Projects/inav`
+1. `docker build -t inav-build .`
+   + This step is only needed the first time.
+2. `docker run --rm -v <PATH_TO_REPO>:/home/src/ inav-build make TARGET=<TARGET>`
+   + Where `<PATH_TO_REPO>` must be replaced with the absolute path of where you cloned this repo (see above), and `<TARGET>` with the name of the target that you want to build.
+
+Refer to the [Linux](#Linux) instructions or the [build script](/build.sh) for more details.


### PR DESCRIPTION
Building firmware as a non-root user in the Docker container avoids unnecessary permissions issues with the `/obj` folder contents in most cases (e.g.: when the host user's UID is 1000).

Related docs have been freshened up and a `.dockerignore` file has been added to avoid sending unnecessary data to the daemon when creating the build context for the base image.