### PR TITLE
Option to remove home position from arming screen

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -367,6 +367,7 @@
 | osd_gforce_alarm | 5 | Value above which the OSD g force indicator will blink (g) |
 | osd_gforce_axis_alarm_max | 5 | Value above which the OSD axis g force indicators will blink (g) |
 | osd_gforce_axis_alarm_min | -5 | Value under which the OSD axis g force indicators will blink (g) |
+| osd_home_position_arm_screen | ON | Should home position coordinates be displayed on the arming screen. |
 | osd_horizon_offset | 0 | To vertically adjust the whole OSD and AHI and scrolling bars |
 | osd_hud_homepoint | 0 | To 3D-display the home point location in the hud |
 | osd_hud_homing | 0 | To display little arrows around the crossair showing where the home point is in the hud |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2969,6 +2969,10 @@ groups:
         default_value: 0
         description: Same as left_sidebar_scroll_step, but for the right sidebar
 
+      - name: osd_home_position_arm_screen
+        type: bool
+        default_value: "ON"
+        description: Should home position coordinates be displayed on the arming screen.
 
   - name: PG_SYSTEM_CONFIG
     type: systemConfig_t

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -185,7 +185,7 @@ static bool osdDisplayHasCanvas;
 
 #define AH_MAX_PITCH_DEFAULT 20 // Specify default maximum AHI pitch value displayed (degrees)
 
-PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 13);
+PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 14);
 PG_REGISTER_WITH_RESET_FN(osdLayoutsConfig_t, osdLayoutsConfig, PG_OSD_LAYOUTS_CONFIG, 0);
 
 static int digitCount(int32_t value)

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2581,6 +2581,7 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .left_sidebar_scroll = OSD_SIDEBAR_SCROLL_NONE,
     .right_sidebar_scroll = OSD_SIDEBAR_SCROLL_NONE,
     .sidebar_scroll_arrows = 0,
+    .osd_home_position_arm_screen = true,
 
     .units = OSD_UNIT_METRIC,
     .main_voltage_decimals = 1,
@@ -3048,13 +3049,15 @@ static void osdShowArmed(void)
 #if defined(USE_GPS)
     if (feature(FEATURE_GPS)) {
         if (STATE(GPS_FIX_HOME)) {
-            osdFormatCoordinate(buf, SYM_LAT, GPS_home.lat);
-            displayWrite(osdDisplayPort, (osdDisplayPort->cols - strlen(buf)) / 2, y, buf);
-            osdFormatCoordinate(buf, SYM_LON, GPS_home.lon);
-            displayWrite(osdDisplayPort, (osdDisplayPort->cols - strlen(buf)) / 2, y + 1, buf);
-            int digits = osdConfig()->plus_code_digits;
-            olc_encode(GPS_home.lat, GPS_home.lon, digits, buf, sizeof(buf));
-            displayWrite(osdDisplayPort, (osdDisplayPort->cols - strlen(buf)) / 2, y + 2, buf);
+            if (osdConfig()->osd_home_position_arm_screen){
+                osdFormatCoordinate(buf, SYM_LAT, GPS_home.lat);
+                displayWrite(osdDisplayPort, (osdDisplayPort->cols - strlen(buf)) / 2, y, buf);
+                osdFormatCoordinate(buf, SYM_LON, GPS_home.lon);
+                displayWrite(osdDisplayPort, (osdDisplayPort->cols - strlen(buf)) / 2, y + 1, buf);
+                int digits = osdConfig()->plus_code_digits;
+                olc_encode(GPS_home.lat, GPS_home.lon, digits, buf, sizeof(buf));
+                displayWrite(osdDisplayPort, (osdDisplayPort->cols - strlen(buf)) / 2, y + 2, buf);
+            }
             y += 4;
 #if defined (USE_SAFE_HOME)
             if (isSafeHomeInUse()) {

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -345,6 +345,7 @@ typedef struct osdConfig_s {
     int8_t sidebar_horizontal_offset;   // Horizontal offset from default position. Units are grid slots for grid OSDs, pixels for pixel based OSDs. Positive values move sidebars closer to the edges.
     uint8_t left_sidebar_scroll_step;   // How many units each sidebar step represents. 0 means the default value for the scroll type.
     uint8_t right_sidebar_scroll_step;  // Same as left_sidebar_scroll_step, but for the right sidebar.
+    bool osd_home_position_arm_screen;
 
     uint8_t crsf_lq_format;
 


### PR DESCRIPTION
Some pilots for whatever reason do not want to publish their flying location when sharing dvr footage. This PR creates an option to remove the coordinates and plus code from the arming screen.

`osd_home_position_arm_screen = ON` (the default):
![2021-01-05 19_09_34-VLC (Direct3D11 output)](https://user-images.githubusercontent.com/880421/103694836-e8408600-4f9b-11eb-87d1-55705e324c25.png)

`osd_home_position_arm_screen = OFF`:
![2021-01-05 19_07_53-VLC (Direct3D11 output)](https://user-images.githubusercontent.com/880421/103694891-f9899280-4f9b-11eb-8ccb-50859a11468a.png)
