### PR TITLE
Add safehome_max_distance option.  Choose nearest safehome.

### DIFF
--- a/docs/Safehomes.md
+++ b/docs/Safehomes.md
@@ -12,7 +12,9 @@ One potential risk when landing is that there might be buildings, trees and othe
 
 ## Safehome
 
-Safehomes are a list of GPS coordinates that identify safe landing points.  When the flight controller is armed, it checks the list of safehomes.  The first one that is enabled and within 200m of the current position will be selected.  Otherwise, it reverts to the old behaviour of using your current GPS position as home.  
+Safehomes are a list of GPS coordinates that identify safe landing points.  When the flight controller is armed, it checks the list of safehomes.  The nearest safehome that is enabled and within ```safehome_max_distance``` (default 200m) of the current position will be selected.  Otherwise, it reverts to the old behaviour of using your current GPS position as home.  
+
+Be aware that the safehome replaces your arming position as home.  When flying, RTH will return to the safehome and OSD elements such as distance to home and direction to home will refer to the selected safehome.
 
 You can define up to 8 safehomes for different locations you fly at.
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2154,6 +2154,12 @@ groups:
         default_value: "0"
         field: general.rth_home_altitude
         max: 65000
+      - name: safehome_max_distance
+        description: "In order for a safehome to be used, it must be less than this distance (in cm) from the arming point."
+        default_value: "20000"
+        field: general.safehome_max_distance
+        min: 0
+        max: 65000
       - name: nav_mc_bank_angle
         description: "Maximum banking angle (deg) that multicopter navigation is allowed to set. Machine must be able to satisfy this angle without loosing altitude"
         default_value: "30"

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -126,7 +126,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .rth_home_altitude = 0,                 // altitude in centimeters
         .rth_abort_threshold = 50000,           // centimeters - 500m should be safe for all aircraft
         .max_terrain_follow_altitude = 100,     // max altitude in centimeters in terrain following mode
-        .safehome_max_distance = 200,           // Max distance that a safehome is from the arming point
+        .safehome_max_distance = 20000,         // Max distance that a safehome is from the arming point
         },
 
     // MC-specific

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -126,6 +126,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .rth_home_altitude = 0,                 // altitude in centimeters
         .rth_abort_threshold = 50000,           // centimeters - 500m should be safe for all aircraft
         .max_terrain_follow_altitude = 100,     // max altitude in centimeters in terrain following mode
+        .safehome_max_distance = 200,           // Max distance that a safehome is from the arming point
         },
 
     // MC-specific
@@ -2428,23 +2429,38 @@ bool isSafeHomeInUse(void)
 /***********************************************************
  *  See if there are any safehomes near where we are arming.
  *  If so, use it instead of the arming point for home.
+ *  Select the nearest safehome
  **********************************************************/
 bool foundNearbySafeHome(void)
 {
     safehome_used = -1;
-    fpVector3_t safeHome;
+    uint32_t nearest_safehome_distance = navConfig()->general.safehome_max_distance + 1;
+    uint32_t distance_to_current;
+    fpVector3_t currentSafeHome;
+    fpVector3_t nearestSafeHome;
     gpsLocation_t shLLH;
     shLLH.alt = 0;
     for (uint8_t i = 0; i < MAX_SAFE_HOMES; i++) {
+		if (!safeHomeConfig(i)->enabled)
+		    continue;
+
         shLLH.lat = safeHomeConfig(i)->lat;
         shLLH.lon = safeHomeConfig(i)->lon;
-        geoConvertGeodeticToLocal(&safeHome, &posControl.gpsOrigin, &shLLH, GEO_ALT_RELATIVE);
-        safehome_distance = calculateDistanceToDestination(&safeHome);
-        if (safehome_distance < 20000) { // 200 m
+        geoConvertGeodeticToLocal(&currentSafeHome, &posControl.gpsOrigin, &shLLH, GEO_ALT_RELATIVE);
+        distance_to_current = calculateDistanceToDestination(&currentSafeHome);
+        if (distance_to_current < nearest_safehome_distance) {
+             // this safehome is the nearest so far - keep track of it.
              safehome_used = i;
-             setHomePosition(&safeHome, 0, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_Z | NAV_POS_UPDATE_HEADING, navigationActualStateHomeValidity());
-             return true;
+             nearest_safehome_distance = distance_to_current;
+             nearestSafeHome.x = currentSafeHome.x;
+             nearestSafeHome.y = currentSafeHome.y;
+             nearestSafeHome.z = currentSafeHome.z;
         }
+    }
+    if (safehome_used >= 0) {
+		safehome_distance = nearest_safehome_distance;
+        setHomePosition(&nearestSafeHome, 0, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_Z | NAV_POS_UPDATE_HEADING, navigationActualStateHomeValidity());
+        return true;
     }
     safehome_distance = 0;
     return false;
@@ -2799,7 +2815,7 @@ void getWaypoint(uint8_t wpNumber, navWaypoint_t * wpData)
         wpData->lon = wpLLH.lon;
         wpData->alt = wpLLH.alt;
     }
-    // WP #254 - special waypoint - get desiredPosition that was set by ground control station if in 3D-guided mode 
+    // WP #254 - special waypoint - get desiredPosition that was set by ground control station if in 3D-guided mode
     else if (wpNumber == 254) {
         navigationFSMStateFlags_t navStateFlags = navGetStateFlags(posControl.navState);
 
@@ -2807,7 +2823,7 @@ void getWaypoint(uint8_t wpNumber, navWaypoint_t * wpData)
             gpsLocation_t wpLLH;
 
             geoConvertLocalToGeodetic(&wpLLH, &posControl.gpsOrigin, &posControl.desiredState.pos);
-            
+
             wpData->lat = wpLLH.lat;
             wpData->lon = wpLLH.lon;
             wpData->alt = wpLLH.alt;

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -200,6 +200,7 @@ typedef struct navConfig_s {
         uint16_t min_rth_distance;              // 0 Disables. Minimal distance for RTH in cm, otherwise it will just autoland
         uint16_t rth_abort_threshold;           // Initiate emergency landing if during RTH we get this much [cm] away from home
         uint16_t max_terrain_follow_altitude;   // Max altitude to be used in SURFACE TRACKING mode
+        uint16_t safehome_max_distance;         // Max distance that a safehome is from the arming point
     } general;
 
     struct {
@@ -386,7 +387,7 @@ typedef enum {
     MW_NAV_STATE_LAND_START_DESCENT,      // Start descent
     MW_NAV_STATE_HOVER_ABOVE_HOME,        // Hover/Loitering above home
     MW_NAV_STATE_EMERGENCY_LANDING,       // Emergency landing
-    MW_NAV_STATE_RTH_CLIMB,               // RTH Climb safe altitude    
+    MW_NAV_STATE_RTH_CLIMB,               // RTH Climb safe altitude
 } navSystemStatus_State_e;
 
 typedef enum {


### PR DESCRIPTION
Fixes #6301 

A new option ```safehome_max_distance``` (default 20000cm, max 65000cm) instead of the previously hardcoded 200m.

The logic also changed to select the nearest safehome, instead of the first enabled safehome within the maximum distance.

It's winter here, so I won't have a chance to flight test this change.  Maybe someone further south could give it a try.