### PR TITLE
Enable DSHOT and ESC sensor for OMNIBUSF7

### DIFF
--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -120,7 +120,7 @@ The following sensors are transmitted
 * **0420** : distance to GPS home fix, in meters
 * **0430** : if `frsky_pitch_roll = ON` set this will be pitch degrees*10
 * **0440** : if `frsky_pitch_roll = ON` set this will be roll degrees*10
-
+* **0450** : 'Flight Path Vector' or 'Course over ground' in degrees*10
 ### Compatible SmartPort/INAV telemetry flight status
 
 To quickly and easily monitor these SmartPort sensors and flight modes, install [iNav LuaTelemetry](https://github.com/iNavFlight/LuaTelemetry) to your Taranis Q X7, X9D, X9D+ or X9E transmitter.

--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -202,6 +202,8 @@
 // Number of available PWM outputs
 #define MAX_PWM_OUTPUT_PORTS    4
 #define TARGET_MOTOR_COUNT      4
+#define USE_DSHOT
+#define USE_ESC_SENSOR
 
 #define TARGET_IO_PORTA 0xffff
 #define TARGET_IO_PORTB 0xffff


### PR DESCRIPTION
I have enabled DSHOT and ESC Telemetry per Default.
I have tested the functionality of the ESCs on OMNIBUSF7 and "Favourite BLHeli S LittleBee-Spring 30A" with @JazzMaverick's bidirectional ESC Firmware [A_H_30_24_REV16_77.HEX](https://github.com/JazzMaverick/BLHeli/blob/16.78_A/BLHeli_S%20SiLabs/Hex_files_16.77/Hex_files_16.77_24k/A_H_30_24_REV16_77.HEX).