### PR TITLE
Lower pos_hold_deadband minimum and default

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -74,7 +74,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig, PG_RC_CONT
 PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
     .deadband = 5,
     .yaw_deadband = 5,
-    .pos_hold_deadband = 20,
+    .pos_hold_deadband = 10,
     .alt_hold_deadband = 50,
     .mid_throttle_deadband = 50,
     .airmodeHandlingType = STICK_CENTER,

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -933,7 +933,7 @@ groups:
         min: 0
         max: 100
       - name: pos_hold_deadband
-        min: 10
+        min: 2
         max: 250
       - name: alt_hold_deadband
         min: 10


### PR DESCRIPTION
The default `pos_hold_deadband` seems quiet high, particularly with the default expo. Lower the default to 10 and also allows to set it even lower.

Related issue: #5391 