### PR TITLE
Output servos as SBUS stream

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -291,6 +291,7 @@ A shorter form is also supported to enable and disable functions using `serial <
 |  alt_hold_deadband  | 50 | Defines the deadband of throttle during alt_hold [r/c points] |
 |  yaw_motor_direction  | 1 | Use if you need to inverse yaw motor direction. |
 |  tri_unarmed_servo  | ON | On tricopter mix only, if this is set to ON, servo will always be correcting regardless of armed state. to disable this, set it to OFF. |
+|  servo_protocol  | PWM | An option to chose the protocol/option that would be used to output servo data. Possible options `PWM` (FC servo outputs), `SERVO_DRIVER` (I2C PCA9685 peripheral), `SBUS` (S.Bus protocol output via a configured serial port) |
 |  servo_lpf_hz  | 20 | Selects the servo PWM output cutoff frequency. Value is in [Hz] |
 |  servo_center_pulse  | 1500 | Servo midpoint |
 |  servo_pwm_rate  | 50 | Output frequency (in Hz) servo pins. When using tricopters or gimbal with digital servo, this rate can be increased. Max of 498Hz (for 500Hz pwm period), and min of 50Hz. Most digital servos will support for example 330Hz. |

--- a/make/source.mk
+++ b/make/source.mk
@@ -105,6 +105,7 @@ COMMON_SRC = \
             flight/dynamic_gyro_notch.c \
             io/beeper.c \
             io/esc_serialshot.c \
+            io/servo_sbus.c \
             io/frsky_osd.c \
             io/osd_dji_hd.c \
             io/lights.c \

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -268,7 +268,7 @@ static bool motorsUseHardwareTimers(void)
 
 static bool servosUseHardwareTimers(void)
 {
-    return !feature(FEATURE_PWM_SERVO_DRIVER);
+    return servoConfig()->servo_protocol == SERVO_TYPE_PWM;
 }
 
 static void pwmInitMotors(timMotorServoHardware_t * timOutputs)

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -50,6 +50,12 @@ typedef enum {
 } motorPwmProtocolTypes_e;
 
 typedef enum {
+    SERVO_TYPE_PWM = 0,
+    SERVO_TYPE_SERVO_DRIVER,
+    SERVO_TYPE_SBUS
+} servoProtocolType_e;
+
+typedef enum {
     PWM_INIT_ERROR_NONE = 0,
     PWM_INIT_ERROR_TOO_MANY_MOTORS,
     PWM_INIT_ERROR_TOO_MANY_SERVOS,

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -37,6 +37,7 @@ FILE_COMPILE_FOR_SPEED
 
 #include "io/pwmdriver_i2c.h"
 #include "io/esc_serialshot.h"
+#include "io/servo_sbus.h"
 #include "sensors/esc_sensor.h"
 
 #include "config/feature.h"
@@ -507,14 +508,27 @@ static void pwmServoWriteExternalDriver(uint8_t index, uint16_t value)
 
 void pwmServoPreconfigure(void)
 {
-    servoWritePtr = pwmServoWriteStandard;
+    // Protocol-specific configuration
+    switch (servoConfig()->servo_protocol) {
+        default:
+        case SERVO_TYPE_PWM:
+            servoWritePtr = pwmServoWriteStandard;
+            break;
 
 #ifdef USE_PWM_SERVO_DRIVER
-    // If PCA9685 is enabled - switch the servo write function to external
-    if (feature(FEATURE_PWM_SERVO_DRIVER)) {
-        servoWritePtr = pwmServoWriteExternalDriver;
-    }
+        case SERVO_TYPE_SERVO_DRIVER:
+            pwmDriverInitialize();
+            servoWritePtr = pwmServoWriteExternalDriver;
+            break;
 #endif
+
+#ifdef USE_SERVO_SBUS
+        case SERVO_TYPE_SBUS:
+            sbusServoInitialize();
+            servoWritePtr = sbusServoUpdate;
+            break;
+#endif
+    }
 }
 
 bool pwmServoConfig(const timerHardware_t *timerHardware, uint8_t servoIndex, uint16_t servoPwmRate, uint16_t servoCenterPulse, bool enableOutput)

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -153,7 +153,7 @@ static const char * const featureNames[] = {
     "", "TELEMETRY", "CURRENT_METER", "REVERSIBLE_MOTORS", "",
     "", "RSSI_ADC", "LED_STRIP", "DASHBOARD", "",
     "BLACKBOX", "", "TRANSPONDER", "AIRMODE",
-    "SUPEREXPO", "VTX", "", "", "PWM_SERVO_DRIVER", "PWM_OUTPUT_ENABLE",
+    "SUPEREXPO", "VTX", "", "", "", "PWM_OUTPUT_ENABLE",
     "OSD", "FW_LAUNCH", NULL
 };
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -217,7 +217,15 @@ void validateAndFixConfig(void)
 #endif
 
 #ifndef USE_PWM_SERVO_DRIVER
-    featureClear(FEATURE_PWM_SERVO_DRIVER);
+    if (servoConfig()->servo_protocol == SERVO_TYPE_SERVO_DRIVER) {
+        servoConfigMutable()->servo_protocol = SERVO_TYPE_PWM;
+    }
+#endif
+
+#ifndef USE_SERVO_SBUS
+    if (servoConfig()->servo_protocol == SERVO_TYPE_SBUS) {
+        servoConfigMutable()->servo_protocol = SERVO_TYPE_PWM;
+    }
 #endif
 
     if (!isSerialConfigValid(serialConfigMutable())) {

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -62,8 +62,8 @@ typedef enum {
     FEATURE_SUPEREXPO_RATES = 1 << 23,
     FEATURE_VTX = 1 << 24,
     FEATURE_UNUSED_8 = 1 << 25,         // RX_SPI
-    FEATURE_UNUSED_9 = 1 << 26,         //SOFTSPI
-    FEATURE_PWM_SERVO_DRIVER = 1 << 27,
+    FEATURE_UNUSED_9 = 1 << 26,         // SOFTSPI
+    FEATURE_UNUSED_11 = 1 << 27,        // FEATURE_PWM_SERVO_DRIVER
     FEATURE_PWM_OUTPUT_ENABLE = 1 << 28,
     FEATURE_OSD = 1 << 29,
     FEATURE_FW_LAUNCH = 1 << 30,

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -643,12 +643,6 @@ void init(void)
     if (feature(FEATURE_VBAT | FEATURE_CURRENT_METER))
         batteryInit();
 
-#ifdef USE_PWM_SERVO_DRIVER
-    if (feature(FEATURE_PWM_SERVO_DRIVER)) {
-        pwmDriverInitialize();
-    }
-#endif
-
 #ifdef USE_RCDEVICE
     rcdeviceInit();
 #endif // USE_RCDEVICE

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -33,6 +33,8 @@ tables:
     values: ["SERIAL", "SPIFLASH", "SDCARD"]
   - name: motor_pwm_protocol
     values: ["STANDARD", "ONESHOT125", "ONESHOT42", "MULTISHOT", "BRUSHED", "DSHOT150", "DSHOT300", "DSHOT600", "DSHOT1200", "SERIALSHOT"]
+  - name: servo_protocol
+    values: ["PWM", "SERVO_DRIVER", "SBUS"]
   - name: failsafe_procedure
     values: ["SET-THR", "DROP", "RTH", "NONE"]
   - name: current_sensor
@@ -726,6 +728,9 @@ groups:
     type: servoConfig_t
     headers: ["flight/servos.h"]
     members:
+      - name: servo_protocol
+        field: servo_protocol
+        table: servo_protocol
       - name: servo_center_pulse
         field: servoCenterPulse
         min: PWM_RANGE_MIN

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -36,6 +36,7 @@
 #include "config/parameter_group_ids.h"
 
 #include "drivers/pwm_output.h"
+#include "drivers/pwm_mapping.h"
 #include "drivers/time.h"
 
 #include "fc/config.h"
@@ -53,12 +54,13 @@
 
 #include "sensors/gyro.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(servoConfig_t, servoConfig, PG_SERVO_CONFIG, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(servoConfig_t, servoConfig, PG_SERVO_CONFIG, 1);
 
 PG_RESET_TEMPLATE(servoConfig_t, servoConfig,
     .servoCenterPulse = 1500,
     .servoPwmRate = 50,             // Default for analog servos
     .servo_lowpass_freq = 20,       // Default servo update rate is 50Hz, everything above Nyquist frequency (25Hz) is going to fold and cause distortions
+    .servo_protocol = SERVO_TYPE_PWM,
     .flaperon_throw_offset = FLAPERON_THROW_DEFAULT,
     .tri_unarmed_servo = 1
 );

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -132,7 +132,7 @@ typedef struct servoConfig_s {
     uint16_t servoPwmRate;                  // The update rate of servo outputs (50-498Hz)
     int16_t servo_lowpass_freq;             // lowpass servo filter frequency selection; 1/1000ths of loop freq
     uint16_t flaperon_throw_offset;
-    uint8_t __reserved;
+    uint8_t servo_protocol;                 // See servoProtocolType_e
     uint8_t tri_unarmed_servo;              // send tail servo correction pulses even when unarmed
 } servoConfig_t;
 

--- a/src/main/io/pwmdriver_i2c.c
+++ b/src/main/io/pwmdriver_i2c.c
@@ -50,6 +50,10 @@ void pwmDriverInitialize(void) {
 }
 
 void pwmDriverSync(void) {
+    if (!STATE(PWM_DRIVER_AVAILABLE)) {
+        return;
+    }
+
     static uint8_t cycle = 0;
 
     (pwmDrivers[driverImplementationIndex].syncFunction)(cycle);

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -53,6 +53,7 @@ typedef enum {
     FUNCTION_TELEMETRY_SIM       = (1 << 19), // 524288
     FUNCTION_FRSKY_OSD           = (1 << 20), // 1048576
     FUNCTION_DJI_HD_OSD          = (1 << 21), // 2097152
+    FUNCTION_SERVO_SERIAL        = (1 << 22), // 4194304
 } serialPortFunction_e;
 
 typedef enum {

--- a/src/main/io/servo_sbus.c
+++ b/src/main/io/servo_sbus.c
@@ -42,7 +42,7 @@
 #if defined(USE_SERVO_SBUS)
 
 #define SERVO_SBUS_UART_BAUD            100000
-#define SERVO_SBUS_OPTIONS              (SERIAL_INVERTED | SERIAL_UNIDIR)
+#define SERVO_SBUS_OPTIONS              (SBUS_PORT_OPTIONS | SERIAL_INVERTED | SERIAL_UNIDIR)
 
 static serialPort_t * servoSbusPort = NULL;
 static sbusFrame_t sbusFrame;

--- a/src/main/io/servo_sbus.c
+++ b/src/main/io/servo_sbus.c
@@ -1,0 +1,133 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <ctype.h>
+#include <math.h>
+
+#include "platform.h"
+
+#include "build/build_config.h"
+#include "build/debug.h"
+
+#include "common/maths.h"
+#include "common/crc.h"
+
+#include "io/serial.h"
+#include "io/servo_sbus.h"
+#include "rx/sbus_channels.h"
+
+#if defined(USE_SERVO_SBUS)
+
+#define SERVO_SBUS_UART_BAUD            100000
+#define SERVO_SBUS_OPTIONS              (SERIAL_INVERTED | SERIAL_UNIDIR)
+
+static serialPort_t * servoSbusPort = NULL;
+static sbusFrame_t sbusFrame;
+
+bool sbusServoInitialize(void)
+{
+    serialPortConfig_t * portConfig;
+
+    // Avoid double initialization
+    if (servoSbusPort) {
+        return true;
+    }
+
+    portConfig = findSerialPortConfig(FUNCTION_SERVO_SERIAL);
+    if (!portConfig) {
+        return false;
+    }
+
+    servoSbusPort = openSerialPort(portConfig->identifier, FUNCTION_SERVO_SERIAL, NULL, NULL, SERVO_SBUS_UART_BAUD, MODE_TX, SERVO_SBUS_OPTIONS);
+    if (!servoSbusPort) {
+        return false;
+    }
+
+    // SBUS V1 magical values
+    sbusFrame.syncByte = 0x0F;
+    sbusFrame.channels.flags = 0;
+    sbusFrame.channels.chan0  = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan1  = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan2  = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan3  = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan4  = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan5  = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan6  = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan7  = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan8  = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan9  = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan10 = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan11 = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan12 = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan13 = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan14 = sbusEncodeChannelValue(1500);
+    sbusFrame.channels.chan15 = sbusEncodeChannelValue(1500);
+    sbusFrame.endByte = 0x00;
+
+    return true;
+}
+
+void sbusServoUpdate(uint8_t index, uint16_t value)
+{
+    switch(index) {
+        case 0: sbusFrame.channels.chan0 = sbusEncodeChannelValue(value); break;
+        case 1: sbusFrame.channels.chan1 = sbusEncodeChannelValue(value); break;
+        case 2: sbusFrame.channels.chan2 = sbusEncodeChannelValue(value); break;
+        case 3: sbusFrame.channels.chan3 = sbusEncodeChannelValue(value); break;
+        case 4: sbusFrame.channels.chan4 = sbusEncodeChannelValue(value); break;
+        case 5: sbusFrame.channels.chan5 = sbusEncodeChannelValue(value); break;
+        case 6: sbusFrame.channels.chan6 = sbusEncodeChannelValue(value); break;
+        case 7: sbusFrame.channels.chan7 = sbusEncodeChannelValue(value); break;
+        case 8: sbusFrame.channels.chan8 = sbusEncodeChannelValue(value); break;
+        case 9: sbusFrame.channels.chan9 = sbusEncodeChannelValue(value); break;
+        case 10: sbusFrame.channels.chan10 = sbusEncodeChannelValue(value); break;
+        case 11: sbusFrame.channels.chan11 = sbusEncodeChannelValue(value); break;
+        case 12: sbusFrame.channels.chan12 = sbusEncodeChannelValue(value); break;
+        case 13: sbusFrame.channels.chan13 = sbusEncodeChannelValue(value); break;
+        case 14: sbusFrame.channels.chan14 = sbusEncodeChannelValue(value); break;
+        case 15: sbusFrame.channels.chan15 = sbusEncodeChannelValue(value); break;
+        default:
+            break;
+    }
+}
+
+void sbusServoSendUpdate(void)
+{
+    // Check if the port is initialized
+    if (!servoSbusPort) {
+        return;
+    }
+
+    // Skip update if previous one is not yet fully sent
+    // This helps to avoid buffer overflow and evenyually the data corruption
+    if (!isSerialTransmitBufferEmpty(servoSbusPort)) {
+        return;
+    }
+
+    serialWriteBuf(servoSbusPort, (const uint8_t *)&sbusFrame, sizeof(sbusFrame));
+}
+
+#endif

--- a/src/main/io/servo_sbus.h
+++ b/src/main/io/servo_sbus.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#pragma once
+
+bool sbusServoInitialize(void);
+void sbusServoUpdate(uint8_t index, uint16_t value);
+void sbusServoSendUpdate(void);

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -53,21 +53,6 @@ FILE_COMPILE_FOR_SPEED
  * time to send frame: 3ms.
  */
 
-#define SBUS_FRAME_SIZE (SBUS_CHANNEL_DATA_LENGTH + 2)
-
-#define SBUS_FRAME_BEGIN_BYTE 0x0F
-
-#define SBUS_BAUDRATE       100000
-#define SBUS_BAUDRATE_FAST  200000
-
-#if !defined(SBUS_PORT_OPTIONS)
-#define SBUS_PORT_OPTIONS (SERIAL_STOPBITS_2 | SERIAL_PARITY_EVEN)
-#endif
-
-#define SBUS_DIGITAL_CHANNEL_MIN 173
-#define SBUS_DIGITAL_CHANNEL_MAX 1812
-
-
 enum {
     DEBUG_SBUS_INTERFRAME_TIME = 0,
     DEBUG_SBUS_FRAME_FLAGS = 1,
@@ -80,19 +65,6 @@ typedef enum {
     STATE_SBUS_WAIT_SYNC
 } sbusDecoderState_e;
 
-typedef struct sbusFrame_s {
-    uint8_t syncByte;
-    sbusChannels_t channels;
-    /**
-     * The endByte is 0x00 on FrSky and some futaba RX's, on Some SBUS2 RX's the value indicates the telemetry byte that is sent after every 4th sbus frame.
-     *
-     * See https://github.com/cleanflight/cleanflight/issues/590#issuecomment-101027349
-     * and
-     * https://github.com/cleanflight/cleanflight/issues/590#issuecomment-101706023
-     */
-    uint8_t endByte;
-} __attribute__ ((__packed__)) sbusFrame_t;
-
 typedef struct sbusFrameData_s {
     sbusDecoderState_e state;
     volatile sbusFrame_t frame;
@@ -101,8 +73,6 @@ typedef struct sbusFrameData_s {
     uint8_t position;
     timeUs_t lastActivityTimeUs;
 } sbusFrameData_t;
-
-STATIC_ASSERT(SBUS_FRAME_SIZE == sizeof(sbusFrame_t), SBUS_FRAME_SIZE_doesnt_match_sbusFrame_t);
 
 // Receive ISR callback
 static void sbusDataReceive(uint16_t c, void *data)

--- a/src/main/rx/sbus_channels.c
+++ b/src/main/rx/sbus_channels.c
@@ -24,17 +24,17 @@
 #ifdef USE_SERIAL_RX
 
 #include "common/utils.h"
+#include "common/maths.h"
 
-#include "rx/rx.h"
 #include "rx/sbus_channels.h"
-
-#define DEBUG_SBUS_FRAME_INTERVAL 3
 
 #define SBUS_FLAG_CHANNEL_17        (1 << 0)
 #define SBUS_FLAG_CHANNEL_18        (1 << 1)
 
 #define SBUS_DIGITAL_CHANNEL_MIN 173
 #define SBUS_DIGITAL_CHANNEL_MAX 1812
+
+STATIC_ASSERT(SBUS_FRAME_SIZE == sizeof(sbusFrame_t), SBUS_FRAME_SIZE_doesnt_match_sbusFrame_t);
 
 uint8_t sbusChannelsDecode(rxRuntimeConfig_t *rxRuntimeConfig, const sbusChannels_t *channels)
 {
@@ -82,11 +82,21 @@ uint8_t sbusChannelsDecode(rxRuntimeConfig_t *rxRuntimeConfig, const sbusChannel
     return RX_FRAME_COMPLETE;
 }
 
-static uint16_t sbusChannelsReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan)
+uint16_t sbusDecodeChannelValue(uint16_t sbusValue)
 {
     // Linear fitting values read from OpenTX-ppmus and comparing with values received by X4R
     // http://www.wolframalpha.com/input/?i=linear+fit+%7B173%2C+988%7D%2C+%7B1812%2C+2012%7D%2C+%7B993%2C+1500%7D
-    return (5 * rxRuntimeConfig->channelData[chan] / 8) + 880;
+    return (5 * constrain(sbusValue, SBUS_DIGITAL_CHANNEL_MIN, SBUS_DIGITAL_CHANNEL_MAX) / 8) + 880;
+}
+
+uint16_t sbusEncodeChannelValue(uint16_t rcValue)
+{
+    return constrain((((int)rcValue - 880) * 8 + 4) / 5, SBUS_DIGITAL_CHANNEL_MIN, SBUS_DIGITAL_CHANNEL_MAX);
+}
+
+static uint16_t sbusChannelsReadRawRC(const rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan)
+{
+    return sbusDecodeChannelValue(rxRuntimeConfig->channelData[chan]);
 }
 
 void sbusChannelsInit(rxRuntimeConfig_t *rxRuntimeConfig)

--- a/src/main/rx/sbus_channels.h
+++ b/src/main/rx/sbus_channels.h
@@ -18,11 +18,24 @@
 #pragma once
 
 #include <stdint.h>
+#include "rx/rx.h"
 
 #define SBUS_MAX_CHANNEL 18
 
 #define SBUS_FLAG_SIGNAL_LOSS       (1 << 2)
 #define SBUS_FLAG_FAILSAFE_ACTIVE   (1 << 3)
+
+#define SBUS_CHANNEL_DATA_LENGTH sizeof(sbusChannels_t)
+#define SBUS_FRAME_SIZE (SBUS_CHANNEL_DATA_LENGTH + 2)
+
+#define SBUS_FRAME_BEGIN_BYTE 0x0F
+
+#define SBUS_BAUDRATE       100000
+#define SBUS_BAUDRATE_FAST  200000
+
+#if !defined(SBUS_PORT_OPTIONS)
+#define SBUS_PORT_OPTIONS (SERIAL_STOPBITS_2 | SERIAL_PARITY_EVEN)
+#endif
 
 typedef struct sbusChannels_s {
     // 176 bits of data (11 bits per channel * 16 channels) = 22 bytes.
@@ -45,7 +58,22 @@ typedef struct sbusChannels_s {
     uint8_t flags;
 } __attribute__((__packed__)) sbusChannels_t;
 
-#define SBUS_CHANNEL_DATA_LENGTH sizeof(sbusChannels_t)
+typedef struct sbusFrame_s {
+    uint8_t syncByte;
+    sbusChannels_t channels;
+    /**
+     * The endByte is 0x00 on FrSky and some futaba RX's, on Some SBUS2 RX's the value indicates the telemetry byte that is sent after every 4th sbus frame.
+     *
+     * See https://github.com/cleanflight/cleanflight/issues/590#issuecomment-101027349
+     * and
+     * https://github.com/cleanflight/cleanflight/issues/590#issuecomment-101706023
+     */
+    uint8_t endByte;
+} __attribute__ ((__packed__)) sbusFrame_t;
+
+
+uint16_t sbusDecodeChannelValue(uint16_t sbusValue);
+uint16_t sbusEncodeChannelValue(uint16_t rcValue);
 
 uint8_t sbusChannelsDecode(rxRuntimeConfig_t *rxRuntimeConfig, const sbusChannels_t *channels);
 

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -46,6 +46,7 @@
 
 #if defined(STM32F4) || defined(STM32F7)
 #define USE_USB_MSC
+#define USE_SERVO_SBUS
 #endif
 
 #define USE_ADC_AVERAGING


### PR DESCRIPTION
We currently have two ways of connecting a servo - PWM and servo driver. This PR adds a third option - a serial output for S.Bus servos (Futaba-compatible).

A new parameter `servo_protocol` will allow user to chose one. feature `PWM_SERVO_DRIVER` is removed.

A new serial function (bit 22, mask 4194304) is added to control assignment of this feature to a serial port.

Configurator support is missing. Untested.

Fixes https://github.com/iNavFlight/inav/issues/5648