### PR TITLE
On MR switch to GPS CoG is available

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1268,6 +1268,12 @@ groups:
         field: gpsMinSats
         min: 5
         max: 10
+      - name: gps_cog_min_velocity
+        description: "GPS Course Over Ground is considered valid when ground speed is above this value in cm/s"
+        field: cogMinVelocity
+        default_value: "300"
+        min: 200
+        max: 1000
 
   - name: PG_RC_CONTROLS_CONFIG
     type: rcControlsConfig_t

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -550,7 +550,7 @@ static void imuCalculateEstimatedAttitude(float dT)
             }
             else {
                 // Re-initialize quaternion from known Roll, Pitch and GPS heading
-                 (attitude.values.roll, attitude.values.pitch, gpsSol.groundCourse);
+                imuComputeQuaternionFromRPY(attitude.values.roll, attitude.values.pitch, gpsSol.groundCourse);
                 gpsHeadingInitialized = true;
 
                 // Force reset of heading hold target

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -534,8 +534,9 @@ static void imuCalculateEstimatedAttitude(float dT)
     bool useCOG = false;
 
 #if defined(USE_GPS)
+    const bool canUseCOG = isGPSHeadingValid();
+
     if (STATE(FIXED_WING_LEGACY)) {
-        bool canUseCOG = isGPSHeadingValid();
 
         // Prefer compass (if available)
         if (canUseMAG) {
@@ -549,7 +550,7 @@ static void imuCalculateEstimatedAttitude(float dT)
             }
             else {
                 // Re-initialize quaternion from known Roll, Pitch and GPS heading
-                imuComputeQuaternionFromRPY(attitude.values.roll, attitude.values.pitch, gpsSol.groundCourse);
+                 (attitude.values.roll, attitude.values.pitch, gpsSol.groundCourse);
                 gpsHeadingInitialized = true;
 
                 // Force reset of heading hold target
@@ -558,9 +559,15 @@ static void imuCalculateEstimatedAttitude(float dT)
         }
     }
     else {
-        // Multicopters don't use GPS heading
+        //Prefer COG if available
         if (canUseMAG) {
-            useMag = true;
+            if (canUseCOG) {
+                courseOverGround = DECIDEGREES_TO_RADIANS(gpsSol.groundCourse);
+                useCOG = true;
+            } else {
+                useMag = true;
+            }
+
         }
     }
 #else

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -115,7 +115,7 @@ static gpsProviderDescriptor_t  gpsProviders[GPS_PROVIDER_COUNT] = {
 
 };
 
-PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 1);
 
 PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .provider = GPS_UBLOX,
@@ -124,7 +124,8 @@ PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .autoBaud = GPS_AUTOBAUD_ON,
     .dynModel = GPS_DYNMODEL_AIR_1G,
     .gpsMinSats = 6,
-    .ubloxUseGalileo = false
+    .ubloxUseGalileo = false,
+    .cogMinVelocity = 300,
 );
 
 void gpsSetState(gpsState_e state)
@@ -471,7 +472,7 @@ bool isGPSHealthy(void)
 
 bool isGPSHeadingValid(void)
 {
-    return sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= 6 && gpsSol.groundSpeed >= 300;
+    return sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= gpsConfig()->gpsMinSats && gpsSol.groundSpeed >= gpsConfig()->cogMinVelocity;
 }
 
 #endif

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -94,6 +94,7 @@ typedef struct gpsConfig_s {
     gpsDynModel_e dynModel;
     bool ubloxUseGalileo;
     uint8_t gpsMinSats;
+    uint16_t cogMinVelocity;
 } gpsConfig_t;
 
 PG_DECLARE(gpsConfig_t, gpsConfig);


### PR DESCRIPTION
On multirotors, switch to GPS Course-Over-Ground if available.
The idea is to ignore magnetic course which is probably off due to mag being tilted anyway.

Experimental feature, do not merge 