### PR TITLE
Simplify RX config for standard receiver setups

### DIFF
--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -406,7 +406,7 @@ bool fportRxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
         NULL,
         FPORT_BAUDRATE,
         MODE_RXTX,
-        FPORT_PORT_OPTIONS | (rxConfig->serialrx_inverted ? SERIAL_INVERTED : 0) | (rxConfig->halfDuplex ? SERIAL_BIDIR : 0)
+        FPORT_PORT_OPTIONS | (rxConfig->serialrx_inverted ? 0 : SERIAL_INVERTED) | (rxConfig->halfDuplex ? SERIAL_BIDIR : 0)
     );
 
     if (fportPort) {


### PR DESCRIPTION
* Fix the meaning of the `serialrx_inverted` setting for F.Port

`serialrx_inverted` is supposed to be set to OFF for the normal expected
polarity of the signal for the selected protocol. Before this change it
needed to be set to ON when a F.Port receiver was connected directly to
the FC without an inverter or through the inverted S.Port wire present on
some receivers. This change uniformizes the meaning of this setting with
its meaning for the protocols others than F.Port

* ~Enable `serialrx_halfduplex` by default~

~Makes standard receivers configuration easier. For example this setting
needs to be turned on for typical F.Port receivers wiring (S.Port
directly connected to UART TX line). It shouldn't be an issue to have it
on by default for any of the other RX protocols~