### PR TITLE
[CMAKE] Override .hex start address with 0x08000000

### DIFF
--- a/cmake/stm32.cmake
+++ b/cmake/stm32.cmake
@@ -189,7 +189,11 @@ endfunction()
 function(add_hex_target name exe hex)
     add_custom_target(${name} ALL
         cmake -E env PATH=$ENV{PATH}
-        ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${exe}> ${hex}
+        # TODO: Overriding the start address with --set-start 0x08000000
+        # seems to be required due to some incorrect assumptions about .hex
+        # files in the configurator. Verify wether that's the case and fix
+        # the bug in configurator or delete this comment.
+        ${CMAKE_OBJCOPY} -Oihex --set-start 0x08000000 $<TARGET_FILE:${exe}> ${hex}
         BYPRODUCTS ${hex}
     )
 endfunction()


### PR DESCRIPTION
The configurator does rely on the .hex start address being set to
0x08000000. I'm not sure this is actually required and we should
fix the configurator instead. However, in order to allow older
versions of configurator to flash newer firmwares, we should
the .hex files built with cmake compatible for at least some
releases.
