### PR TITLE
Fix OSD hang due to compiler optimization bug

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -22,8 +22,6 @@
 
 #include "platform.h"
 
-FILE_COMPILE_FOR_SPEED
-
 #ifdef USE_MAX7456
 
 #include "common/bitarray.h"


### PR DESCRIPTION
Introduced by fce005f

Fixes #5690