### PR TITLE
Option for local plus codes on osd

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -385,7 +385,7 @@
 | osd_main_voltage_decimals | 1 | Number of decimals for the battery voltages displayed in the OSD [1-2]. |
 | osd_neg_alt_alarm | 5 | Value below which (negative altitude) to make the OSD relative altitude indicator blink (meters) |
 | osd_plus_code_digits |  |  |
-| osd_plus_code_type | GLOBAL | Select plus code type, `LOCAL` removes first four digits and needs a reference location within ~40 km to recover the original coordinates. |
+| osd_plus_code_type | GLOBAL | Select plus code type. Each consecutive setting (`COUNTRY`, `LOCAL`, `FIELD`) removes two extra digits from the beginning of the plus code. This requires a reference location within respectively ~800km, ~40 km and ~2km to recover the original coordinates. |
 | osd_right_sidebar_scroll |  |  |
 | osd_right_sidebar_scroll_step | 0 | Same as left_sidebar_scroll_step, but for the right sidebar |
 | osd_row_shiftdown | 0 | Number of rows to shift the OSD display (increase if top rows are cut off) |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -384,8 +384,8 @@
 | osd_link_quality_alarm | 70 | LQ % indicator blinks below this value. For Crossfire use 70%, for Tracer use 50% |
 | osd_main_voltage_decimals | 1 | Number of decimals for the battery voltages displayed in the OSD [1-2]. |
 | osd_neg_alt_alarm | 5 | Value below which (negative altitude) to make the OSD relative altitude indicator blink (meters) |
-| osd_plus_code_digits |  |  |
-| osd_plus_code_format | GLOBAL | Select plus code format. Each consecutive setting (`COUNTRY`, `LOCAL`, `FIELD`) removes two extra digits from the beginning of the plus code. This requires a reference location within respectively ~800km, ~40 km and ~2km to recover the original coordinates. |
+| osd_plus_code_digits | 10 | Numer of plus code digits before shortening with `osd_plus_code_short`. Precision at the equator: 10=13.9x13.9m; 11=2.8x3.5m; 12=56x87cm; 13=11x22cm. |
+| osd_plus_code_short | 0 | Number of leading digits removed from plus code. Removing 2, 4 and 6 digits requires a reference location within, respectively, ~800km, ~40 km and ~2km to recover the original coordinates. |
 | osd_right_sidebar_scroll |  |  |
 | osd_right_sidebar_scroll_step | 0 | Same as left_sidebar_scroll_step, but for the right sidebar |
 | osd_row_shiftdown | 0 | Number of rows to shift the OSD display (increase if top rows are cut off) |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -385,7 +385,7 @@
 | osd_main_voltage_decimals | 1 | Number of decimals for the battery voltages displayed in the OSD [1-2]. |
 | osd_neg_alt_alarm | 5 | Value below which (negative altitude) to make the OSD relative altitude indicator blink (meters) |
 | osd_plus_code_digits |  |  |
-| osd_plus_code_type | GLOBAL | Select plus code type. Each consecutive setting (`COUNTRY`, `LOCAL`, `FIELD`) removes two extra digits from the beginning of the plus code. This requires a reference location within respectively ~800km, ~40 km and ~2km to recover the original coordinates. |
+| osd_plus_code_format | GLOBAL | Select plus code format. Each consecutive setting (`COUNTRY`, `LOCAL`, `FIELD`) removes two extra digits from the beginning of the plus code. This requires a reference location within respectively ~800km, ~40 km and ~2km to recover the original coordinates. |
 | osd_right_sidebar_scroll |  |  |
 | osd_right_sidebar_scroll_step | 0 | Same as left_sidebar_scroll_step, but for the right sidebar |
 | osd_row_shiftdown | 0 | Number of rows to shift the OSD display (increase if top rows are cut off) |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -385,6 +385,7 @@
 | osd_main_voltage_decimals | 1 | Number of decimals for the battery voltages displayed in the OSD [1-2]. |
 | osd_neg_alt_alarm | 5 | Value below which (negative altitude) to make the OSD relative altitude indicator blink (meters) |
 | osd_plus_code_digits |  |  |
+| osd_plus_code_type | GLOBAL | Select plus code type, `LOCAL` removes first four digits and needs a reference location within ~40 km to recover the original coordinates. |
 | osd_right_sidebar_scroll |  |  |
 | osd_right_sidebar_scroll_step | 0 | Same as left_sidebar_scroll_step, but for the right sidebar |
 | osd_row_shiftdown | 0 | Number of rows to shift the OSD display (increase if top rows are cut off) |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -155,6 +155,9 @@ tables:
   - name: nav_overrides_motor_stop
     enum: navOverridesMotorStop_e
     values: ["OFF_ALWAYS", "OFF", "AUTO_ONLY", "ALL_NAV"]
+  - name: osd_plus_code_type
+    enum: osd_plus_code_type_e
+    values: ["GLOBAL", "LOCAL"]
 
 groups:
   - name: PG_GYRO_CONFIG
@@ -2913,6 +2916,12 @@ groups:
         field: plus_code_digits
         min: 10
         max: 13
+      - name: osd_plus_code_type
+        description: "Select plus code type, `LOCAL` removes first four digits and needs a reference location within ~40 km to recover the original coordinates."
+        field: plus_code_type
+        default_value: "GLOBAL"
+        table: osd_plus_code_type
+        type: uint8_t
 
       - name: osd_ahi_style
         description: "Sets OSD Artificial Horizon style \"DEFAULT\" or \"LINE\" for the FrSky Graphical OSD."

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -156,7 +156,6 @@ tables:
     enum: navOverridesMotorStop_e
     values: ["OFF_ALWAYS", "OFF", "AUTO_ONLY", "ALL_NAV"]
   - name: osd_plus_code_short
-    # enum: osd_plus_code_short_e
     values: ["0", "2", "4", "6"]
 
 groups:

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -155,9 +155,9 @@ tables:
   - name: nav_overrides_motor_stop
     enum: navOverridesMotorStop_e
     values: ["OFF_ALWAYS", "OFF", "AUTO_ONLY", "ALL_NAV"]
-  - name: osd_plus_code_format
-    enum: osd_plus_code_format_e
-    values: ["GLOBAL", "COUNTRY", "LOCAL", "FIELD"]
+  - name: osd_plus_code_short
+    # enum: osd_plus_code_short_e
+    values: ["0", "2", "4", "6"]
 
 groups:
   - name: PG_GYRO_CONFIG
@@ -2913,14 +2913,16 @@ groups:
         type: bool
 
       - name: osd_plus_code_digits
+        description: "Numer of plus code digits before shortening with `osd_plus_code_short`. Precision at the equator: 10=13.9x13.9m; 11=2.8x3.5m; 12=56x87cm; 13=11x22cm."
         field: plus_code_digits
+        default_value: 10
         min: 10
         max: 13
-      - name: osd_plus_code_format
-        description: "Select plus code format. Each consecutive setting (`COUNTRY`, `LOCAL`, `FIELD`) removes two extra digits from the beginning of the plus code. This requires a reference location within respectively ~800km, ~40 km and ~2km to recover the original coordinates."
-        field: plus_code_format
-        default_value: "GLOBAL"
-        table: osd_plus_code_format
+      - name: osd_plus_code_short
+        description: "Number of leading digits removed from plus code. Removing 2, 4 and 6 digits requires a reference location within, respectively, ~800km, ~40 km and ~2km to recover the original coordinates."
+        field: plus_code_short
+        default_value: "0"
+        table: osd_plus_code_short
         type: uint8_t
 
       - name: osd_ahi_style

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -155,8 +155,8 @@ tables:
   - name: nav_overrides_motor_stop
     enum: navOverridesMotorStop_e
     values: ["OFF_ALWAYS", "OFF", "AUTO_ONLY", "ALL_NAV"]
-  - name: osd_plus_code_type
-    enum: osd_plus_code_type_e
+  - name: osd_plus_code_format
+    enum: osd_plus_code_format_e
     values: ["GLOBAL", "COUNTRY", "LOCAL", "FIELD"]
 
 groups:
@@ -2916,11 +2916,11 @@ groups:
         field: plus_code_digits
         min: 10
         max: 13
-      - name: osd_plus_code_type
-        description: "Select plus code type. Each consecutive setting (`COUNTRY`, `LOCAL`, `FIELD`) removes two extra digits from the beginning of the plus code. This requires a reference location within respectively ~800km, ~40 km and ~2km to recover the original coordinates."
-        field: plus_code_type
+      - name: osd_plus_code_format
+        description: "Select plus code format. Each consecutive setting (`COUNTRY`, `LOCAL`, `FIELD`) removes two extra digits from the beginning of the plus code. This requires a reference location within respectively ~800km, ~40 km and ~2km to recover the original coordinates."
+        field: plus_code_format
         default_value: "GLOBAL"
-        table: osd_plus_code_type
+        table: osd_plus_code_format
         type: uint8_t
 
       - name: osd_ahi_style

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -157,7 +157,7 @@ tables:
     values: ["OFF_ALWAYS", "OFF", "AUTO_ONLY", "ALL_NAV"]
   - name: osd_plus_code_type
     enum: osd_plus_code_type_e
-    values: ["GLOBAL", "LOCAL"]
+    values: ["GLOBAL", "COUNTRY", "LOCAL", "FIELD"]
 
 groups:
   - name: PG_GYRO_CONFIG
@@ -2917,7 +2917,7 @@ groups:
         min: 10
         max: 13
       - name: osd_plus_code_type
-        description: "Select plus code type, `LOCAL` removes first four digits and needs a reference location within ~40 km to recover the original coordinates."
+        description: "Select plus code type. Each consecutive setting (`COUNTRY`, `LOCAL`, `FIELD`) removes two extra digits from the beginning of the plus code. This requires a reference location within respectively ~800km, ~40 km and ~2km to recover the original coordinates."
         field: plus_code_type
         default_value: "GLOBAL"
         table: osd_plus_code_type

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2275,6 +2275,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             STATIC_ASSERT(GPS_DEGREES_DIVIDER == OLC_DEG_MULTIPLIER, invalid_olc_deg_multiplier);
             int digits = osdConfig()->plus_code_digits;
+            int digitsRemoved = osdConfig()->plus_code_type * 2;
             if (STATE(GPS_FIX)) {
                 olc_encode(gpsSol.llh.lat, gpsSol.llh.lon, digits, buff, sizeof(buff));
             } else {
@@ -2284,11 +2285,9 @@ static bool osdDrawSingleElement(uint8_t item)
                 buff[8] = '+';
                 buff[digits + 1] = '\0';
             }
-            if (osdConfig()->plus_code_type == OSD_PLUS_CODE_LOCAL) {
-                // Use local code (see https://github.com/google/open-location-code/wiki/Guidance-for-shortening-codes)
-                memmove(buff, buff+4, strlen(buff)+4);
-                buff[digits + 1 - 4] = '\0';
-            }
+            // Optionally trim digits from the left
+            memmove(buff, buff+digitsRemoved, strlen(buff) + digitsRemoved);
+            buff[digits + 1 - digitsRemoved] = '\0';
             break;
         }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2277,6 +2277,7 @@ static bool osdDrawSingleElement(uint8_t item)
             int digits = osdConfig()->plus_code_digits;
             if (STATE(GPS_FIX)) {
                 olc_encode(gpsSol.llh.lat, gpsSol.llh.lon, digits, buff, sizeof(buff));
+                buff[0] = buff[1] = buff[2] = buff[3] = ' ';
             } else {
                 // +codes with > 8 digits have a + at the 9th digit
                 // and we only support 10 and up.

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2282,6 +2282,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 // +codes with > 8 digits have a + at the 9th digit
                 // and we only support 10 and up.
                 memset(buff, '-', digits + 1);
+                buff[0] = buff[1] = buff[2] = buff[3] = ' ';
                 buff[8] = '+';
                 buff[digits + 1] = '\0';
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -185,7 +185,7 @@ static bool osdDisplayHasCanvas;
 
 #define AH_MAX_PITCH_DEFAULT 20 // Specify default maximum AHI pitch value displayed (degrees)
 
-PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 13);
+PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 14);
 PG_REGISTER_WITH_RESET_FN(osdLayoutsConfig_t, osdLayoutsConfig, PG_OSD_LAYOUTS_CONFIG, 0);
 
 static int digitCount(int32_t value)

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2275,7 +2275,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             STATIC_ASSERT(GPS_DEGREES_DIVIDER == OLC_DEG_MULTIPLIER, invalid_olc_deg_multiplier);
             int digits = osdConfig()->plus_code_digits;
-            int digitsRemoved = osdConfig()->plus_code_type * 2;
+            int digitsRemoved = osdConfig()->plus_code_format * 2;
             if (STATE(GPS_FIX)) {
                 olc_encode(gpsSol.llh.lat, gpsSol.llh.lon, digits, buff, sizeof(buff));
             } else {
@@ -2595,7 +2595,7 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .osd_failsafe_switch_layout = false,
 
     .plus_code_digits = 11,
-    .plus_code_type = OSD_PLUS_CODE_GLOBAL,
+    .plus_code_format = OSD_PLUS_CODE_GLOBAL,
 
     .ahi_width = OSD_AHI_WIDTH * OSD_CHAR_WIDTH,
     .ahi_height = OSD_AHI_HEIGHT * OSD_CHAR_HEIGHT,

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2275,7 +2275,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             STATIC_ASSERT(GPS_DEGREES_DIVIDER == OLC_DEG_MULTIPLIER, invalid_olc_deg_multiplier);
             int digits = osdConfig()->plus_code_digits;
-            int digitsRemoved = osdConfig()->plus_code_format * 2;
+            int digitsRemoved = osdConfig()->plus_code_short * 2;
             if (STATE(GPS_FIX)) {
                 olc_encode(gpsSol.llh.lat, gpsSol.llh.lon, digits, buff, sizeof(buff));
             } else {
@@ -2595,7 +2595,7 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .osd_failsafe_switch_layout = false,
 
     .plus_code_digits = 11,
-    .plus_code_format = OSD_PLUS_CODE_GLOBAL,
+    .plus_code_short = 0,
 
     .ahi_width = OSD_AHI_WIDTH * OSD_CHAR_WIDTH,
     .ahi_height = OSD_AHI_HEIGHT * OSD_CHAR_HEIGHT,

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2277,15 +2277,16 @@ static bool osdDrawSingleElement(uint8_t item)
             int digits = osdConfig()->plus_code_digits;
             if (STATE(GPS_FIX)) {
                 olc_encode(gpsSol.llh.lat, gpsSol.llh.lon, digits, buff, sizeof(buff));
-                buff[0] = buff[1] = buff[2] = buff[3] = ' ';
             } else {
                 // +codes with > 8 digits have a + at the 9th digit
                 // and we only support 10 and up.
                 memset(buff, '-', digits + 1);
-                buff[0] = buff[1] = buff[2] = buff[3] = ' ';
                 buff[8] = '+';
                 buff[digits + 1] = '\0';
             }
+            // Use local code
+            memmove(buff, buff+4, strlen(buff)+4);
+            buff[digits + 1 - 4] = '\0';
             break;
         }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2284,9 +2284,11 @@ static bool osdDrawSingleElement(uint8_t item)
                 buff[8] = '+';
                 buff[digits + 1] = '\0';
             }
-            // Use local code
-            memmove(buff, buff+4, strlen(buff)+4);
-            buff[digits + 1 - 4] = '\0';
+            if (osdConfig()->plus_code_type == OSD_PLUS_CODE_LOCAL) {
+                // Use local code (see https://github.com/google/open-location-code/wiki/Guidance-for-shortening-codes)
+                memmove(buff, buff+4, strlen(buff)+4);
+                buff[digits + 1 - 4] = '\0';
+            }
             break;
         }
 
@@ -2594,6 +2596,7 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .osd_failsafe_switch_layout = false,
 
     .plus_code_digits = 11,
+    .plus_code_type = OSD_PLUS_CODE_GLOBAL,
 
     .ahi_width = OSD_AHI_WIDTH * OSD_CHAR_WIDTH,
     .ahi_height = OSD_AHI_HEIGHT * OSD_CHAR_HEIGHT,

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -273,7 +273,7 @@ typedef enum {
     OSD_PLUS_CODE_COUNTRY,
     OSD_PLUS_CODE_LOCAL,
     OSD_PLUS_CODE_FIELD,
-} osd_plus_code_type_e;
+} osd_plus_code_format_e;
 
 typedef struct osdLayoutsConfig_s {
     // Layouts
@@ -343,7 +343,7 @@ typedef struct osdConfig_s {
 
     bool osd_failsafe_switch_layout;
     uint8_t plus_code_digits; // Number of digits to use in OSD_PLUS_CODE
-    uint8_t plus_code_type; 
+    uint8_t plus_code_format; 
     uint8_t osd_ahi_style;
     uint8_t force_grid;                 // Force a pixel based OSD to use grid mode.
     uint8_t ahi_bordered;               // Only used by the AHI widget

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -268,6 +268,11 @@ typedef enum {
     OSD_CRSF_LQ_TYPE2,
 } osd_crsf_lq_format_e;
 
+typedef enum {
+    OSD_PLUS_CODE_GLOBAL,
+    OSD_PLUS_CODE_LOCAL,
+} osd_plus_code_type_e;
+
 typedef struct osdLayoutsConfig_s {
     // Layouts
     uint16_t item_pos[OSD_LAYOUT_COUNT][OSD_ITEM_COUNT];
@@ -336,6 +341,7 @@ typedef struct osdConfig_s {
 
     bool osd_failsafe_switch_layout;
     uint8_t plus_code_digits; // Number of digits to use in OSD_PLUS_CODE
+    uint8_t plus_code_type; 
     uint8_t osd_ahi_style;
     uint8_t force_grid;                 // Force a pixel based OSD to use grid mode.
     uint8_t ahi_bordered;               // Only used by the AHI widget

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -270,7 +270,9 @@ typedef enum {
 
 typedef enum {
     OSD_PLUS_CODE_GLOBAL,
+    OSD_PLUS_CODE_COUNTRY,
     OSD_PLUS_CODE_LOCAL,
+    OSD_PLUS_CODE_FIELD,
 } osd_plus_code_type_e;
 
 typedef struct osdLayoutsConfig_s {

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -268,13 +268,6 @@ typedef enum {
     OSD_CRSF_LQ_TYPE2,
 } osd_crsf_lq_format_e;
 
-typedef enum {
-    OSD_PLUS_CODE_GLOBAL,
-    OSD_PLUS_CODE_COUNTRY,
-    OSD_PLUS_CODE_LOCAL,
-    OSD_PLUS_CODE_FIELD,
-} osd_plus_code_format_e;
-
 typedef struct osdLayoutsConfig_s {
     // Layouts
     uint16_t item_pos[OSD_LAYOUT_COUNT][OSD_ITEM_COUNT];
@@ -343,7 +336,7 @@ typedef struct osdConfig_s {
 
     bool osd_failsafe_switch_layout;
     uint8_t plus_code_digits; // Number of digits to use in OSD_PLUS_CODE
-    uint8_t plus_code_format; 
+    uint8_t plus_code_short; 
     uint8_t osd_ahi_style;
     uint8_t force_grid;                 // Force a pixel based OSD to use grid mode.
     uint8_t ahi_bordered;               // Only used by the AHI widget


### PR DESCRIPTION
This PR resolves #5114 by implementing a CLI command `osd_plus_code_type` with options `GLOBAL` (the default) and `LOCAL`, where `LOCAL` chops off the first four digits of the plus code. To find the original location you'll need a reference point like a nearby city or mountain within 0.4 degrees longitude and 0.4 latitude, roughly 40 km.

~~The configurator does not yet understand this option so it doesn't allow placing the shorter plus code against the right edge of the screen. To position the osd element like in this screengrab you need to use CLI command `osd_layout 0 97 21 12 V`.~~ Configurator side: iNavFlight/inav-configurator#1150.

![2021-01-03 11_41_35-PICT0010 AVI - VLC Media Player](https://user-images.githubusercontent.com/880421/103476932-18c8ca00-4dba-11eb-9db2-b3810edcb728.png)


