### PR TITLE
[MAKE] Avoid adding our custom CFLAGS twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,11 @@ SIZE        = $(ARM_SDK_PREFIX)size
 # Tool options.
 #
 
+# Save original CFLAGS before modifying them, so we don't
+# add them twice when calling this Makefile recursively
+# for each target
+SAVED_CFLAGS	:= $(CFLAGS)
+
 ifeq ($(DEBUG),GDB)
 LTO_FLAGS   = 
 else
@@ -360,7 +365,7 @@ release: $(RELEASE_TARGETS)
 $(VALID_TARGETS):
 	$(V0) echo "" && \
 	echo "Building $@" && \
-	$(MAKE) -j 8 TARGET=$@ && \
+	CFLAGS=$(SAVED_CFLAGS) $(MAKE) -j 8 TARGET=$@ && \
 	echo "Building $@ succeeded."
 
 ## clean             : clean up all temporary / machine-generated files


### PR DESCRIPTION
We don't clear CFLAGS becase we want to allow them to be passed
via command line. However, when building a target we add our
custom ones once in the first parsing of the Makefile and then
again a second time when we invoke make recursively for each target.
This breaks compilation with -Werror.

To workaround this, save the initial CFLAGS in a variable, then
pass them to the recursive invocation of make.