### PR TITLE
add MS5611 baro to KakuteF7

### DIFF
--- a/src/main/target/KAKUTEF7/target.h
+++ b/src/main/target/KAKUTEF7/target.h
@@ -134,6 +134,7 @@
 
 #define USE_BARO
 #define USE_BARO_BMP280
+#define USE_BARO_MS5611
 #define BARO_I2C_BUS            BUS_I2C1
 
 #define USE_MAG


### PR DESCRIPTION
A user on RCG wanted to use a MS5611 as the on-board BMP280 drifts significantly. This trival PR enables it. Different I2C address so no conflict with the on-board device.