### PR TITLE
Ability to read current waypoint index as part of LC

### DIFF
--- a/docs/Programming Framework.md
+++ b/docs/Programming Framework.md
@@ -111,6 +111,24 @@ IPF can be edited using INAV Configurator user interface, of via CLI
 | 23            | IS_WP                 | boolean `0`/`1`               |
 | 24            | IS_LANDING            | boolean `0`/`1`               |
 | 25            | IS_FAILSAFE           | boolean `0`/`1`               |
+| 26            | STABILIZED_ROLL       | Roll PID controller output `[-500:500]`   |
+| 27            | STABILIZED_PITCH      | Pitch PID controller output `[-500:500]`  |
+| 28            | STABILIZED_YAW        | Yaw PID controller output `[-500:500]`    |
+| 29            | ACTIVE_WAYPOINT_INDEX | Indexed from `1`. To verify WP is in progress, use `IS_WP` |
+| 30            | ACTIVE_WAYPOINT_ACTION | See ACTIVE_WAYPOINT_ACTION paragraph |
+
+##### ACTIVE_WAYPOINT_ACTION
+
+| Action        |  Value   |
+|----           |----      |
+| WAYPOINT      | 1      |
+| HOLD_TIME     | 3      |
+| RTH           | 4      |
+| SET_POI       | 5      |
+| JUMP          | 6      |
+| SET_HEAD      | 7      |
+| LAND          | 8      |
+
 
 #### FLIGHT_MODE
 

--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -466,6 +466,14 @@ static int logicConditionGetFlightOperandValue(int operand) {
             return axisPID[PITCH];
             break;
 
+        case LOGIC_CONDITION_OPERAND_FLIGHT_WAYPOINT_INDEX:
+            return NAV_Status.activeWpNumber;
+            break;
+
+        case LOGIC_CONDITION_OPERAND_FLIGHT_WAYPOINT_ACTION:
+            return NAV_Status.activeWpAction;
+            break;
+
         default:
             return 0;
             break;

--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -110,6 +110,8 @@ typedef enum {
     LOGIC_CONDITION_OPERAND_FLIGHT_STABILIZED_ROLL,                         // 26
     LOGIC_CONDITION_OPERAND_FLIGHT_STABILIZED_PITCH,                        // 27
     LOGIC_CONDITION_OPERAND_FLIGHT_STABILIZED_YAW,                          // 28
+    LOGIC_CONDITION_OPERAND_FLIGHT_WAYPOINT_INDEX,                          // 29
+    LOGIC_CONDITION_OPERAND_FLIGHT_WAYPOINT_ACTION,                         // 30
 } logicFlightOperands_e;
 
 typedef enum {


### PR DESCRIPTION
This allows to trigger a servo output at waypoint with the help of Programming framework. See the following example

```
# If current waypoint is equal to previous waypoint index
logic 0 1 -1 1 5 7 2 29 0       
# Not LC#0
logic 1 1 -1 12 4 0 0 0 0
# If waypoint index changed and is WP mission, use this LC to react
logic 2 1 -1 7 2 23 4 1 0
# Store previous waypoint index
logic 31 1 -1 18 0 7 2 29 0
```

closes #5573
closes #5854