### PR TITLE
[GPS] Support GPS baud 230400

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -72,7 +72,7 @@ gpsStatistics_t   gpsStats;
 gpsSolutionData_t gpsSol;
 
 // Map gpsBaudRate_e index to baudRate_e
-baudRate_e gpsToSerialBaudRate[GPS_BAUDRATE_COUNT] = { BAUD_115200, BAUD_57600, BAUD_38400, BAUD_19200, BAUD_9600 };
+baudRate_e gpsToSerialBaudRate[GPS_BAUDRATE_COUNT] = { BAUD_115200, BAUD_57600, BAUD_38400, BAUD_19200, BAUD_9600, BAUD_230400 };
 
 static gpsProviderDescriptor_t  gpsProviders[GPS_PROVIDER_COUNT] = {
     /* NMEA GPS */
@@ -228,7 +228,8 @@ void gpsInit(void)
 
     // Start with baud rate index as configured for serial port
     int baudrateIndex;
-    for (gpsState.baudrateIndex = 0, baudrateIndex = 0; baudrateIndex < GPS_BAUDRATE_COUNT; baudrateIndex++) {
+    gpsState.baudrateIndex = GPS_BAUDRATE_115200;
+    for (baudrateIndex = 0, gpsState.baudrateIndex = 0; baudrateIndex < GPS_BAUDRATE_COUNT; baudrateIndex++) {
         if (gpsToSerialBaudRate[baudrateIndex] == gpsPortConfig->gps_baudrateIndex) {
             gpsState.baudrateIndex = baudrateIndex;
             break;

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -58,6 +58,7 @@ typedef enum {
     GPS_BAUDRATE_38400,
     GPS_BAUDRATE_19200,
     GPS_BAUDRATE_9600,
+    GPS_BAUDRATE_230400,
     GPS_BAUDRATE_COUNT
 } gpsBaudRate_e;
 

--- a/src/main/io/gps_nmea.c
+++ b/src/main/io/gps_nmea.c
@@ -293,7 +293,8 @@ static const char * mtkBaudInitData[GPS_BAUDRATE_COUNT] = {
     "$PMTK251,57600*2C\r\n",      // GPS_BAUDRATE_57600
     "$PMTK251,38400*27\r\n",      // GPS_BAUDRATE_38400
     "$PMTK251,19200*22\r\n",      // GPS_BAUDRATE_19200
-    "$PMTK251,9600*17\r\n"        // GPS_BAUDRATE_9600
+    "$PMTK251,9600*17\r\n",       // GPS_BAUDRATE_9600
+    "$PMTK251,230400*1D\r\n",     // GPS_BAUDRATE_230400
 };
 
 STATIC_PROTOTHREAD(gpsProtocolStateThreadMTK)

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -76,7 +76,8 @@ static const char * baudInitDataNMEA[GPS_BAUDRATE_COUNT] = {
     "$PUBX,41,1,0003,0001,57600,0*2D\r\n",      // GPS_BAUDRATE_57600
     "$PUBX,41,1,0003,0001,38400,0*26\r\n",      // GPS_BAUDRATE_38400
     "$PUBX,41,1,0003,0001,19200,0*23\r\n",      // GPS_BAUDRATE_19200
-    "$PUBX,41,1,0003,0001,9600,0*16\r\n"        // GPS_BAUDRATE_9600
+    "$PUBX,41,1,0003,0001,9600,0*16\r\n",       // GPS_BAUDRATE_9600
+    "$PUBX,41,1,0003,0001,230400,0*1C\r\n",     // GPS_BAUDRATE_230400
 };
 
 // payload types


### PR DESCRIPTION
In some scenarios GPS may end up being configured to 230400 baud (from the factory or by 3-rd party software (Ardupilot, PX4 etc). In this scenario INAV will fail to detect the GPS or reconfigure it to one of the supported baud rates.

This PR adds 230400 to supported baud rates and allows INAV to reconfigure such the GPS modules correctly.

Fixes #6159