### PR TITLE
add USE_BARO,USE_MAG to non-I2C KAKUTEF4 V1 (for MSP sensors)

### DIFF
--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -70,6 +70,9 @@
 #   define BARO_I2C_BUS            BUS_I2C1
 #   define USE_BARO_MS5611
 #   define USE_BARO_BMP280
+#else // V1 does not have I2C exposed, common_post.h will pull in USE_*_MSP
+#   define USE_BARO
+#   define USE_MAG
 #endif
 
 #define USE_OSD


### PR DESCRIPTION
For MATEK MSP GPS, tested OK by RCG user `yelrx8`