### PR TITLE
automatically raise BIDIR flag on softserial port if RX and TX pins are set to the same pin

### DIFF
--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -227,6 +227,12 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
     IO_t rxIO = IOGetByTag(tagRx);
     IO_t txIO = IOGetByTag(tagTx);
 
+	if (tagRx == tagTx) {
+		if ((mode & MODE_RX) && (mode & MODE_TX)) {
+			options |= SERIAL_BIDIR;
+		}
+	}
+    
     if (options & SERIAL_BIDIR) {
         // If RX and TX pins are both assigned, we CAN use either with a timer.
         // However, for consistency with hardware UARTs, we only use TX pin,


### PR DESCRIPTION
SoftSerial 1 is using the same pin for TX and RX in FLYWOOF411 target. 
This allows to have Smartport, SPORT and LTM telemetry on this pin, because they request TX or BIDIR modes from UART.
But Mavlink telemetry does not work. It requests full RX & TX mode.
Initializing softserial port with pins shared will not do any good anyway: all messages  get echoed (I am not even sure it works).
Starting port in BIDIR mode is sufficient to have one-directional Mavlink telemetry, and even Bi-directional, if user can setup half-duplex communication.
This is better solution for: https://github.com/iNavFlight/inav/issues/5482