### PR TITLE
[GYRO] Add support for MPU6000 to FIREWORKS V2 board

### DIFF
--- a/src/main/target/FIREWORKSV2/target.c
+++ b/src/main/target/FIREWORKSV2/target.c
@@ -29,11 +29,19 @@
 #include "drivers/pwm_mapping.h"
 #include "drivers/timer.h"
 #include "drivers/bus.h"
+#include "drivers/sensor.h"
 
 #include "drivers/pwm_output.h"
 #include "common/maths.h"
 #include "fc/config.h"
 
+// Board hardware definitions - IMU1 slot
+BUSDEV_REGISTER_SPI_TAG(busdev_1_mpu6000,   DEVHW_MPU6000,  IMU_1_SPI_BUS,  IMU_1_CS_PIN,   NONE,   0,  DEVFLAGS_NONE,  IMU_1_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_1_mpu6500,   DEVHW_MPU6500,  IMU_1_SPI_BUS,  IMU_1_CS_PIN,   NONE,   0,  DEVFLAGS_NONE,  IMU_1_ALIGN);
+
+// Board hardware definitions - IMU2 slot
+BUSDEV_REGISTER_SPI_TAG(busdev_2_mpu6000,   DEVHW_MPU6000,  IMU_2_SPI_BUS,  IMU_2_CS_PIN,   NONE,   1,  DEVFLAGS_NONE,  IMU_2_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_2_mpu6500,   DEVHW_MPU6500,  IMU_2_SPI_BUS,  IMU_2_CS_PIN,   NONE,   1,  DEVFLAGS_NONE,  IMU_2_ALIGN);
 
 const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM10, CH1, PB8, TIM_USE_PPM,                           0, 0), // PPM

--- a/src/main/target/FIREWORKSV2/target.h
+++ b/src/main/target/FIREWORKSV2/target.h
@@ -62,23 +62,27 @@
 #define GYRO_INT_EXTI            PC8
 // #define USE_MPU_DATA_READY_SIGNAL        // Not connected on FireworksV2
 
+#define USE_DUAL_GYRO
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS     // Don't use common busdev descriptors for IMU
 #define USE_IMU_MPU6500
+#define USE_IMU_MPU6000
 
 #if defined(OMNIBUSF4V6)
-#define MPU6500_CS_PIN          PC14
-#define MPU6500_SPI_BUS         BUS_SPI1
-#define IMU_MPU6500_ALIGN       CW0_DEG
+#   define IMU_1_CS_PIN            PA4
+#   define IMU_1_SPI_BUS           BUS_SPI1
+#   define IMU_1_ALIGN             CW180_DEG
+#   define IMU_2_CS_PIN            PC14
+#   define IMU_2_SPI_BUS           BUS_SPI1
+#   define IMU_2_ALIGN             CW0_DEG
 #else
-#define MPU6500_CS_PIN          PD2
-#define MPU6500_SPI_BUS         BUS_SPI3
-#define IMU_MPU6500_ALIGN       CW180_DEG
+    // FIREWORKS V2
+#   define IMU_1_CS_PIN            PD2
+#   define IMU_1_SPI_BUS           BUS_SPI3
+#   define IMU_1_ALIGN             CW180_DEG
+#   define IMU_2_CS_PIN            PA4
+#   define IMU_2_SPI_BUS           BUS_SPI1
+#   define IMU_2_ALIGN             CW0_DEG_FLIP
 #endif
-
-// OmnibusF4 Nano v6 and OmnibusF4 V6 has a MPU6000
-#define USE_IMU_MPU6000
-#define IMU_MPU6000_ALIGN       CW180_DEG
-#define MPU6000_CS_PIN          PA4
-#define MPU6000_SPI_BUS         BUS_SPI1
 
 #define USE_MAG
 #if defined(OMNIBUSF4V6)


### PR DESCRIPTION
As made obvious in https://github.com/iNavFlight/inav/issues/5710 `FIREWORKSV2` target doesn't support `MPU6000` as the primary IMU. This PR will add both `MPU6500` and `MPU6000` as primary gyros and also enable `DUAL_GYRO` on both `OMNIBUSF4V6` and `FIREWORKSV2` targets