### PR TITLE
Add Wing Autolaunch settings in the OSD menu as a submenu

### DIFF
--- a/src/main/cms/cms_menu_navigation.c
+++ b/src/main/cms/cms_menu_navigation.c
@@ -96,9 +96,9 @@ static const CMS_Menu cmsx_menuRTH = {
     .entries = cmsx_menuRTHEntries
 };
 
-static const OSD_Entry cmsx_menuFixedWingEntries[] =
+static const OSD_Entry cmsx_menuFWCruiseEntries[] =
 {
-    OSD_LABEL_ENTRY("-- FIXED WING --"),
+    OSD_LABEL_ENTRY("-- CRUISE --"),
 
     OSD_SETTING_ENTRY("CRUISE THROTTLE", SETTING_NAV_FW_CRUISE_THR),
     OSD_SETTING_ENTRY("MIN THROTTLE", SETTING_NAV_FW_MIN_THR),
@@ -113,7 +113,58 @@ static const OSD_Entry cmsx_menuFixedWingEntries[] =
     OSD_BACK_AND_END_ENTRY,
 };
 
-static const CMS_Menu cmsx_menuFixedWing = {
+static const CMS_Menu cmsx_menuFWCruise = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "MENUNAVFWCRUISE",
+    .GUARD_type = OME_MENU,
+#endif
+    .onEnter = NULL,
+    .onExit = NULL,
+    .onGlobalExit = NULL,
+    .entries = cmsx_menuFWCruiseEntries
+};
+
+static const OSD_Entry cmsx_menuFWLaunchEntries[] =
+{
+    OSD_LABEL_ENTRY("-- AUTOLAUNCH --"),
+
+    OSD_SETTING_ENTRY("LAUNCH THR", SETTING_NAV_FW_LAUNCH_THR),
+    OSD_SETTING_ENTRY("IDLE THROTTLE", SETTING_NAV_FW_LAUNCH_IDLE_THR),
+    OSD_SETTING_ENTRY("MOTOR SPINUP TIME", SETTING_NAV_FW_LAUNCH_SPINUP_TIME),
+    OSD_SETTING_ENTRY("TIMEOUT", SETTING_NAV_FW_LAUNCH_TIMEOUT),
+    OSD_SETTING_ENTRY("MAX ALTITUDE", SETTING_NAV_FW_LAUNCH_MAX_ALTITUDE),
+    OSD_SETTING_ENTRY("CLIMB ANGLE", SETTING_NAV_FW_LAUNCH_CLIMB_ANGLE),
+    OSD_SETTING_ENTRY("MAX BANK ANGLE", SETTING_NAV_FW_LAUNCH_MAX_ANGLE),
+    OSD_SETTING_ENTRY("MOTOR DELAY", SETTING_NAV_FW_LAUNCH_MOTOR_DELAY),
+    OSD_SETTING_ENTRY("VELOCITY", SETTING_NAV_FW_LAUNCH_VELOCITY),
+    OSD_SETTING_ENTRY("ACCELERATION", SETTING_NAV_FW_LAUNCH_ACCEL),
+    OSD_SETTING_ENTRY("DETECT TIME", SETTING_NAV_FW_LAUNCH_DETECT_TIME),
+
+    OSD_BACK_AND_END_ENTRY,
+ };
+
+static const CMS_Menu cmsx_menuFWLaunch = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "MENUNAVFWLAUNCH",
+    .GUARD_type = OME_MENU,
+#endif
+    .onEnter = NULL,
+    .onExit = NULL,
+    .onGlobalExit = NULL,
+    .entries = cmsx_menuFWLaunchEntries
+};
+
+static const OSD_Entry cmsx_menuFWSettingsEntries[] =
+{
+    OSD_LABEL_ENTRY("-- FIXED WING --"),
+
+    OSD_SUBMENU_ENTRY("AUTOLAUNCH", &cmsx_menuFWLaunch),
+    OSD_SUBMENU_ENTRY("CRUISE", &cmsx_menuFWCruise),
+
+    OSD_BACK_AND_END_ENTRY,
+};
+
+static const CMS_Menu cmsx_menuFWSettings = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUNAVFW",
     .GUARD_type = OME_MENU,
@@ -121,7 +172,7 @@ static const CMS_Menu cmsx_menuFixedWing = {
     .onEnter = NULL,
     .onExit = NULL,
     .onGlobalExit = NULL,
-    .entries = cmsx_menuFixedWingEntries
+    .entries = cmsx_menuFWSettingsEntries
 };
 
 static const OSD_Entry cmsx_menuNavigationEntries[] =
@@ -130,7 +181,7 @@ static const OSD_Entry cmsx_menuNavigationEntries[] =
 
     OSD_SUBMENU_ENTRY("BASIC SETTINGS", &cmsx_menuNavSettings),
     OSD_SUBMENU_ENTRY("RTH", &cmsx_menuRTH),
-    OSD_SUBMENU_ENTRY("FIXED WING", &cmsx_menuFixedWing),
+    OSD_SUBMENU_ENTRY("FIXED WING", &cmsx_menuFWSettings),
 
     OSD_BACK_AND_END_ENTRY,
 };


### PR DESCRIPTION
Add Wing Autolaunch settings in the OSD menu as a submenu named "AUTOLAUNCH". The settings related to the Wing cruise was moved to a new submenu named "CRUISE", Both submenus are now under the "FIXED WING" menu. More fixed wing settings may be added there

https://youtu.be/EaAqPe392xE


Discussion:
Not many of us will carry a laptop at the field... There were a few situations when I was forced to abandon the autolaunch or even the flight, for one or more reason below:
- you're at the field and broke the propeller and you have a smaller one to replace, so you need to increase the launch throttle, or in the other side, a bigger propeller and you need to reduce the launch throttle to protect the motor/esc
- you're in a high tree spot and you want to increase the launch climb angle, to avoid a crash in a tree
- you need to increase the launch timeout, because you want to fit your goggles and lay comfortable in a chair
- you want to change some settings in the launch detection, maybe you screw up one, etc.

I hope these modifications to add more value and usability to the Fixed wing users

