### PR TITLE
Allow throttle_idle to be 0 for better 3D compatibility

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -647,7 +647,7 @@ groups:
         description: "The percentage of the throttle range (`max_throttle` - `min_command`) above `min_command` used for minimum / idle throttle."
         default_value: "15"
         field: throttleIdle
-        min: 4
+        min: 0
         max: 30
       - name: motor_poles
         field: motorPoleCount


### PR DESCRIPTION
fixes #5802

In reversible mode, `throttle_idle` can now be set to `0` what allows full output from `min_command` to `max_throttle`