### PR TITLE
Anti windup only once after arm on airplanes

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -521,15 +521,15 @@ static void handlePIDAntiWindup(throttleStatus_e throttleStatus)
     if (!ARMING_FLAG(ARMED)) {
         antiWindupWasDeactivatedOnce = false;
     }
-    // In MANUAL mode we reset integrators prevent I-term wind-up (PID output is not used in MANUAL) 
+    // In MANUAL mode we reset integrators prevent I-term wind-up (PID output is not used in MANUAL)
     if (FLIGHT_MODE(MANUAL_MODE) || !ARMING_FLAG(ARMED)) {
         DISABLE_STATE(ANTI_WINDUP);
         pidResetErrorAccumulators();
         return;
     }
-    
+
     rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
-   
+
     // Set antiWindupWasDeactivatedOnce to prevent anti windup from being activated again
     if ((throttleStatus != THROTTLE_LOW) && (rollPitchStatus != CENTERED)) {
         antiWindupWasDeactivatedOnce = true;

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -513,6 +513,68 @@ void tryArm(void)
     }
 }
 
+static void handlePIDAntiWindup(throttleStatus_e throttleStatus)
+{
+    static bool antiWindupWasActivatedOnce = false;
+
+    // Track if ANTI_WINDUP was activated
+    if (!ARMING_FLAG(ARMED)) {
+        antiWindupWasActivatedOnce = false;
+    }
+    // In MANUAL mode we reset integrators prevent I-term wind-up (PID output is not used in MANUAL) 
+    if (FLIGHT_MODE(MANUAL_MODE) || !ARMING_FLAG(ARMED)) {
+        DISABLE_STATE(ANTI_WINDUP);
+        pidResetErrorAccumulators();
+        return;
+    }
+
+    // At non-zero throttle - always disable ANTI_WINDUP
+    if (throttleStatus != THROTTLE_LOW) {
+        DISABLE_STATE(ANTI_WINDUP);
+        return;
+    }
+
+    // This case applies only to MR when Airmode management is throttle threshold activated
+    if (rcControlsConfig()->airmodeHandlingType == THROTTLE_THRESHOLD) {
+        DISABLE_STATE(ANTI_WINDUP);
+        if (throttleStatus == THROTTLE_LOW && !STATE(AIRMODE_ACTIVE)) {
+            pidResetErrorAccumulators();
+        }
+        return;
+    }
+
+    rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
+
+    if (STATE(FIXED_WING_LEGACY)) {
+        if (STATE(AIRMODE_ACTIVE)) {
+            // On airplanes only activate ANTI_WINDUP if throttle = low, roll/pitch = center and ANTI_WINDUP was never activated this flight
+            if ((rollPitchStatus == CENTERED) && !antiWindupWasActivatedOnce) {
+                ENABLE_STATE(ANTI_WINDUP);
+                antiWindupWasActivatedOnce = true;
+            }
+            else {
+                DISABLE_STATE(ANTI_WINDUP);
+            }
+        }
+        else {
+            DISABLE_STATE(ANTI_WINDUP);
+        }
+    }
+    else {  // MULTI_ROTOR
+        if (STATE(AIRMODE_ACTIVE) && !failsafeIsActive()) {
+            if ((rollPitchStatus == CENTERED) || feature(FEATURE_MOTOR_STOP)) {
+                ENABLE_STATE(ANTI_WINDUP);
+            }
+            else {
+                DISABLE_STATE(ANTI_WINDUP);
+            }
+        }
+        else {
+            DISABLE_STATE(ANTI_WINDUP);
+        }
+    }
+}
+
 void processRx(timeUs_t currentTimeUs)
 {
     // Calculate RPY channel data
@@ -649,38 +711,7 @@ void processRx(timeUs_t currentTimeUs)
     /* In airmode Iterm should be prevented to grow when Low thottle and Roll + Pitch Centered.
        This is needed to prevent Iterm winding on the ground, but keep full stabilisation on 0 throttle while in air
        Low Throttle + roll and Pitch centered is assuming the copter is on the ground. Done to prevent complex air/ground detections */
-    if (FLIGHT_MODE(MANUAL_MODE) || !ARMING_FLAG(ARMED)) {
-        /* In MANUAL mode we reset integrators prevent I-term wind-up (PID output is not used in MANUAL) */
-        pidResetErrorAccumulators();
-    }
-    else if (STATE(FIXED_WING_LEGACY) || rcControlsConfig()->airmodeHandlingType == STICK_CENTER) {
-        if (throttleStatus == THROTTLE_LOW) {
-            if (STATE(AIRMODE_ACTIVE) && !failsafeIsActive() && ARMING_FLAG(ARMED)) {
-                rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
-
-                // ANTI_WINDUP at centred stick with MOTOR_STOP is needed on MRs and not needed on FWs
-                if ((rollPitchStatus == CENTERED) || (feature(FEATURE_MOTOR_STOP) && !STATE(FIXED_WING_LEGACY))) {
-                    ENABLE_STATE(ANTI_WINDUP);
-                }
-                else {
-                    DISABLE_STATE(ANTI_WINDUP);
-                }
-            }
-            else {
-                DISABLE_STATE(ANTI_WINDUP);
-                pidResetErrorAccumulators();
-            }
-        }
-        else {
-            DISABLE_STATE(ANTI_WINDUP);
-        }
-    } else if (rcControlsConfig()->airmodeHandlingType == THROTTLE_THRESHOLD) {
-        DISABLE_STATE(ANTI_WINDUP);
-        //This case applies only to MR when Airmode management is throttle threshold activated
-        if (throttleStatus == THROTTLE_LOW && !STATE(AIRMODE_ACTIVE)) {
-            pidResetErrorAccumulators();
-        }
-    }
+    handlePIDAntiWindup(throttleStatus);
 
     if (mixerConfig()->platformType == PLATFORM_AIRPLANE) {
         DISABLE_FLIGHT_MODE(HEADFREE_MODE);

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -654,6 +654,8 @@ void processRx(timeUs_t currentTimeUs)
         DISABLE_STATE(ANTI_WINDUP_DEACTIVATED);
     }
 
+    const rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
+
     // In MANUAL mode we reset integrators prevent I-term wind-up (PID output is not used in MANUAL)
     if (FLIGHT_MODE(MANUAL_MODE) || !ARMING_FLAG(ARMED)) {
         DISABLE_STATE(ANTI_WINDUP);
@@ -662,7 +664,6 @@ void processRx(timeUs_t currentTimeUs)
     else if (rcControlsConfig()->airmodeHandlingType == STICK_CENTER) {
         if (throttleStatus == THROTTLE_LOW) {
              if (STATE(AIRMODE_ACTIVE) && !failsafeIsActive()) {
-                 rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
                  if ((rollPitchStatus == CENTERED) || (feature(FEATURE_MOTOR_STOP) && !STATE(FIXED_WING_LEGACY))) {
                      ENABLE_STATE(ANTI_WINDUP);
                  }
@@ -680,7 +681,6 @@ void processRx(timeUs_t currentTimeUs)
          }
     }
     else if (rcControlsConfig()->airmodeHandlingType == STICK_CENTER_ONCE) {
-        rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
         if (throttleStatus == THROTTLE_LOW) {
              if (STATE(AIRMODE_ACTIVE) && !failsafeIsActive()) {
                  if ((rollPitchStatus == CENTERED) && !STATE(ANTI_WINDUP_DEACTIVATED)) {

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -659,7 +659,7 @@ void processRx(timeUs_t currentTimeUs)
         DISABLE_STATE(ANTI_WINDUP);
         pidResetErrorAccumulators();
     }
-    else if (rcControlsConfig->airmodeHandlingType == STICK_CENTER) {
+    else if (rcControlsConfig()->airmodeHandlingType == STICK_CENTER) {
         if (throttleStatus == THROTTLE_LOW) {
              if (STATE(AIRMODE_ACTIVE) && !failsafeIsActive()) {
                  rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
@@ -679,7 +679,7 @@ void processRx(timeUs_t currentTimeUs)
              DISABLE_STATE(ANTI_WINDUP);
          }
     }
-    else if (rcControlsConfig->airmodeHandlingType == STICK_CENTER_ONCE) {
+    else if (rcControlsConfig()->airmodeHandlingType == STICK_CENTER_ONCE) {
         rollPitchStatus_e rollPitchStatus = calculateRollPitchCenterStatus();
         if (throttleStatus == THROTTLE_LOW) {
              if (STATE(AIRMODE_ACTIVE) && !failsafeIsActive()) {
@@ -697,9 +697,9 @@ void processRx(timeUs_t currentTimeUs)
          }
          else {
              DISABLE_STATE(ANTI_WINDUP);
-	     if (rollPitchStatus != CENTERED) {
+             if (rollPitchStatus != CENTERED) {
                  ENABLE_STATE(ANTI_WINDUP_DEACTIVATED);
-	     }
+             }
          }
     }
     else if (rcControlsConfig()->airmodeHandlingType == THROTTLE_THRESHOLD) {

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -57,7 +57,8 @@ typedef enum {
 
 typedef enum {
     STICK_CENTER = 0,
-    THROTTLE_THRESHOLD
+    THROTTLE_THRESHOLD,
+    STICK_CENTER_ONCE
 } airmodeAndAntiWindupHandlingType_e;
 
 typedef enum {

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -59,7 +59,7 @@ typedef enum {
     STICK_CENTER = 0,
     THROTTLE_THRESHOLD,
     STICK_CENTER_ONCE
-} airmodeAndAntiWindupHandlingType_e;
+} airmodeHandlingType_e;
 
 typedef enum {
     ROL_LO = (1 << (2 * ROLL)),

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -63,7 +63,7 @@ static void processAirmodeAirplane(void) {
 }
 
 static void processAirmodeMultirotor(void) {
-    if (rcControlsConfig()->airmodeHandlingType == STICK_CENTER) {
+    if ((rcControlsConfig()->airmodeHandlingType == STICK_CENTER) || (rcControlsConfig()->airmodeHandlingType == STICK_CENTER_ONCE)) {
         if (feature(FEATURE_AIRMODE) || IS_RC_MODE_ACTIVE(BOXAIRMODE)) {
             ENABLE_STATE(AIRMODE_ACTIVE);
         } else {

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -131,6 +131,7 @@ typedef enum {
     MOVE_FORWARD_ONLY                   = (1 << 22),
     SET_REVERSIBLE_MOTORS_FORWARD       = (1 << 23),
     FW_HEADING_USE_YAW                  = (1 << 24),
+    ANTI_WINDUP_DEACTIVATED             = (1 << 25),
 } stateFlags_t;
 
 #define DISABLE_STATE(mask) (stateFlags &= ~(mask))

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -128,7 +128,7 @@ tables:
     values: ["GYRO", "SETPOINT"]
     enum: itermRelaxType_e
   - name: airmodeHandlingType
-    values: ["STICK_CENTER", "THROTTLE_THRESHOLD"]
+    values: ["STICK_CENTER", "THROTTLE_THRESHOLD", "STICK_CENTER_ONCE"]
   - name: nav_extra_arming_safety
     values: ["OFF", "ON", "ALLOW_BYPASS"]
     enum: navExtraArmingSafety_e


### PR DESCRIPTION
This is a pull request to fix issue #2834.

I've verified the functionality on my AR Wing. See attached blackbox log.
[LOG00001.TXT](https://github.com/iNavFlight/inav/files/5138462/LOG00001.2.TXT)

@Daemon42 - Can you validate the functionality is in accordance to your request?

@DzikuVx - I believe you made the latest changes to the anti windup part of the code with the THROTTLE_THRESHOLD setting. Could you test this new code to verify that the functionality still is the same as before for MR?

@shellixyz , @digitalentity - I'm tagging you too since you had a lot of input on the issue.

Is there anything else needed before this can be merged?

Thanks,
Arvid
