### PR TITLE
Do not show efficiency on osd when ground speed is below 1 m/s

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2928,7 +2928,7 @@ static void osdShowStats(void)
     if (osdDisplayIsPAL())
         displayWrite(osdDisplayPort, statNameX, top++, "  --- STATS ---");
 
-    if (STATE(GPS_FIX)) {
+    if (feature(FEATURE_GPS)) {
         displayWrite(osdDisplayPort, statNameX, top, "MAX SPEED        :");
         osdFormatVelocityStr(buff, stats.max_speed, true);
         osdLeftAlignString(buff);
@@ -2980,7 +2980,7 @@ static void osdShowStats(void)
         displayWrite(osdDisplayPort, statValuesX, top++, buff);
 
         int32_t totalDistance = getTotalTravelDistance();
-        if (STATE(GPS_FIX)) {
+        if (feature(FEATURE_GPS)) {
             displayWrite(osdDisplayPort, statNameX, top, "AVG EFFICIENCY   :");
             if (osdConfig()->stats_energy_unit == OSD_STATS_ENERGY_UNIT_MAH)
                 tfp_sprintf(buff, "%d%c%c", (int)(getMAhDrawn() * 100000 / totalDistance),

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2980,7 +2980,7 @@ static void osdShowStats(void)
         displayWrite(osdDisplayPort, statValuesX, top++, buff);
 
         int32_t totalDistance = getTotalTravelDistance();
-        if (totalDistance > 0) {
+        if (totalDistance > 10000) {
             displayWrite(osdDisplayPort, statNameX, top, "AVG EFFICIENCY   :");
             if (osdConfig()->stats_energy_unit == OSD_STATS_ENERGY_UNIT_MAH)
                 tfp_sprintf(buff, "%d%c%c", (int)(getMAhDrawn() * 100000 / totalDistance),

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2102,7 +2102,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             // amperage is in centi amps, speed is in cms/s. We want
             // mah/km. Values over 999 are considered useless and
-            // displayed as "---""
+            // displayed as "---". Only shows if ground speed > 1m/s.
             static pt1Filter_t eFilterState;
             static timeUs_t efficiencyUpdated = 0;
             int32_t value = 0;
@@ -2118,7 +2118,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     value = eFilterState.state;
                 }
             }
-            if (value > 0 && value <= 999) {
+            if (value > 0 && value <= 999 && gpsSol.groundSpeed > 100) {
                 tfp_sprintf(buff, "%3d", (int)value);
             } else {
                 buff[0] = buff[1] = buff[2] = '-';
@@ -2133,7 +2133,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             // amperage is in centi amps, speed is in cms/s. We want
             // mWh/km. Values over 999Wh/km are considered useless and
-            // displayed as "---""
+            // displayed as "---". Only shows if ground speed > 1m/s.
             static pt1Filter_t eFilterState;
             static timeUs_t efficiencyUpdated = 0;
             int32_t value = 0;
@@ -2149,7 +2149,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     value = eFilterState.state;
                 }
             }
-            if (value > 0 && value <= 999999) {
+            if (value > 0 && value <= 999999 && gpsSol.groundSpeed > 100) {
                 osdFormatCentiNumber(buff, value / 10, 0, 2, 0, 3);
             } else {
                 buff[0] = buff[1] = buff[2] = '-';

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2101,8 +2101,7 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_EFFICIENCY_MAH_PER_KM:
         {
             // amperage is in centi amps, speed is in cms/s. We want
-            // mah/km. Values over 999 are considered useless and
-            // displayed as "---". Only shows if ground speed > 1m/s.
+            // mah/km. Only show when ground speed > 1m/s.
             static pt1Filter_t eFilterState;
             static timeUs_t efficiencyUpdated = 0;
             int32_t value = 0;
@@ -2118,7 +2117,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     value = eFilterState.state;
                 }
             }
-            if (value > 0 && value <= 999 && gpsSol.groundSpeed > 100) {
+            if (value > 0 && gpsSol.groundSpeed > 100) {
                 tfp_sprintf(buff, "%3d", (int)value);
             } else {
                 buff[0] = buff[1] = buff[2] = '-';
@@ -2132,8 +2131,7 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_EFFICIENCY_WH_PER_KM:
         {
             // amperage is in centi amps, speed is in cms/s. We want
-            // mWh/km. Values over 999Wh/km are considered useless and
-            // displayed as "---". Only shows if ground speed > 1m/s.
+            // mWh/km. Only show when ground speed > 1m/s.
             static pt1Filter_t eFilterState;
             static timeUs_t efficiencyUpdated = 0;
             int32_t value = 0;
@@ -2149,7 +2147,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     value = eFilterState.state;
                 }
             }
-            if (value > 0 && value <= 999999 && gpsSol.groundSpeed > 100) {
+            if (value > 0 && gpsSol.groundSpeed > 100) {
                 osdFormatCentiNumber(buff, value / 10, 0, 2, 0, 3);
             } else {
                 buff[0] = buff[1] = buff[2] = '-';

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2980,7 +2980,7 @@ static void osdShowStats(void)
         displayWrite(osdDisplayPort, statValuesX, top++, buff);
 
         int32_t totalDistance = getTotalTravelDistance();
-        if (totalDistance > 10000) {
+        if (STATE(GPS_FIX)) {
             displayWrite(osdDisplayPort, statNameX, top, "AVG EFFICIENCY   :");
             if (osdConfig()->stats_energy_unit == OSD_STATS_ENERGY_UNIT_MAH)
                 tfp_sprintf(buff, "%d%c%c", (int)(getMAhDrawn() * 100000 / totalDistance),
@@ -2990,6 +2990,19 @@ static void osdShowStats(void)
                 buff[3] = SYM_WH_KM_0;
                 buff[4] = SYM_WH_KM_1;
                 buff[5] = '\0';
+            }
+            // If traveled distance is less than 100 meters efficiency numbers are useless and unreliable so display --- instead
+            if (totalDistance < 10000) {
+                buff[0] = buff[1] = buff[2] = '-';
+                if (osdConfig()->stats_energy_unit == OSD_STATS_ENERGY_UNIT_MAH){
+                    buff[3] = SYM_MAH_KM_0;
+                    buff[4] = SYM_MAH_KM_1;
+                    buff[5] = '\0';
+                } else {
+                    buff[3] = SYM_WH_KM_0;
+                    buff[4] = SYM_WH_KM_1;
+                    buff[5] = '\0';
+                }
             }
             displayWrite(osdDisplayPort, statValuesX, top++, buff);
         }


### PR DESCRIPTION
Fixes #6467. I replaced the sanity checks for a reasonable efficiency (<999mAh/km and <999Wh/km) by an explicit check for a ground speed above 1m/s.