### PR TITLE
report launch flight mode with higher priority

### DIFF
--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -144,6 +144,9 @@ flightModeForTelemetry_e getFlightModeForTelemetry(void)
     if (FLIGHT_MODE(MANUAL_MODE))
         return FLM_MANUAL;
 
+    if (FLIGHT_MODE(NAV_LAUNCH_MODE))
+        return FLM_LAUNCH;
+
     if (FLIGHT_MODE(NAV_RTH_MODE))
         return FLM_RTH;
 
@@ -165,8 +168,6 @@ flightModeForTelemetry_e getFlightModeForTelemetry(void)
     if (FLIGHT_MODE(HORIZON_MODE))
         return FLM_HORIZON;
 
-    if (FLIGHT_MODE(NAV_LAUNCH_MODE))
-        return FLM_LAUNCH;
 
     return STATE(AIRMODE_ACTIVE) ? FLM_ACRO_AIR : FLM_ACRO;
 }


### PR DESCRIPTION
IS: Launch ( TakeOff) mode is not reported with Mavlink protocol.
Manual, Angle or Horizon are reported instead (whatever is selected by user).

SHOULD: TakeOff mode should be reported while aircraft is in launch mode.

Fixed: report FLM_LAUNCH with higher priority.

inav version used: 2.6.0