### PR TITLE
ZEEZF7 Add VTX power on/off via PINIO on pin PB11

### DIFF
--- a/src/main/target/ZEEZF7/config.c
+++ b/src/main/target/ZEEZF7/config.c
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "fc/fc_msp_box.h"
+
+#include "io/piniobox.h"
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1; // VTX power switcher
+    //pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+}

--- a/src/main/target/ZEEZF7/target.h
+++ b/src/main/target/ZEEZF7/target.h
@@ -84,7 +84,7 @@
 // *************** PINIO ***************************
 #define USE_PINIO
 #define USE_PINIOBOX
-#define PINIO1_PIN              PB11
+#define PINIO1_PIN              PB11 // VTX power switcher
 
 // *************** UART *****************************
 #define USE_VCP


### PR DESCRIPTION
The ZEEZF7 target currently has no way to enable the VTX. The board has a built-in transistor circuit to turn the VTX power on or off (off by default) but currently there is no way to turn this on.

This PR adds `PINIO` features to the target and defines GPIO pin `PB11` (VTX enable) as `PINIO1_PIN`. It also associates the pin with `USER1` box, so that the VTX is enabled through `USER1` the same as it is in Betaflight.