### PR TITLE
Update target.h for MAMBA F722

### DIFF
--- a/src/main/target/MAMBAF722/target.h
+++ b/src/main/target/MAMBAF722/target.h
@@ -92,8 +92,8 @@
 #define UART6_TX_PIN                    PC6
 #define UART6_RX_PIN                    PC7
 
-#define SOFTSERIAL_1_TX_PIN             PA2
-#define SOFTSERIAL_1_RX_PIN             PA2
+#define SOFTSERIAL_1_TX_PIN             PB9
+#define SOFTSERIAL_1_RX_PIN             PB9
 
 #define SERIAL_PORT_COUNT               8
 


### PR DESCRIPTION
Softserial1 to B09 (PPM) instead of A02 (UART2?)