### PR TITLE
Added functions to retrieve the UART Idle state (Needed for Spektrum SRXL2 support)

### DIFF
--- a/src/main/drivers/serial.c
+++ b/src/main/drivers/serial.c
@@ -111,3 +111,11 @@ bool serialIsConnected(const serialPort_t *instance)
     // If API is not defined - assume connected
     return true;
 }
+
+bool serialIsIdle(serialPort_t *instance)
+{
+    if (instance->vTable->isIdle)
+        return instance->vTable->isIdle(instance);
+    else
+        return false;
+}

--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -95,6 +95,8 @@ struct serialPortVTable {
 
     bool (*isConnected)(const serialPort_t *instance);
 
+    bool (*isIdle)(serialPort_t *instance);
+
     // Optional functions used to buffer large writes.
     void (*beginWrite)(serialPort_t *instance);
     void (*endWrite)(serialPort_t *instance);
@@ -111,6 +113,7 @@ bool isSerialTransmitBufferEmpty(const serialPort_t *instance);
 void serialPrint(serialPort_t *instance, const char *str);
 uint32_t serialGetBaudRate(serialPort_t *instance);
 bool serialIsConnected(const serialPort_t *instance);
+bool serialIsIdle(serialPort_t *instance);
 
 // A shim that adapts the bufWriter API to the serialWriteBuf() API.
 void serialWriteBufShim(void *instance, const uint8_t *data, int count);

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -628,7 +628,8 @@ static const struct serialPortVTable softSerialVTable = {
     .isConnected = NULL,
     .writeBuf = NULL,
     .beginWrite = NULL,
-    .endWrite = NULL
+    .endWrite = NULL,
+    .isIdle = NULL,
 };
 
 #endif

--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -247,6 +247,17 @@ void uartWrite(serialPort_t *instance, uint8_t ch)
     USART_ITConfig(s->USARTx, USART_IT_TXE, ENABLE);
 }
 
+bool isUartIdle(serialPort_t *instance)
+{
+    uartPort_t *s = (uartPort_t *)instance;
+    if(USART_GetFlagStatus(s->USARTx, USART_FLAG_IDLE)) {
+        uartClearIdleFlag(s);
+        return true;
+    } else {
+        return false;
+    }
+}
+
 const struct serialPortVTable uartVTable[] = {
     {
         .serialWrite = uartWrite,
@@ -260,5 +271,6 @@ const struct serialPortVTable uartVTable[] = {
         .writeBuf = NULL,
         .beginWrite = NULL,
         .endWrite = NULL,
+        .isIdle = isUartIdle,
     }
 };

--- a/src/main/drivers/serial_uart.h
+++ b/src/main/drivers/serial_uart.h
@@ -64,6 +64,7 @@ typedef struct {
 } uartPort_t;
 
 void uartGetPortPins(UARTDevice_e device, serialPortPins_t * pins);
+void uartClearIdleFlag(uartPort_t *s);
 serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_t mode, portOptions_t options);
 
 // serialPort API

--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -246,6 +246,17 @@ void uartWrite(serialPort_t *instance, uint8_t ch)
     __HAL_UART_ENABLE_IT(&s->Handle, UART_IT_TXE);
 }
 
+bool isUartIdle(serialPort_t *instance)
+{
+    uartPort_t *s = (uartPort_t *)instance;
+    if(__HAL_UART_GET_FLAG(&s->Handle, UART_FLAG_IDLE)) {
+        __HAL_UART_CLEAR_IDLEFLAG(&s->Handle);
+        return true;
+    } else {
+        return false;
+    }
+}
+
 const struct serialPortVTable uartVTable[] = {
     {
         .serialWrite = uartWrite,
@@ -259,5 +270,6 @@ const struct serialPortVTable uartVTable[] = {
         .writeBuf = NULL,
         .beginWrite = NULL,
         .endWrite = NULL,
+        .isIdle = isUartIdle,
     }
 };

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -371,6 +371,11 @@ void usartIrqHandler(uartPort_t *s)
     }
 }
 
+void uartClearIdleFlag(uartPort_t *s)
+{
+    USART_ClearITPendingBit(s->USARTx, USART_IT_IDLE);
+}
+
 #ifdef USE_UART1
 void USART1_IRQHandler(void)
 {

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -253,6 +253,12 @@ void uartGetPortPins(UARTDevice_e device, serialPortPins_t * pins)
     }
 }
 
+void uartClearIdleFlag(uartPort_t *s)
+{
+    (void) s->USARTx->SR;
+    (void) s->USARTx->DR;
+}
+
 uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_t mode, portOptions_t options)
 {
     uartPort_t *s;

--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -187,7 +187,8 @@ static const struct serialPortVTable usbVTable[] = {
         .isConnected = usbVcpIsConnected,
         .writeBuf = usbVcpWriteBuf,
         .beginWrite = usbVcpBeginWrite,
-        .endWrite = usbVcpEndWrite
+        .endWrite = usbVcpEndWrite,
+        .isIdle = NULL,
     }
 };
 


### PR DESCRIPTION
As discussed in issue #5540, it was preferred for the UART idle flag to be polled rather than using the interrupt to handle buffer switching for SRXL2. This pull requests include the functions needed to retrieve/clear the flag status. Not sure if I went about this in an acceptable manner. Please let me know otherwise.

This change is needed in order for SRXL2 to work. Will make a pull request for that once this is approved.