### PR TITLE
Correct test for Galileo capability

### DIFF
--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -651,7 +651,17 @@ static bool gpsParceFrameUBLOX(void)
             // EXT CORE 3.01 (107900)
             // 01234567890123456789012
             gpsState.hwVersion = fastA2I(_buffer.ver.hwVersion);
-            capGalileo = ((gpsState.hwVersion >= 80000) && (_buffer.ver.swVersion[9] > '2')); // M8N and SW major 3 or later
+            if  ((gpsState.hwVersion >= 80000) && (_buffer.ver.swVersion[9] > '2')) {
+                // check extensions;
+                // after hw + sw vers; each is 30 bytes, ensure NUL terminated
+                for(int j = 40; j < _payload_length; j += 30) {
+                    _buffer.bytes[j+29] = 0;
+                    if (strstr((const char *)(_buffer.bytes+j), "GAL")) {
+                        capGalileo = true;
+                        break;
+                    }
+                }
+            }
         }
         break;
     case MSG_ACK_ACK:

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -653,7 +653,7 @@ static bool gpsParceFrameUBLOX(void)
             gpsState.hwVersion = fastA2I(_buffer.ver.hwVersion);
             if  ((gpsState.hwVersion >= 80000) && (_buffer.ver.swVersion[9] > '2')) {
                 // check extensions;
-                // after hw + sw vers; each is 30 bytes, ensure NUL terminated
+                // after hw + sw vers; each is 30 bytes
                 for(int j = 40; j < _payload_length; j += 30) {
                     if (strnstr((const char *)(_buffer.bytes+j), "GAL", 30)) {
                         capGalileo = true;

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -655,8 +655,7 @@ static bool gpsParceFrameUBLOX(void)
                 // check extensions;
                 // after hw + sw vers; each is 30 bytes, ensure NUL terminated
                 for(int j = 40; j < _payload_length; j += 30) {
-                    _buffer.bytes[j+29] = 0;
-                    if (strstr((const char *)(_buffer.bytes+j), "GAL")) {
+                    if (strnstr((const char *)(_buffer.bytes+j), "GAL", 30)) {
                         capGalileo = true;
                         break;
                     }


### PR DESCRIPTION
@Mateyhv discovered that if one has a BN220 based on ublox-8 rather than Ublox M8N, then:
* The versions are (HW [00080000]  SW[3.01]) are the same
* The ublox-8 does not have flash
* The ublox-8 does NOT support Galileo

This can result in erroneously reserving channel slots that cannot be used as the device passes the HW/SW test.
See  https://www.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_%28UBX-13003221%29.pdf page 5

This PR changes the test to explicitly test the version extensions for "GAL"; it may also be considered to be a corner case to far.
 