### PR TITLE
New target for OMNIBUSF4V3

### DIFF
--- a/src/main/target/OMNIBUSF4/OMNIBUSF4V3_LED_SS.mk
+++ b/src/main/target/OMNIBUSF4/OMNIBUSF4V3_LED_SS.mk
@@ -1,0 +1,3 @@
+# OMNIBUSF4V3_LED_SS is a (almost identical) variant of OMNIBUSF4PRO target,
+# except for a SOFTSERIAL1 UART6 and SOFTSERIAL2 (RX&TX) on LEDSTIRP PIN (PB6)
+FEATURES       = VCP SDCARD MSC

--- a/src/main/target/OMNIBUSF4/target.c
+++ b/src/main/target/OMNIBUSF4/target.c
@@ -24,7 +24,7 @@
 #include "drivers/bus.h"
 
 const timerHardware_t timerHardware[] = {
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_LED_SS)
     DEF_TIM(TIM10, CH1, PB8,  TIM_USE_PPM,                  0, 0), // PPM
     DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_ANY,                  0, 0), // S2_IN
 #else
@@ -42,7 +42,7 @@ const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,               0, 0), // S4_OUT D1_ST1
 
     // { TIM9,  IO_TAG(PA3),  TIM_Channel_2, 1, IOCFG_AF_PP_PD, GPIO_AF_TIM9, TIM_USE_MC_MOTOR                    | TIM_USE_FW_SERVO }, // MOTOR_3
-#if (defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)) && !(defined(OMNIBUSF4PRO_LEDSTRIPM5) || defined(OMNIBUSF4V3_S6_SS) || defined(OMNIBUSF4V3_S5S6_SS) || defined(OMNIBUSF4V3_S5_S6_2SS))
+#if (defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)) && !(defined(OMNIBUSF4PRO_LEDSTRIPM5) || defined(OMNIBUSF4V3_S6_SS) || defined(OMNIBUSF4V3_S5S6_SS) || defined(OMNIBUSF4V3_S5_S6_2SS)) || defined(OMNIBUSF4V3_LED_SS)
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,                0, 0), // S5_OUT
     DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,                0, 0), // S6_OUT
 #elif defined(OMNIBUSF4V3_S5S6_SS) || defined(OMNIBUSF4V3_S5_S6_2SS)
@@ -51,9 +51,11 @@ const timerHardware_t timerHardware[] = {
 #elif defined(OMNIBUSF4V3_S6_SS)
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,                0, 0), // S5_OUT
     DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_ANY,                                                           0, 0), // S6_OUT SOFTSERIAL
-#elif defined(OMNIBUSF4PRO_LEDSTRIPM5)
+#elif defined(OMNIBUSF4PRO_LEDSTRIPM5) 
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_LED,                                                           0, 0), // S5_OUT LED strip
     DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,                0, 0), // S6_OUT
+#elif defined(OMNIBUSF4V3_LED_SS)
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_ANY,                                                           0, 0)  // // LED strip pin as SOFTSERIAL2
 #else
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO | TIM_USE_LED,  0, 0), // S5_OUT MOTOR, SERVO or LED
     DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MC_MOTOR | TIM_USE_MC_SERVO | TIM_USE_FW_SERVO,                0, 0), // S6_OUT

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -22,7 +22,7 @@
 #define OMNIBUSF4PRO
 #endif
 //Same target as OMNIBUSF4V3 with softserial in M5 and M6
-#if defined(OMNIBUSF4V3_S6_SS) || defined(OMNIBUSF4V3_S5S6_SS) || defined(OMNIBUSF4V3_S5_S6_2SS)
+#if defined(OMNIBUSF4V3_S6_SS) || defined(OMNIBUSF4V3_S5S6_SS) || defined(OMNIBUSF4V3_S5_S6_2SS) || defined(OMNIBUSF4V3_LED_SS)
 #define OMNIBUSF4V3
 #endif
 
@@ -162,7 +162,7 @@
   #define INVERTER_PIN_UART6_TX PC9
 #endif
 
-#if defined(OMNIBUSF4V3) && !(defined(OMNIBUSF4V3_S6_SS) || defined(OMNIBUSF4V3_S5S6_SS) || defined(OMNIBUSF4V3_S5_S6_2SS))
+#if defined(OMNIBUSF4V3) && !(defined(OMNIBUSF4V3_S6_SS)) && !(defined(OMNIBUSF4V3_LED_SS)) || defined(OMNIBUSF4V3_S5S6_SS) || defined(OMNIBUSF4V3_S5_S6_2SS)
 #define USE_SOFTSERIAL1
 #define SOFTSERIAL_1_RX_PIN     PC6     // shared with UART6 TX
 #define SOFTSERIAL_1_TX_PIN     PC6     // shared with UART6 TX
@@ -193,6 +193,17 @@
 #define SOFTSERIAL_2_TX_PIN     PA8     // S6 output
 
 #define SERIAL_PORT_COUNT       6       // VCP, USART1, USART3, USART6, SOFTSERIAL1, SOFTSERIAL2
+
+#elif defined(OMNIBUSF4V3_LED_SS)        // two softserials, one on UART6 and one on LEDSTRIP
+#define USE_SOFTSERIAL1
+#define SOFTSERIAL_1_RX_PIN     PC6     // shared with UART6 TX
+#define SOFTSERIAL_1_TX_PIN     PC6     // shared with UART6 TX
+
+#define USE_SOFTSERIAL2
+#define SOFTSERIAL_2_RX_PIN     PB6     // LEDSTRIP OUTPUT
+#define SOFTSERIAL_2_TX_PIN     PB6     // LEDSTRIP OUTPUT
+
+#define SERIAL_PORT_COUNT       6       // VCP, USART1, USART3, USART6, SOFTSERIAL1
 
 #else                                   // One softserial on versions other than OMNIBUSF4V3
 #define USE_SOFTSERIAL1

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -217,7 +217,7 @@
 
 #define USE_SPI_DEVICE_1
 
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_LED_SS)
   #define USE_SPI_DEVICE_2
   #define SPI2_NSS_PIN          PB12
   #define SPI2_SCK_PIN          PB13
@@ -226,7 +226,7 @@
 #endif
 
 #define USE_SPI_DEVICE_3
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_LED_SS)
   #define SPI3_NSS_PIN          PA15
 #else
   #define SPI3_NSS_PIN          PB3
@@ -240,7 +240,7 @@
 #define MAX7456_SPI_BUS         BUS_SPI3
 #define MAX7456_CS_PIN          PA15
 
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_LED_SS)
   #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
   #define USE_SDCARD
   #define USE_SDCARD_SPI


### PR DESCRIPTION
Added a new target OMNIBUSF4V3_LED_SS and its features:
- SOFTWARESERIAL1 ON UART6
- SOFTWARESERIAL2 ON LEDSTRIP (RX&TX)

Used in a fixed wing airplane (DIY FT Simple Cub) the following config:
- UART6 - SBUS IN - Tested working
- UART1 - BN220 GPS - Tested working
- UART3/I2C - HMC5883  - Tested working
- BUZZER
- CAMERA & VTX (no tramp) on OSD - Working
- VBAT working
- Frsky SmartPort Telemetry - Working

Motors and servo outputs working:
- Motor on PWM1
- Servos on PWM3-6

It did not maiden yet and I don't believe it will till the end of the quarantine but is looking pretty good. I love your platform! I would love to see this target on the platform. Thanks.