### PR TITLE
Adds DJI OSD support to 2x F3 boards

### DIFF
--- a/src/main/target/AIRHEROF3/target.h
+++ b/src/main/target/AIRHEROF3/target.h
@@ -76,6 +76,10 @@
 #define VBAT_ADC_CHANNEL                ADC_CHN_1
 #define AIRSPEED_ADC_CHANNEL            ADC_CHN_2
 
+#define USE_DJI_HD_OSD
+#define USE_OSD
+#undef USE_CMS
+#undef CMS_MENU_OSD
 
 /*
 #define USE_LED_STRIP

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -93,6 +93,11 @@
 #define CURRENT_METER_ADC_CHANNEL       ADC_CHN_2
 #define RSSI_ADC_CHANNEL                ADC_CHN_3
 
+#define USE_DJI_HD_OSD
+#define USE_OSD
+#undef USE_CMS
+#undef CMS_MENU_OSD
+
 #define USE_LED_STRIP
 #define WS2811_PIN                      PA8
 


### PR DESCRIPTION
- SPRACINGF3 and AIRHEROF3
- both boards have no analog OSD hardware
- (This patch works on master and 2.5.x)
- Enables DJI-OSD without the menu CMS system since it can't be used with DJI anyway.
- Actually REDUCES flash usage by 1%, ram usage by almost 5%.

Compiles nicely. Tested on both boards with DJI OSD. Configurable in the iNav Configurator.

Replaces #6262– seems there's a rule to merge from non-master branches only I want to do it right!