### PR TITLE
[OSD/CMS] Avoid initializing CMS when OSD is disabled

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -766,7 +766,7 @@ void cmsMenuOpen(void)
 {
     if (!cmsInMenu) {
         // New open
-	setServoOutputEnabled(false);
+        setServoOutputEnabled(false);
         pCurrentDisplay = cmsDisplayPortSelectCurrent();
         if (!pCurrentDisplay)
             return;

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -536,13 +536,6 @@ void init(void)
     }
 #endif
 
-#if defined(USE_MSP_DISPLAYPORT) && defined(USE_CMS)
-    // If OSD is not active, then register MSP_DISPLAYPORT as a CMS device.
-    if (!osdDisplayPort) {
-        cmsDisplayPortRegister(displayPortMspInit());
-    }
-#endif
-
 #ifdef USE_UAV_INTERCONNECT
     uavInterconnectBusInit();
 #endif


### PR DESCRIPTION
Currently we are falling back on MSP DisplayPort for CMS if OSD is disabled. Combined with the fact that CMS now disables servos, this may cause what looks like a FC lockup on a disarmed plane.

This PR removes falling back on MSP Displayport for CMS. Now CMS will only be enabled if OSD is enabled as well.

This may break some esoteric setups.
A follow up PR that adds a setting to force a displayport device for OSD may be required.

This is a potential fix for #5433