### PR TITLE
enable flying wing on mambaf405us

### DIFF
--- a/src/main/target/MAMBAF405US/target.c
+++ b/src/main/target/MAMBAF405US/target.c
@@ -27,10 +27,10 @@
 const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM11,  CH1,  PB9,   TIM_USE_PPM,       0, 0 ),     // PPM IN
 
-    DEF_TIM(TIM1,   CH2,  PA9,   TIM_USE_MC_MOTOR,  0, 1 ),     // S4_OUT – D(2, 2, 6)
-    DEF_TIM(TIM1,   CH1,  PA8,   TIM_USE_MC_MOTOR,  0, 1 ),     // S3_OUT – D(2, 1, 6)
-    DEF_TIM(TIM8,   CH4,  PC9,   TIM_USE_MC_MOTOR,  0, 0 ),     // S2_OUT – D(2, 7, 7)
-    DEF_TIM(TIM8,   CH3,  PC8,   TIM_USE_MC_MOTOR,  0, 0 ),     // S1_OUT – D(2, 4, 7)
+    DEF_TIM(TIM1,   CH2,  PA9,   TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR,  0, 1 ),     // S4_OUT – D(2, 2, 6)
+    DEF_TIM(TIM1,   CH1,  PA8,   TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR,  0, 1 ),     // S3_OUT – D(2, 1, 6)
+    DEF_TIM(TIM8,   CH4,  PC9,   TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 0 ),     // S2_OUT – D(2, 7, 7)
+    DEF_TIM(TIM8,   CH3,  PC8,   TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 0 ),     // S1_OUT – D(2, 4, 7)
 
     DEF_TIM(TIM2,   CH2,  PB3,   TIM_USE_LED,       0, 0 ),     // LED_STRIP – D(1, 6, 3)
 };


### PR DESCRIPTION
Enable (minimal) flying wing configuration (2xmotor, 2xservo). Tested and reported working by telegram user "slibbinas".