### PR TITLE
[BOT] Add no-response bot configuration

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,12 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 3
+# Label requiring a response
+responseRequiredLabel: Missing Information
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because the information we asked
+  to be provided when opening it was not supplied by the original author.
+  With only the information that is currently in the issue, we don't have
+  enough information to take action.


### PR DESCRIPTION
Issues labeled "Missing Information" will be closed after 3 days of inactivity.