### PR TITLE
Handle leading spaces in craft name

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -472,7 +472,12 @@ static void dumpPgValue(const setting_t *value, uint8_t dumpMask)
         settingGetName(value, name);
         if (dumpMask & SHOW_DEFAULTS && !equalsDefault) {
             cliPrintf(defaultFormat, name);
-            printValuePointer(value, defaultValuePointer, 0);
+            // if the craftname has a leading space, then enclose the name in quotes
+            if (strcmp(name, "name") == 0 && ((const char *)valuePointer)[0] == ' ') {
+                cliPrintf("\"%s\"", (const char *)valuePointer);
+            } else {
+                printValuePointer(value, valuePointer, 0);
+            }
             cliPrintLinefeed();
         }
         cliPrintf(format, name);
@@ -2822,7 +2827,13 @@ static void cliGet(char *cmdline)
         val = settingGet(i);
         if (settingNameContains(val, name, cmdline)) {
             cliPrintf("%s = ", name);
-            cliPrintVar(val, 0);
+            if (strcmp(name, "name") == 0) {
+                // if the craftname has a leading space, then enclose the name in quotes
+                const char * v = (const char *)settingGetValuePointer(val);
+                cliPrintf(v[0] == ' ' ? "\"%s\"" : "%s", v);
+            } else {
+                cliPrintVar(val, 0);
+            }
             cliPrintLinefeed();
             cliPrintVarRange(val);
             cliPrintLinefeed();
@@ -2880,7 +2891,12 @@ static void cliSet(char *cmdline)
             if (settingNameIsExactMatch(val, name, cmdline, variableNameLength)) {
                 const setting_type_e type = SETTING_TYPE(val);
                 if (type == VAR_STRING) {
-                    settingSetString(val, eqptr, strlen(eqptr));
+                    // if setting the craftname, remove any quotes around the name.  This allows leading spaces in the name
+                    if (strcmp(name, "name") == 0 && eqptr[0] == '"' && eqptr[strlen(eqptr)-1] == '"') {
+                        settingSetString(val, eqptr + 1, strlen(eqptr)-2);
+                    } else {
+                        settingSetString(val, eqptr, strlen(eqptr));
+                    }
                     return;
                 }
                 const setting_mode_e mode = SETTING_MODE(val);


### PR DESCRIPTION
This change fixes a bug where leading spaces in the craftname are dropped when set via CLI.

The reasoning for this change is here:  #4973

When the craftname is set from iNav-configurator, the name can have leading spaces.  However, when set through the CLI, the leading spaces are dropped. 

I changed the handling of the "name" setting to enclose the name with quotes when there are leading spaces.