### PR TITLE
[CMS] fix editing of negative servo weights

### DIFF
--- a/src/main/cms/cms_menu_mixer_servo.c
+++ b/src/main/cms/cms_menu_mixer_servo.c
@@ -202,7 +202,7 @@ static const OSD_Entry cmsx_menuServoMixerEntries[] =
        OSD_UINT8_CALLBACK_ENTRY("SERVO MIX", cmsx_menuServoMixerIndexOnChange, (&(const OSD_UINT8_t){ &tmpcurrentServoMixerIndex, 1, MAX_SERVO_RULES, 1})),
        OSD_UINT8_DYN_ENTRY("SERVO", (&(const OSD_UINT8_t){ &tmpServoMixer.targetChannel, 0, MAX_SUPPORTED_SERVOS, 1})),
        OSD_TAB_DYN_ENTRY("INPUT", (&(const OSD_TAB_t){ &tmpServoMixer.inputSource, SERVO_MIXER_INPUT_CMS_NAMES_COUNT - 1, servoMixerInputCmsNames})),
-       OSD_INT16_DYN_ENTRY("WEIGHT", (&(const OSD_INT16_t){&tmpServoMixer.rate, 0, 1000, 1})),
+       OSD_INT16_DYN_ENTRY("WEIGHT", (&(const OSD_INT16_t){&tmpServoMixer.rate, -1000, 1000, 1})),
        OSD_UINT8_DYN_ENTRY("SPEED", (&(const OSD_UINT8_t){&tmpServoMixer.speed, 0, 255, 1})),
        OSD_BACK_AND_END_ENTRY
 };


### PR DESCRIPTION
 The OSD/CMS doesn't allow correct editing of negative servo mixer weights.
The value can only be made larger (towards positive) but not smaller.
Fix that by setting the min. value for the weight to -1000.

This is based on release_2.5.2 to get it fixed ASAP.