### PR TITLE
[NAV/MIXER] Refactor getMotorStop() code for better readability

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -263,6 +263,7 @@
 | nav_fw_launch_accel | 1863 | Forward acceleration threshold for bungee launch of throw launch [cm/s/s], 1G = 981 cm/s/s |
 | nav_fw_launch_climb_angle | 18 | Climb angle for launch sequence (degrees), is also restrained by global max_angle_inclination_pit |
 | nav_fw_launch_detect_time | 40 | Time for which thresholds have to breached to consider launch happened [ms] |
+| nav_fw_launch_end_time | 2000 | Time for the transition of throttle and pitch angle, between the launch state and the subsequent flight mode [ms] |
 | nav_fw_launch_idle_thr | 1000 | Launch idle throttle - throttle to be set before launch sequence is initiated. If set below minimum throttle it will force motor stop or at idle throttle (depending if the MOTOR_STOP is enabled). If set above minimum throttle it will force throttle to this value (if MOTOR_STOP is enabled it will be handled according to throttle stick position) |
 | nav_fw_launch_max_altitude | 0 | Altitude (centimeters) at which LAUNCH mode will be turned off and regular flight mode will take over [0-60000]. |
 | nav_fw_launch_max_angle | 45 | Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg] |

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3649,10 +3649,16 @@ bool navigationIsExecutingAnEmergencyLanding(void)
     return navGetCurrentStateFlags() & NAV_CTL_EMERG;
 }
 
-bool navigationIsControllingThrottle(void)
+bool navigationInAutomaticThrottleMode(void)
 {
     navigationFSMStateFlags_t stateFlags = navGetCurrentStateFlags();
-    return ((stateFlags & (NAV_CTL_ALT | NAV_CTL_EMERG | NAV_CTL_LAUNCH | NAV_CTL_LAND)) && (getMotorStatus() != MOTOR_STOPPED_USER));
+    return (stateFlags & (NAV_CTL_ALT | NAV_CTL_EMERG | NAV_CTL_LAUNCH | NAV_CTL_LAND));
+}
+
+bool navigationIsControllingThrottle(void)
+{
+    // Note that this makes a detour into mixer code to evaluate actual motor status
+    return navigationInAutomaticThrottleMode() && (getMotorStatus() != MOTOR_STOPPED_USER);
 }
 
 bool navigationIsFlyingAutonomousMode(void)

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -513,6 +513,7 @@ void abortForcedRTH(void);
 rthState_e getStateOfForcedRTH(void);
 
 /* Getter functions which return data about the state of the navigation system */
+bool navigationInAutomaticThrottleMode(void);
 bool navigationIsControllingThrottle(void);
 bool isFixedWingAutoThrottleManuallyIncreased(void);
 bool navigationIsFlyingAutonomousMode(void);


### PR DESCRIPTION
Due to a multi-level logic condition in `getMotorStop()` we missed the fact that in certain configuration `getMotorStop()` and `navigationIsControllingThrottle()` could call each other in an infinite loop causing a crash when entering a navigation mode that controls throttle.

Logic is now changed by creating a separate function `navigationInAutomaticThrottleMode()` to probe if our Navigation core is in mode that may be controlling throttle, provided mixer allows that. `navigationIsControllingThrottle()` now correctly evaluates if the Navigation core is indeed in control of motor throttle.

Fixes #6296