### PR TITLE
Missing SNR Alarm Level default added

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2568,7 +2568,9 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .baro_temp_alarm_min = -200,
     .baro_temp_alarm_max = 600,
 #endif
-
+#ifdef USE_SERIALRX_CRSF
+    .snr_alarm = 5,
+#endif
 #ifdef USE_TEMPERATURE_SENSOR
     .temp_label_align = OSD_ALIGN_LEFT,
 #endif


### PR DESCRIPTION
SNR Alarm Level default added. 5dB
A good range is 3 to 5dB.