### PR TITLE
[OSD] Fix overflow in osdGridBufferClearGridRect()

### DIFF
--- a/src/main/drivers/osd.c
+++ b/src/main/drivers/osd.c
@@ -72,7 +72,7 @@ void osdGridBufferClearGridRect(int x, int y, int w, int h)
     osdGridBufferConstrainRect(&x, &y, &w, &h, OSD_CHARACTER_GRID_MAX_WIDTH, OSD_CHARACTER_GRID_MAX_HEIGHT);
     int maxX = x + w;
     int maxY = y + h;
-    for (int ii = x; ii <= maxX + w; ii++) {
+    for (int ii = x; ii <= maxX; ii++) {
         for (int jj = y; jj <= maxY; jj++) {
             *osdCharacterGridBufferGetEntryPtr(ii, jj) = 0;
         }


### PR DESCRIPTION
Width was added twice, causing an overflow when 2x the rect width
ended up being bigger than the screen width in grid columns.
