### PR TITLE
Fix GHST telemetry

### DIFF
--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -241,7 +241,7 @@ uint8_t ghstFrameStatus(rxRuntimeConfig_t *rxRuntimeState)
 {
     UNUSED(rxRuntimeState);
 
-    if(serialIsIdle(serialPort)) {
+    if (serialIsIdle(serialPort)) {
         ghstIdle();
     }
 

--- a/src/main/telemetry/ghst.c
+++ b/src/main/telemetry/ghst.c
@@ -163,7 +163,7 @@ bool checkGhstTelemetryState(void)
 // Called periodically by the scheduler
  void handleGhstTelemetry(timeUs_t currentTimeUs)
 {
-    static uint32_t ghstLastCycleTime;
+    static timeUs_t ghstLastCycleTime;
 
     if (!ghstTelemetryEnabled) {
         return;


### PR DESCRIPTION
Fixes #6457

After overflow, telemetry was generated every 2ms instead of 100ms. That was slowly clogging serial port so failsafe was triggered.

@tonycake you might be interested in this one