### PR TITLE
Servo midpoint as first servo command on initialization

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -133,7 +133,7 @@ void servosInit(void)
 {
     // give all servos a default command
     for (int i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
-        servo[i] = DEFAULT_SERVO_MIDDLE;
+        servo[i] = servoParams(i)->middle;
     }
 
     /*


### PR DESCRIPTION
I have a camera on a tilt mechanism where 1000 is up and 2000 is down (sticking out from under the fuselage), and it is very annoying that it jerks to 1500 on power up before the LC's that drive the servo kick in. This PR makes it so that the first command sent to the servo's is the servo midpoint from the outputs tab, instead of 1500us regardless of servo midpoint. I cannot think of any situation where this is not desirable, but if there is I can make this a configurable option instead.