### PR TITLE
[CI] Make the GH CI test job require all the build jobs first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             path: ./obj/*.hex
 
   test:
-    needs: download-toolchain
+    needs: [download-toolchain, build]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This way we only need to mark the test job as required.