### PR TITLE
Enable DSHOT support on FF_F35/WINGFC

### DIFF
--- a/src/main/target/FF_F35_LIGHTNING/target.h
+++ b/src/main/target/FF_F35_LIGHTNING/target.h
@@ -27,6 +27,8 @@
 #define BEEPER                  PA1
 #define BEEPER_INVERTED
 
+#define USE_DSHOT
+
 // MPU interrupt
 #define USE_EXTI
 #define GYRO_INT_EXTI            PC4


### PR DESCRIPTION
This enables DSHOT protocol support on Wing FC and FuriousFPV F-35 Lightning targets.

Tested on WINGFC with DSHOT600.