### PR TITLE
[BITARRAY] Bounds check in the first iteration in bitArrayFindFirstSet()

### DIFF
--- a/src/main/common/bitarray.c
+++ b/src/main/common/bitarray.c
@@ -75,17 +75,19 @@ int bitArrayFindFirstSet(const bitarrayElement_t *array, unsigned start, size_t 
     const uint32_t *end = ptr + (size / 4);
     const uint32_t *p = ptr + start / (8 * 4);
     int ret;
-    // First iteration might need to mask some bits
-    uint32_t mask = 0xFFFFFFFF << (start % (8 * 4));
-    if ((ret = __CTZ(*p & mask)) != 32) {
-        return (((char *)p) - ((char *)ptr)) * 8 + ret;
-    }
-    p++;
-    while (p < end) {
-        if ((ret = __CTZ(*p)) != 32) {
+    if (p < end) {
+        // First iteration might need to mask some bits
+        uint32_t mask = 0xFFFFFFFF << (start % (8 * 4));
+        if ((ret = __CTZ(*p & mask)) != 32) {
             return (((char *)p) - ((char *)ptr)) * 8 + ret;
         }
         p++;
+        while (p < end) {
+            if ((ret = __CTZ(*p)) != 32) {
+                return (((char *)p) - ((char *)ptr)) * 8 + ret;
+            }
+            p++;
+        }
     }
     return -1;
 }

--- a/src/test/unit/bitarray_unittest.cc
+++ b/src/test/unit/bitarray_unittest.cc
@@ -83,3 +83,14 @@ TEST(BitArrayTest, TestSetClrAll)
         EXPECT_EQ(ii, BITARRAY_FIND_FIRST_SET(p, ii));
     }
 }
+
+TEST(BitArrayTest, TestOutOfBounds)
+{
+    const int bits = 32 * 4;
+
+    BITARRAY_DECLARE(p, bits);
+    BITARRAY_CLR_ALL(p);
+    EXPECT_EQ(-1, BITARRAY_FIND_FIRST_SET(p, 0));
+    EXPECT_EQ(-1, BITARRAY_FIND_FIRST_SET(p, bits));
+    EXPECT_EQ(-1, BITARRAY_FIND_FIRST_SET(p, bits + 1));
+}


### PR DESCRIPTION
We already had bounds checking for the 2nd and subsequent 32 bit
blocks, but since the first block was handled separately (due to the
masking needed if it doesn't fall on a 32 bit boundary) it skipped
the check. With this change, any start bit >= the number of bits
in the array will return -1.
