### PR TITLE
[SYSTEM] Avoid performing a 64bit division in micros()

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -132,7 +132,9 @@ timeUs_t microsISR(void)
         pending = sysTickPending;
     }
 
-    return ((timeUs_t)(ms + pending) * 1000LL) + (usTicks * 1000LL - (timeUs_t)cycle_cnt) / usTicks;
+    // XXX: Be careful to not trigger 64 bit division
+    uint32_t partial = (((uint32_t)usTicks) * 1000U - cycle_cnt) / ((uint32_t)usTicks);
+    return ((timeUs_t)(ms + pending) * 1000LL) + partial;
 }
 
 timeUs_t micros(void)
@@ -152,7 +154,9 @@ timeUs_t micros(void)
         cycle_cnt = SysTick->VAL;
     } while (ms != sysTickUptime || cycle_cnt > sysTickValStamp);
 
-    return ((timeUs_t)ms * 1000LL) + (usTicks * 1000LL - (timeUs_t)cycle_cnt) / usTicks;
+    // XXX: Be careful to not trigger 64 bit division
+    uint32_t partial = (((uint32_t)usTicks) * 1000U - cycle_cnt) / ((uint32_t)usTicks);
+    return ((timeUs_t)ms * 1000U) + partial;
 }
 
 // Return system uptime in milliseconds (rollover in 49 days)


### PR DESCRIPTION
Since the sub-ms step fits in an uint32_t, we can do the calculation
using just 32 bits, then perform a 64 bit add to the (ms * 1000)
value. This is way faster because cortex-m[4,7] do have 32 bit
integer division in HW, but not for 64 bit.

This reduces the number of cycles used by micros() from ~177
to ~57 (there's a small 3-4 cycle variance due to pipelining).