### PR TITLE
Return GCS waypoint in the case of waypoint 255 when GCS assist enabled

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -83,6 +83,10 @@ PG_REGISTER_ARRAY(navSafeHome_t, MAX_SAFE_HOMES, safeHomeConfig, PG_SAFE_HOME_CO
 #endif
 
 #if defined(USE_NAV)
+
+// waypoint 254, 255 are special waypoints
+STATIC_ASSERT(NAV_MAX_WAYPOINTS < 254, NAV_MAX_WAYPOINTS_exceeded_allowable_range);
+
 #if defined(NAV_NON_VOLATILE_WAYPOINT_STORAGE)
 PG_REGISTER_ARRAY(navWaypoint_t, NAV_MAX_WAYPOINTS, nonVolatileWaypointList, PG_WAYPOINT_MISSION_STORAGE, 0);
 #endif

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2782,20 +2782,27 @@ void getWaypoint(uint8_t wpNumber, navWaypoint_t * wpData)
             wpData->alt = GPS_home.alt;
         }
     }
-    // WP #255 - special waypoint - get desiredPosition that was set by ground control station if in GCS assisted mode, otherwise return current position
+    // WP #255 - special waypoint - directly get actualPosition
     else if (wpNumber == 255) {
         gpsLocation_t wpLLH;
 
-        if ((posControl.gpsOrigin.valid) && (posControl.flags.isGCSAssistedNavigationEnabled) && (posControl.navState == NAV_STATE_POSHOLD_3D_IN_PROGRESS)) {
-            geoConvertLocalToGeodetic(&wpLLH, &posControl.gpsOrigin, &posControl.desiredState.pos);
-        }
-        else {
-            geoConvertLocalToGeodetic(&wpLLH, &posControl.gpsOrigin, &navGetCurrentActualPositionAndVelocity()->pos);
-        }
+        geoConvertLocalToGeodetic(&wpLLH, &posControl.gpsOrigin, &navGetCurrentActualPositionAndVelocity()->pos);
 
         wpData->lat = wpLLH.lat;
         wpData->lon = wpLLH.lon;
         wpData->alt = wpLLH.alt;
+    }
+    // WP #254 - special waypoint - get desiredPosition that was set by ground control station if in GCS assisted mode
+    else if (wpNumber == 254) {
+        if ((posControl.gpsOrigin.valid) && (posControl.flags.isGCSAssistedNavigationEnabled) && (posControl.navState == NAV_STATE_POSHOLD_3D_IN_PROGRESS)) {
+            gpsLocation_t wpLLH;
+
+            geoConvertLocalToGeodetic(&wpLLH, &posControl.gpsOrigin, &posControl.desiredState.pos);
+            
+            wpData->lat = wpLLH.lat;
+            wpData->lon = wpLLH.lon;
+            wpData->alt = wpLLH.alt;
+        }
     }
     // WP #1 - #60 - common waypoints - pre-programmed mission
     else if ((wpNumber >= 1) && (wpNumber <= NAV_MAX_WAYPOINTS)) {

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2782,11 +2782,16 @@ void getWaypoint(uint8_t wpNumber, navWaypoint_t * wpData)
             wpData->alt = GPS_home.alt;
         }
     }
-    // WP #255 - special waypoint - directly get actualPosition
+    // WP #255 - special waypoint - get desiredPosition that was set by ground control station if in GCS assisted mode, otherwise return current position
     else if (wpNumber == 255) {
         gpsLocation_t wpLLH;
 
-        geoConvertLocalToGeodetic(&wpLLH, &posControl.gpsOrigin, &navGetCurrentActualPositionAndVelocity()->pos);
+        if ((posControl.gpsOrigin.valid) && (posControl.flags.isGCSAssistedNavigationEnabled) && (posControl.navState == NAV_STATE_POSHOLD_3D_IN_PROGRESS)) {
+            geoConvertLocalToGeodetic(&wpLLH, &posControl.gpsOrigin, &posControl.desiredState.pos);
+        }
+        else {
+            geoConvertLocalToGeodetic(&wpLLH, &posControl.gpsOrigin, &navGetCurrentActualPositionAndVelocity()->pos);
+        }
 
         wpData->lat = wpLLH.lat;
         wpData->lon = wpLLH.lon;

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2796,9 +2796,11 @@ void getWaypoint(uint8_t wpNumber, navWaypoint_t * wpData)
         wpData->lon = wpLLH.lon;
         wpData->alt = wpLLH.alt;
     }
-    // WP #254 - special waypoint - get desiredPosition that was set by ground control station if in GCS assisted mode
+    // WP #254 - special waypoint - get desiredPosition that was set by ground control station if in 3D-guided mode 
     else if (wpNumber == 254) {
-        if ((posControl.gpsOrigin.valid) && (posControl.flags.isGCSAssistedNavigationEnabled) && (posControl.navState == NAV_STATE_POSHOLD_3D_IN_PROGRESS)) {
+        navigationFSMStateFlags_t navStateFlags = navGetStateFlags(posControl.navState);
+
+        if ((posControl.gpsOrigin.valid) && (navStateFlags & NAV_CTL_ALT) && (navStateFlags & NAV_CTL_POS)) {
             gpsLocation_t wpLLH;
 
             geoConvertLocalToGeodetic(&wpLLH, &posControl.gpsOrigin, &posControl.desiredState.pos);

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -67,6 +67,9 @@ bool foundNearbySafeHome(void);                  // Did we find a safehome nearb
 
 #ifndef NAV_MAX_WAYPOINTS
 #define NAV_MAX_WAYPOINTS 15
+
+// waypoint 254, 255 are special waypoints
+STATIC_ASSERT(NAV_MAX_WAYPOINTS < 254, NAV_MAX_WAYPOINTS_exceeded_allowable_range);
 #endif
 
 #define NAV_ACCEL_CUTOFF_FREQUENCY_HZ 2       // low-pass filter on XY-acceleration target

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -67,9 +67,6 @@ bool foundNearbySafeHome(void);                  // Did we find a safehome nearb
 
 #ifndef NAV_MAX_WAYPOINTS
 #define NAV_MAX_WAYPOINTS 15
-
-// waypoint 254, 255 are special waypoints
-STATIC_ASSERT(NAV_MAX_WAYPOINTS < 254, NAV_MAX_WAYPOINTS_exceeded_allowable_range);
 #endif
 
 #define NAV_ACCEL_CUTOFF_FREQUENCY_HZ 2       // low-pass filter on XY-acceleration target


### PR DESCRIPTION
This is a pull request to fix issue #3810.

For MSP query in the case of waypoint 255, if GCS assist mode is not enabled, the current position is returned to preserve compatibility. With GCS assist mode enabled, in this commit the ground control station commanded waypoint is returned, which is consistent with waypoint 255 set behavior. This is also the desired behavior to affirm users that the correct waypoint from GCS is loaded. 