### PR TITLE
[GHST] Failsafe detection

### DIFF
--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -61,8 +61,8 @@
 // At max frame rate 222Hz we should expect to see each of 3 RC frames at least every 13.5ms
 // Set the individual frame timeout high-enough to tolerate 2 on-wire frames being lost + some jitter
 // As a recovery condition we would expect at least 3 packets arriving on time
-#define GHST_RC_FRAME_TIMEOUT_MS        45
-#define GHST_RC_FRAME_COUNT_THRESHOLD   4       // should correspond to ~50-60ms in the best case
+#define GHST_RC_FRAME_TIMEOUT_MS        300
+#define GHST_RC_FRAME_COUNT_THRESHOLD   2       // should correspond to ~50-60ms in the best case
 
 #define GHST_PAYLOAD_OFFSET offsetof(ghstFrameDef_t, type)
 
@@ -74,7 +74,6 @@ STATIC_UNIT_TESTED ghstFrame_t ghstIncomingFrame;   // incoming frame, raw, not 
 STATIC_UNIT_TESTED ghstFrame_t ghstValidatedFrame;  // validated frame, CRC is ok, destination address is ok, ready for decode
 
 STATIC_UNIT_TESTED uint32_t ghstChannelData[GHST_MAX_NUM_CHANNELS];
-
 
 typedef struct ghstFailsafeTracker_s {
     unsigned onTimePacketCounter;

--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -215,6 +215,12 @@ static bool ghstDetectFailsafe(void)
     // as a failsafe condition
 
     for (pktIdx = 0; pktIdx < GHST_UL_RC_CHANS_FRAME_COUNT; pktIdx++) {
+
+        // If a frame was not seen at least once, it's not sent and we should not detaect failsafe based on that
+        if (ghstFsTracker[pktIdx].lastSeenMs == 0) {
+            continue;
+        }
+
         // Packet timeout. We didn't receive the packet containing the channel data within GHST_RC_FRAME_TIMEOUT_MS
         // This is a consistent signal loss, reset the recovery packet counter and report signal loss condition
         if ((currentTimeMs - ghstFsTracker[pktIdx].lastSeenMs) >= GHST_RC_FRAME_TIMEOUT_MS) {

--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -61,7 +61,7 @@
 // At max frame rate 222Hz we should expect to see each of 3 RC frames at least every 13.5ms
 // Set the individual frame timeout high-enough to tolerate 2 on-wire frames being lost + some jitter
 // As a recovery condition we would expect at least 3 packets arriving on time
-#define GHST_RC_FRAME_TIMEOUT_MS        45
+#define GHST_RC_FRAME_TIMEOUT_MS        300     // To accommodate the LR mode (12Hz)
 #define GHST_RC_FRAME_COUNT_THRESHOLD   4       // should correspond to ~50-60ms in the best case
 
 #define GHST_PAYLOAD_OFFSET offsetof(ghstFrameDef_t, type)

--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -58,6 +58,10 @@
 #define GHST_RX_TO_TELEMETRY_MIN_US     1000
 #define GHST_RX_TO_TELEMETRY_MAX_US     2000
 
+// At max frame rate 222Hz we should expect to see each of 3 RC frames at least every 13.5ms
+// Set the individual frame timeout high-enough to tolerate 2 on-wire frames being lost + some jitter
+#define GHST_RC_FRAME_TIMEOUT_MS        45
+
 #define GHST_PAYLOAD_OFFSET offsetof(ghstFrameDef_t, type)
 
 STATIC_UNIT_TESTED volatile bool ghstFrameAvailable = false;
@@ -69,11 +73,18 @@ STATIC_UNIT_TESTED ghstFrame_t ghstValidatedFrame;  // validated frame, CRC is o
 
 STATIC_UNIT_TESTED uint32_t ghstChannelData[GHST_MAX_NUM_CHANNELS];
 
+
+typedef struct ghstFailsafeTracker_s {
+    bool     wasEverSeen;
+    timeMs_t lastSeenMs;
+} ghstFailsafeTracker_t;
+
 static serialPort_t *serialPort;
 static timeUs_t ghstRxFrameStartAtUs = 0;
 static timeUs_t ghstRxFrameEndAtUs = 0;
 static uint8_t telemetryBuf[GHST_FRAME_SIZE_MAX];
 static uint8_t telemetryBufLen = 0;
+static ghstFailsafeTracker_t ghstFsTracker[GHST_UL_RC_CHANS_FRAME_COUNT];
 
 /* GHST Protocol
  * Ghost uses 420k baud single-wire, half duplex connection, connected to a FC UART 'Tx' pin
@@ -177,6 +188,41 @@ static void ghstIdle(void)
     }
 }
 
+static void ghstUpdateFailsafe(unsigned pktIdx)
+{
+    // pktIdx is an offset of RC channel packet, 
+    // as we expect RC frame types 0x10 - 0x1f, we can have up to 16 possible packets arriving periodically
+    // We'll track arrival time of each of the frame types we ever saw arriving from this receiver
+    if (pktIdx < GHST_UL_RC_CHANS_FRAME_COUNT) {
+        ghstFsTracker[pktIdx].wasEverSeen = true;
+        ghstFsTracker[pktIdx].lastSeenMs = millis();    // don't need microsecond resolution here
+    }
+}
+
+static bool ghstDetectFailsafe(void)
+{
+    const timeMs_t currentTimeMs = millis();
+    int pktIdx;
+
+
+    // Inspect all of the frame types we ever saw arriving. If any of them times out - assume signal loss
+    // We should track all frame types because we care about all channels, not only AETR. Losing AUX may
+    // prevent the pilot from switching flight mode or disarming which is unsafe and should also be treated
+    // as a failsafe condition
+
+    for (pktIdx = 0; pktIdx < GHST_UL_RC_CHANS_FRAME_COUNT; pktIdx++) {
+        if (!ghstFsTracker[pktIdx].wasEverSeen) {
+            continue;
+        }
+
+        if ((currentTimeMs - ghstFsTracker[pktIdx].lastSeenMs) >= GHST_RC_FRAME_TIMEOUT_MS) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 uint8_t ghstFrameStatus(rxRuntimeConfig_t *rxRuntimeState)
 {
     UNUSED(rxRuntimeState);
@@ -185,6 +231,8 @@ uint8_t ghstFrameStatus(rxRuntimeConfig_t *rxRuntimeState)
         ghstIdle();
     }
 
+    uint8_t ghstFailsafeFlag = ghstDetectFailsafe() ? RX_FRAME_FAILSAFE : 0;
+
     if (ghstFrameAvailable) {
         ghstFrameAvailable = false;
 
@@ -192,17 +240,17 @@ uint8_t ghstFrameStatus(rxRuntimeConfig_t *rxRuntimeState)
         const int fullFrameLength = ghstValidatedFrame.frame.len + GHST_FRAME_LENGTH_ADDRESS + GHST_FRAME_LENGTH_FRAMELENGTH;
         if (crc == ghstValidatedFrame.bytes[fullFrameLength - 1] && ghstValidatedFrame.frame.addr == GHST_ADDR_FC) {
             ghstValidatedFrameAvailable = true;
-            return RX_FRAME_COMPLETE | RX_FRAME_PROCESSING_REQUIRED;            // request callback through ghstProcessFrame to do the decoding  work
+            return ghstFailsafeFlag | RX_FRAME_COMPLETE | RX_FRAME_PROCESSING_REQUIRED;            // request callback through ghstProcessFrame to do the decoding  work
         }
 
-        return RX_FRAME_DROPPED;                            // frame was invalid
+        return ghstFailsafeFlag | RX_FRAME_DROPPED;                            // frame was invalid
     }
 
     if (shouldSendTelemetryFrame()) {
-        return RX_FRAME_PROCESSING_REQUIRED;
+        return ghstFailsafeFlag | RX_FRAME_PROCESSING_REQUIRED;
     }
 
-    return RX_FRAME_PENDING;
+    return ghstFailsafeFlag | RX_FRAME_PENDING;
 }
 
 static bool ghstProcessFrame(const rxRuntimeConfig_t *rxRuntimeConfig)
@@ -224,6 +272,9 @@ static bool ghstProcessFrame(const rxRuntimeConfig_t *rxRuntimeConfig)
             ghstValidatedFrame.frame.type <= GHST_UL_RC_CHANS_HS4_LAST
         ) {
             const ghstPayloadPulses_t* const rcChannels = (ghstPayloadPulses_t*)&ghstValidatedFrame.frame.payload;
+
+            // notify GHST failsafe detection that we received a channel packet
+            ghstUpdateFailsafe(ghstValidatedFrame.frame.type - GHST_UL_RC_CHANS_HS4_FIRST);
 
             // all uplink frames contain CH1..4 data (12 bit)
             ghstChannelData[0] = rcChannels->ch1to4.ch1 >> 1;

--- a/src/main/rx/ghst_protocol.h
+++ b/src/main/rx/ghst_protocol.h
@@ -56,7 +56,9 @@ typedef enum {
     GHST_UL_RC_CHANS_HS4_LAST   = 0x1f      // Last frame type including 4 primary channels
 } ghstUl_e;
 
-#define GHST_UL_RC_CHANS_SIZE       12      // 1 (type) + 10 (data) + 1 (crc)
+#define GHST_UL_RC_CHANS_FRAME_COUNT    (GHST_UL_RC_CHANS_HS4_13TO16 - GHST_UL_RC_CHANS_HS4_5TO8 + 1)   // CH1-16
+#define GHST_UL_RC_TOTAL_FRAME_COUNT    (GHST_UL_RC_CHANS_HS4_LAST - GHST_UL_RC_CHANS_HS4_FIRST + 1)    // Include service frames - RSSI etc
+#define GHST_UL_RC_CHANS_SIZE           12      // 1 (type) + 10 (data) + 1 (crc)
 
 typedef enum {
     GHST_DL_OPENTX_SYNC         = 0x20,

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -439,10 +439,13 @@ bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime)
     }
 
     const uint8_t frameStatus = rxRuntimeConfig.rcFrameStatusFn(&rxRuntimeConfig);
-    if (frameStatus & RX_FRAME_COMPLETE) {
-        rxDataProcessingRequired = true;
+    if (frameStatus & RX_FRAME_FAILSAFE) {
         rxIsInFailsafeMode = (frameStatus & RX_FRAME_FAILSAFE) != 0;
         rxSignalReceived = !rxIsInFailsafeMode;
+    }
+
+    if (frameStatus & RX_FRAME_COMPLETE) {
+        rxDataProcessingRequired = true;
         needRxSignalBefore = currentTimeUs + rxRuntimeConfig.rxSignalTimeout;
     }
 


### PR DESCRIPTION
GHST protocol doesn't communicate the signal loss condition to the FC and also does not send all the RC channels in one frame - instead channels are interleaved over 3 different frame types.

Regardless of how the OTA protocol behaves, since we have to rely on the timeout to detect GHST failsafe, we must ensure that we periodically receive all 3 different packet types containing RC channels.

With this PR will monitor which RC frames we receive from the GHST RX and will signal failsafe if we don't receive any of them for a while (45ms). Generic RX code is also modified to allow RX driver to indicate signal loss condition asynchronously from a valid packet (since valid packet is not guaranteed to come at all with GHST).

@tonycake FYI