### PR TITLE
OSD improvements when gps fix is lost

### DIFF
--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -132,6 +132,7 @@ typedef enum {
     SET_REVERSIBLE_MOTORS_FORWARD       = (1 << 23),
     FW_HEADING_USE_YAW                  = (1 << 24),
     ANTI_WINDUP_DEACTIVATED             = (1 << 25),
+    GPS_FIX_LOST                        = (1 << 26)
 } stateFlags_t;
 
 #define DISABLE_STATE(mask) (stateFlags &= ~(mask))

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -168,6 +168,9 @@ void gpsProcessNewSolutionData(void)
         DISABLE_STATE(GPS_FIX);
     }
 
+    // Check if fix was lost
+    isGPSFixLost();
+
     // Set sensor as ready and available
     sensorsSet(SENSOR_GPS);
 
@@ -485,6 +488,20 @@ bool isGPSHealthy(void)
 bool isGPSHeadingValid(void)
 {
     return sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= 6 && gpsSol.groundSpeed >= 300;
+}
+
+void isGPSFixLost(void)
+{
+    static bool gpsFixEver = false;
+    if (STATE(GPS_FIX)){
+        gpsFixEver = true;
+    }
+
+    if (!STATE(GPS_FIX) && gpsFixEver) {
+        ENABLE_STATE(GPS_FIX_LOST);
+    } else {
+        DISABLE_STATE(GPS_FIX_LOST);
+    }
 }
 
 #endif

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -169,7 +169,11 @@ void gpsProcessNewSolutionData(void)
     }
 
     // Check if fix was lost
-    isGPSFixLost();
+    if (isGPSFixLost()) {
+        ENABLE_STATE(GPS_FIX_LOST);
+    } else {
+        DISABLE_STATE(GPS_FIX_LOST);
+    }
 
     // Set sensor as ready and available
     sensorsSet(SENSOR_GPS);
@@ -490,7 +494,7 @@ bool isGPSHeadingValid(void)
     return sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= 6 && gpsSol.groundSpeed >= 300;
 }
 
-void isGPSFixLost(void)
+bool isGPSFixLost(void)
 {
     static bool gpsFixEver = false;
     if (STATE(GPS_FIX)){
@@ -498,9 +502,9 @@ void isGPSFixLost(void)
     }
 
     if (!STATE(GPS_FIX) && gpsFixEver) {
-        ENABLE_STATE(GPS_FIX_LOST);
+        return true;
     } else {
-        DISABLE_STATE(GPS_FIX_LOST);
+        return false;
     }
 }
 

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -163,6 +163,7 @@ bool gpsUpdate(void);
 void updateGpsIndicator(timeUs_t currentTimeUs);
 bool isGPSHealthy(void);
 bool isGPSHeadingValid(void);
+bool isGPSFixLost(void);
 struct serialPort_s;
 void gpsEnablePassthrough(struct serialPort_s *gpsPassthroughPort);
 void mspGPSReceiveNewData(const uint8_t * bufferPtr);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1322,12 +1322,40 @@ static bool osdDrawSingleElement(uint8_t item)
         }
 
     case OSD_GPS_LAT:
-        osdFormatCoordinate(buff, SYM_LAT, gpsSol.llh.lat);
-        break;
+        {
+            int digits = osdConfig()->coordinate_digits;
+            static int32_t previousLat;
+            if (STATE(GPS_FIX)) {
+                osdFormatCoordinate(buff, SYM_LAT, gpsSol.llh.lat);
+                previousLat = gpsSol.llh.lat;
+            } else if (STATE(GPS_FIX_LOST)){
+                osdFormatCoordinate(buff, SYM_LAT, previousLat);
+                TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
+            } else {
+                memset(buff, '-', digits+1);
+                buff[0] = SYM_LAT;
+                buff[digits+1] = '\0';
+            }
+            break;
+        }
 
     case OSD_GPS_LON:
-        osdFormatCoordinate(buff, SYM_LON, gpsSol.llh.lon);
-        break;
+        {
+            int digits = osdConfig()->coordinate_digits;
+            static int32_t previousLon;
+            if (STATE(GPS_FIX)) {
+                osdFormatCoordinate(buff, SYM_LON, gpsSol.llh.lon);
+                previousLon = gpsSol.llh.lon;
+            } else if (STATE(GPS_FIX_LOST)){
+                osdFormatCoordinate(buff, SYM_LON, previousLon);
+                TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
+            } else {
+                memset(buff, '-', digits+1);
+                buff[0] = SYM_LON;
+                buff[digits+1] = '\0';
+            }
+            break;
+        }
 
     case OSD_HOME_DIR:
         {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1312,12 +1312,20 @@ static bool osdDrawSingleElement(uint8_t item)
         break;
 
     case OSD_GPS_SPEED:
-        osdFormatVelocityStr(buff, gpsSol.groundSpeed, false);
-        break;
+        {
+            osdFormatVelocityStr(buff, gpsSol.groundSpeed, false);
+            if (!STATE(GPS_FIX)) {
+                buff[0] = buff[1] = buff[2]= '-';
+            }
+            break;
+        }
 
     case OSD_3D_SPEED:
         {
             osdFormatVelocityStr(buff, osdGet3DSpeed(), true);
+            if (!STATE(GPS_FIX)) {
+                buff[0] = buff[1] = buff[2]= '-';
+            }
             break;
         }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2303,8 +2303,15 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             STATIC_ASSERT(GPS_DEGREES_DIVIDER == OLC_DEG_MULTIPLIER, invalid_olc_deg_multiplier);
             int digits = osdConfig()->plus_code_digits;
+            static int32_t previousLat;
+            static int32_t previousLon;
             if (STATE(GPS_FIX)) {
                 olc_encode(gpsSol.llh.lat, gpsSol.llh.lon, digits, buff, sizeof(buff));
+                previousLat = gpsSol.llh.lat;
+                previousLon = gpsSol.llh.lon;
+            } else if (STATE(GPS_FIX_LOST)) {
+                olc_encode(previousLat, previousLon, digits, buff, sizeof(buff));
+                TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
             } else {
                 // +codes with > 8 digits have a + at the 9th digit
                 // and we only support 10 and up.


### PR DESCRIPTION
As reported in #6466, there are some inconsistencies and strange behavior in the osd when the number of locked satellites falls below `gps_min_sats`, or when the fix is lost completely. This PR addresses some these issues. Since `STATE(GPS_FIX)` is already used for arming safety, and the gps position generally becomes very unreliable when this state flag is false, I thought it best to use this flag to determine the osd elements' display.

Changes: 
- Lat/lon coordinates and the plus code now all display dashes until a fix is acquired. When a fix is acquired and subsequently lost, the last know value is shown blinking to attend the user to the fact the coordinates are no longer being updated.
- GPS and 3D speed are replaced with dashes when there is no fix. I considered also making these elements blink when a fix is lost, but I think this is too much blinking. 

Still to do and/or to discuss:
- I was planning on also making the home and trip distance blink on gps loss, but there is already a alarm for home distance so this would be a bit confusing.
- @skorokithakis asked to do something for when there is a gps hardware failure in flight. I tried to change the logic for `STATE(GPS_FIX)` to include the check `getHwGPSStatus() == HW_SENSOR_UNAVAILABLE || getHwGPSStatus() == HW_SENSOR_UNHEALTHY` from #6479 or `HW_SENSOR_IS_HEALTHY(getHwGPSStatus())` but this didn't work. I think the problem is with `getHwGPSStatus()` which calls `isGPSHealthy()`, but this function is always true. Not sure what the idea behind this is. https://github.com/iNavFlight/inav/blob/e14e172f5df8e2af00b737002719e5956602f47c/src/main/io/gps.c#L160-L162
- In general I think it would make sense to treat a gps failure the same as a "normal" loss of fix, perhaps apart from the GPS sats osd element itself and a system message.
- So far, this only affects the way information is displayed on the osd, not how it it transmitted as telemetry or is logged to the blackbox.