### PR TITLE
[CI] Add GH action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: Build firmware
+on: [push]
+
+jobs:
+  # This downloads the GNU toolchain from ARM once, then
+  # saves it as an artifact for the remaining jobs, making
+  # the download way faster.
+  download-toolchain:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare ARM toolchain environment
+        run: |
+          echo "::set-env name=ARM_SDK_FILENAME::$(make arm_sdk_print_filename)"
+          echo "::set-env name=ARM_SDK_DOWNLOAD_PATH::$(make arm_sdk_print_download_path)"
+      - name: Download ARM toolchain
+        run: make arm_sdk_download
+      - name: Save toolchain as artifact
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: ${{ env.ARM_SDK_FILENAME }}
+          path: ${{ env.ARM_SDK_DOWNLOAD_PATH }}
+
+  build:
+    needs: download-toolchain
+    runs-on: ubuntu-18.04
+    strategy:
+        matrix:
+          start: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+          count: [10]
+
+    steps:
+        - uses: actions/checkout@v2
+        - name: Setup environment
+          run: |
+            echo "::set-env name=TARGETS::$(./src/utils/build-targets.sh -n -s ${{ matrix.start }} -c ${{ matrix.count }})"
+            echo "::set-env name=BUILD_SUFFIX::ci-$(git rev-parse --short ${{ github.ref }})"
+            echo "::set-env name=IS_LAST_JOB::$([ $(expr ${{ strategy.job-index }} + 1) = ${{ strategy.job-total }} ] && echo yes)"
+        - name: Ensure all targets will be tested
+          if: ${{ env.IS_LAST_JOB }}
+          run: |
+            UNTESTED=$(./src/utils/build-targets.sh -n -s $(expr ${{ matrix.start }} + ${{ matrix.count }}) -c 10000)
+            if ! [ -z "${UNTESTED}" ]; then
+              echo "Untested targets: ${UNTESTED}" >&2
+              exit 1
+            fi
+        - name: Prepare ARM toolchain environment
+          if: ${{ env.TARGETS }}
+          run: |
+            echo "::set-env name=ARM_SDK_FILENAME::$(make arm_sdk_print_filename)"
+            echo "::set-env name=ARM_SDK_DOWNLOAD_DIR::$(dirname $(make arm_sdk_print_download_path))"
+        - name: Download ARM toolchain
+          if: ${{ env.TARGETS }}
+          uses: actions/download-artifact@v1
+          with:
+            name: ${{ env.ARM_SDK_FILENAME }}
+            path: ${{ env.ARM_SDK_DOWNLOAD_DIR }}
+        - name: Install ARM toolchain
+          if: ${{ env.TARGETS }}
+          run: make arm_sdk_install
+        - name: Build targets (${{ matrix.start }})
+          if: ${{ env.TARGETS }}
+          run: ./src/utils/build-targets.sh -s ${{ matrix.start }} -c ${{ matrix.count }} -S ${{ env.BUILD_SUFFIX }}
+        - name: Upload artifacts
+          if: ${{ env.TARGETS }}
+          uses: actions/upload-artifact@v2-preview
+          with:
+            name: inav-${{ env.BUILD_SUFFIX }}.zip
+            path: ./obj/*.hex
+
+  test:
+    needs: download-toolchain
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare ARM toolchain environment
+        run: |
+          echo "::set-env name=ARM_SDK_FILENAME::$(make arm_sdk_print_filename)"
+          echo "::set-env name=ARM_SDK_DOWNLOAD_DIR::$(dirname $(make arm_sdk_print_download_path))"
+      - name: Download ARM toolchain
+        uses: actions/download-artifact@v1
+        with:
+          name: ${{ env.ARM_SDK_FILENAME }}
+          path: ${{ env.ARM_SDK_DOWNLOAD_DIR }}
+      - name: Install ARM toolchain
+        run: make arm_sdk_install
+      - name: Run Tests
+        run: make test

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -32,8 +32,19 @@ ifdef WINDOWS
 endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
+ARM_SDK_DOWNLOAD_PATH := $(DL_DIR)/$(ARM_SDK_FILE)
 
 SDK_INSTALL_MARKER := $(ARM_SDK_DIR)/bin/arm-none-eabi-gcc-$(GCC_REQUIRED_VERSION)
+
+.PHONY: arm_sdk_print_filename
+
+arm_sdk_print_filename:
+	@echo $(ARM_SDK_FILE)
+
+.PHONY: arm_sdk_print_download_path
+
+arm_sdk_print_download_path:
+	@echo $(ARM_SDK_DOWNLOAD_PATH)
 
 arm_sdk_install: | $(TOOLS_DIR)
 
@@ -42,17 +53,17 @@ arm_sdk_install: arm_sdk_download $(SDK_INSTALL_MARKER)
 $(SDK_INSTALL_MARKER):
 ifneq ($(OSFAMILY), windows)
     # binary only release so just extract it
-	$(V1) tar -C $(TOOLS_DIR) -xjf "$(DL_DIR)/$(ARM_SDK_FILE)"
+	$(V1) tar -C $(TOOLS_DIR) -xjf "$(ARM_SDK_DOWNLOAD_PATH)"
 else
-	$(V1) unzip -q -d $(ARM_SDK_DIR) "$(DL_DIR)/$(ARM_SDK_FILE)"
+	$(V1) unzip -q -d $(ARM_SDK_DIR) "$(ARM_SDK_DOWNLOAD_PATH)"
 endif
 
 .PHONY: arm_sdk_download
 arm_sdk_download: | $(DL_DIR)
-arm_sdk_download: $(DL_DIR)/$(ARM_SDK_FILE)
-$(DL_DIR)/$(ARM_SDK_FILE):
+arm_sdk_download: $(ARM_SDK_DOWNLOAD_PATH)
+$(ARM_SDK_DOWNLOAD_PATH):
     # download the source only if it's newer than what we already have
-	$(V1) curl -L -k -o "$(DL_DIR)/$(ARM_SDK_FILE)" -z "$(DL_DIR)/$(ARM_SDK_FILE)" "$(ARM_SDK_URL)"
+	$(V1) curl -L -k -o "$(ARM_SDK_DOWNLOAD_PATH)" -z "$(ARM_SDK_DOWNLOAD_PATH)" "$(ARM_SDK_URL)"
 
 
 ## arm_sdk_clean     : Uninstall Arm SDK
@@ -69,7 +80,7 @@ arm_sdk_clean:
 
 ifeq ($(shell [ -d "$(ARM_SDK_DIR)" ] && echo "exists"), exists)
   ARM_SDK_PREFIX := $(ARM_SDK_DIR)/bin/arm-none-eabi-
-else ifeq (,$(findstring _install,$(MAKECMDGOALS)))
+else ifeq (,$(filter targets,$(MAKECMDGOALS))$(findstring arm_sdk,$(MAKECMDGOALS)))
   GCC_VERSION = $(shell arm-none-eabi-gcc -dumpversion)
   ifeq ($(GCC_VERSION),)
     $(error **ERROR** arm-none-eabi-gcc not in the PATH. Run 'make arm_sdk_install' to install automatically in the tools folder of this repo)

--- a/src/utils/build-targets.sh
+++ b/src/utils/build-targets.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+usage()
+{
+   echo "Usage ${0} [-n] [-S suffix] -s START -c COUNT]" >&2;
+   echo "Build COUNT targets starting at index START" >&2;
+   echo "Targets are retrieved via make targets" >&2;
+   echo "-n prints the targets instead of building them" >&2;
+   echo "-S sets the BUILD_SUFFIX" >&2;
+   exit 1;
+}
+
+is_number()
+{
+    ! [ -z ${1} ] && [ ${1} -eq ${1} ] 2>/dev/null
+}
+
+START=
+COUNT=
+DRY_RUN=
+BUILD_SUFFIX=
+
+args=`getopt nS:s:c: $*`
+set -- $args
+for i
+do
+    case "$i"
+    in
+        -n)
+            DRY_RUN=1
+            shift;;
+        -S)
+            BUILD_SUFFIX=${2}; shift;
+            shift;;
+        -s)
+            START=${2}; shift;
+            shift;;
+        -c)
+            COUNT=${2}; shift;
+            shift;;
+        --)
+            shift; break;;
+    esac
+done
+
+if ! is_number ${START} || ! is_number ${COUNT}; then
+    usage;
+fi
+
+ALL_TARGETS=$(make targets | grep Valid | awk -F' *: *' '{print $2}')
+START_IDX=$(expr ${START} + 1)
+END_IDX=$(expr ${START} + ${COUNT})
+SELECTED_TARGETS=$(echo ${ALL_TARGETS} | cut -d ' ' -f ${START_IDX}-${END_IDX})
+
+if [ -z "${DRY_RUN}" ]; then
+    # make without arguments builds the default
+    # target, so make sure ${SELECTED_TARGETS} is
+    # not empty
+    if [ -n "${SELECTED_TARGETS}" ]; then
+        BUILD_SUFFIX=${BUILD_SUFFIX} V=0 CFLAGS=-Werror make ${SELECTED_TARGETS}
+    fi
+else
+    echo "${SELECTED_TARGETS}"
+fi


### PR DESCRIPTION
Add a workflow file which is triggered on every commit, runs the
tests and tries to compile all targets with -Werror.

On each run of the actions, all the built binaries are saved as
build artifacts, so this can be helpful for providing binaries
for testing.