### PR TITLE
New target - Flywoo f411 Goku V2

### DIFF
--- a/docs/Board - FLYWOOF411.md
+++ b/docs/Board - FLYWOOF411.md
@@ -1,5 +1,16 @@
 # Board - FLYWOOF411
 
+## Flywoo 411 Flight controllers
+Most of the Flywoo FC do not have I2C, BARO or both so may not suitable for iNav
+
+Flywoo Goku F411 V1 does not have BARO or I2C pads:
+https://cdn.shopify.com/s/files/1/0010/7410/2324/files/0e7d0153c93500f48670455f119034da.jpg?v=1575563256
+
+Flywoo Goku F411 V2 does have I2C pads. Some boards may have a BARO. This board is suitable for iNav but but may require external BARO and Compass
+https://cdn.shopifycdn.net/s/files/1/0010/7410/2324/products/20201126012224_2048x2048.png?v=1606326840
+
+
+## NOXE F4
 ![Banggood](https://img.staticbg.com/thumb/view/oaupload/banggood/images/A5/01/79d28a2c-ef4b-4e4f-bab6-14edf66bbb23.jpg)
 ![Banggood](https://img.staticbg.com/images/oaupload/banggood/images/2E/C5/c14a1e86-4e58-4bc8-85de-8e344cb382b9.jpg)
 ![Banggood](https://img.staticbg.com/images/oaupload/banggood/images/42/F7/45a68ade-9be1-4fff-afec-bbdd45f0331d.jpg)
@@ -31,3 +42,8 @@
 
 ## Where to buy:
 * [Banggood](https://inavflight.com/shop/s/bg/1310419)
+
+## Available TARGETS
+
+* `FLYWOOF411` Warning - Serial 2 TX is shared with soft serial for use as S.Port or VTX control
+* `FLYWOOF411GV2` Flywoo F411 Goku V2 with softserial full-duplex (TX = M5, RX = M6)

--- a/src/main/target/FLYWOOF411/CMakeLists.txt
+++ b/src/main/target/FLYWOOF411/CMakeLists.txt
@@ -1,1 +1,3 @@
 target_stm32f411xe(FLYWOOF411)
+target_stm32f411xe(FLYWOOF411GV2)
+

--- a/src/main/target/FLYWOOF411/target.c
+++ b/src/main/target/FLYWOOF411/target.c
@@ -25,8 +25,7 @@
 
 
 const timerHardware_t timerHardware[] = {
-    DEF_TIM(TIM9, CH1, PA2,   TIM_USE_PPM,   0, 0), // PPM IN
-
+//  DEF_TIM(TIM9, CH1, PA2,  TIM_USE_PPM,   0, 0), // PPM IN
     DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 1),
 #if defined(FLYWOOF411GV2)
     DEF_TIM(TIM2, CH2, PB3,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 0), 
@@ -41,7 +40,8 @@ const timerHardware_t timerHardware[] = {
 #if defined(FLYWOOF411GV2)
 //  DEF_TIM(TIM5, CH4, PA3,  TIM_USE_ANY,   0, 1), //  RX2
     DEF_TIM(TIM5, CH1, PA0,  TIM_USE_LED,   0, 0), //  LED
-    DEF_TIM(TIM4, CH1, PB6,  TIM_USE_ANY,   0, 0), //  SOFTSERIAL
+    DEF_TIM(TIM4, CH1, PB6,  TIM_USE_ANY,   0, 0), //  SOFTSERIAL TX
+    DEF_TIM(TIM4, CH2, PB7,  TIM_USE_ANY,   0, 0), //  SOFTSERIAL RX
 #elif defined(FLYWOOF411GV1)
     DEF_TIM(TIM5, CH4, PA3,  TIM_USE_ANY,   0, 1), //  RX2    1,0
     DEF_TIM(TIM2, CH1, PA15, TIM_USE_LED,   0, 0), //  LED    1,5

--- a/src/main/target/FLYWOOF411/target.c
+++ b/src/main/target/FLYWOOF411/target.c
@@ -27,15 +27,30 @@
 const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM9, CH1, PA2,   TIM_USE_PPM,   0, 0), // PPM IN
 
-    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 1), // S1_OUT 2,1
-    DEF_TIM(TIM1, CH2, PA9,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 1), // S2_OUT 2,2
-    DEF_TIM(TIM1, CH3, PA10, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 0), // S3_OUT 2,6
-    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR,  0, 0), // S4_OUT 1,7
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 1),
+#if defined(FLYWOOF411GV2)
+    DEF_TIM(TIM2, CH2, PB3,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 0), 
+    DEF_TIM(TIM2, CH3, PB10, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 0), 
+    DEF_TIM(TIM2, CH1, PA15, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR,  0, 0), 
+#else
+    DEF_TIM(TIM1, CH2, PA9,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 1), 
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 0), 
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR,  0, 0), 
+#endif    
 
+#if defined(FLYWOOF411GV2)
+//  DEF_TIM(TIM5, CH4, PA3,  TIM_USE_ANY,   0, 1), //  RX2
+    DEF_TIM(TIM5, CH1, PA0,  TIM_USE_LED,   0, 0), //  LED
+    DEF_TIM(TIM4, CH1, PB6,  TIM_USE_ANY,   0, 0), //  SOFTSERIAL
+#elif defined(FLYWOOF411GV1)
+    DEF_TIM(TIM5, CH4, PA3,  TIM_USE_ANY,   0, 1), //  RX2    1,0
+    DEF_TIM(TIM2, CH1, PA15, TIM_USE_LED,   0, 0), //  LED    1,5
+    DEF_TIM(TIM3, CH1, PB4,  TIM_USE_ANY,   0, 0), //  SOFTSERIAL M5
+#else
     DEF_TIM(TIM3, CH4, PB1,  TIM_USE_ANY,   0, 0), //  RSSI   1,2
     DEF_TIM(TIM5, CH4, PA3,  TIM_USE_ANY,   0, 1), //  RX2    1,0
     DEF_TIM(TIM2, CH1, PA15, TIM_USE_LED,   0, 0), //  LED    1,5
-
+#endif   
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/FLYWOOF411/target.h
+++ b/src/main/target/FLYWOOF411/target.h
@@ -99,6 +99,8 @@
 
 // *************** UART *****************************
 #define USE_VCP
+#define VBUS_SENSING_PIN        PC15
+#define VBUS_SENSING_ENABLED
 
 #define USE_UART1
 #if defined(FLYWOOF411GV2)

--- a/src/main/target/FLYWOOF411/target.h
+++ b/src/main/target/FLYWOOF411/target.h
@@ -17,30 +17,35 @@
 
 #pragma once
 
-#define TARGET_BOARD_IDENTIFIER "FW41"
 #define USBD_PRODUCT_STRING     "FLYWOOF411"
+
+// *************** Identifier **********************
+#if defined(FLYWOOF411GV2)
+#define TARGET_BOARD_IDENTIFIER "FGV2"
+#elif defined(FLYWOOF411GV1)
+#define TARGET_BOARD_IDENTIFIER "FGV1"
+#else
+#define TARGET_BOARD_IDENTIFIER "FW41"
+#endif
 
 #define LED0                    PC13
 
 #define BEEPER                  PC14
 #define BEEPER_INVERTED
 
-
 // *************** SPI **********************
 #define USE_SPI
 #define USE_SPI_DEVICE_1
-#define SPI1_SCK_PIN           PA5
-#define SPI1_MISO_PIN   	   PA6
-#define SPI1_MOSI_PIN   	   PA7
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN   	      PA6
+#define SPI1_MOSI_PIN   	      PA7
 
 #define USE_SPI_DEVICE_2
-#define SPI2_SCK_PIN           PB13
-#define SPI2_MISO_PIN  		   PB14
-#define SPI2_MOSI_PIN  		   PB15
-
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN  		      PB14
+#define SPI2_MOSI_PIN  		      PB15
 
 // *************** SPI Gyro & ACC **********************
-
 #define USE_IMU_MPU6000
 #define MPU6000_CS_PIN          PA4
 #define MPU6000_SPI_BUS         BUS_SPI1
@@ -52,18 +57,21 @@
 #define IMU_ICM20689_ALIGN      CW180_DEG
 
 #define USE_EXTI
+#if defined(FLYWOOF411GV2)
+#define GYRO_INT_EXTI           PB5
+#else
 #define GYRO_INT_EXTI           PB3
+#endif
 #define USE_MPU_DATA_READY_SIGNAL
 
 // *************** Baro *****************************
-
 #define USE_I2C
 #define USE_I2C_DEVICE_1
 #define I2C1_SCL                PB8
 #define I2C1_SDA                PB9
 
 #define USE_BARO
-#define BARO_I2C_BUS		    BUS_I2C1
+#define BARO_I2C_BUS		        BUS_I2C1
 #define USE_BARO_BMP280
 #define USE_BARO_MS5611
 
@@ -93,16 +101,35 @@
 #define USE_VCP
 
 #define USE_UART1
+#if defined(FLYWOOF411GV2)
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+#else
 #define UART1_TX_PIN            PB6
 #define UART1_RX_PIN            PB7
+#endif
 
 #define USE_UART2
+#if defined(FLYWOOF411GV2) || defined(FLYWOOF411GV1)  
+#define UART2_TX_PIN            PA2 
+#define UART2_RX_PIN            PA3
+#else
 #define UART2_TX_PIN            NONE    //PA2
 #define UART2_RX_PIN            PA3
+#endif
 
 #define USE_SOFTSERIAL1
+#if defined(FLYWOOF411GV2)
+#define SOFTSERIAL_1_TX_PIN     PB6     
+#define SOFTSERIAL_1_RX_PIN     PB7
+#elif defined(FLYWOOF411GV1)
+#define SOFTSERIAL_1_TX_PIN     PA15
+#define SOFTSERIAL_1_RX_PIN     PA1
+#else
 #define SOFTSERIAL_1_TX_PIN     PA2     // Clash with TX2, possible to use as S.Port or VTX control
 #define SOFTSERIAL_1_RX_PIN     PA2
+#endif
+
 
 #define SERIAL_PORT_COUNT       4       // VCP, USART1, USART2, SS1
 
@@ -113,17 +140,35 @@
 // *************** ADC *****************************
 #define USE_ADC
 #define ADC_INSTANCE                    ADC1
+#if defined(FLYWOOF411GV2)
+#define ADC_CHANNEL_1_PIN               PA1
+#define ADC_CHANNEL_2_PIN               PB1
+#define ADC_CHANNEL_3_PIN               NONE
+#elif defined(FLYWOOF411GV1)
+#define ADC_CHANNEL_1_PIN               NONE
+#define ADC_CHANNEL_2_PIN               PA0
+#define ADC_CHANNEL_3_PIN               PB1
+#else
 #define ADC_CHANNEL_1_PIN               PA1
 #define ADC_CHANNEL_2_PIN               PA0
 #define ADC_CHANNEL_3_PIN               PB1
+#endif
 
 #define CURRENT_METER_ADC_CHANNEL       ADC_CHN_1
 #define VBAT_ADC_CHANNEL                ADC_CHN_2
 #define RSSI_ADC_CHANNEL                ADC_CHN_3
 
+
 // *************** LED2812 ************************
 #define USE_LED_STRIP
+#if defined(FLYWOOF411GV2)
+#define WS2811_PIN                      PA0
+#elif defined(FLYWOOF411GV1)
+#define WS2811_PIN                      NONE
+#else
 #define WS2811_PIN                      PA15
+#endif
+
 
 // ***************  OTHERS *************************
 #define DEFAULT_FEATURES                (FEATURE_TX_PROF_SEL | FEATURE_OSD | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_SOFTSERIAL)


### PR DESCRIPTION
Use target - FLYWOOF411GV2 
Connections as diagram: https://cdn.shopifycdn.net/s/files/1/0010/7410/2324/products/20201126012224_2048x2048.png?v=1606326840

Flywoo Goku F411 V1 has no BARO. 
Defines are included within the target files, but have not added to cmake as unlikely users will add baro to use for iNav. 

