### PR TITLE
Fix LC IS_FAILSAFE only occuring when RX_LOSS_MONITORING

### DIFF
--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -455,7 +455,7 @@ static int logicConditionGetFlightOperandValue(int operand) {
             break;
 
         case LOGIC_CONDITION_OPERAND_FLIGHT_IS_FAILSAFE: // 0/1
-            return (failsafePhase() == FAILSAFE_RX_LOSS_MONITORING) ? 1 : 0;
+            return (failsafePhase() != FAILSAFE_IDLE) ? 1 : 0;
             break;
         
         case LOGIC_CONDITION_OPERAND_FLIGHT_STABILIZED_YAW: // 


### PR DESCRIPTION
Fixes #6156

Will break compatibility although only in obscure cases where no failsafe mode is set. That is the only case where this would work as intended. This makes it work for all cases except when no failsafe is active.