### PR TITLE
Add RC Channel Values to OSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 .project
 .settings
 .cproject
+*.vcxproj.*
+*.vcxproj
 startup_stm32f10x_md_gcc.s
 .vagrant/
 .vscode/

--- a/docs/osd_rcchan.md
+++ b/docs/osd_rcchan.md
@@ -1,0 +1,78 @@
+OSD_RCCHAN
+==========
+
+Allows the display of up to 4 rc channels on the OSD. The channel values can be
+scaled as required and a prefix and/or postfix can be added. Max/min alarms can
+also be specified.
+
+The parameters are specified in the cli as follows:
+
+**\#osd_rcchan index channel minimum maximum decimals minAlarm maxAlarm prefix
+postfix**
+
+Where the parameters are as follows
+
+| **Name** | **Description**                                                                                         | **Default** | **Range**          |
+|----------|---------------------------------------------------------------------------------------------------------|-------------|--------------------|
+| index    | The index of the osd_rcchan.                                                                            |             | 0 to 3             |
+| channel  | The rc channel number to be displayed                                                                   |             | 1 to 16            |
+| minimum  | The value to be displayed in the OSD when the channel value is 1000                                     | 1000        | \-5000 to 5000     |
+| minimum  | The value to be displayed in the OSD when the channel value is 2000                                     | 2000        | \-5000 to 5000     |
+| decimals | Number of decimals to be displayed.                                                                     | 0           | 0 to 4             |
+| minAlarm | Values below minAlarm will blink in OSD. Disabled if zero                                               | 0           | minimum to maximum |
+| maxAlarm | Values above maxAlarm will blink in OSD. Disabled if zero                                               | 0           | minimum to maximum |
+| prefix   | Prefix to display before value. If prefix is an integer then the corresponding symbol will be displayed |             | 3 character max    |
+| postfix  | Text to display after value. If prefix is an integer then the corresponding symbol will be displayed    |             | 3 character max    |
+
+Examples:
+---------
+
+### Get parameter list for all indices
+
+**\#osd_rcchan**
+
+osd_rcchan 0 4 1000 2000 0 1200 1800 THR
+
+osd_rcchan 1 4 0 100 2 0 0 LFR %
+
+osd_rcchan 2 0 1000 2000 0 0 0
+
+osd_rcchan 3 0 1000 2000 0 0 0
+
+### Get parameter list for one index
+
+**\#osd_rcchan 1 4 0 100 2 0 0 LFR %**
+
+osd_rcchan 1 4 0 100 2 0 0 LFR %
+
+### Display the value of channel 4 (Throttle?) with no decimal places. The display will blink at throttle levels \>1800 or \< 1200. 
+
+**\#osd_rcchan 0 4 1000 2000 0 1200 1800 THR**
+
+osd_rcchan 0 4 1000 2000 0 1200 1800 THR
+
+### Display the value of channel 9 with 2 decimal places. The prefix is left arrow. The values will range from 0 to 100 and will blink if above 50. The postfix is % .
+
+**\#osd_rcchan 0 9 0 100 2 0 50 2 %**
+
+osd_rcchan 0 9 0 100 2 0 50 2 %
+
+### Reset channel 1 to default
+
+\#osd_rcchan 1 0
+
+osd_rcchan 1 0 1000 2000 0 0 0
+
+**NB**
+
+In order to have the values displayed in the OSD, the screen coordinates for
+each osd_rcchan item must be set in the cli. Unlike other OSD components, this
+is not currently possible using the configurator.
+
+In INav 2.4, the item numbers for the four osd_rcchan entries are 107, 108, 109,
+110 and the settings must be viewed and modified using the cli. These indices
+will probably be different in other releases
+
+**\#osd_layout 0 107 2 9 V**
+
+osd_layout 0 107 2 9 V

--- a/src/main/common/string_light.c
+++ b/src/main/common/string_light.c
@@ -19,6 +19,7 @@
 
 #include "string_light.h"
 #include "typeconversion.h"
+#include <string.h>
 
 int sl_isalnum(int c)
 {
@@ -71,4 +72,19 @@ int sl_strncasecmp(const char * s1, const char * s2, int n)
     }
 
     return d;
+}
+
+// Shift string by nplaces to the right. Space is filled with char nchar
+// Make sure outBuf has space for the output!
+void sl_rightShift(char * buffer,int nplaces,char nchar)
+{
+	if (nplaces <= 0)return;
+
+	int len = strlen(buffer);
+	for(int ii=len-1;ii>=0;ii--)
+	{
+		buffer[ii + nplaces] = buffer[ii];
+	}
+	for (int ii = 0; ii < nplaces; ii++)buffer[ii] = nchar;
+	buffer[len + nplaces] = '\0';
 }

--- a/src/main/common/string_light.h
+++ b/src/main/common/string_light.h
@@ -26,3 +26,5 @@ int sl_toupper(int c);
 
 int sl_strcasecmp(const char * s1, const char * s2);
 int sl_strncasecmp(const char * s1, const char * s2, int n);
+
+void sl_rightShift(char * buffer,int nplaces,char nchar);

--- a/src/main/common/typeconversion.h
+++ b/src/main/common/typeconversion.h
@@ -28,7 +28,8 @@ char *ftoa(float x, char *floatString);
 float fastA2F(const char *p);
 unsigned long int fastA2UL(const char *p);
 int fastA2I(const char *s);
-
+void ftoa_decs(float x, char *outBuf, int ndecs);
+int isInteger(const char *s);
 #ifndef HAVE_ITOA_FUNCTION
 char *itoa(int i, char *a, int r);
 #endif

--- a/src/main/fc/cli.h
+++ b/src/main/fc/cli.h
@@ -24,3 +24,6 @@ void cliInit(const struct serialConfig_s *serialConfig);
 void cliProcess(void);
 struct serialPort_s;
 void cliEnter(struct serialPort_s *serialPort);
+
+typedef struct osdRCChan_s osdRCChan_t;
+void OsdChan_Reset(osdRCChan_t* rcchan);

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -152,6 +152,12 @@ typedef enum {
     OSD_VTX_POWER,
     OSD_ESC_RPM,
     OSD_ESC_TEMPERATURE,
+
+    OSD_RC_CHAN_0,
+    OSD_RC_CHAN_1,
+    OSD_RC_CHAN_2,
+    OSD_RC_CHAN_3,
+
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -192,6 +198,23 @@ typedef enum {
     OSD_AHI_STYLE_DEFAULT,
     OSD_AHI_STYLE_LINE,
 } osd_ahi_style_e;
+
+// Declarations for osdRCChan
+// if OSD_RCCHAN_COUNT is changed, changes in osd.c will also be required
+
+#define OSD_RCCHAN_COUNT 4    // The number of RCChannels available for display
+
+typedef struct osdRCChan_s {
+    int8_t channel;       // The rc channel to be displayed
+    int16_t minimum;      // The value to be displayed at receiver=1000
+    int16_t maximum;      // The value to be displayed at receiver=2000
+    int8_t decimals;      // The number of decimals to be displayed
+    int16_t minAlarm;     // Values below this limit will blink
+    int16_t maxAlarm;     // Values above this value will blink
+    char prefix[4];       // Prefix -  Max 3 characters. If integer then assume symbol
+    char postfix[4];      // Postfix - Max 3 characters. If integer then assume symbol
+} osdRCChan_t;
+
 
 typedef struct osdConfig_s {
     // Layouts
@@ -239,8 +262,9 @@ typedef struct osdConfig_s {
     uint16_t hud_radar_range_min;
     uint16_t hud_radar_range_max;
     uint16_t hud_radar_nearest;
+
     uint8_t hud_wp_disp;
-    
+ 
     uint8_t left_sidebar_scroll; // from osd_sidebar_scroll_e
     uint8_t right_sidebar_scroll; // from osd_sidebar_scroll_e
     uint8_t sidebar_scroll_arrows;
@@ -251,9 +275,13 @@ typedef struct osdConfig_s {
     bool    estimations_wind_compensation; // use wind compensation for estimated remaining flight/distance
     uint8_t coordinate_digits;
 
+    osdRCChan_t rc_chan[OSD_RCCHAN_COUNT];
+
     bool osd_failsafe_switch_layout;
     uint8_t plus_code_digits; // Number of digits to use in OSD_PLUS_CODE
+
     uint8_t osd_ahi_style;
+
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);
@@ -285,5 +313,6 @@ void osdCrosshairPosition(uint8_t *x, uint8_t *y);
 bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int maxDecimals, int maxScaledDecimals, int length);
 void osdFormatAltitudeSymbol(char *buff, int32_t alt);
 void osdFormatVelocityStr(char* buff, int32_t vel, bool _3D);
+
 // Returns a heading angle in degrees normalized to [0, 360).
 int osdGetHeadingAngle(int angle);


### PR DESCRIPTION
Refers to and hopefully solves issue https://github.com/iNavFlight/inav/issues/5659

### **Allows for display of values from up to 4 rc channels in the OSD.** 

Using the cli command osd_rcchan, the user can specify the channels to be displayed, the scaling required and the number of decimals to be displayed.  A prefix and postfix can be applied to the displayed item - both text and symbols can be used. Min/Max alarms can optionally be specified which cause the displayed value to blink when exceeded.

In order to make the new osd elements actually appear, it is necessary to issue appropriate osd_layout commands (e.g. #osd_layout 0 107 2 9 V) to position the elements and set their visibility. Could be easily incorporated into the configurator if desired.

docs/osd_rcchan.md contains more details.

I was unable to create this branch from the inav development branch because 2.5.0 RC1 and later seem to cause my MAMBAF722 to hang up and so I was unable to test. 

**This branch is therefore created from 2.4.0 and I understand will therefore need rebasing.**

I have been using it to display "Lost Frame Rate" which has been recently introduced by FrSky in their ACCESS firmware. It is sent down to the radio by telemetry and can be sent back to the model on a free channel and displayed using this addition.

I am a complete beginner with git and will need some help if rebasing is required.


 