### PR TITLE
Enable internal pull-up for bidir (half duplex) UARTs by default

### DIFF
--- a/src/main/drivers/io.h
+++ b/src/main/drivers/io.h
@@ -46,6 +46,7 @@
 #define IOCFG_AF_PP_PD       IO_CONFIG(GPIO_MODE_AF_PP,     GPIO_SPEED_FREQ_LOW,  GPIO_PULLDOWN)
 #define IOCFG_AF_PP_UP       IO_CONFIG(GPIO_MODE_AF_PP,     GPIO_SPEED_FREQ_LOW,  GPIO_PULLUP)
 #define IOCFG_AF_OD          IO_CONFIG(GPIO_MODE_AF_OD,     GPIO_SPEED_FREQ_LOW,  GPIO_NOPULL)
+#define IOCFG_AF_OD_UP       IO_CONFIG(GPIO_MODE_AF_OD,     GPIO_SPEED_FREQ_LOW,  GPIO_PULLUP)
 #define IOCFG_IPD            IO_CONFIG(GPIO_MODE_INPUT,     GPIO_SPEED_FREQ_LOW,  GPIO_PULLDOWN)
 #define IOCFG_IPU            IO_CONFIG(GPIO_MODE_INPUT,      GPIO_SPEED_FREQ_LOW,  GPIO_PULLUP)
 #define IOCFG_IN_FLOATING    IO_CONFIG(GPIO_MODE_INPUT,     GPIO_SPEED_FREQ_LOW,  GPIO_NOPULL)
@@ -63,6 +64,7 @@
 #define IOCFG_AF_PP_PD       IO_CONFIG(GPIO_Mode_AF,  0, GPIO_OType_PP, GPIO_PuPd_DOWN)
 #define IOCFG_AF_PP_UP       IO_CONFIG(GPIO_Mode_AF,  0, GPIO_OType_PP, GPIO_PuPd_UP)
 #define IOCFG_AF_OD          IO_CONFIG(GPIO_Mode_AF,  0, GPIO_OType_OD, GPIO_PuPd_NOPULL)
+#define IOCFG_AF_OD_UP       IO_CONFIG(GPIO_Mode_AF,  0, GPIO_OType_OD, GPIO_PuPd_UP)
 #define IOCFG_IPD            IO_CONFIG(GPIO_Mode_IN,  0, 0,             GPIO_PuPd_DOWN)
 #define IOCFG_IPU            IO_CONFIG(GPIO_Mode_IN,  0, 0,             GPIO_PuPd_UP)
 #define IOCFG_IN_FLOATING    IO_CONFIG(GPIO_Mode_IN,  0, 0,             GPIO_PuPd_NOPULL)
@@ -74,6 +76,7 @@
 # define IOCFG_OUT_OD         0
 # define IOCFG_AF_PP          0
 # define IOCFG_AF_OD          0
+# define IOCFG_AF_OD_UP       0
 # define IOCFG_IPD            0
 # define IOCFG_IPU            0
 # define IOCFG_IN_FLOATING    0

--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -49,6 +49,7 @@ typedef enum portOptions_t {
     SERIAL_BIDIR_OD      = 0 << 4,
     SERIAL_BIDIR_PP      = 1 << 4,
     SERIAL_BIDIR_NOPULL  = 1 << 5, // disable pulls in BIDIR RX mode
+    SERIAL_BIDIR_UP      = 0 << 5, // enable pullup in BIDIR mode
 } portOptions_t;
 
 typedef void (*serialReceiveCallbackPtr)(uint16_t data, void *rxCallbackData);   // used by serial drivers to return frames to app

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -292,10 +292,13 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_t mode, 
 
     if (options & SERIAL_BIDIR) {
         IOInit(tx, OWNER_SERIAL, RESOURCE_UART_TXRX, RESOURCE_INDEX(device));
-        if (options & SERIAL_BIDIR_PP)
+        if (options & SERIAL_BIDIR_PP) {
             IOConfigGPIOAF(tx, IOCFG_AF_PP, uart->af);
-        else
-            IOConfigGPIOAF(tx, IOCFG_AF_OD, uart->af);
+        } else {
+            IOConfigGPIOAF(tx,
+                    (options & SERIAL_BIDIR_NOPULL) ? IOCFG_AF_OD : IOCFG_AF_OD_UP,
+                    uart->af);
+        }
     }
     else {
         if (mode & MODE_TX) {


### PR DESCRIPTION
While most F.Port receivers would already have the pull-up connected to the signal line, that's not always the case (especially when using uninvert mods).

This PR enables F.Port to work on F4 FCs without having to solder external pull-ups.
Verified on OMNIBUSF4V3 (clone).

## Scope captures
Before: no telemetry, only control
![Before: no telemetry, only control](https://user-images.githubusercontent.com/15348181/92628155-0d1a3a80-f2d5-11ea-8da1-8330104c1e52.png)

After: telemetry works
![After: telemetry works](https://user-images.githubusercontent.com/15348181/92628161-11465800-f2d5-11ea-8da5-954e45df4226.png)