### PR TITLE
Fix EEPROM loading code

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -218,7 +218,7 @@ void init(void)
 #endif
 
     initEEPROM();
-    //ensureEEPROMContainsValidData();
+    ensureEEPROMContainsValidData();
     readEEPROM();
 
     // Re-initialize system clock to their final values (if necessary)


### PR DESCRIPTION
Fixes potential hardfault when `findEEPROM()` attempts to read beyond `__config_end`. Restores a missing check to `ensureEEPROMContainsValidData()` to do a pre-check of EEPROM before attempting to load it.

Fixes #6382