### PR TITLE
Changed default settings for fixed wing throttle smoothing in navigation modes

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2286,13 +2286,13 @@ groups:
         max: 100
       - name: nav_fw_pitch2thr_smoothing
         description:  "How smoothly the autopilot makes pitch to throttle correction inside a deadband defined by pitch_to_throttle_thresh."
-        default_value: "0"
+        default_value: "6"
         field: fw.pitch_to_throttle_smooth
         min: 0
         max: 9
       - name: nav_fw_pitch2thr_threshold
         description: "Threshold from average pitch where momentary pitch_to_throttle correction kicks in. [decidegrees]"
-        default_value: "0"
+        default_value: "50"
         field: fw.pitch_to_throttle_thresh
         min: 0
         max: 900


### PR DESCRIPTION
This pull request contains a proposal of changed default settings for the new throttle smoothing feature introduced in pull request #6104. The change is a result of the testing performed by me and @avsaase, and will let all fixed wing pilots take advantage of this feature by default in the next release.

The proposed defaults:
`nav_fw_pitch2thr_smoothing = 6` which equals a low pass filter cutoff frequency of 0.14 Hz.
`nav_fw_pitch2thr_threshold = 50` which equals +/- 5 degrees deadband around the filtered pitch angle.