### PR TITLE
remove all traces of RX_TYPE_PWM

### DIFF
--- a/docs/Rx.md
+++ b/docs/Rx.md
@@ -154,10 +154,8 @@ The receiver type can be set from the configurator or CLI.
 ```
 # get receiver_type
 receiver_type = NONE
-Allowed values: NONE, PWM, PPM, SERIAL, MSP, SPI, UIB
+Allowed values: NONE, PPM, SERIAL, MSP, SPI, UIB
 ```
-
-Note that `PWM` is a synonym for `NONE`. 
 
 ### RX signal-loss detection
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -163,7 +163,7 @@ __attribute__((weak)) void targetConfiguration(void)
 
 uint32_t getLooptime(void) {
     return gyro.targetLooptime;
-} 
+}
 
 void validateAndFixConfig(void)
 {
@@ -183,28 +183,12 @@ void validateAndFixConfig(void)
     // Disable unused features
     featureClear(FEATURE_UNUSED_3 | FEATURE_UNUSED_4 | FEATURE_UNUSED_5 | FEATURE_UNUSED_6 | FEATURE_UNUSED_7 | FEATURE_UNUSED_8 | FEATURE_UNUSED_9 | FEATURE_UNUSED_10);
 
-#if defined(DISABLE_RX_PWM_FEATURE) || !defined(USE_RX_PWM)
-    if (rxConfig()->receiverType == RX_TYPE_PWM) {
-        rxConfigMutable()->receiverType = RX_TYPE_NONE;
-    }
-#endif
-
 #if !defined(USE_RX_PPM)
     if (rxConfig()->receiverType == RX_TYPE_PPM) {
         rxConfigMutable()->receiverType = RX_TYPE_NONE;
     }
 #endif
 
-
-    if (rxConfig()->receiverType == RX_TYPE_PWM) {
-#if defined(CHEBUZZ) || defined(STM32F3DISCOVERY)
-        // led strip needs the same ports
-        featureClear(FEATURE_LED_STRIP);
-#endif
-
-        // software serial needs free PWM ports
-        featureClear(FEATURE_SOFTSERIAL);
-    }
 
 #if defined(USE_LED_STRIP) && (defined(USE_SOFTSERIAL1) || defined(USE_SOFTSERIAL2))
     if (featureConfigured(FEATURE_SOFTSERIAL) && featureConfigured(FEATURE_LED_STRIP)) {

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -253,10 +253,10 @@ void init(void)
 
 #if defined(AVOID_UART2_FOR_PWM_PPM)
     serialInit(feature(FEATURE_SOFTSERIAL),
-            (rxConfig()->receiverType == RX_TYPE_PWM) || (rxConfig()->receiverType == RX_TYPE_PPM) ? SERIAL_PORT_USART2 : SERIAL_PORT_NONE);
+            (rxConfig()->receiverType == RX_TYPE_PPM) ? SERIAL_PORT_USART2 : SERIAL_PORT_NONE);
 #elif defined(AVOID_UART3_FOR_PWM_PPM)
     serialInit(feature(FEATURE_SOFTSERIAL),
-            (rxConfig()->receiverType == RX_TYPE_PWM) || (rxConfig()->receiverType == RX_TYPE_PPM) ? SERIAL_PORT_USART3 : SERIAL_PORT_NONE);
+            (rxConfig()->receiverType == RX_TYPE_PPM) ? SERIAL_PORT_USART3 : SERIAL_PORT_NONE);
 #else
     serialInit(feature(FEATURE_SOFTSERIAL), SERIAL_PORT_NONE);
 #endif
@@ -295,37 +295,6 @@ void init(void)
     else {
         ENABLE_ARMING_FLAG(ARMING_DISABLED_PWM_OUTPUT_ERROR);
     }
-
-    /*
-    drv_pwm_config_t pwm_params;
-    memset(&pwm_params, 0, sizeof(pwm_params));
-
-    // when using airplane/wing mixer, servo/motor outputs are remapped
-    pwm_params.flyingPlatformType = mixerConfig()->platformType;
-
-    pwm_params.useParallelPWM = (rxConfig()->receiverType == RX_TYPE_PWM);
-    pwm_params.usePPM = (rxConfig()->receiverType == RX_TYPE_PPM);
-    pwm_params.useSerialRx = (rxConfig()->receiverType == RX_TYPE_SERIAL);
-
-    pwm_params.useServoOutputs = isMixerUsingServos();
-    pwm_params.servoCenterPulse = servoConfig()->servoCenterPulse;
-    pwm_params.servoPwmRate = servoConfig()->servoPwmRate;
-
-
-    pwm_params.enablePWMOutput = feature(FEATURE_PWM_OUTPUT_ENABLE);
-
-#if defined(USE_RX_PWM) || defined(USE_RX_PPM)
-    pwmRxInit(systemConfig()->pwmRxInputFilteringMode);
-#endif
-
-#ifdef USE_PWM_SERVO_DRIVER
-    // If external PWM driver is enabled, for example PCA9685, disable internal
-    // servo handling mechanism, since external device will do that
-    if (feature(FEATURE_PWM_SERVO_DRIVER)) {
-        pwm_params.useServoOutputs = false;
-    }
-#endif
-    */
 
     systemState |= SYSTEM_STATE_MOTORS_READY;
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -22,7 +22,7 @@ tables:
     values: ["NONE", "AUTO", "MS4525", "ADC", "VIRTUAL", "FAKE"]
     enum: pitotSensor_e
   - name: receiver_type
-    values: ["NONE", "PWM", "PPM", "SERIAL", "MSP", "SPI", "UIB"]
+    values: ["NONE", "PPM", "SERIAL", "MSP", "SPI", "UIB"]
     enum: rxReceiverType_e
   - name: serial_rx
     values: ["SPEK1024", "SPEK2048", "SBUS", "SUMD", "SUMH", "XB-B", "XB-B-RJ01", "IBUS", "JETIEXBUS", "CRSF", "FPORT", "SBUS_FAST"]

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -327,7 +327,6 @@ void rxInit(void)
 
         default:
         case RX_TYPE_NONE:
-        case RX_TYPE_PWM:
             rxConfigMutable()->receiverType = RX_TYPE_NONE;
             rxRuntimeConfig.rcReadRawFn = nullReadRawRC;
             rxRuntimeConfig.rcFrameStatusFn = nullFrameStatus;

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -104,7 +104,7 @@ static rcChannel_t rcChannels[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 rxRuntimeConfig_t rxRuntimeConfig;
 static uint8_t rcSampleIndex = 0;
 
-PG_REGISTER_WITH_RESET_TEMPLATE(rxConfig_t, rxConfig, PG_RX_CONFIG, 8);
+PG_REGISTER_WITH_RESET_TEMPLATE(rxConfig_t, rxConfig, PG_RX_CONFIG, 9);
 
 #ifndef RX_SPI_DEFAULT_PROTOCOL
 #define RX_SPI_DEFAULT_PROTOCOL 0

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -59,12 +59,11 @@ typedef enum {
 
 typedef enum {
     RX_TYPE_NONE        = 0,
-    RX_TYPE_PWM         = 1,
-    RX_TYPE_PPM         = 2,
-    RX_TYPE_SERIAL      = 3,
-    RX_TYPE_MSP         = 4,
-    RX_TYPE_SPI         = 5,
-    RX_TYPE_UIB         = 6
+    RX_TYPE_PPM         = 1,
+    RX_TYPE_SERIAL      = 2,
+    RX_TYPE_MSP         = 3,
+    RX_TYPE_SPI         = 4,
+    RX_TYPE_UIB         = 5
 } rxReceiverType_e;
 
 typedef enum {
@@ -153,7 +152,7 @@ typedef struct rxRuntimeConfig_s {
     rcReadRawDataFnPtr rcReadRawFn;
     rcFrameStatusFnPtr rcFrameStatusFn;
     rcProcessFrameFnPtr rcProcessFrameFn;
-    rxLinkQualityTracker_e * lqTracker;     // Pointer to a 
+    rxLinkQualityTracker_e * lqTracker;     // Pointer to a
     uint16_t *channelData;
     void *frameData;
 } rxRuntimeConfig_t;


### PR DESCRIPTION
For the benefit of users who will not or cannot read documentation, this patch removed all traces of RX_TYPE_PWM.

Note: This requires a coordinated change to the configurator.

Much as I dislike removing obsolete legacy enums, this seems preferable than having options of "NONE", "AGAIN NONE, "PPM" ...