### PR TITLE
SPRACINGAIRBIT - Target support.

### DIFF
--- a/src/main/target/SPRACINGF3EVO/target.c
+++ b/src/main/target/SPRACINGF3EVO/target.c
@@ -31,15 +31,26 @@ const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM15, CH1, PA2,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,                     0), // PWM3 [TIM2_CH3 (D1_CH1)] [TIM15_CH1  (D1_CH5)]
     DEF_TIM(TIM15, CH2, PA3,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,                     0), // PWM4 [TIM2_CH4 (D1_CH7)]
 
-#ifdef SPRACINGF3EVO_1SS
+#if defined(SPRACINGAIRBIT)
+    // SPRACINGAIRBIT uses same pins as F3EVO, but in a different order.
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,                     0), // Silkscreen: 'SERVO1' 2.54mm pitch headers.
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,                     0), // Silkscreen: 'SERVO2' 2.54mm pitch headers.
+    DEF_TIM(TIM3,  CH2, PA7,  TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,                     0), // Silkscreen: 'MS', for MicroServo 3-pin picoblade connection.
+    DEF_TIM(TIM16, CH1, PA6,  TIM_USE_ANY, /*TIM_USE_CAMERA_CONTROL*/                  0), // Silkscreen: 'CAM', for CAMERA connection.
+
+#else
+
+#if defined(SPRACINGF3EVO_1SS)
     DEF_TIM(TIM16, CH1, PA6,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,                     0), // PWM5
     DEF_TIM(TIM17, CH1, PA7,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,                     0), // PWM6
 #else
     DEF_TIM(TIM3,  CH1, PA6,  TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,  0), // PWM5
     DEF_TIM(TIM3,  CH2, PA7,  TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,  0), // PWM6
 #endif
+
     DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,  0), // PWM7
     DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,  0), // PWM8
+#endif // !SPRACINGAIRBIT
 
     // UART3 RX/TX
     DEF_TIM(TIM2,  CH3, PB10, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,                     0), // RC_CH4 - PB10 - *TIM2_CH3, UART3_TX (AF7)

--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -17,7 +17,11 @@
 
 #pragma once
 
+#if defined(SPRACINGAIRBIT)
+#define TARGET_BOARD_IDENTIFIER "SPAB"
+#else
 #define TARGET_BOARD_IDENTIFIER "SPEV"
+#endif
 
 #define LED0                    PB8
 
@@ -49,8 +53,13 @@
 
 #define USE_BARO
 #define BARO_I2C_BUS            BUS_I2C1
+
+#ifdef SPRACINGAIRBIT
+#define USE_BARO_BMP388
+#else
 #define USE_BARO_BMP280
 #define USE_BARO_MS5611
+#endif
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
@@ -67,7 +76,6 @@
 #define USE_UART1
 #define USE_UART2
 #define USE_UART3
-#define USE_SOFTSERIAL1
 
 #define UART1_TX_PIN            PA9
 #define UART1_RX_PIN            PA10
@@ -78,19 +86,28 @@
 #define UART3_TX_PIN            PB10 // PB10 (AF7)
 #define UART3_RX_PIN            PB11 // PB11 (AF7)
 
-#ifdef SPRACINGF3EVO_1SS
-    #define SERIAL_PORT_COUNT       5
-
+#if defined(SPRACINGF3AIRBIT)
+    // no softserial
+#elif defined(SPRACINGF3EVO_1SS)
+    #define USE_SOFTSERIAL1
     #define SOFTSERIAL_1_RX_PIN     PB0
     #define SOFTSERIAL_1_TX_PIN     PB1
 #else
-    #define USE_SOFTSERIAL2
-    #define SERIAL_PORT_COUNT       6
-
+    #define USE_SOFTSERIAL1
     #define SOFTSERIAL_1_RX_PIN     PA6
     #define SOFTSERIAL_1_TX_PIN     PA7
+
+    #define USE_SOFTSERIAL2
     #define SOFTSERIAL_2_RX_PIN     PB0
     #define SOFTSERIAL_2_TX_PIN     PB1
+#endif
+
+#if defined(USE_SOFTSERIAL1) && defined (USE_SOFTSERIAL2)
+    #define SERIAL_PORT_COUNT       6
+#elif defined(USE_SOFTSERIAL1) || defined (USE_SOFTSERIAL2)
+    #define SERIAL_PORT_COUNT       5
+#else
+    #define SERIAL_PORT_COUNT       4
 #endif
 
 #define USE_I2C
@@ -126,6 +143,13 @@
 #define CURRENT_METER_ADC_CHANNEL       ADC_CHN_2
 #define RSSI_ADC_CHANNEL                ADC_CHN_3
 
+#ifdef SPRACINGAIRBIT
+// No RSSI                      (PB2 Used for BARO INT)
+#undef ADC_CHANNEL_3_PIN
+#undef RSSI_ADC_CHANNEL
+#endif
+
+
 #define USE_LED_STRIP
 #define WS2811_PIN                      PA8
 
@@ -138,8 +162,37 @@
 
 #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
 
+#ifdef SPRACINGAIRBIT
+// SPRacingAIRBIT is designed specifically for SERIAL_RX SPEKTRUM1024 + LTM telemetry or RX via MSP.
+#define USE_TELEMETRY
+#define USE_TELEMETRY_LTM
+#undef USE_TELEMETRY_FRSKY
+#define USE_RX_MSP
+
+#undef USE_RX_PPM
+#undef USE_RX_PWM
+#undef USE_SERIALRX_CRSF       // Team Black Sheep Crossfire protocol
+#undef USE_SERIALRX_IBUS       // FlySky and Turnigy receivers
+#undef USE_SERIALRX_SBUS       // Frsky and Futaba receivers
+#undef USE_SERIALRX_SUMD       // Graupner Hott protocol
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#else
 #define DEFAULT_RX_TYPE         RX_TYPE_PPM
-#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_TRANSPONDER | FEATURE_BLACKBOX | FEATURE_RSSI_ADC | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY)
+#endif
+
+#ifdef SPRACINGAIRBIT
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_MSP
+#define USE_OPFLOW
+#define USE_OPFLOW_MSP
+#endif
+
+#ifdef SPRACINGAIRBIT
+#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY)
+#else
+#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX | FEATURE_RSSI_ADC | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY)
+#endif
 
 #define USE_SPEKTRUM_BIND
 #define BIND_PIN                PB11 // UART3

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -190,7 +190,7 @@ void telemetryProcess(timeUs_t currentTimeUs)
 {
     UNUSED(currentTimeUs); // since not used by all the telemetry protocols
 
-    #if defined(USE_TELEMETRY_FRSKY)
+#if defined(USE_TELEMETRY_FRSKY)
     handleFrSkyTelemetry();
 #endif
 
@@ -214,7 +214,7 @@ void telemetryProcess(timeUs_t currentTimeUs)
     handleJetiExBusTelemetry();
 #endif
 
-#if defined(USE_TELEMETRY_IBUS)
+#if defined(USE_SERIALRX_IBUS) && defined(USE_TELEMETRY_IBUS)
     handleIbusTelemetry();
 #endif
 


### PR DESCRIPTION
This PR adds support for the SPRacing AIRBIT FC, an F3 based flight controller for EDUCATION/SCHOOLS.

Available from: https://www.makekit.no/airbit

The AIRBIT FC pairs with a MicroBIT which acts as a receiver which currently emulates a Spektrum RX.

The SPRacingAIRBIT is thus the target has other RX protocols DISABLED to free space for other peripherals that will be used.

The SPRacingAIRBIT is variant of the SPRacingF3EVO and is implemented as such.

This PR includes the commit from https://github.com/iNavFlight/inav/pull/5383.  Merge #5383 first, then this to avoid merge conflicts/compilation errors.
