### PR TITLE
Pan servo home direction offset

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -390,7 +390,7 @@
 | osd_main_voltage_decimals | 1 | Number of decimals for the battery voltages displayed in the OSD [1-2]. |
 | osd_neg_alt_alarm | 5 | Value below which (negative altitude) to make the OSD relative altitude indicator blink (meters) |
 | osd_pan_servo_index |  | Index of the pan servo to adjust osd home heading direction based on camera pan. Note that this feature does not work with continiously rotating servos. |
-| osd_pan_servo_us2centideg | 0 | Centidegrees of rotation of the pan servo per us PWM signal. A servo with 180 degrees of rotation from 1000 to 2000 us PWM typically needs `18` for this setting. Change sign to inverse direction. |
+| osd_pan_servo_pwm2centideg | 0 | Centidegrees of pan servo rotation us PWM signal. A servo with 180 degrees of rotation from 1000 to 2000 us PWM typically needs `18` for this setting. Change sign to inverse direction. |
 | osd_plus_code_digits | 10 | Numer of plus code digits before shortening with `osd_plus_code_short`. Precision at the equator: 10=13.9x13.9m; 11=2.8x3.5m; 12=56x87cm; 13=11x22cm. |
 | osd_plus_code_short | 0 | Number of leading digits removed from plus code. Removing 2, 4 and 6 digits requires a reference location within, respectively, ~800km, ~40 km and ~2km to recover the original coordinates. |
 | osd_right_sidebar_scroll |  |  |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -389,6 +389,8 @@
 | osd_link_quality_alarm | 70 | LQ % indicator blinks below this value. For Crossfire use 70%, for Tracer use 50% |
 | osd_main_voltage_decimals | 1 | Number of decimals for the battery voltages displayed in the OSD [1-2]. |
 | osd_neg_alt_alarm | 5 | Value below which (negative altitude) to make the OSD relative altitude indicator blink (meters) |
+| osd_pan_servo_index |  | Index of the pan servo to adjust osd home heading direction based on camera pan. Note that this feature does not work with continiously rotating servos. |
+| osd_pan_servo_us2centideg | 0 | Centidegrees of rotation of the pan servo per us PWM signal. A servo with 180 degrees of rotation from 1000 to 2000 us PWM typically needs `18` for this setting. Change sign to inverse direction. |
 | osd_plus_code_digits | 10 | Numer of plus code digits before shortening with `osd_plus_code_short`. Precision at the equator: 10=13.9x13.9m; 11=2.8x3.5m; 12=56x87cm; 13=11x22cm. |
 | osd_plus_code_short | 0 | Number of leading digits removed from plus code. Removing 2, 4 and 6 digits requires a reference location within, respectively, ~800km, ~40 km and ~2km to recover the original coordinates. |
 | osd_right_sidebar_scroll |  |  |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3021,9 +3021,9 @@ groups:
         min: 0
         max: 10
 
-      - name: osd_pan_servo_us2centideg
-        description: Centidegrees of rotation of the pan servo per us PWM signal. A servo with 180 degrees of rotation from 1000 to 2000 us PWM typically needs `18` for this setting. Change sign to inverse direction.
-        field: pan_servo_us2centideg
+      - name: osd_pan_servo_pwm2centideg
+        description: Centidegrees of pan servo rotation us PWM signal. A servo with 180 degrees of rotation from 1000 to 2000 us PWM typically needs `18` for this setting. Change sign to inverse direction.
+        field: pan_servo_pwm2centideg
         default_value: 0
         min: -36
         max: 36

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3022,7 +3022,7 @@ groups:
         max: 10
 
       - name: osd_pan_servo_us2centideg
-        type: uint16_t
+        type: float
         field: pan_servo_us2centideg
         default_value: 9
         min: -36

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3016,15 +3016,15 @@ groups:
         description: Should home position coordinates be displayed on the arming screen.
 
       - name: osd_pan_servo_index
-        type: uint8_t
+        description: Index of the pan servo to adjust osd home heading direction based on camera pan. Note that this feature does not work with continiously rotating servos.
         field: pan_servo_index
         min: 0
         max: 10
 
       - name: osd_pan_servo_us2centideg
-        type: float
+        description: Centidegrees of rotation of the pan servo per us PWM signal. A servo with 180 degrees of rotation from 1000 to 2000 us PWM typically needs `18` for this setting.
         field: pan_servo_us2centideg
-        default_value: 9
+        default_value: 0
         min: -36
         max: 36
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3015,6 +3015,20 @@ groups:
         default_value: "ON"
         description: Should home position coordinates be displayed on the arming screen.
 
+      - name: osd_pan_servo_index
+        type: uint8_t
+        field: pan_servo_index
+        min: 0
+        max: 10
+
+      - name: osd_pan_servo_us2centideg
+        type: uint16_t
+        field: pan_servo_us2centideg
+        default_value: 9
+        min: -36
+        max: 36
+
+
   - name: PG_SYSTEM_CONFIG
     type: systemConfig_t
     headers: ["fc/config.h"]

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3022,7 +3022,7 @@ groups:
         max: 10
 
       - name: osd_pan_servo_us2centideg
-        description: Centidegrees of rotation of the pan servo per us PWM signal. A servo with 180 degrees of rotation from 1000 to 2000 us PWM typically needs `18` for this setting.
+        description: Centidegrees of rotation of the pan servo per us PWM signal. A servo with 180 degrees of rotation from 1000 to 2000 us PWM typically needs `18` for this setting. Change sign to inverse direction.
         field: pan_servo_us2centideg
         default_value: 0
         min: -36

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -954,7 +954,7 @@ int16_t osdPanServoHomeDirectionOffset(void)
     int8_t servoIndex = osdConfig()->pan_servo_index;
     int16_t servoPosition = servo[servoIndex];
     int16_t servoMiddle = servoParams(servoIndex)->middle;
-    return (int16_t)CENTIDEGREES_TO_DEGREES((servoPosition - servoMiddle) * osdConfig()->pan_servo_us2centideg);
+    return (int16_t)CENTIDEGREES_TO_DEGREES((servoPosition - servoMiddle) * osdConfig()->pan_servo_pwm2centideg);
 }
 
 // Returns a heading angle in degrees normalized to [0, 360).
@@ -1347,7 +1347,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 else
                 {
                     int16_t panHomeDirOffset = 0;
-                    if (!(osdConfig()->pan_servo_us2centideg == 0)){
+                    if (!(osdConfig()->pan_servo_pwm2centideg == 0)){
                         panHomeDirOffset = osdPanServoHomeDirectionOffset();
                     }
                     int homeDirection = GPS_directionToHome - DECIDEGREES_TO_DEGREES(osdGetHeading()) + panHomeDirOffset;
@@ -2605,7 +2605,7 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .sidebar_scroll_arrows = 0,
     .osd_home_position_arm_screen = true,
     .pan_servo_index = 0,
-    .pan_servo_us2centideg = 0,
+    .pan_servo_pwm2centideg = 0,
 
     .units = OSD_UNIT_METRIC,
     .main_voltage_decimals = 1,

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1340,7 +1340,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_HOME_DIR:
         {
-            if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME) && isImuHeadingValid()) {
+            if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) { // && isImuHeadingValid()
                 if (GPS_distanceToHome < (navConfig()->general.min_rth_distance / 100) ) {
                     displayWriteChar(osdDisplayPort, elemPosX, elemPosY, SYM_HOME_NEAR);
                 }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -949,6 +949,14 @@ int16_t osdGetHeading(void)
     return attitude.values.yaw;
 }
 
+int16_t osdPanServoHomeDirectionOffset(void)
+{
+    int8_t servoIndex = osdConfig()->pan_servo_index;
+    int16_t servoPosition = servo[servoIndex];
+    int16_t servoMiddle = servoParams(servoIndex)->middle;
+    return (int16_t)CENTIDEGREES_TO_DEGREES((servoPosition - servoMiddle) * osdConfig()->pan_servo_us2centideg);
+}
+
 // Returns a heading angle in degrees normalized to [0, 360).
 int osdGetHeadingAngle(int angle)
 {
@@ -1127,14 +1135,6 @@ static int16_t osdGet3DSpeed(void)
     int16_t vert_speed = getEstimatedActualVelocity(Z);
     int16_t hor_speed = gpsSol.groundSpeed;
     return (int16_t)sqrtf(sq(hor_speed) + sq(vert_speed));
-}
-
-static int16_t osdPanServoHomeDirectionOffset(void)
-{
-    int8_t servoIndex = osdConfig()->pan_servo_index;
-    int16_t servoPosition = servo[servoIndex];
-    int16_t servoMiddle = servoParams(servoIndex)->middle;
-    return (int16_t)CENTIDEGREES_TO_DEGREES((servoPosition - servoMiddle) * osdConfig()->pan_servo_us2centideg);
 }
 
 #endif
@@ -1340,7 +1340,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_HOME_DIR:
         {
-            if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME)) { // && isImuHeadingValid()
+            if (STATE(GPS_FIX) && STATE(GPS_FIX_HOME) && isImuHeadingValid()) {
                 if (GPS_distanceToHome < (navConfig()->general.min_rth_distance / 100) ) {
                     displayWriteChar(osdDisplayPort, elemPosX, elemPosY, SYM_HOME_NEAR);
                 }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1134,7 +1134,7 @@ static int16_t osdPanServoHomeDirectionOffset(void)
     int8_t servoIndex = osdConfig()->pan_servo_index;
     int16_t servoPosition = servo[servoIndex];
     int16_t servoMiddle = servoParams(servoIndex)->middle;
-    return (int16_t)((servoPosition - servoMiddle) * CENTIDEGREES_TO_DEGREES(osdConfig()->pan_servo_us2centideg));
+    return (int16_t)CENTIDEGREES_TO_DEGREES((servoPosition - servoMiddle) * osdConfig()->pan_servo_us2centideg);
 }
 
 #endif
@@ -1347,7 +1347,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 else
                 {
                     int16_t panHomeDirOffset = 0;
-                    if (!osdConfig()->pan_servo_us2centideg){
+                    if (!(osdConfig()->pan_servo_us2centideg == 0)){
                         panHomeDirOffset = osdPanServoHomeDirectionOffset();
                     }
                     int homeDirection = GPS_directionToHome - DECIDEGREES_TO_DEGREES(osdGetHeading()) + panHomeDirOffset;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -348,7 +348,8 @@ typedef struct osdConfig_s {
     uint8_t left_sidebar_scroll_step;   // How many units each sidebar step represents. 0 means the default value for the scroll type.
     uint8_t right_sidebar_scroll_step;  // Same as left_sidebar_scroll_step, but for the right sidebar.
     bool osd_home_position_arm_screen;
-
+    uint8_t pan_servo_index;            // Index of the pan servo used for home direction offset
+    uint16_t pan_servo_us2centideg;          // cenitdegrees per us pwm
     uint8_t crsf_lq_format;
 
 } osdConfig_t;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -349,7 +349,7 @@ typedef struct osdConfig_s {
     uint8_t right_sidebar_scroll_step;  // Same as left_sidebar_scroll_step, but for the right sidebar.
     bool osd_home_position_arm_screen;
     uint8_t pan_servo_index;            // Index of the pan servo used for home direction offset
-    float pan_servo_us2centideg;          // cenitdegrees per us pwm
+    int8_t pan_servo_us2centideg;          // centidegrees per us pwm
     uint8_t crsf_lq_format;
 
 } osdConfig_t;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -349,7 +349,7 @@ typedef struct osdConfig_s {
     uint8_t right_sidebar_scroll_step;  // Same as left_sidebar_scroll_step, but for the right sidebar.
     bool osd_home_position_arm_screen;
     uint8_t pan_servo_index;            // Index of the pan servo used for home direction offset
-    uint16_t pan_servo_us2centideg;          // cenitdegrees per us pwm
+    float pan_servo_us2centideg;          // cenitdegrees per us pwm
     uint8_t crsf_lq_format;
 
 } osdConfig_t;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -349,7 +349,7 @@ typedef struct osdConfig_s {
     uint8_t right_sidebar_scroll_step;  // Same as left_sidebar_scroll_step, but for the right sidebar.
     bool osd_home_position_arm_screen;
     uint8_t pan_servo_index;            // Index of the pan servo used for home direction offset
-    int8_t pan_servo_us2centideg;          // centidegrees per us pwm
+    int8_t pan_servo_pwm2centideg;      // Centidegrees of servo rotation per us pwm
     uint8_t crsf_lq_format;
 
 } osdConfig_t;


### PR DESCRIPTION
Resolves #6500 (@Jetrell can you confirm this is what you asked for?). This PR creates two cli commands: `osd_pan_servo_index` to select the pan servo and `osd_pan_servo_pwm2centideg` to set the rotation of the pan servo as a function of the pwm signal. For a 180 degrees servo this most likely needs to be set to `18`. Change the sign to reverse the offset direction.

Example:

https://user-images.githubusercontent.com/880421/104463356-f56bff00-55b1-11eb-95d8-d30fc8ee05aa.mp4

Testing this on the bench is a bit of a hassle. I found the easiest way is to set a safehome nearby and remove ` && isImuHeadingValid()` from https://github.com/iNavFlight/inav/blob/01799179e9b8ac8bf36a3ab1bb69fbe248afd2a5/src/main/io/osd.c#L1334

This could also be applied to other OSD elements, the HUD elements would be good candidates for this (obviously that also needs a tilt offset). If there is interest I can make a separate PR for that or add it to this one.