### PR TITLE
Set OSD Layout with global functions

### DIFF
--- a/docs/Global Functions.md
+++ b/docs/Global Functions.md
@@ -26,8 +26,9 @@ _Global Functions_ (abbr. GF) are a mechanism allowing to override certain fligh
 | 5             | INVERT_PITCH                  | Inverts PITCH axis input for PID/PIFF controller  |
 | 6             | INVERT_YAW                    | Inverts YAW axis input for PID/PIFF controller |
 | 7             | OVERRIDE_THROTTLE             | Override throttle value that is fed to the motors by mixer. Operand is scaled in us. `1000` means throttle cut, `1500` means half throttle |
-| 8             | SET_VTX_BAND           | Sets VTX band. Accepted values are `1-5` |
-| 8             | SET_VTX_CHANNEL           | Sets VTX channel. Accepted values are `1-8` |
+| 8             | SET_VTX_BAND                  | Sets VTX band. Accepted values are `1-5` |
+| 9             | SET_VTX_CHANNEL               | Sets VTX channel. Accepted values are `1-8` |
+| 10            | SET_OSD_LAYOUT                | Sets OSD layout. Accepted values are `0-3` |
 
 ## Flags
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -52,6 +52,7 @@ FILE_COMPILE_FOR_SPEED
 #include "common/time.h"
 #include "common/typeconversion.h"
 #include "common/utils.h"
+#include "programming/global_functions.h"
 
 #include "config/feature.h"
 #include "config/parameter_group.h"
@@ -3241,6 +3242,11 @@ void osdUpdate(timeUs_t currentTimeUs)
         if (IS_RC_MODE_ACTIVE(BOXOSDALT1))
             activeLayout = 1;
         else
+#ifdef USE_PROGRAMMING_FRAMEWORK
+        if (GLOBAL_FUNCTION_FLAG(GLOBAL_FUNCTION_FLAG_OVERRIDE_OSD_LAYOUT))
+            activeLayout = constrain(globalFunctionValues[GLOBAL_FUNCTION_ACTION_SET_OSD_LAYOUT], 0, OSD_ALTERNATE_LAYOUT_COUNT); 
+        else
+#endif
             activeLayout = 0;
     }
     if (currentLayout != activeLayout) {

--- a/src/main/programming/global_functions.c
+++ b/src/main/programming/global_functions.c
@@ -135,6 +135,12 @@ void globalFunctionsProcess(int8_t functionId) {
                     GLOBAL_FUNCTION_FLAG_ENABLE(GLOBAL_FUNCTION_FLAG_OVERRIDE_THROTTLE);
                 }
                 break;
+            case GLOBAL_FUNCTION_ACTION_SET_OSD_LAYOUT:
+                if(conditionValue){
+                    globalFunctionValues[GLOBAL_FUNCTION_ACTION_SET_OSD_LAYOUT] = globalFunctionsStates[functionId].value;
+                    GLOBAL_FUNCTION_FLAG_ENABLE(GLOBAL_FUNCTION_FLAG_OVERRIDE_OSD_LAYOUT);
+                }
+                break;
         }
     }
 }

--- a/src/main/programming/global_functions.h
+++ b/src/main/programming/global_functions.h
@@ -39,6 +39,7 @@ typedef enum {
     GLOBAL_FUNCTION_ACTION_OVERRIDE_THROTTLE,               // 7
     GLOBAL_FUNCTION_ACTION_SET_VTX_BAND,                    // 8
     GLOBAL_FUNCTION_ACTION_SET_VTX_CHANNEL,                 // 9
+    GLOBAL_FUNCTION_ACTION_SET_OSD_LAYOUT,                  // 10
     GLOBAL_FUNCTION_ACTION_LAST
 } globalFunctionActions_e;
 
@@ -50,6 +51,7 @@ typedef enum {
     GLOBAL_FUNCTION_FLAG_OVERRIDE_INVERT_PITCH = (1 << 4),
     GLOBAL_FUNCTION_FLAG_OVERRIDE_INVERT_YAW = (1 << 5),
     GLOBAL_FUNCTION_FLAG_OVERRIDE_THROTTLE = (1 << 6),
+    GLOBAL_FUNCTION_FLAG_OVERRIDE_OSD_LAYOUT = (1 << 7),
 } globalFunctionFlags_t;
 
 typedef struct globalFunction_s {


### PR DESCRIPTION
Added the ability to change OSD layout with global function.
It can be useful for example to show a layout with gps coordinates when the distance from home is major of a certain threshold, while a layout without GPS coordinates will be showed when the UAV is near.