### PR TITLE
Remove PID iterm constrain for NAV PID controller

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1235,7 +1235,7 @@ groups:
         min: 0
         max: 255
       - name: nav_fw_pos_hdg_pidsum_limit
-        field: pidSumLimitYaw
+        field: navFwPosHdgPidsumLimit
         min: PID_SUM_LIMIT_MIN
         max: PID_SUM_LIMIT_MAX
       - name: mc_iterm_relax_type

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -150,7 +150,7 @@ typedef struct pidProfile_s {
     float antigravityAccelerator;
     uint8_t antigravityCutoff;
 
-    int navFwPosHdgPidsumLimit;
+    uint16_t navFwPosHdgPidsumLimit;
 } pidProfile_t;
 
 typedef struct pidAutotuneConfig_s {

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1863,11 +1863,6 @@ float navPidApply3(pidController_t *pid, const float setpoint, const float measu
         }
     }
 
-    /*
-     * Limit both output and Iterm to limit windup
-     */
-    pid->integrator = constrain(pid->integrator, outMin, outMax);
-
     return outValConstrained;
 }
 


### PR DESCRIPTION
This is the probable fix for #5516 
PosHold looks good from the outside, not rock solid since it's a windy/gusty day. 
BB log inside. @stronnag if you could take a look and flight test if possible if it also fixes your problems

[LOG00002.zip](https://github.com/iNavFlight/inav/files/4365286/LOG00002.zip)
