### PR TITLE
Add TPA to inflight adjustment (+ OSD element)

### DIFF
--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -268,6 +268,14 @@ static const adjustmentConfig_t defaultAdjustmentConfigs[ADJUSTMENT_FUNCTION_COU
         .adjustmentFunction = ADJUSTMENT_VTX_POWER_LEVEL,
         .mode = ADJUSTMENT_MODE_STEP,
         .data = { .stepConfig = { .step = 1 }}
+    }, {
+        .adjustmentFunction = ADJUSTMENT_TPA,
+        .mode = ADJUSTMENT_MODE_STEP,
+        .data = { .stepConfig = { .step = 1 }}
+    }, {
+        .adjustmentFunction = ADJUSTMENT_TPA_BREAKPOINT,
+        .mode = ADJUSTMENT_MODE_STEP,
+        .data = { .stepConfig = { .step = 5 }}
 #ifdef USE_INFLIGHT_PROFILE_ADJUSTMENT
     }, {
         .adjustmentFunction = ADJUSTMENT_PROFILE,
@@ -558,6 +566,12 @@ static void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t 
             }
             break;
 #endif
+        case ADJUSTMENT_TPA:
+            applyAdjustmentU8(ADJUSTMENT_TPA, &controlRateConfig->throttle.dynPID, delta, 0, CONTROL_RATE_CONFIG_TPA_MAX);
+            break;
+        case ADJUSTMENT_TPA_BREAKPOINT:
+            applyAdjustmentU16(ADJUSTMENT_TPA_BREAKPOINT, &controlRateConfig->throttle.pa_breakpoint, delta, PWM_RANGE_MIN, PWM_RANGE_MAX);
+            break;
         default:
             break;
     };

--- a/src/main/fc/rc_adjustments.h
+++ b/src/main/fc/rc_adjustments.h
@@ -75,8 +75,10 @@ typedef enum {
     ADJUSTMENT_VEL_Z_D                  = 47,
     ADJUSTMENT_FW_MIN_THROTTLE_DOWN_PITCH_ANGLE = 48,
     ADJUSTMENT_VTX_POWER_LEVEL = 49,
+    ADJUSTMENT_TPA                      = 50,
+    ADJUSTMENT_TPA_BREAKPOINT           = 51,
 #ifdef USE_INFLIGHT_PROFILE_ADJUSTMENT
-    ADJUSTMENT_PROFILE                  = 50,
+    ADJUSTMENT_PROFILE                  = 52,
 #endif
     ADJUSTMENT_FUNCTION_COUNT // must be last
 } adjustmentFunction_e;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2411,7 +2411,29 @@ static bool osdDrawSingleElement(uint8_t item)
             return true;
         }
 #endif
+    case OSD_TPA:
+        {
+            char buff[4];
+            textAttributes_t attr;
 
+            displayWrite(osdDisplayPort, elemPosX, elemPosY, "TPA BP");
+
+            attr = TEXT_ATTRIBUTES_NONE;
+            tfp_sprintf(buff, "TPA  %3d", currentControlRateProfile->throttle.dynPID);
+            if (isAdjustmentFunctionSelected(ADJUSTMENT_TPA)) {
+                TEXT_ATTRIBUTES_ADD_BLINK(attr);
+            }
+            displayWriteWithAttr(osdDisplayPort, elemPosX, elemPosY, buff, attr);
+
+            attr = TEXT_ATTRIBUTES_NONE;
+            tfp_sprintf(buff, "BP  %4d", currentControlRateProfile->throttle.pa_breakpoint);
+            if (isAdjustmentFunctionSelected(ADJUSTMENT_TPA_BREAKPOINT)) {
+                TEXT_ATTRIBUTES_ADD_BLINK(attr);
+            }
+            displayWriteWithAttr(osdDisplayPort, elemPosX, elemPosY + 1, buff, attr);
+
+            return true;
+        }
     default:
         return false;
     }

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -215,6 +215,7 @@ typedef enum {
     OSD_GVAR_1,
     OSD_GVAR_2,
     OSD_GVAR_3,
+    OSD_TPA,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
Duplicate of #6055, i had some problems with git, so i had to do a new PR:

This allows to tune Thrust PID Attenuation (TPA) and TPA Breakpoint via inflight adjustments.
Also adds an OSD Element that shows the values.

See #5965 and #5985

PR for configurator: iNavFlight/inav-configurator#1054