### PR TITLE
Create separate target for SDCARD default for MATEKF722WPX

### DIFF
--- a/src/main/target/MATEKF722PX/CMakeLists.txt
+++ b/src/main/target/MATEKF722PX/CMakeLists.txt
@@ -1,1 +1,2 @@
 target_stm32f722xe(MATEKF722PX)
+target_stm32f722xe(MATEKF722WPX)

--- a/src/main/target/MATEKF722PX/target.h
+++ b/src/main/target/MATEKF722PX/target.h
@@ -21,7 +21,7 @@
 #define TARGET_BOARD_IDENTIFIER "MF7P"
 #define USBD_PRODUCT_STRING  "MATEKF722PX"
 
-#define LED0                    PA14  //Blue   SWCLK 
+#define LED0                    PA14  //Blue   SWCLK
 #define LED1                    PA13  //Green  SWDIO
 
 #define BEEPER                  PC13
@@ -79,17 +79,20 @@
 #define SPI2_MOSI_PIN           PC3
 
 //F722-PX,F722-HD
-#define USE_FLASHFS
-#define USE_FLASH_M25P16
-#define M25P16_SPI_BUS          BUS_SPI2
-#define M25P16_CS_PIN           PB12
-#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
-
+#if defined(MATEKF722PX)
+ #define USE_FLASHFS
+ #define USE_FLASH_M25P16
+ #define M25P16_SPI_BUS          BUS_SPI2
+ #define M25P16_CS_PIN           PB12
+ #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#else
 //F722-WPX
-#define USE_SDCARD
-#define USE_SDCARD_SPI
-#define SDCARD_SPI_BUS          BUS_SPI2
-#define SDCARD_CS_PIN           PC15
+ #define USE_SDCARD
+ #define USE_SDCARD_SPI
+ #define SDCARD_SPI_BUS          BUS_SPI2
+ #define SDCARD_CS_PIN           PC15
+ #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+#endif
 
 // *************** UART *****************************
 #define USE_VCP
@@ -119,7 +122,7 @@
 #define USE_UART6
 #define UART6_TX_PIN            PC6
 #define UART6_RX_PIN            PC7
-     
+
 #define USE_SOFTSERIAL1
 #define SOFTSERIAL_1_TX_PIN      PA2 //TX2 pad
 #define SOFTSERIAL_1_RX_PIN      NONE
@@ -170,4 +173,3 @@
 #define USE_DSHOT
 #define USE_SERIALSHOT
 #define USE_ESC_SENSOR
-


### PR DESCRIPTION
The recent changes to the MATEKF722PX `target.h` enabling SD card logging on MATEKF722WPX have the unfortunate side-effect of causing the configurator to freeze when the Blackbox log tab is accessed on the SDCARD variant, due the the default logging device being set to SPIFLASH.

The use could remedy this by setting `set blackbox_device = SDCARD` in the CLI, but many of them won't.

This PR resolves this usability issue by creating a separate target. Appreciate this is sub-optimal target proliferation, but I'm not aware of any other way to resolve this. 

Discussion with reporting user https://www.rcgroups.com/forums/showpost.php?p=45781093&postcount=26671 et al.