### PR TITLE
Allow using GPS altitude instead of barometer

### DIFF
--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -189,7 +189,7 @@ void initActiveBoxIds(void)
     activeBoxIds[activeBoxIdCount++] = BOXCAMSTAB;
 
 #ifdef USE_GPS
-    if (STATE(ALTITUDE_CONTROL) && (sensors(SENSOR_BARO) || (STATE(AIRPLANE) && feature(FEATURE_GPS)))) {
+    if (STATE(ALTITUDE_CONTROL) && (sensors(SENSOR_BARO) || (feature(FEATURE_GPS) && (STATE(AIRPLANE) || positionEstimationConfig()->use_gps_no_baro)))) {
         activeBoxIds[activeBoxIdCount++] = BOXNAVALTHOLD;
         activeBoxIds[activeBoxIdCount++] = BOXSURFACE;
     }

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1858,6 +1858,9 @@ groups:
         default_value: "ON"
         field: use_gps_velned
         type: bool
+      - name: inav_use_gps_no_baro
+        field: use_gps_no_baro
+        type: bool
       - name: inav_allow_dead_reckoning
         description: "Defines if inav will dead-reckon over short GPS outages. May also be useful for indoors OPFLOW navigation"
         default_value: "OFF"

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -136,6 +136,8 @@ typedef struct positionEstimationConfig_s {
 
     float max_eph_epv;  // Max estimated position error acceptable for estimation (cm)
     float baro_epv;     // Baro position error
+
+    uint8_t use_gps_no_baro;
 } positionEstimationConfig_t;
 
 PG_DECLARE(positionEstimationConfig_t, positionEstimationConfig);

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -54,7 +54,7 @@
 
 navigationPosEstimator_t posEstimator;
 
-PG_REGISTER_WITH_RESET_TEMPLATE(positionEstimationConfig_t, positionEstimationConfig, PG_POSITION_ESTIMATION_CONFIG, 4);
+PG_REGISTER_WITH_RESET_TEMPLATE(positionEstimationConfig_t, positionEstimationConfig, PG_POSITION_ESTIMATION_CONFIG, 5);
 
 PG_RESET_TEMPLATE(positionEstimationConfig_t, positionEstimationConfig,
         // Inertial position estimator parameters

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -62,7 +62,8 @@ PG_RESET_TEMPLATE(positionEstimationConfig_t, positionEstimationConfig,
         .reset_altitude_type = NAV_RESET_ON_FIRST_ARM,
         .reset_home_type = NAV_RESET_ON_FIRST_ARM,
         .gravity_calibration_tolerance = 5,     // 5 cm/s/s calibration error accepted (0.5% of gravity)
-        .use_gps_velned = 1,         // "Disabled" is mandatory with gps_dyn_model = Pedestrian
+        .use_gps_velned = 1,                    // "Disabled" is mandatory with gps_dyn_model = Pedestrian
+        .use_gps_no_baro = 0,                   // Use GPS altitude if no baro is available on all aircrafts
         .allow_dead_reckoning = 0,
 
         .max_surface_altitude = 200,
@@ -581,7 +582,7 @@ static bool estimationCalculateCorrection_Z(estimationContext_t * ctx)
 
         return true;
     }
-    else if (STATE(FIXED_WING_LEGACY) && (ctx->newFlags & EST_GPS_Z_VALID)) {
+    else if ((STATE(FIXED_WING_LEGACY) || positionEstimationConfig()->use_gps_no_baro) && (ctx->newFlags & EST_GPS_Z_VALID)) {
         // If baro is not available - use GPS Z for correction on a plane
         // Reset current estimate to GPS altitude if estimate not valid
         if (!(ctx->newFlags & EST_Z_VALID)) {


### PR DESCRIPTION
Experimental.

Allows baroless multicopter setups. 
Caveat: GPS loss might result in uncontrolled altitude change until emergency landing kicks  in