### PR TITLE
Added craft name to the osd armed page

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -615,6 +615,19 @@ static void osdFormatCoordinate(char *buff, char sym, int32_t val)
     buff[coordinateLength] = '\0';
 }
 
+static void osdFormatCraftName(char *buff)
+{
+    if (strlen(systemConfig()->name) == 0)
+            strcpy(buff, "CRAFT_NAME");
+    else {
+        for (int i = 0; i < MAX_NAME_LENGTH; i++) {
+            buff[i] = sl_toupper((unsigned char)systemConfig()->name[i]);
+            if (systemConfig()->name[i] == 0)
+                break;
+        }
+    }
+}
+
 // Used twice, make sure it's exactly the same string
 // to save some memory
 #define RC_RX_LINK_LOST_MSG "!RC RX LINK LOST!"
@@ -1659,15 +1672,7 @@ static bool osdDrawSingleElement(uint8_t item)
         }
 
     case OSD_CRAFT_NAME:
-        if (strlen(systemConfig()->name) == 0)
-            strcpy(buff, "CRAFT_NAME");
-        else {
-            for (int i = 0; i < MAX_NAME_LENGTH; i++) {
-                buff[i] = sl_toupper((unsigned char)systemConfig()->name[i]);
-                if (systemConfig()->name[i] == 0)
-                    break;
-            }
-        }
+        osdFormatCraftName(buff);
         break;
 
     case OSD_THROTTLE_POS:
@@ -3072,14 +3077,21 @@ static void osdShowArmed(void)
 {
     dateTime_t dt;
     char buf[MAX(32, FORMATTED_DATE_TIME_BUFSIZE)];
+    char craftNameBuf[MAX_NAME_LENGTH];
     char *date;
     char *time;
-    // We need 7 visible rows
-    uint8_t y = MIN((osdDisplayPort->rows / 2) - 1, osdDisplayPort->rows - 7 - 1);
+    // We need 10 visible rows
+    uint8_t y = MIN((osdDisplayPort->rows / 2) - 1, osdDisplayPort->rows - 10 - 1);
 
     displayClearScreen(osdDisplayPort);
     displayWrite(osdDisplayPort, 12, y, "ARMED");
     y += 2;
+
+    if (strlen(systemConfig()->name) > 0) {
+        osdFormatCraftName(craftNameBuf);
+        displayWrite(osdDisplayPort, (osdDisplayPort->cols - strlen(systemConfig() -> name)) / 2, y, craftNameBuf );
+        y += 2;
+    }
 
 #if defined(USE_GPS)
     if (feature(FEATURE_GPS)) {


### PR DESCRIPTION
If the craft name is set then it is displayed on the OSD "armed" page, otherwise it is not.  Images attached.

The "ARMED" message on the first row of this screen have been moved up to allow for the craft name to be displayed under it, if set.

Closes iNavFlight/inav#5809

<img width="662" alt="iNAVIssue5809_armedPage1_withName" src="https://user-images.githubusercontent.com/20749266/88174279-61a32100-cc67-11ea-9bd3-3e2098550991.png">
<img width="660" alt="iNAVIssue5809_armedPage1_noName" src="https://user-images.githubusercontent.com/20749266/88174283-64057b00-cc67-11ea-9c0f-611009f6ac53.png">