### PR TITLE
Align OSD waypoint number display with geospatial waypoints

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1386,21 +1386,20 @@ static void osdDisplayAdjustableDecimalValue(uint8_t elemPosX, uint8_t elemPosY,
 int8_t getGeoWaypointNumber(int8_t waypointIndex)
 {
     static int8_t lastWaypointIndex = 1;
-    static int8_t lastGeoWaypointIndex;
+    static int8_t geoWaypointIndex;
 
     if (waypointIndex != lastWaypointIndex) {
-        lastWaypointIndex = waypointIndex;
-        lastGeoWaypointIndex = waypointIndex;
+        lastWaypointIndex = geoWaypointIndex = waypointIndex;
         for (uint8_t i = 0; i <= waypointIndex; i++) {
             if (posControl.waypointList[i].action == NAV_WP_ACTION_SET_POI ||
                 posControl.waypointList[i].action == NAV_WP_ACTION_SET_HEAD ||
                 posControl.waypointList[i].action == NAV_WP_ACTION_JUMP) {
-                    lastGeoWaypointIndex -= 1;
+                    geoWaypointIndex -= 1;
             }
         }
     }
 
-    return lastGeoWaypointIndex + 1;
+    return geoWaypointIndex + 1;
 }
 
 static bool osdDrawSingleElement(uint8_t item)

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1385,7 +1385,7 @@ static void osdDisplayAdjustableDecimalValue(uint8_t elemPosX, uint8_t elemPosY,
 
 int8_t getGeoWaypointNumber(int8_t waypointIndex)
 {
-    if ((posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_JUMP || posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_SET_POI || posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_SET_HEAD)) {
+    if (posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_JUMP) {
         return posControl.waypointList[waypointIndex - 1].p3;
     } else {
         return posControl.waypointList[waypointIndex].p3;
@@ -1995,8 +1995,9 @@ static bool osdDrawSingleElement(uint8_t item)
                         fpVector3_t poi;
                         geoConvertGeodeticToLocal(&poi, &posControl.gpsOrigin, &wp2, waypointMissionAltConvMode(posControl.waypointList[j].p3));
                         int32_t altConvModeAltitude = waypointMissionAltConvMode(posControl.waypointList[j].p3) == GEO_ALT_ABSOLUTE ? osdGetAltitudeMsl() : osdGetAltitude();
-                        while (j > 9) j -= 10; // Only the last digit displayed if WP>=10, no room for more
-                        osdHudDrawPoi(calculateDistanceToDestination(&poi) / 100, osdGetHeadingAngle(calculateBearingToDestination(&poi) / 100), (posControl.waypointList[j].alt - altConvModeAltitude)/ 100, 2, SYM_WAYPOINT, 49 + j, i);
+                        j = getGeoWaypointNumber(j);
+                        while (j > 9) j -= 10; // Only the last digit displayed if WP>=10, no room for more (48 = ascii 0)
+                        osdHudDrawPoi(calculateDistanceToDestination(&poi) / 100, osdGetHeadingAngle(calculateBearingToDestination(&poi) / 100), (posControl.waypointList[j].alt - altConvModeAltitude)/ 100, 2, SYM_WAYPOINT, 48 + j, i);
                     }
                 }
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1385,7 +1385,22 @@ static void osdDisplayAdjustableDecimalValue(uint8_t elemPosX, uint8_t elemPosY,
 
 int8_t getGeoWaypointNumber(int8_t waypointIndex)
 {
-    return posControl.geoWaypointList[waypointIndex];
+    static int8_t lastWaypointIndex = 1;
+    static int8_t lastGeoWaypointIndex;
+
+    if (waypointIndex != lastWaypointIndex) {
+        lastWaypointIndex = waypointIndex;
+        lastGeoWaypointIndex = waypointIndex;
+        for (uint8_t i = 0; i <= waypointIndex; i++) {
+            if (posControl.waypointList[i].action == NAV_WP_ACTION_SET_POI ||
+                posControl.waypointList[i].action == NAV_WP_ACTION_SET_HEAD ||
+                posControl.waypointList[i].action == NAV_WP_ACTION_JUMP) {
+                    lastGeoWaypointIndex -= 1;
+            }
+        }
+    }
+
+    return lastGeoWaypointIndex + 1;
 }
 
 static bool osdDrawSingleElement(uint8_t item)

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1383,6 +1383,19 @@ static void osdDisplayAdjustableDecimalValue(uint8_t elemPosX, uint8_t elemPosY,
     displayWriteWithAttr(osdDisplayPort, elemPosX + strlen(str) + 1 + valueOffset, elemPosY, buff, elemAttr);
 }
 
+int8_t getGeoWaypointNumber(int8_t waypointIndex)
+{
+    if (posControl.waypointList[waypointIndex].flag == NAV_WP_FLAG_LAST) {
+        if ((posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_JUMP || posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_SET_POI || posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_SET_HEAD)) {
+            return posControl.waypointList[waypointIndex - 1].flag;
+        } else {
+            return posControl.waypointList[waypointIndex - 1].flag + 1;
+        }
+    } else {
+        return posControl.waypointList[waypointIndex].flag;
+    }
+}
+
 static bool osdDrawSingleElement(uint8_t item)
 {
     uint16_t pos = osdLayoutsConfig()->item_pos[currentLayout][item];
@@ -3833,7 +3846,7 @@ textAttributes_t osdGetSystemMessage(char *buff, size_t buff_size, bool isCenter
                         // Countdown display for remaining Waypoints
                         char buf[6];
                         osdFormatDistanceSymbol(buf, posControl.wpDistance, 0);
-                        tfp_sprintf(messageBuf, "TO WP %u/%u (%s)", posControl.activeWaypointIndex + 1, posControl.waypointCount, buf);
+                        tfp_sprintf(messageBuf, "TO WP %u/%u (%s)", getGeoWaypointNumber(posControl.activeWaypointIndex), posControl.geoWaypointCount, buf);
                         messages[messageCount++] = messageBuf;
                     } else if (NAV_Status.state == MW_NAV_STATE_HOLD_TIMED) {
                         // WP hold time countdown in seconds

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1385,11 +1385,7 @@ static void osdDisplayAdjustableDecimalValue(uint8_t elemPosX, uint8_t elemPosY,
 
 int8_t getGeoWaypointNumber(int8_t waypointIndex)
 {
-    if (posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_JUMP) {
-        return posControl.waypointList[waypointIndex - 1].p3;
-    } else {
-        return posControl.waypointList[waypointIndex].p3;
-    }
+    return posControl.geoWaypointList[waypointIndex];
 }
 
 static bool osdDrawSingleElement(uint8_t item)

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1385,14 +1385,10 @@ static void osdDisplayAdjustableDecimalValue(uint8_t elemPosX, uint8_t elemPosY,
 
 int8_t getGeoWaypointNumber(int8_t waypointIndex)
 {
-    if (posControl.waypointList[waypointIndex].flag == NAV_WP_FLAG_LAST) {
-        if ((posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_JUMP || posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_SET_POI || posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_SET_HEAD)) {
-            return posControl.waypointList[waypointIndex - 1].flag;
-        } else {
-            return posControl.waypointList[waypointIndex - 1].flag + 1;
-        }
+    if ((posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_JUMP || posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_SET_POI || posControl.waypointList[waypointIndex].action == NAV_WP_ACTION_SET_HEAD)) {
+        return posControl.waypointList[waypointIndex - 1].p3;
     } else {
-        return posControl.waypointList[waypointIndex].flag;
+        return posControl.waypointList[waypointIndex].p3;
     }
 }
 

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2839,10 +2839,12 @@ void setWaypoint(uint8_t wpNumber, const navWaypoint_t * wpData)
                 posControl.waypointList[wpNumber - 1] = *wpData;
 
                 if(wpData->action == NAV_WP_ACTION_SET_POI || wpData->action == NAV_WP_ACTION_SET_HEAD || wpData->action == NAV_WP_ACTION_JUMP) {
+                    nonGeoWaypointCount += 1;
                     if(wpData->action == NAV_WP_ACTION_JUMP) {
                         posControl.waypointList[wpNumber - 1].p1 -= 1; // make index (vice WP #)
-                    }
-                    nonGeoWaypointCount += 1;
+                    } else {
+                        posControl.waypointList[wpNumber - 1].p3 = wpNumber - nonGeoWaypointCount;
+                    }                    
                 } else {
                     posControl.waypointList[wpNumber - 1].p3 = wpNumber - nonGeoWaypointCount;
                 }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2833,13 +2833,25 @@ void setWaypoint(uint8_t wpNumber, const navWaypoint_t * wpData)
     else if ((wpNumber >= 1) && (wpNumber <= NAV_MAX_WAYPOINTS) && !ARMING_FLAG(ARMED)) {
         if (wpData->action == NAV_WP_ACTION_WAYPOINT || wpData->action == NAV_WP_ACTION_JUMP || wpData->action == NAV_WP_ACTION_RTH || wpData->action == NAV_WP_ACTION_HOLD_TIME || wpData->action == NAV_WP_ACTION_LAND || wpData->action == NAV_WP_ACTION_SET_POI || wpData->action == NAV_WP_ACTION_SET_HEAD ) {
             // Only allow upload next waypoint (continue upload mission) or first waypoint (new mission)
+            static int8_t nonGeoWaypointCount = 0;
+            
             if (wpNumber == (posControl.waypointCount + 1) || wpNumber == 1) {
                 posControl.waypointList[wpNumber - 1] = *wpData;
-                if(wpData->action == NAV_WP_ACTION_JUMP) {
+                if (wpData->action == NAV_WP_ACTION_JUMP) {
                     posControl.waypointList[wpNumber - 1].p1 -= 1; // make index (vice WP #)
+                    nonGeoWaypointCount += 1;
+                }
+                if (wpData->action == NAV_WP_ACTION_SET_POI || wpData->action == NAV_WP_ACTION_SET_HEAD) {
+                    nonGeoWaypointCount += 1;                          
                 }
                 posControl.waypointCount = wpNumber;
                 posControl.waypointListValid = (wpData->flag == NAV_WP_FLAG_LAST);
+                posControl.geoWaypointCount = posControl.waypointCount - nonGeoWaypointCount;
+                if (posControl.waypointListValid) {
+                    nonGeoWaypointCount = 0;
+                } else {                    
+                    posControl.waypointList[wpNumber - 1].flag = wpNumber - nonGeoWaypointCount;
+                }                                                                                             
             }
         }
     }
@@ -2851,6 +2863,7 @@ void resetWaypointList(void)
     if (!ARMING_FLAG(ARMED)) {
         posControl.waypointCount = 0;
         posControl.waypointListValid = false;
+        posControl.geoWaypointCount = 0;
     }
 }
 

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2843,7 +2843,6 @@ void setWaypoint(uint8_t wpNumber, const navWaypoint_t * wpData)
                         posControl.waypointList[wpNumber - 1].p1 -= 1; // make index (vice WP #)
                     }
                 }
-                posControl.geoWaypointList[wpNumber - 1] = wpNumber - nonGeoWaypointCount;
 
                 posControl.waypointCount = wpNumber;
                 posControl.waypointListValid = (wpData->flag == NAV_WP_FLAG_LAST);

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2844,7 +2844,7 @@ void setWaypoint(uint8_t wpNumber, const navWaypoint_t * wpData)
                         posControl.waypointList[wpNumber - 1].p1 -= 1; // make index (vice WP #)
                     } else {
                         posControl.waypointList[wpNumber - 1].p3 = wpNumber - nonGeoWaypointCount;
-                    }                    
+                    }
                 } else {
                     posControl.waypointList[wpNumber - 1].p3 = wpNumber - nonGeoWaypointCount;
                 }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2834,24 +2834,25 @@ void setWaypoint(uint8_t wpNumber, const navWaypoint_t * wpData)
         if (wpData->action == NAV_WP_ACTION_WAYPOINT || wpData->action == NAV_WP_ACTION_JUMP || wpData->action == NAV_WP_ACTION_RTH || wpData->action == NAV_WP_ACTION_HOLD_TIME || wpData->action == NAV_WP_ACTION_LAND || wpData->action == NAV_WP_ACTION_SET_POI || wpData->action == NAV_WP_ACTION_SET_HEAD ) {
             // Only allow upload next waypoint (continue upload mission) or first waypoint (new mission)
             static int8_t nonGeoWaypointCount = 0;
-            
+
             if (wpNumber == (posControl.waypointCount + 1) || wpNumber == 1) {
                 posControl.waypointList[wpNumber - 1] = *wpData;
-                if (wpData->action == NAV_WP_ACTION_JUMP) {
-                    posControl.waypointList[wpNumber - 1].p1 -= 1; // make index (vice WP #)
+
+                if(wpData->action == NAV_WP_ACTION_SET_POI || wpData->action == NAV_WP_ACTION_SET_HEAD || wpData->action == NAV_WP_ACTION_JUMP) {
+                    if(wpData->action == NAV_WP_ACTION_JUMP) {
+                        posControl.waypointList[wpNumber - 1].p1 -= 1; // make index (vice WP #)
+                    }
                     nonGeoWaypointCount += 1;
+                } else {
+                    posControl.waypointList[wpNumber - 1].p3 = wpNumber - nonGeoWaypointCount;
                 }
-                if (wpData->action == NAV_WP_ACTION_SET_POI || wpData->action == NAV_WP_ACTION_SET_HEAD) {
-                    nonGeoWaypointCount += 1;                          
-                }
+
                 posControl.waypointCount = wpNumber;
                 posControl.waypointListValid = (wpData->flag == NAV_WP_FLAG_LAST);
                 posControl.geoWaypointCount = posControl.waypointCount - nonGeoWaypointCount;
                 if (posControl.waypointListValid) {
                     nonGeoWaypointCount = 0;
-                } else {                    
-                    posControl.waypointList[wpNumber - 1].flag = wpNumber - nonGeoWaypointCount;
-                }                                                                                             
+                }
             }
         }
     }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2837,17 +2837,13 @@ void setWaypoint(uint8_t wpNumber, const navWaypoint_t * wpData)
 
             if (wpNumber == (posControl.waypointCount + 1) || wpNumber == 1) {
                 posControl.waypointList[wpNumber - 1] = *wpData;
-
                 if(wpData->action == NAV_WP_ACTION_SET_POI || wpData->action == NAV_WP_ACTION_SET_HEAD || wpData->action == NAV_WP_ACTION_JUMP) {
                     nonGeoWaypointCount += 1;
                     if(wpData->action == NAV_WP_ACTION_JUMP) {
                         posControl.waypointList[wpNumber - 1].p1 -= 1; // make index (vice WP #)
-                    } else {
-                        posControl.waypointList[wpNumber - 1].p3 = wpNumber - nonGeoWaypointCount;
                     }
-                } else {
-                    posControl.waypointList[wpNumber - 1].p3 = wpNumber - nonGeoWaypointCount;
                 }
+                posControl.geoWaypointList[wpNumber - 1] = wpNumber - nonGeoWaypointCount;
 
                 posControl.waypointCount = wpNumber;
                 posControl.waypointListValid = (wpData->flag == NAV_WP_FLAG_LAST);

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -357,7 +357,6 @@ typedef struct {
     bool                        waypointListValid;
     int8_t                      waypointCount;
     int8_t                      geoWaypointCount;                       // total geospatial WPs in mission
-    int8_t                      geoWaypointList[NAV_MAX_WAYPOINTS];     // holds realigned geospacial WP numbering index
 
     navWaypointPosition_t       activeWaypoint;     // Local position and initial bearing, filled on waypoint activation
     int8_t                      activeWaypointIndex;

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -357,7 +357,7 @@ typedef struct {
     bool                        waypointListValid;
     int8_t                      waypointCount;
     int8_t                      geoWaypointCount;    // total geospatial WPs in mission
-    
+
     navWaypointPosition_t       activeWaypoint;     // Local position and initial bearing, filled on waypoint activation
     int8_t                      activeWaypointIndex;
     float                       wpInitialAltitude; // Altitude at start of WP

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -356,7 +356,8 @@ typedef struct {
     navWaypoint_t               waypointList[NAV_MAX_WAYPOINTS];
     bool                        waypointListValid;
     int8_t                      waypointCount;
-    int8_t                      geoWaypointCount;    // total geospatial WPs in mission
+    int8_t                      geoWaypointCount;                       // total geospatial WPs in mission
+    int8_t                      geoWaypointList[NAV_MAX_WAYPOINTS];     // holds realigned geospacial WP numbering index
 
     navWaypointPosition_t       activeWaypoint;     // Local position and initial bearing, filled on waypoint activation
     int8_t                      activeWaypointIndex;

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -356,7 +356,8 @@ typedef struct {
     navWaypoint_t               waypointList[NAV_MAX_WAYPOINTS];
     bool                        waypointListValid;
     int8_t                      waypointCount;
-
+    int8_t                      geoWaypointCount;    // total geospatial WPs in mission
+    
     navWaypointPosition_t       activeWaypoint;     // Local position and initial bearing, filled on waypoint activation
     int8_t                      activeWaypointIndex;
     float                       wpInitialAltitude; // Altitude at start of WP

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -356,9 +356,9 @@ typedef struct {
     navWaypoint_t               waypointList[NAV_MAX_WAYPOINTS];
     bool                        waypointListValid;
     int8_t                      waypointCount;
-    int8_t                      geoWaypointCount;                       // total geospatial WPs in mission
+    int8_t                      geoWaypointCount;  // total geospatial WPs in mission
 
-    navWaypointPosition_t       activeWaypoint;     // Local position and initial bearing, filled on waypoint activation
+    navWaypointPosition_t       activeWaypoint;    // Local position and initial bearing, filled on waypoint activation
     int8_t                      activeWaypointIndex;
     float                       wpInitialAltitude; // Altitude at start of WP
     float                       wpInitialDistance; // Distance when starting flight to WP


### PR DESCRIPTION
Waypoint missions that include nongeospatial waypoints, JUMP, HEADING, POI, display WP numbers in the OSD that follow the numeric sequence of all WPs in the mission rather than just the geospatial WPs which would seem a more intuitive expectation from a user point of view. This means the displayed WP numbers can appear inconsistent and increment by more than 1 when nongeo WPs are passed.

This PR fixes this by realigning the WP numbers displayed in the OSD with just the geospatial WPs and also adds a geospatial WP total count.

Tested in flight and works as expected for fixed wing and multirotor.

