### PR TITLE
add support for ADSB receivers

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -320,6 +320,8 @@ main_sources(COMMON_SRC
     flight/dynamic_gyro_notch.c
     flight/dynamic_gyro_notch.h
 
+    io/adsb.c
+    io/adsb.h
     io/beeper.c
     io/beeper.h
     io/esc_serialshot.c

--- a/src/main/drivers/osd_symbols.h
+++ b/src/main/drivers/osd_symbols.h
@@ -217,6 +217,8 @@
 #define SYM_HUD_SIGNAL_3          0xFB  // 251 Hud signal icon 75%
 #define SYM_HUD_SIGNAL_4          0xFC  // 252 Hud signal icon 100%
 
+#define SYM_ADSB                  0xFD  // 253 ADSB
+
 #define SYM_LOGO_START            0x101 // 257 to 280, INAV logo
 #define SYM_LOGO_WIDTH            6
 #define SYM_LOGO_HEIGHT           4

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2909,7 +2909,21 @@ groups:
         max: 255
         default_value: 0
         description: Same as left_sidebar_scroll_step, but for the right sidebar
-
+        
+      - name: osd_adsb_range
+        description: "Distance in meters of adsb aircraft that are displayed"
+        default_value: "20000"
+        field: adsb_range
+        min: 0
+        max: 64000
+        type: uint16_t        
+      - name: osd_adsb_alarm
+        description: "Distance inside which adsb data flashes for proximity warning"
+        default_value: "2000"
+        field: adsb_alarm
+        min: 0
+        max: 64000
+        type: uint16_t  
 
   - name: PG_SYSTEM_CONFIG
     type: systemConfig_t

--- a/src/main/io/adsb.c
+++ b/src/main/io/adsb.c
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+
+#include "io/adsb.h"
+#include "navigation/navigation.h"
+#include "common/maths.h"
+#include "math.h"
+#include "build/debug.h"
+#include "common/time.h"
+#include "drivers/time.h"
+
+adsbVehicle_t adsb;
+static timeUs_t lastADSB = 0;
+
+void GPS_distance_cm_bearing(int32_t currentLat1, int32_t currentLon1, int32_t destinationLat2, int32_t destinationLon2, uint32_t *dist, int32_t *bearing)
+{
+  #define DISTANCE_BETWEEN_TWO_LONGITUDE_POINTS_AT_EQUATOR    1.113195f  // MagicEarthNumber from APM
+  float GPS_scaleLonDown = cos_approx((fabsf((float)gpsSol.llh.lat) / 10000000.0f) * 0.0174532925f);
+  const float dLat = destinationLat2 - currentLat1; // difference of latitude in 1/10 000 000 degrees
+  const float dLon = (float)(destinationLon2 - currentLon1) * GPS_scaleLonDown;
+
+  *dist = sqrtf(sq(dLat) + sq(dLon)) * DISTANCE_BETWEEN_TWO_LONGITUDE_POINTS_AT_EQUATOR;
+  *bearing = 9000.0f + RADIANS_TO_CENTIDEGREES(atan2_approx(-dLat, dLon));      // Convert the output radians to 100xdeg
+  if (*bearing < 0){
+    *bearing += 36000;
+  }
+};
+
+void adsbNewVehicle(uint32_t avicao, int32_t avlat, int32_t avlon, int32_t avalt)
+{
+   uint32_t avdist; int32_t avdir; uint8_t avupdate = 1; 
+  if (STATE(GPS_FIX) && gpsSol.numSat >= 4) {
+    GPS_distance_cm_bearing(gpsSol.llh.lat, gpsSol.llh.lon, avlat, avlon, &avdist, &avdir); 
+    avdist /= 100; avdir /= 100;
+#if defined(USE_NAV)
+    avalt -= getEstimatedActualPosition(Z)+GPS_home.alt;
+#elif defined(USE_BARO)
+    avalt -= baro.alt+GPS_home.alt;
+#endif
+    avalt /= 1000;
+    if (avdist > adsb.dist && adsb.dist > 0){
+      avupdate = 0;
+    }   
+    if (adsb.ttl <= 1){
+      avupdate = 1;
+    }    
+    if (avicao == adsb.icao){
+      avupdate = 1;
+    }      
+    if (avdist > 64000){ // limit display to aircraft < 64Km
+      avupdate = 0;
+    }  
+    if (avupdate == 1){
+      adsb.icao = avicao;
+      adsb.dist = avdist;       
+      adsb.alt = avalt; 
+      adsb.dir = avdir; 
+      adsb.ttl = 10;    // 10 secs default timeout    
+    }
+  }   
+};
+
+void adsbexpiry(void){
+  uint64_t currentTimeUs = micros();
+  if ((currentTimeUs - lastADSB) > 1000*1000) {
+    lastADSB = currentTimeUs;
+    if (adsb.ttl > 0){
+      adsb.ttl--;
+    }
+    else{
+      adsb.icao = 0;
+      adsb.dist = 0;       
+      adsb.alt = 0; 
+      adsb.dir = 0;       
+    }
+  }
+};
+

--- a/src/main/io/adsb.h
+++ b/src/main/io/adsb.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <stdint.h>
+#include "common/time.h"
+#include "fc/runtime_config.h"
+
+typedef struct adsbVehicle_s{
+  uint32_t icao;
+  int32_t  alt;
+  uint16_t cog;
+  uint16_t dir;
+  uint32_t dist;     
+  uint8_t  ttl; 
+} adsbVehicle_t;
+
+extern void adsbNewVehicle(uint32_t avicao, int32_t avlat, int32_t avlon, int32_t avalt);
+extern void adsbexpiry(void);
+extern adsbVehicle_t adsb;
+
+
+
+
+
+
+
+
+
+

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -64,6 +64,7 @@ FILE_COMPILE_FOR_SPEED
 #include "drivers/time.h"
 #include "drivers/vtx_common.h"
 
+#include "io/adsb.h"
 #include "io/flashfs.h"
 #include "io/gps.h"
 #include "io/osd.h"
@@ -1444,7 +1445,35 @@ static bool osdDrawSingleElement(uint8_t item)
             osdFormatCentiNumber(&buff[2], centiHDOP, 0, 1, 0, 2);
             break;
         }
-
+#if defined(USE_TELEMETRY) && defined(USE_TELEMETRY_MAVLINK)
+    case OSD_ADSB:
+        {         
+            static uint8_t adsblen=1;
+            for (int i = 0; i <= adsblen; i++) {
+                buff[i] = SYM_BLANK;
+            }
+            buff[adsblen]='\0';
+            displayWrite(osdDisplayPort, elemPosX, elemPosY, buff); // clear any previous chars because variable element size
+            adsbexpiry();
+            adsblen=1;
+            buff[0] = SYM_ADSB;   
+            if ((adsb.dist > 0) && (adsb.dist < osdConfig()->adsb_range)){
+                osdFormatDistanceStr(&buff[1], adsb.dist*100);
+                adsblen = strlen(buff);
+                int dir = osdGetHeadingAngle(adsb.dir + 11);
+                unsigned arrowOffset = dir * 2 / 45;
+                buff[adsblen-1]=SYM_ARROW_UP + arrowOffset;
+                osdFormatDistanceStr(&buff[adsblen], adsb.alt*100);
+                adsblen = strlen(buff)-1;
+                if (adsb.dist < osdConfig()->adsb_alarm) {
+                    TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
+                }
+            }  
+            buff[adsblen]='\0';          
+            displayWriteWithAttr(osdDisplayPort, elemPosX, elemPosY, buff, elemAttr);
+            return true;
+        }
+#endif
     case OSD_MAP_NORTH:
         {
             static uint16_t drawn = 0;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -157,6 +157,7 @@ typedef enum {
     OSD_CRSF_LQ,
     OSD_CRSF_SNR_DB,
     OSD_CRSF_TX_POWER,
+    OSD_ADSB,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -217,6 +218,7 @@ typedef struct osdConfig_s {
     uint16_t dist_alarm; // home distance in m
     uint16_t neg_alt_alarm; // abs(negative altitude) in m
     uint8_t current_alarm; // current consumption in A
+    uint16_t adsb_alarm; 
     int16_t imu_temp_alarm_min;
     int16_t imu_temp_alarm_max;
     int16_t esc_temp_alarm_min;
@@ -256,6 +258,7 @@ typedef struct osdConfig_s {
     uint16_t hud_radar_range_max;
     uint16_t hud_radar_nearest;
     uint8_t hud_wp_disp;
+    uint16_t adsb_range;
 
     uint8_t left_sidebar_scroll; // from osd_sidebar_scroll_e
     uint8_t right_sidebar_scroll; // from osd_sidebar_scroll_e


### PR DESCRIPTION
ADSB support for uAvionix pingRX tiny ADSB (and others).
OSD display nearest ADSB equipped aircraft.
Flashing warning for proximity

Similar to link:
https://github.com/ShikOfTheRa/scarab-osd/wiki/ADSB