### PR TITLE
Added idle interrupt callback to UART driver (Needed for Spektrum SRXL2 support)

### DIFF
--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -120,7 +120,7 @@ The following sensors are transmitted
 * **0420** : distance to GPS home fix, in meters
 * **0430** : if `frsky_pitch_roll = ON` set this will be pitch degrees*10
 * **0440** : if `frsky_pitch_roll = ON` set this will be roll degrees*10
-
+* **0450** : 'Flight Path Vector' or 'Course over ground' in degrees*10
 ### Compatible SmartPort/INAV telemetry flight status
 
 To quickly and easily monitor these SmartPort sensors and flight modes, install [iNav LuaTelemetry](https://github.com/iNavFlight/LuaTelemetry) to your Taranis Q X7, X9D, X9D+ or X9E transmitter.

--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -52,6 +52,7 @@ typedef enum portOptions_t {
 } portOptions_t;
 
 typedef void (*serialReceiveCallbackPtr)(uint16_t data, void *rxCallbackData);   // used by serial drivers to return frames to app
+typedef void (*serialIdleCallbackPtr)();
 
 typedef struct serialPort_s {
 
@@ -74,6 +75,9 @@ typedef struct serialPort_s {
 
     serialReceiveCallbackPtr rxCallback;
     void *rxCallbackData;
+    
+    serialIdleCallbackPtr idleCallback;
+
 } serialPort_t;
 
 struct serialPortVTable {

--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -162,6 +162,7 @@ serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr rxCallbac
     if (mode & MODE_RX) {
         USART_ClearITPendingBit(s->USARTx, USART_IT_RXNE);
         USART_ITConfig(s->USARTx, USART_IT_RXNE, ENABLE);
+        USART_ITConfig(s->USARTx, USART_IT_IDLE, ENABLE);
     }
 
     if (mode & MODE_TX) {

--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -104,6 +104,9 @@ static void uartReconfigure(uartPort_t *uartPort)
 
         /* Enable the UART Data Register not empty Interrupt */
         SET_BIT(uartPort->USARTx->CR1, USART_CR1_RXNEIE);
+
+        /* Enable Idle Line detection */
+        SET_BIT(uartPort->USARTx->CR1, USART_CR1_IDLEIE);
     }
 
     // Transmit IRQ

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -369,6 +369,13 @@ void usartIrqHandler(uartPort_t *s)
     {
         USART_ClearITPendingBit (s->USARTx, USART_IT_ORE);
     }
+    if (ISR & USART_FLAG_IDLE) {
+        if (s->port.idleCallback) {
+            s->port.idleCallback();
+        }
+
+        USART_ClearITPendingBit(s->USARTx, USART_IT_IDLE);
+    }
 }
 
 #ifdef USE_UART1

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -237,6 +237,16 @@ void uartIrqHandler(uartPort_t *s)
     {
         USART_ClearITPendingBit (s->USARTx, USART_IT_ORE);
     }
+
+    if (USART_GetITStatus(s->USARTx, USART_IT_IDLE) == SET) {
+        if (s->port.idleCallback) {
+            s->port.idleCallback();
+        }
+
+        // clear
+        (void) s->USARTx->SR;
+        (void) s->USARTx->DR;
+    }
 }
 
 void uartGetPortPins(UARTDevice_e device, serialPortPins_t * pins)

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -29,6 +29,8 @@
 #include "serial_uart.h"
 #include "serial_uart_impl.h"
 
+#include "stm32f7xx_ll_usart.h"
+
 #define UART_RX_BUFFER_SIZE UART1_RX_BUFFER_SIZE
 #define UART_TX_BUFFER_SIZE UART1_TX_BUFFER_SIZE
 
@@ -315,6 +317,14 @@ void uartIrqHandler(uartPort_t *s)
     /* UART in mode Transmitter (transmission end) -----------------------------*/
     if ((__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET)) {
         HAL_UART_IRQHandler(huart);
+    }
+
+    if (__HAL_UART_GET_IT(huart, UART_IT_IDLE)) {
+        if (s->port.idleCallback) {
+            s->port.idleCallback();
+        }
+
+        __HAL_UART_CLEAR_IDLEFLAG(huart);
     }
 }
 


### PR DESCRIPTION
This enables the UART Idle interrupt option, and adds a serialIdleCallbackPtr option for the UART driver. This change is needed in order for SRXL2 to work. Will make a pull request for that once this is approved.