### PR TITLE
replicate ~old sport unidir/half duplex in order to make SPort work post #5455 on WINGFC

### DIFF
--- a/src/main/target/FF_F35_LIGHTNING/config.c
+++ b/src/main/target/FF_F35_LIGHTNING/config.c
@@ -48,6 +48,6 @@ void targetConfiguration(void)
     rxConfigMutable()->serialrx_provider = SERIALRX_CRSF;
 
     serialConfigMutable()->portConfigs[6].functionMask = FUNCTION_TELEMETRY_SMARTPORT;
-
+    telemetryConfigMutable()->halfDuplex = 0;
     mixerConfigMutable()->platformType = PLATFORM_AIRPLANE;
 }


### PR DESCRIPTION
Since #5455, the following small patch is necessary to have SPort working again on WINGFC (and probably FF_F35_LIGHTNING). 