### PR TITLE
[SETTINGS] Make the settings compiler understand more complex conditionals

### DIFF
--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -749,7 +749,27 @@ class Generator
         add_condition = -> (c) {
             if c && !conditions.include?(c)
                 conditions.add(c)
-                buf << "#ifdef #{c}\n"
+                buf << "#if "
+                in_word = false
+                c.split('').each do |ch|
+                    if in_word
+                        if !ch.match(/^[a-zA-Z0-9_]$/)
+                            in_word = false
+                            buf << ")"
+                        end
+                        buf << ch
+                    else
+                        if ch.match(/^[a-zA-Z_]$/)
+                            in_word = true
+                            buf << "defined("
+                        end
+                        buf << ch
+                    end
+                end
+                if in_word
+                    buf << ")"
+                end
+                buf << "\n"
                 buf << "#pragma message(#{c.inspect})\n"
                 buf << "#endif\n"
             end


### PR DESCRIPTION
Arbitrary combinations of || and && are now supported, even with
parens. ! is not supported yet.
