### PR TITLE
added FreeBSD OS identification as Linux

### DIFF
--- a/make/system-id.mk
+++ b/make/system-id.mk
@@ -18,6 +18,13 @@ ifeq ($(UNAME), Linux)
   LINUX := 1
 endif
 
+# FreeBSD
+ifeq ($(UNAME), FreeBSD)
+  OSFAMILY := linux
+  LINUX := 1
+endif
+
+
 # Mac OSX
 ifeq ($(UNAME), Darwin)
   OSFAMILY := macosx


### PR DESCRIPTION
This patch makes little easier cross-compilation of target using FreeBSD. Cross compilation is similar. The utilities are almost the same.

 