### PR TITLE
Force the motors to stop until the throttle is raised in Autolaunch mode

### DIFF
--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -196,12 +196,12 @@ static void setCurrentState(fixedWingLaunchState_t nextState, timeUs_t currentTi
 /* Wing control Helpers */
 
 static bool isThrottleIdleEnabled(void) {
-    return navConfig()->fw.launch_idle_throttle > getThrottleIdleValue();
+    return navConfig()->fw.launch_idle_throttle > motorConfig()->mincommand;
 }
 
 static void forceMotorsToStop(void) {
     ENABLE_STATE(NAV_MOTOR_STOP_OR_IDLE);                              // If MOTOR_STOP is enabled mixer will keep motor stopped
-    rcCommand[THROTTLE] = getThrottleIdleValue();                      // If MOTOR_STOP is disabled, motors will spin at minthrottle
+    rcCommand[THROTTLE] = motorConfig()->mincommand;                   // If MOTOR_STOP is disabled, motors will not spin at all
 }
 
 static void applyThrottleIdle(void) {
@@ -274,7 +274,7 @@ static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_MOTOR_IDLE(timeUs_t 
         applyThrottleIdle();
         return FW_LAUNCH_EVENT_SUCCESS;
     } else {
-        rcCommand[THROTTLE] = scaleRangef(elapsedTimeMs, 0.0f, LAUNCH_MOTOR_IDLE_SPINUP_TIME, getThrottleIdleValue(), navConfig()->fw.launch_idle_throttle);
+        rcCommand[THROTTLE] = scaleRangef(elapsedTimeMs, 0.0f, LAUNCH_MOTOR_IDLE_SPINUP_TIME, motorConfig()->mincommand, navConfig()->fw.launch_idle_throttle);
         fwLaunch.pitchAngle = scaleRangef(elapsedTimeMs, 0.0f, LAUNCH_MOTOR_IDLE_SPINUP_TIME, 0, navConfig()->fw.launch_climb_angle);
     }
 
@@ -340,8 +340,7 @@ static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_MOTOR_SPINUP(timeUs_
         rcCommand[THROTTLE] = launchThrottle;
         return FW_LAUNCH_EVENT_SUCCESS;
     } else {
-        const uint16_t minIdleThrottle = MAX(getThrottleIdleValue(), navConfig()->fw.launch_idle_throttle);
-        rcCommand[THROTTLE] = scaleRangef(elapsedTimeMs, 0.0f, motorSpinUpMs,  minIdleThrottle, launchThrottle);
+        rcCommand[THROTTLE] = scaleRangef(elapsedTimeMs, 0.0f, motorSpinUpMs,  navConfig()->fw.launch_idle_throttle, launchThrottle);
     }
 
     return FW_LAUNCH_EVENT_NONE;

--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -199,12 +199,16 @@ static bool isThrottleIdleEnabled(void) {
     return navConfig()->fw.launch_idle_throttle > getThrottleIdleValue();
 }
 
+static void forceMotorsToStop(void) {
+    ENABLE_STATE(NAV_MOTOR_STOP_OR_IDLE);                              // If MOTOR_STOP is enabled mixer will keep motor stopped
+    rcCommand[THROTTLE] = getThrottleIdleValue();                      // If MOTOR_STOP is disabled, motors will spin at minthrottle
+}
+
 static void applyThrottleIdle(void) {
     if (isThrottleIdleEnabled()) {
         rcCommand[THROTTLE] = navConfig()->fw.launch_idle_throttle;
     } else {
-      ENABLE_STATE(NAV_MOTOR_STOP_OR_IDLE);                              // If MOTOR_STOP is enabled mixer will keep motor stopped
-      rcCommand[THROTTLE] = getThrottleIdleValue();                      // If MOTOR_STOP is disabled, motors will spin at minthrottle
+        forceMotorsToStop();
     }
 }
 
@@ -246,6 +250,8 @@ static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_IDLE(timeUs_t curren
 static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_WAIT_THROTTLE(timeUs_t currentTimeUs) {
     UNUSED(currentTimeUs);
 
+    forceMotorsToStop();
+    
     if (!isThrottleLow()) {
         if (isThrottleIdleEnabled()) {
             return FW_LAUNCH_EVENT_SUCCESS;


### PR DESCRIPTION
With `nav_overrides_motor_stop = ALL_NAV` the motors will spin at `throttle_idle` as soon as the arm is hit, so replacing `getThrottleIdleValue()` with `motorConfig()->mincommand` the motors will be forced to stay off until the throttle is raised.
The issue appeared in https://github.com/iNavFlight/inav/issues/6312