### PR TITLE
Remove Air from OSD mode display

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1655,8 +1655,6 @@ static bool osdDrawSingleElement(uint8_t item)
                 p = "ANGL";
             else if (FLIGHT_MODE(HORIZON_MODE))
                 p = "HOR ";
-            else if (STATE(AIRMODE_ACTIVE))
-                p = "AIR ";
 
             displayWrite(osdDisplayPort, elemPosX, elemPosY, p);
             return true;


### PR DESCRIPTION
The current problem is if Airmode is permanently enabled or turned on, it will overwrite Acro in the OSD with Air. There are a few problems with this:

1. Airmode in its self is not a flight or navigation mode. It extends the current flight mode and increases control at low throttle. 

2. Airmode can be active with Acro, Horizon, and Angle. So only replacing Acro with Air is inconsistent. And having Air replace all those flight modes and the navigation modes that use them, could result in an useless mode display. This would be 100% the case when Airmode is permanently enabled. 

A better solution would be to add another parameter to the OSD to display Air when Airmode is active, independent of the mode display. This would only be useful to people who still have Airmode on a switch still. It would be unnecessary if Airmode is permanently enabled.

3. The current mode display is inconsistent with the iNav LUA script, as that will show Acro rather than Air.

4. The current mode display create confusion, especially among new pilots. They think that Airmode is Acro, which is incorrect.