### PR TITLE
Revert "Do not run tests for docs-only PRs"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,7 @@ name: Build firmware
 # Don't enable CI on push, just on PR. If you
 # are working on the main repo and want to trigger
 # a CI build submit a draft PR.
-on:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
Reverts iNavFlight/inav#6404. GH Actions [don't support](https://github.community/t/feature-request-conditional-required-checks/16761) "Required to pass **when present**" checks as of today. The `test` job and its builds needs to run for each PR to block merging until checks pass.