### PR TITLE
[BUILD] Fix compilation with USE_SERVO_SBUS without USE_PWM_SERVO_DRIVER

### DIFF
--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -86,7 +86,7 @@ typedef enum {
 #ifdef USE_LED_STRIP
     TASK_LEDSTRIP,
 #endif
-#ifdef USE_PWM_SERVO_DRIVER
+#if defined(USE_PWM_SERVO_DRIVER) || defined(USE_SERVO_SBUS)
     TASK_PWMDRIVER,
 #endif
 #ifdef STACK_CHECK


### PR DESCRIPTION
TASK_PWMDRIVER is used by any of those features but it was only
declared when USE_PWM_SERVO_DRIVER was defined, causing a compilation
error when just USE_SERVO_SBUS was defined.
