### PR TITLE
Improve the settings generator's error reporting

### DIFF
--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -532,6 +532,7 @@ class Generator
         table_names.each do |name|
             buf << "const char * const #{table_variable_name(name)}[] = {\n"
             tbl = @tables[name]
+            raise "values not found for table #{name}" unless tbl.has_key? 'values'
             tbl["values"].each do |v|
                 buf << "\t#{v.inspect},\n"
             end


### PR DESCRIPTION
Make the settings generator report when it can't find the values for a table instead of outputting a cryptic error