### PR TITLE
Refactor NVIC; Fix ATOMIC_BLOCK not being actually atomic

### DIFF
--- a/src/main/build/atomic.h
+++ b/src/main/build/atomic.h
@@ -44,5 +44,10 @@ static inline uint8_t __basepriSetMemRetVal(uint8_t prio)
 
 // Run block with elevated BASEPRI (using BASEPRI_MAX), restoring BASEPRI on exit. All exit paths are handled
 // Full memory barrier is placed at start and exit of block
+#ifdef UNIT_TEST
+#define ATOMIC_BLOCK(prio) {}
+#else
 #define ATOMIC_BLOCK(prio) for ( uint8_t __basepri_save __attribute__((__cleanup__(__basepriRestoreMem))) = __get_BASEPRI(), \
                                      __ToDo = __basepriSetMemRetVal((prio) << (8U - __NVIC_PRIO_BITS)); __ToDo ; __ToDo = 0 )
+
+#endif // UNIT_TEST

--- a/src/main/build/atomic.h
+++ b/src/main/build/atomic.h
@@ -17,25 +17,9 @@
 
 #pragma once
 
-// only set_BASEPRI is implemented in device library. It does always create memory barrier
-// missing versions are implemented here
-
 #ifdef UNIT_TEST
 static inline void __set_BASEPRI(uint32_t basePri) {(void)basePri;}
 static inline void __set_BASEPRI_MAX(uint32_t basePri) {(void)basePri;}
-static inline void __set_BASEPRI_nb(uint32_t basePri) {(void)basePri;}
-static inline void __set_BASEPRI_MAX_nb(uint32_t basePri) {(void)basePri;}
-#else
-// set BASEPRI and BASEPRI_MAX register, but do not create memory barrier
-__attribute__( ( always_inline ) ) static inline void __set_BASEPRI_nb(uint32_t basePri)
-{
-   __ASM volatile ("\tMSR basepri, %0\n" : : "r" (basePri) );
-}
-
-__attribute__( ( always_inline ) ) static inline void __set_BASEPRI_MAX_nb(uint32_t basePri)
-{
-   __ASM volatile ("\tMSR basepri_max, %0\n" : : "r" (basePri) );
-}
 #endif // UNIT_TEST
 
 // cleanup BASEPRI restore function, with global memory barrier
@@ -51,19 +35,6 @@ static inline uint8_t __basepriSetMemRetVal(uint8_t prio)
     return 1;
 }
 
-// cleanup BASEPRI restore function, no memory barrier
-static inline void __basepriRestore(uint8_t *val)
-{
-    __set_BASEPRI_nb(*val);
-}
-
-// set BASEPRI_MAX function, no memory barrier, returns true
-static inline uint8_t __basepriSetRetVal(uint8_t prio)
-{
-    __set_BASEPRI_MAX_nb(prio);
-    return 1;
-}
-
 // The CMSIS provides the function __set_BASEPRI(priority) for changing the value of the BASEPRI register.
 // The function uses the hardware convention for the ‘priority’ argument, which means that the priority must
 // be shifted left by the number of unimplemented bits (8 – __NVIC_PRIO_BITS).
@@ -73,53 +44,5 @@ static inline uint8_t __basepriSetRetVal(uint8_t prio)
 
 // Run block with elevated BASEPRI (using BASEPRI_MAX), restoring BASEPRI on exit. All exit paths are handled
 // Full memory barrier is placed at start and exit of block
-#ifdef UNIT_TEST
-#define ATOMIC_BLOCK(prio) {}
-#define ATOMIC_BLOCK_NB(prio) {}
-#else
 #define ATOMIC_BLOCK(prio) for ( uint8_t __basepri_save __attribute__((__cleanup__(__basepriRestoreMem))) = __get_BASEPRI(), \
                                      __ToDo = __basepriSetMemRetVal((prio) << (8U - __NVIC_PRIO_BITS)); __ToDo ; __ToDo = 0 )
-
-// Run block with elevated BASEPRI (using BASEPRI_MAX), but do not create any (explicit) memory barrier.
-// Be careful when using this, you must use some method to prevent optimizer form breaking things
-// - lto is used for Cleanflight compilation, so function call is not memory barrier
-// - use ATOMIC_BARRIER or proper volatile to protect used variables
-// - gcc 4.8.4 does write all values in registers to memory before 'asm volatile', so this optimization does not help much
-//    but that can change in future versions
-#define ATOMIC_BLOCK_NB(prio) for ( uint8_t __basepri_save __attribute__((__cleanup__(__basepriRestore))) = __get_BASEPRI(), \
-                                    __ToDo = __basepriSetRetVal((prio) << (8U - __NVIC_PRIO_BITS)); __ToDo ; __ToDo = 0 ) \
-
-#endif // UNIT_TEST
-
-// ATOMIC_BARRIER
-// Create memory barrier
-// - at the beginning (all data must be reread from memory)
-// - at exit of block (all exit paths) (all data must be written, but may be cached in register for subsequent use)
-// ideally this would only protect memory passed as parameter (any type should work), but gcc is currently creating almost full barrier
-// this macro can be used only ONCE PER LINE, but multiple uses per block are fine
-
-#if (__GNUC__ > 9)
-#warning "Please verify that ATOMIC_BARRIER works as intended"
-// increment version number is BARRIER works
-// TODO - use flag to disable ATOMIC_BARRIER and use full barrier instead
-// you should check that local variable scope with cleanup spans entire block
-#endif
-
-#ifndef __UNIQL
-# define __UNIQL_CONCAT2(x,y) x ## y
-# define __UNIQL_CONCAT(x,y) __UNIQL_CONCAT2(x,y)
-# define __UNIQL(x) __UNIQL_CONCAT(x,__LINE__)
-#endif
-
-// this macro uses local function for cleanup. CLang block can be substituted
-#define ATOMIC_BARRIER(data)                                            \
-    __extension__ void  __UNIQL(__barrierEnd)(typeof(data) **__d) {     \
-        __asm__ volatile ("\t# barier(" #data ")  end\n" : : "m" (**__d));                          \
-    }                                                                   \
-    typeof(data)  __attribute__((__cleanup__(__UNIQL(__barrierEnd)))) *__UNIQL(__barrier) = &data; \
-    __asm__ volatile ("\t# barier (" #data ") start\n" : "+m" (*__UNIQL(__barrier)))
-
-
-// define these wrappers for atomic operations, use gcc buildins
-#define ATOMIC_OR(ptr, val) __sync_fetch_and_or(ptr, val)
-#define ATOMIC_AND(ptr, val) __sync_fetch_and_and(ptr, val)

--- a/src/main/drivers/bus_i2c_hal.c
+++ b/src/main/drivers/bus_i2c_hal.c
@@ -317,9 +317,10 @@ void i2cInit(I2CDevice device)
     /* Enable the Analog I2C Filter */
     HAL_I2CEx_ConfigAnalogFilter(&i2cHandle[device].Handle,I2C_ANALOGFILTER_ENABLE);
 
-    HAL_NVIC_SetPriority(i2cHardwareMap[device].er_irq, NVIC_PRIORITY_BASE(NVIC_PRIO_I2C_ER), NVIC_PRIORITY_SUB(NVIC_PRIO_I2C_ER));
+    HAL_NVIC_SetPriority(i2cHardwareMap[device].er_irq, NVIC_PRIO_I2C_ER, 0);
     HAL_NVIC_EnableIRQ(i2cHardwareMap[device].er_irq);
-    HAL_NVIC_SetPriority(i2cHardwareMap[device].ev_irq, NVIC_PRIORITY_BASE(NVIC_PRIO_I2C_EV), NVIC_PRIORITY_SUB(NVIC_PRIO_I2C_EV));
+
+    HAL_NVIC_SetPriority(i2cHardwareMap[device].ev_irq, NVIC_PRIO_I2C_EV, 0);
     HAL_NVIC_EnableIRQ(i2cHardwareMap[device].ev_irq);
     state->initialised = true;
 }

--- a/src/main/drivers/dma_stm32f3xx.c
+++ b/src/main/drivers/dma_stm32f3xx.c
@@ -98,18 +98,13 @@ void dmaInit(DMA_t dma, resourceOwner_e owner, uint8_t resourceIndex)
 
 void dmaSetHandler(DMA_t dma, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
 {
-    NVIC_InitTypeDef NVIC_InitStructure;
-
     dmaEnableClock(dma);
 
     dma->irqHandlerCallback = callback;
     dma->userParam = userParam;
 
-    NVIC_InitStructure.NVIC_IRQChannel = dma->irqNumber;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(priority);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(priority);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(dma->irqNumber, priority);
+    NVIC_EnableIRQ(dma->irqNumber);
 }
 
 DMA_t dmaGetByRef(const DMA_Channel_TypeDef * ref)

--- a/src/main/drivers/dma_stm32f4xx.c
+++ b/src/main/drivers/dma_stm32f4xx.c
@@ -106,18 +106,13 @@ void dmaInit(DMA_t dma, resourceOwner_e owner, uint8_t resourceIndex)
 
 void dmaSetHandler(DMA_t dma, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
 {
-    NVIC_InitTypeDef NVIC_InitStructure;
-
     dmaEnableClock(dma);
 
     dma->irqHandlerCallback = callback;
     dma->userParam = userParam;
 
-    NVIC_InitStructure.NVIC_IRQChannel = dma->irqNumber;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(priority);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(priority);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(dma->irqNumber, priority);
+    NVIC_EnableIRQ(dma->irqNumber);
 }
 
 uint32_t dmaGetChannelByTag(dmaTag_t tag)

--- a/src/main/drivers/dma_stm32f7xx.c
+++ b/src/main/drivers/dma_stm32f7xx.c
@@ -110,7 +110,7 @@ void dmaSetHandler(DMA_t dma, dmaCallbackHandlerFuncPtr callback, uint32_t prior
     dma->irqHandlerCallback = callback;
     dma->userParam = userParam;
 
-    HAL_NVIC_SetPriority(dma->irqNumber, NVIC_PRIORITY_BASE(priority), NVIC_PRIORITY_SUB(priority));
+    HAL_NVIC_SetPriority(dma->irqNumber, priority, 0);
     HAL_NVIC_EnableIRQ(dma->irqNumber);
 }
 

--- a/src/main/drivers/exti.c
+++ b/src/main/drivers/exti.c
@@ -90,7 +90,7 @@ void EXTIConfig(IO_t io, extiCallbackRec_t *cb, int irqPriority, ioConfig_t conf
 
     if (extiGroupPriority[group] > irqPriority) {
         extiGroupPriority[group] = irqPriority;
-        HAL_NVIC_SetPriority(extiGroupIRQn[group], NVIC_PRIORITY_BASE(irqPriority), NVIC_PRIORITY_SUB(irqPriority));
+        HAL_NVIC_SetPriority(extiGroupIRQn[group], irqPriority, 0);
         HAL_NVIC_EnableIRQ(extiGroupIRQn[group]);
     }
 }
@@ -131,12 +131,8 @@ void EXTIConfig(IO_t io, extiCallbackRec_t *cb, int irqPriority, EXTITrigger_Typ
     if (extiGroupPriority[group] > irqPriority) {
         extiGroupPriority[group] = irqPriority;
 
-        NVIC_InitTypeDef NVIC_InitStructure;
-        NVIC_InitStructure.NVIC_IRQChannel = extiGroupIRQn[group];
-        NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(irqPriority);
-        NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(irqPriority);
-        NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-        NVIC_Init(&NVIC_InitStructure);
+        NVIC_SetPriority(extiGroupIRQn[group], irqPriority);
+        NVIC_EnableIRQ(extiGroupIRQn[group]);
     }
 }
 #endif

--- a/src/main/drivers/nvic.h
+++ b/src/main/drivers/nvic.h
@@ -2,43 +2,25 @@
 #pragma once
 
 
-// can't use 0
-#define NVIC_PRIO_MAX                      NVIC_BUILD_PRIORITY(0, 1)
-#define NVIC_PRIO_TIMER                    NVIC_BUILD_PRIORITY(1, 1)
-#define NVIC_PRIO_BARO_EXTI                NVIC_BUILD_PRIORITY(0x0f, 0x0f)
-#define NVIC_PRIO_SONAR_EXTI               NVIC_BUILD_PRIORITY(2, 0)  // maybe increate slightly
-#define NVIC_PRIO_TRANSPONDER_DMA          NVIC_BUILD_PRIORITY(3, 0)
-#define NVIC_PRIO_GYRO_INT_EXTI             NVIC_BUILD_PRIORITY(0x0f, 0x0f)
-#define NVIC_PRIO_MAG_INT_EXTI             NVIC_BUILD_PRIORITY(0x0f, 0x0f)
-#define NVIC_PRIO_WS2811_DMA               NVIC_BUILD_PRIORITY(1, 2)  // TODO - is there some reason to use high priority? (or to use DMA IRQ at all?)
-#define NVIC_PRIO_SERIALUART1              NVIC_BUILD_PRIORITY(1, 1)
-#define NVIC_PRIO_SERIALUART2              NVIC_BUILD_PRIORITY(1, 2)
-#define NVIC_PRIO_SERIALUART3              NVIC_BUILD_PRIORITY(1, 2)
-#define NVIC_PRIO_SERIALUART4              NVIC_BUILD_PRIORITY(1, 2)
-#define NVIC_PRIO_SERIALUART5              NVIC_BUILD_PRIORITY(1, 2)
-#define NVIC_PRIO_SERIALUART6              NVIC_BUILD_PRIORITY(1, 2)
-#define NVIC_PRIO_SERIALUART7              NVIC_BUILD_PRIORITY(1, 2)
-#define NVIC_PRIO_SERIALUART8              NVIC_BUILD_PRIORITY(1, 2)
-#define NVIC_PRIO_I2C_ER                   NVIC_BUILD_PRIORITY(0, 0)
-#define NVIC_PRIO_I2C_EV                   NVIC_BUILD_PRIORITY(0, 0)
-#define NVIC_PRIO_USB                      NVIC_BUILD_PRIORITY(2, 0)
-#define NVIC_PRIO_USB_WUP                  NVIC_BUILD_PRIORITY(1, 0)
-#define NVIC_PRIO_SONAR_ECHO               NVIC_BUILD_PRIORITY(0x0f, 0x0f)
-#define NVIC_PRIO_MPU_DATA_READY           NVIC_BUILD_PRIORITY(0x0f, 0x0f)
-#define NVIC_PRIO_MAG_DATA_READY           NVIC_BUILD_PRIORITY(0x0f, 0x0f)
-#define NVIC_PRIO_CALLBACK                 NVIC_BUILD_PRIORITY(0x0f, 0x0f)
-#define NVIC_PRIO_MAX7456_DMA              NVIC_BUILD_PRIORITY(3, 0)
+// NVIC_SetPriority expects priority encoded according to priority grouping
+// We allocate zero bits for sub-priority, therefore we have 16 priorities to use on STM32
 
+// can't use 0
+#define NVIC_PRIO_MAX                       1
+#define NVIC_PRIO_I2C_ER                    2
+#define NVIC_PRIO_I2C_EV                    2
+#define NVIC_PRIO_TIMER                     3
+#define NVIC_PRIO_TIMER_DMA                 3
+#define NVIC_PRIO_SDIO                      3
+#define NVIC_PRIO_GYRO_INT_EXTI             4
+#define NVIC_PRIO_USB                       5
+#define NVIC_PRIO_SERIALUART                5
+#define NVIC_PRIO_SONAR_EXTI                7
+
+
+// Use all available bits for priority and zero bits to sub-priority
 #ifdef USE_HAL_DRIVER
-// utility macros to join/split priority
-#define NVIC_PRIORITY_GROUPING NVIC_PRIORITYGROUP_2
-#define NVIC_BUILD_PRIORITY(base,sub) (((((base)<<(4-(7-(NVIC_PRIORITY_GROUPING))))|((sub)&(0x0f>>(7-(NVIC_PRIORITY_GROUPING)))))<<4)&0xf0)
-#define NVIC_PRIORITY_BASE(prio) (((prio)>>(4-(7-(NVIC_PRIORITY_GROUPING))))>>4)
-#define NVIC_PRIORITY_SUB(prio) (((prio)&(0x0f>>(7-(NVIC_PRIORITY_GROUPING))))>>4)
+#define NVIC_PRIORITY_GROUPING NVIC_PRIORITYGROUP_4
 #else
-// utility macros to join/split priority
-#define NVIC_PRIORITY_GROUPING NVIC_PriorityGroup_2
-#define NVIC_BUILD_PRIORITY(base,sub) (((((base)<<(4-(7-(NVIC_PRIORITY_GROUPING>>8))))|((sub)&(0x0f>>(7-(NVIC_PRIORITY_GROUPING>>8)))))<<4)&0xf0)
-#define NVIC_PRIORITY_BASE(prio) (((prio)>>(4-(7-(NVIC_PRIORITY_GROUPING>>8))))>>4)
-#define NVIC_PRIORITY_SUB(prio) (((prio)&(0x0f>>(7-(NVIC_PRIORITY_GROUPING>>8))))>>4)
+#define NVIC_PRIORITY_GROUPING NVIC_PriorityGroup_4
 #endif

--- a/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c
+++ b/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c
@@ -1411,12 +1411,8 @@ bool SD_Initialize_LL(DMA_Stream_TypeDef *dmaRef)
     IOConfigGPIOAF(cmd, SDIO_CMD, GPIO_AF_SDIO);
 
     // NVIC configuration for SDIO interrupts
-    NVIC_InitTypeDef NVIC_InitStructure;
-    NVIC_InitStructure.NVIC_IRQChannel = SDIO_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(1);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(0);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(SDIO_IRQn, NVIC_PRIO_SDIO);
+    NVIC_EnableIRQ(SDIO_IRQn);
 
     dma_stream = dmaRef;
     RCC->AHB1ENR |= RCC_AHB1ENR_DMA2EN;

--- a/src/main/drivers/sdcard/sdmmc_sdio_f7xx.c
+++ b/src/main/drivers/sdcard/sdmmc_sdio_f7xx.c
@@ -1329,10 +1329,8 @@ bool SD_Initialize_LL(DMA_Stream_TypeDef * dmaRef)
     IOInit(cmd, OWNER_SDCARD, RESOURCE_NONE, 0);
     IOConfigGPIOAF(cmd, SDMMC_CMD, GPIO_AF12_SDMMC1);
 
-    uint32_t PriorityGroup = NVIC_GetPriorityGrouping();
-
     // NVIC configuration for SDIO interrupts
-    NVIC_SetPriority(SDMMC1_IRQn, NVIC_EncodePriority(PriorityGroup, 1, 0));
+    NVIC_SetPriority(SDMMC1_IRQn, NVIC_PRIO_SDIO);
     NVIC_EnableIRQ(SDMMC1_IRQn);
 
     dma_stream = dmaRef;

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -169,7 +169,6 @@ void serialUARTInit(IO_t tx, IO_t rx, portMode_t mode, portOptions_t options, ui
 #ifdef USE_UART1
 uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t options)
 {
-    NVIC_InitTypeDef NVIC_InitStructure;
     uartPort_t *s;
 
     static volatile uint8_t rx1Buffer[UART1_RX_BUFFER_SIZE];
@@ -191,11 +190,8 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
 
     serialUARTInit(IOGetByTag(IO_TAG(UART1_TX_PIN)), IOGetByTag(IO_TAG(UART1_RX_PIN)), mode, options, GPIO_AF_7, 1);
 
-    NVIC_InitStructure.NVIC_IRQChannel = USART1_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_SERIALUART1);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_SERIALUART1);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(USART1_IRQn, NVIC_PRIO_SERIALUART);
+    NVIC_EnableIRQ(USART1_IRQn);
 
     return s;
 }
@@ -204,7 +200,6 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
 #ifdef USE_UART2
 uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t options)
 {
-    NVIC_InitTypeDef NVIC_InitStructure;
     uartPort_t *s;
 
     static volatile uint8_t rx2Buffer[UART2_RX_BUFFER_SIZE];
@@ -226,11 +221,8 @@ uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t option
 
     serialUARTInit(IOGetByTag(IO_TAG(UART2_TX_PIN)), IOGetByTag(IO_TAG(UART2_RX_PIN)), mode, options, GPIO_AF_7, 2);
 
-    NVIC_InitStructure.NVIC_IRQChannel = USART2_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_SERIALUART2);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_SERIALUART2);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(USART2_IRQn, NVIC_PRIO_SERIALUART);
+    NVIC_EnableIRQ(USART2_IRQn);
 
     return s;
 }
@@ -239,7 +231,6 @@ uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t option
 #ifdef USE_UART3
 uartPort_t *serialUART3(uint32_t baudRate, portMode_t mode, portOptions_t options)
 {
-    NVIC_InitTypeDef NVIC_InitStructure;
     uartPort_t *s;
 
     static volatile uint8_t rx3Buffer[UART3_RX_BUFFER_SIZE];
@@ -261,11 +252,8 @@ uartPort_t *serialUART3(uint32_t baudRate, portMode_t mode, portOptions_t option
 
     serialUARTInit(IOGetByTag(IO_TAG(UART3_TX_PIN)), IOGetByTag(IO_TAG(UART3_RX_PIN)), mode, options, GPIO_AF_7, 3);
 
-    NVIC_InitStructure.NVIC_IRQChannel = USART3_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_SERIALUART3);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_SERIALUART3);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(USART3_IRQn, NVIC_PRIO_SERIALUART);
+    NVIC_EnableIRQ(USART3_IRQn);
 
     return s;
 }
@@ -277,7 +265,6 @@ uartPort_t *serialUART4(uint32_t baudRate, portMode_t mode, portOptions_t option
     uartPort_t *s;
     static volatile uint8_t rx4Buffer[UART4_RX_BUFFER_SIZE];
     static volatile uint8_t tx4Buffer[UART4_TX_BUFFER_SIZE];
-    NVIC_InitTypeDef NVIC_InitStructure;
 
     s = &uartPort4;
     s->port.vTable = uartVTable;
@@ -295,11 +282,8 @@ uartPort_t *serialUART4(uint32_t baudRate, portMode_t mode, portOptions_t option
 
     serialUARTInit(IOGetByTag(IO_TAG(UART4_TX_PIN)), IOGetByTag(IO_TAG(UART4_RX_PIN)), mode, options, GPIO_AF_5, 4);
 
-    NVIC_InitStructure.NVIC_IRQChannel = UART4_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_SERIALUART4);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_SERIALUART4);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(UART4_IRQn, NVIC_PRIO_SERIALUART);
+    NVIC_EnableIRQ(UART4_IRQn);
 
     return s;
 }
@@ -311,7 +295,6 @@ uartPort_t *serialUART5(uint32_t baudRate, portMode_t mode, portOptions_t option
     uartPort_t *s;
     static volatile uint8_t rx5Buffer[UART5_RX_BUFFER_SIZE];
     static volatile uint8_t tx5Buffer[UART5_TX_BUFFER_SIZE];
-    NVIC_InitTypeDef NVIC_InitStructure;
 
     s = &uartPort5;
     s->port.vTable = uartVTable;
@@ -329,11 +312,8 @@ uartPort_t *serialUART5(uint32_t baudRate, portMode_t mode, portOptions_t option
 
     serialUARTInit(IOGetByTag(IO_TAG(UART5_TX_PIN)), IOGetByTag(IO_TAG(UART5_RX_PIN)), mode, options, GPIO_AF_5, 5);
 
-    NVIC_InitStructure.NVIC_IRQChannel = UART5_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_SERIALUART5);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_SERIALUART5);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(UART5_IRQn, NVIC_PRIO_SERIALUART);
+    NVIC_EnableIRQ(UART5_IRQn);
 
     return s;
 }

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -60,7 +60,7 @@ static uartDevice_t uart1 =
 #endif
     .rcc_apb2 = RCC_APB2(USART1),
     .irq = USART1_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART1
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -76,7 +76,7 @@ static uartDevice_t uart2 =
 #endif
     .rcc_apb1 = RCC_APB1(USART2),
     .irq = USART2_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART2
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -92,7 +92,7 @@ static uartDevice_t uart3 =
 #endif
     .rcc_apb1 = RCC_APB1(USART3),
     .irq = USART3_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART3
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -108,7 +108,7 @@ static uartDevice_t uart4 =
 #endif
     .rcc_apb1 = RCC_APB1(UART4),
     .irq = UART4_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART4
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -124,7 +124,7 @@ static uartDevice_t uart5 =
 #endif
     .rcc_apb1 = RCC_APB1(UART5),
     .irq = UART5_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART5
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -140,7 +140,7 @@ static uartDevice_t uart6 =
 #endif
     .rcc_apb2 = RCC_APB2(USART6),
     .irq = USART6_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART6
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -153,7 +153,7 @@ static uartDevice_t uart7 =
     .af = GPIO_AF_UART7,
     .rcc_apb1 = RCC_APB1(UART7),
     .irq = UART7_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART7
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -166,7 +166,7 @@ static uartDevice_t uart8 =
     .af = GPIO_AF_UART8,
     .rcc_apb1 = RCC_APB1(UART8),
     .irq = UART8_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART8
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -256,7 +256,6 @@ void uartGetPortPins(UARTDevice_e device, serialPortPins_t * pins)
 uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_t mode, portOptions_t options)
 {
     uartPort_t *s;
-    NVIC_InitTypeDef NVIC_InitStructure;
 
     uartDevice_t *uart = uartHardwareMap[device];
     if (!uart) return NULL;
@@ -304,11 +303,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_t mode, 
         }
     }
 
-    NVIC_InitStructure.NVIC_IRQChannel = uart->irq;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(uart->irqPriority);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(uart->irqPriority);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(uart->irq, uart->irqPriority);
+    NVIC_EnableIRQ(uart->irq);
 
     return s;
 }

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -64,7 +64,7 @@ static uartDevice_t uart1 =
 #endif
     .rcc_apb2 = RCC_APB2(USART1),
     .irq = USART1_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART1
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -84,7 +84,7 @@ static uartDevice_t uart2 =
 #endif
     .rcc_apb1 = RCC_APB1(USART2),
     .irq = USART2_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART2
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -104,7 +104,7 @@ static uartDevice_t uart3 =
 #endif
     .rcc_apb1 = RCC_APB1(USART3),
     .irq = USART3_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART3
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -124,7 +124,7 @@ static uartDevice_t uart4 =
 #endif
     .rcc_apb1 = RCC_APB1(UART4),
     .irq = UART4_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART4
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -144,7 +144,7 @@ static uartDevice_t uart5 =
 #endif
     .rcc_apb1 = RCC_APB1(UART5),
     .irq = UART5_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART5
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -164,7 +164,7 @@ static uartDevice_t uart6 =
 #endif
     .rcc_apb2 = RCC_APB2(USART6),
     .irq = USART6_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART6
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -184,7 +184,7 @@ static uartDevice_t uart7 =
 #endif
     .rcc_apb1 = RCC_APB1(UART7),
     .irq = UART7_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART7
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 #ifdef USE_UART8
@@ -203,7 +203,7 @@ static uartDevice_t uart8 =
 #endif
     .rcc_apb1 = RCC_APB1(UART8),
     .irq = UART8_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART8
+    .irqPriority = NVIC_PRIO_SERIALUART
 };
 #endif
 
@@ -372,7 +372,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_t mode, 
         }
     }
 
-    HAL_NVIC_SetPriority(uart->irq, NVIC_PRIORITY_BASE(uart->irqPriority), NVIC_PRIORITY_SUB(uart->irqPriority));
+    HAL_NVIC_SetPriority(uart->irq, uart->irqPriority, 0);
     HAL_NVIC_EnableIRQ(uart->irq);
 
     return s;

--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -62,12 +62,12 @@ void impl_timerInitContext(timHardwareContext_t * timCtx)
 void impl_timerNVICConfigure(TCH_t * tch, int irqPriority)
 {
     if (tch->timCtx->timDef->irq) {
-        HAL_NVIC_SetPriority(tch->timCtx->timDef->irq, NVIC_PRIORITY_BASE(irqPriority), NVIC_PRIORITY_SUB(irqPriority));
+        HAL_NVIC_SetPriority(tch->timCtx->timDef->irq, irqPriority, 0);
         HAL_NVIC_EnableIRQ(tch->timCtx->timDef->irq);
     }
 
     if (tch->timCtx->timDef->secondIrq) {
-        HAL_NVIC_SetPriority(tch->timCtx->timDef->secondIrq, NVIC_PRIORITY_BASE(irqPriority), NVIC_PRIORITY_SUB(irqPriority));
+        HAL_NVIC_SetPriority(tch->timCtx->timDef->secondIrq, irqPriority, 0);
         HAL_NVIC_EnableIRQ(tch->timCtx->timDef->secondIrq);
     }
 }
@@ -380,7 +380,7 @@ bool impl_timerPWMConfigChannelDMA(TCH_t * tch, void * dmaBuffer, uint8_t dmaBuf
     init.PeriphBurst = LL_DMA_PBURST_SINGLE;
 
     dmaInit(tch->dma, OWNER_TIMER, 0);
-    dmaSetHandler(tch->dma, impl_timerDMA_IRQHandler, NVIC_PRIO_WS2811_DMA, (uint32_t)tch);
+    dmaSetHandler(tch->dma, impl_timerDMA_IRQHandler, NVIC_PRIO_TIMER_DMA, (uint32_t)tch);
 
     LL_DMA_Init(tch->dma->dma, streamLL, &init);
 

--- a/src/main/drivers/timer_impl_stdperiph.c
+++ b/src/main/drivers/timer_impl_stdperiph.c
@@ -44,20 +44,14 @@ void impl_timerInitContext(timHardwareContext_t * timCtx)
 
 void impl_timerNVICConfigure(TCH_t * tch, int irqPriority)
 {
-    NVIC_InitTypeDef NVIC_InitStructure;
-
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(irqPriority);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(irqPriority);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-
     if (tch->timCtx->timDef->irq) {
-        NVIC_InitStructure.NVIC_IRQChannel = tch->timCtx->timDef->irq;
-        NVIC_Init(&NVIC_InitStructure);
+        NVIC_SetPriority(tch->timCtx->timDef->irq, irqPriority);
+        NVIC_EnableIRQ(tch->timCtx->timDef->irq);
     }
 
     if (tch->timCtx->timDef->secondIrq) {
-        NVIC_InitStructure.NVIC_IRQChannel = tch->timCtx->timDef->secondIrq;
-        NVIC_Init(&NVIC_InitStructure);
+        NVIC_SetPriority(tch->timCtx->timDef->secondIrq, irqPriority);
+        NVIC_EnableIRQ(tch->timCtx->timDef->secondIrq);
     }
 }
 
@@ -311,7 +305,7 @@ bool impl_timerPWMConfigChannelDMA(TCH_t * tch, void * dmaBuffer, uint8_t dmaBuf
     TIM_Cmd(timer, ENABLE);
 
     dmaInit(tch->dma, OWNER_TIMER, 0);
-    dmaSetHandler(tch->dma, impl_timerDMA_IRQHandler, NVIC_PRIO_WS2811_DMA, (uint32_t)tch);
+    dmaSetHandler(tch->dma, impl_timerDMA_IRQHandler, NVIC_PRIO_TIMER_DMA, (uint32_t)tch);
 
     DMA_DeInit(tch->dma->ref);
     DMA_Cmd(tch->dma->ref, DISABLE);

--- a/src/main/drivers/usb_msc_f4xx.c
+++ b/src/main/drivers/usb_msc_f4xx.c
@@ -112,7 +112,7 @@ uint8_t mscStart(void)
 
     // NVIC configuration for SYSTick
     NVIC_DisableIRQ(SysTick_IRQn);
-    NVIC_SetPriority(SysTick_IRQn, NVIC_BUILD_PRIORITY(0, 0));
+    NVIC_SetPriority(SysTick_IRQn, 0);
     NVIC_EnableIRQ(SysTick_IRQn);
 
     return 0;

--- a/src/main/drivers/usb_msc_f7xx.c
+++ b/src/main/drivers/usb_msc_f7xx.c
@@ -110,7 +110,7 @@ uint8_t mscStart(void)
 
     // NVIC configuration for SYSTick
     NVIC_DisableIRQ(SysTick_IRQn);
-    NVIC_SetPriority(SysTick_IRQn, NVIC_BUILD_PRIORITY(0, 0));
+    NVIC_SetPriority(SysTick_IRQn, 0);
     NVIC_EnableIRQ(SysTick_IRQn);
 
     return 0;

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -119,7 +119,7 @@ bool handleCrsfMspFrameBuffer(uint8_t payloadSize, mspResponseFnPtr responseFn)
             requestHandled |= sendMspReply(payloadSize, responseFn);
         }
         pos += CRSF_MSP_LENGTH_OFFSET + mspFrameLength;
-        ATOMIC_BLOCK(NVIC_PRIO_SERIALUART1) {
+        ATOMIC_BLOCK(NVIC_PRIO_SERIALUART) {
             if (pos >= mspRxBuffer.len) {
                 mspRxBuffer.len = 0;
                 return requestHandled;

--- a/src/main/vcp/hw_config.c
+++ b/src/main/vcp/hw_config.c
@@ -194,23 +194,11 @@ void Leave_LowPowerMode(void)
  *******************************************************************************/
 void USB_Interrupts_Config(void)
 {
-    NVIC_InitTypeDef NVIC_InitStructure;
+    NVIC_SetPriority(USB_LP_CAN1_RX0_IRQn, NVIC_PRIO_USB);
+    NVIC_EnableIRQ(USB_LP_CAN1_RX0_IRQn);
 
-    /* 2 bit for pre-emption priority, 2 bits for subpriority */
-    NVIC_PriorityGroupConfig(NVIC_PRIORITY_GROUPING);     // is this really neccesary?
-
-    /* Enable the USB interrupt */
-    NVIC_InitStructure.NVIC_IRQChannel = USB_LP_CAN1_RX0_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_USB);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_USB);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
-
-    /* Enable the USB Wake-up interrupt */
-    NVIC_InitStructure.NVIC_IRQChannel = USBWakeUp_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_USB_WUP);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_USB_WUP);
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(USBWakeUp_IRQn, NVIC_PRIO_USB);
+    NVIC_EnableIRQ(USBWakeUp_IRQn);
 }
 
 /*******************************************************************************

--- a/src/main/vcpf4/usb_bsp.c
+++ b/src/main/vcpf4/usb_bsp.c
@@ -49,23 +49,14 @@ void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE *pdev)
     (void)pdev;
     GPIO_InitTypeDef GPIO_InitStructure;
 
-#ifndef USE_ULPI_PHY
-#ifdef USB_OTG_FS_LOW_PWR_MGMT_SUPPORT
-    EXTI_InitTypeDef EXTI_InitStructure;
-    NVIC_InitTypeDef NVIC_InitStructure;
-#endif
-#endif
 
-    NVIC_InitTypeDef NVIC_InitStructure;
 #ifdef USE_USB_OTG_HS
-    NVIC_InitStructure.NVIC_IRQChannel = OTG_HS_IRQn;
+    NVIC_SetPriority(OTG_HS_IRQn, NVIC_PRIO_USB);
+    NVIC_DisableIRQ(OTG_HS_IRQn);
 #else
-    NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_IRQn;
+    NVIC_SetPriority(OTG_FS_IRQn, NVIC_PRIO_USB);
+    NVIC_DisableIRQ(OTG_FS_IRQn);
 #endif
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_USB);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_USB);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
-    NVIC_Init(&NVIC_InitStructure);
 
     RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_GPIOA , ENABLE);
 
@@ -101,32 +92,13 @@ void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE *pdev)
 void USB_OTG_BSP_EnableInterrupt(USB_OTG_CORE_HANDLE *pdev)
 {
     (void)pdev;
-    NVIC_InitTypeDef NVIC_InitStructure;
 
-    NVIC_PriorityGroupConfig(NVIC_PRIORITY_GROUPING);
 #ifdef USE_USB_OTG_HS
-    NVIC_InitStructure.NVIC_IRQChannel = OTG_HS_IRQn;
+    NVIC_SetPriority(OTG_HS_IRQn, NVIC_PRIO_USB);
+    NVIC_EnableIRQ(OTG_HS_IRQn);
 #else
-    NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_IRQn;
-#endif
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_USB);
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_USB);
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
-#ifdef USB_OTG_HS_DEDICATED_EP1_ENABLED
-    NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
-    NVIC_InitStructure.NVIC_IRQChannel = OTG_HS_EP1_OUT_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 2;
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
-
-    NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
-    NVIC_InitStructure.NVIC_IRQChannel = OTG_HS_EP1_IN_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 1;
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
+    NVIC_SetPriority(OTG_FS_IRQn, NVIC_PRIO_USB);
+    NVIC_EnableIRQ(OTG_FS_IRQn);
 #endif
 }
 /**


### PR DESCRIPTION
Heavy refactoring of NVIC, get rid of priority/subpriority mess.
Fix `ATOMIC_GROUP` not being atomic due to setting wrong value of `BASEPRI` register.