### PR TITLE
[SERIAL] Fix word length on F7+ when using parity

### DIFF
--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -71,7 +71,7 @@ static void uartReconfigure(uartPort_t *uartPort)
 
     HAL_UART_DeInit(&uartPort->Handle);
     uartPort->Handle.Init.BaudRate = uartPort->port.baudRate;
-    uartPort->Handle.Init.WordLength = UART_WORDLENGTH_8B;
+    uartPort->Handle.Init.WordLength = (uartPort->port.options & SERIAL_PARITY_EVEN) ? UART_WORDLENGTH_9B : UART_WORDLENGTH_8B;
     uartPort->Handle.Init.StopBits = (uartPort->port.options & SERIAL_STOPBITS_2) ? USART_STOPBITS_2 : USART_STOPBITS_1;
     uartPort->Handle.Init.Parity = (uartPort->port.options & SERIAL_PARITY_EVEN) ? USART_PARITY_EVEN : USART_PARITY_NONE;
     uartPort->Handle.Init.HwFlowCtl = UART_HWCONTROL_NONE;


### PR DESCRIPTION
Word length has to be 9 bits when using parity and 8b data. Partity never worked correctly when transmitting data on H7. Receiving was apparently not affected.