### PR TITLE
[GYRO] Refactor gyro driver for dual-gyro support

### DIFF
--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -30,7 +30,11 @@ extern uint8_t detectedSensors[SENSOR_INDEX_COUNT];
 
 hardwareSensorStatus_e getHwGyroStatus(void)
 {
-    // Gyro is assumed to be always healthy
+    // Gyro is assumed to be always healthy, but it must be present
+    if (detectedSensors[SENSOR_INDEX_GYRO] == GYRO_NONE) {
+        return HW_SENSOR_UNAVAILABLE;
+    }
+
     return HW_SENSOR_OK;
 }
 

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -364,7 +364,7 @@ bool gyroIsCalibrationComplete(void)
     return zeroCalibrationIsCompleteV(&gyroCalibration[0]) && zeroCalibrationIsSuccessfulV(&gyroCalibration[0]);
 }
 
-STATIC_UNIT_TESTED void performgyroCalibration(gyroDev_t *dev, zeroCalibrationVector_t *gyroCalibration)
+STATIC_UNIT_TESTED void performGyroCalibration(gyroDev_t *dev, zeroCalibrationVector_t *gyroCalibration)
 {
     fpVector3_t v;
 
@@ -425,7 +425,7 @@ static bool FAST_CODE NOINLINE gyroUpdateAndCalibrate(gyroDev_t * gyroDev, zeroC
 
             return true;
         } else {
-            performgyroCalibration(gyroDev, gyroCal);
+            performGyroCalibration(gyroDev, gyroCal);
 
             // Reset gyro values to zero to prevent other code from using uncalibrated data
             gyroADCf[X] = 0.0f;

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -50,6 +50,7 @@ typedef enum {
 #define DYN_NOTCH_RANGE_HZ_LOW 1000
 
 typedef struct gyro_s {
+    bool initialized;
     uint32_t targetLooptime;
     float gyroADCf[XYZ_AXIS_COUNT];
 } gyro_t;
@@ -80,7 +81,6 @@ typedef struct gyroConfig_s {
 PG_DECLARE(gyroConfig_t, gyroConfig);
 
 bool gyroInit(void);
-void gyroInitFilters(void);
 void gyroGetMeasuredRotationRate(fpVector3_t *imuMeasuredRotationBF);
 void gyroUpdate(void);
 void gyroStartCalibration(void);

--- a/src/test/unit/sensor_gyro_unittest.cc
+++ b/src/test/unit/sensor_gyro_unittest.cc
@@ -39,7 +39,7 @@ extern "C" {
     #include "sensors/sensors.h"
 
     extern zeroCalibrationVector_t gyroCalibration;
-    extern gyroDev_t gyroDev0;
+    extern gyroDev_t gyroDev[];
 
     STATIC_UNIT_TESTED gyroSensor_e gyroDetect(gyroDev_t *dev, gyroSensor_e gyroHardware);
     STATIC_UNIT_TESTED void performGyroCalibration(gyroDev_t *dev, zeroCalibrationVector_t *gyroCalibration);
@@ -50,9 +50,8 @@ extern "C" {
 
 TEST(SensorGyro, Detect)
 {
-    const gyroSensor_e detected = gyroDetect(&gyroDev0, GYRO_AUTODETECT);
+    const gyroSensor_e detected = gyroDetect(&gyroDev[0], GYRO_AUTODETECT);
     EXPECT_EQ(GYRO_FAKE, detected);
-    EXPECT_EQ(GYRO_FAKE, detectedSensors[SENSOR_INDEX_GYRO]);
 }
 
 TEST(SensorGyro, Init)
@@ -67,11 +66,11 @@ TEST(SensorGyro, Read)
     gyroInit();
     EXPECT_EQ(GYRO_FAKE, detectedSensors[SENSOR_INDEX_GYRO]);
     fakeGyroSet(5, 6, 7);
-    const bool read = gyroDev0.readFn(&gyroDev0);
+    const bool read = gyroDev[0].readFn(&gyroDev[0]);
     EXPECT_EQ(true, read);
-    EXPECT_EQ(5, gyroDev0.gyroADCRaw[X]);
-    EXPECT_EQ(6, gyroDev0.gyroADCRaw[Y]);
-    EXPECT_EQ(7, gyroDev0.gyroADCRaw[Z]);
+    EXPECT_EQ(5, gyroDev[0].gyroADCRaw[X]);
+    EXPECT_EQ(6, gyroDev[0].gyroADCRaw[Y]);
+    EXPECT_EQ(7, gyroDev[0].gyroADCRaw[Z]);
 }
 
 TEST(SensorGyro, Calibrate)
@@ -79,25 +78,25 @@ TEST(SensorGyro, Calibrate)
     gyroStartCalibration();
     gyroInit();
     fakeGyroSet(5, 6, 7);
-    const bool read = gyroDev0.readFn(&gyroDev0);
+    const bool read = gyroDev[0].readFn(&gyroDev[0]);
     EXPECT_EQ(true, read);
-    EXPECT_EQ(5, gyroDev0.gyroADCRaw[X]);
-    EXPECT_EQ(6, gyroDev0.gyroADCRaw[Y]);
-    EXPECT_EQ(7, gyroDev0.gyroADCRaw[Z]);
-    gyroDev0.gyroZero[X] = 8;
-    gyroDev0.gyroZero[Y] = 9;
-    gyroDev0.gyroZero[Z] = 10;
-    performGyroCalibration(&gyroDev0, &gyroCalibration);
-    EXPECT_EQ(0, gyroDev0.gyroZero[X]);
-    EXPECT_EQ(0, gyroDev0.gyroZero[Y]);
-    EXPECT_EQ(0, gyroDev0.gyroZero[Z]);
+    EXPECT_EQ(5, gyroDev[0].gyroADCRaw[X]);
+    EXPECT_EQ(6, gyroDev[0].gyroADCRaw[Y]);
+    EXPECT_EQ(7, gyroDev[0].gyroADCRaw[Z]);
+    gyroDev[0].gyroZero[X] = 8;
+    gyroDev[0].gyroZero[Y] = 9;
+    gyroDev[0].gyroZero[Z] = 10;
+    performGyroCalibration(&gyroDev[0], &gyroCalibration);
+    EXPECT_EQ(0, gyroDev[0].gyroZero[X]);
+    EXPECT_EQ(0, gyroDev[0].gyroZero[Y]);
+    EXPECT_EQ(0, gyroDev[0].gyroZero[Z]);
     EXPECT_EQ(false, gyroIsCalibrationComplete());
     while (!gyroIsCalibrationComplete()) {
-        performGyroCalibration(&gyroDev0, &gyroCalibration);
+        performGyroCalibration(&gyroDev[0], &gyroCalibration);
     }
-    EXPECT_EQ(5, gyroDev0.gyroZero[X]);
-    EXPECT_EQ(6, gyroDev0.gyroZero[Y]);
-    EXPECT_EQ(7, gyroDev0.gyroZero[Z]);
+    EXPECT_EQ(5, gyroDev[0].gyroZero[X]);
+    EXPECT_EQ(6, gyroDev[0].gyroZero[Y]);
+    EXPECT_EQ(7, gyroDev[0].gyroZero[Z]);
 }
 
 TEST(SensorGyro, Update)
@@ -112,9 +111,9 @@ TEST(SensorGyro, Update)
         gyroUpdate();
     }
     EXPECT_EQ(true, gyroIsCalibrationComplete());
-    EXPECT_EQ(5, gyroDev0.gyroZero[X]);
-    EXPECT_EQ(6, gyroDev0.gyroZero[Y]);
-    EXPECT_EQ(7, gyroDev0.gyroZero[Z]);
+    EXPECT_EQ(5, gyroDev[0].gyroZero[X]);
+    EXPECT_EQ(6, gyroDev[0].gyroZero[Y]);
+    EXPECT_EQ(7, gyroDev[0].gyroZero[Z]);
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[X]);
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[Y]);
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[Z]);
@@ -125,9 +124,9 @@ TEST(SensorGyro, Update)
     EXPECT_FLOAT_EQ(0, gyro.gyroADCf[Z]);
     fakeGyroSet(15, 26, 97);
     gyroUpdate();
-    EXPECT_FLOAT_EQ(10 * gyroDev0.scale, gyro.gyroADCf[X]); // gyroADCf values are scaled
-    EXPECT_FLOAT_EQ(20 * gyroDev0.scale, gyro.gyroADCf[Y]);
-    EXPECT_FLOAT_EQ(90 * gyroDev0.scale, gyro.gyroADCf[Z]);
+    EXPECT_FLOAT_EQ(10 * gyroDev[0].scale, gyro.gyroADCf[X]); // gyroADCf values are scaled
+    EXPECT_FLOAT_EQ(20 * gyroDev[0].scale, gyro.gyroADCf[Y]);
+    EXPECT_FLOAT_EQ(90 * gyroDev[0].scale, gyro.gyroADCf[Z]);
 }
 
 


### PR DESCRIPTION
Decouple gyro reading and calibration from `gyroUpdate`. This is a pre-requisite for dual-gyro support. 