### PR TITLE
OSD summary stats improvements

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -399,6 +399,7 @@
 | osd_sidebar_scroll_arrows |  |  |
 | osd_snr_alarm | 4 | Value below which Crossfire SNR Alarm pops-up. (dB) |
 | osd_stats_energy_unit | MAH | Unit used for the drawn energy in the OSD stats [MAH/WH] (milliAmpere hour/ Watt hour) |
+| osd_stats_min_voltage_unit | BATTERY | Display minimum voltage of the whole `BATTERY` or the average per `CELL` in the OSD stats. |
 | osd_temp_label_align | LEFT | Allows to chose between left and right alignment for the OSD temperature sensor labels. Valid values are `LEFT` and `RIGHT` |
 | osd_time_alarm | 10 | Value above which to make the OSD flight time indicator blink (minutes) |
 | osd_units | METRIC | IMPERIAL, METRIC, UK |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -66,6 +66,9 @@ tables:
   - name: osd_stats_energy_unit
     values: ["MAH", "WH"]
     enum: osd_stats_energy_unit_e
+  - name: osd_stats_min_voltage_unit
+    values: ["BATTERY", "CELL"]
+    enum: osd_stats_min_voltage_unit_e
   - name: osd_video_system
     values: ["AUTO", "PAL", "NTSC"]
     enum: videoSystem_e
@@ -2694,6 +2697,12 @@ groups:
         default_value: "MAH"
         field: stats_energy_unit
         table: osd_stats_energy_unit
+        type: uint8_t
+      - name: osd_stats_min_voltage_unit
+        description: "Display minimum voltage of the whole `BATTERY` or the average per `CELL` in the OSD stats."
+        default_value: "BATTERY"
+        field: stats_min_voltage_unit
+        table: osd_stats_min_voltage_unit
         type: uint8_t
 
       - name: osd_rssi_alarm

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2968,14 +2968,27 @@ static void osdShowStats(void)
     if (osdConfig()->stats_min_voltage_unit == OSD_STATS_MIN_VOLTAGE_UNIT_BATTERY){
         displayWrite(osdDisplayPort, statNameX, top, "MIN BATTERY VOLT :");
         osdFormatCentiNumber(buff, stats.min_voltage, 0, osdConfig()->main_voltage_decimals, 0, osdConfig()->main_voltage_decimals + 2);
+        strcat(buff, "V");
+        osdLeftAlignString(buff);
+        strcat(buff, "/");
+        displayWrite(osdDisplayPort, statValuesX, top, buff);
+        osdFormatCentiNumber(buff, getBatteryRawVoltage(), 0, osdConfig()->main_voltage_decimals, 0, osdConfig()->main_voltage_decimals + 2);
+        strcat(buff, "V");
+        osdLeftAlignString(buff);
+        displayWrite(osdDisplayPort, statValuesX + 4 + osdConfig()->main_voltage_decimals, top++, buff);
     } else {
         displayWrite(osdDisplayPort, statNameX, top, "MIN CELL VOLT    :");
         osdFormatCentiNumber(buff, stats.min_voltage / getBatteryCellCount(), 0, 2, 0, 3);
+        strcat(buff, "V");
+        osdLeftAlignString(buff);
+        strcat(buff, "/");
+        displayWrite(osdDisplayPort, statValuesX, top, buff);
+        osdFormatCentiNumber(buff, getBatteryAverageCellVoltage(), 0, 2, 0, 3);
+        strcat(buff, "V");
+        osdLeftAlignString(buff);
+        displayWrite(osdDisplayPort, statValuesX + 5, top++, buff);
     }
-    strcat(buff, "V");
-    osdLeftAlignString(buff);
-    displayWrite(osdDisplayPort, statValuesX, top++, buff);
-
+    
     displayWrite(osdDisplayPort, statNameX, top, "MIN RSSI         :");
     itoa(stats.min_rssi, buff, 10);
     strcat(buff, "%");

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2977,15 +2977,16 @@ static void osdShowStats(void)
     displayWrite(osdDisplayPort, statValuesX, top++, buff);
 
     if (feature(FEATURE_CURRENT_METER)) {
-        displayWrite(osdDisplayPort, statNameX, top, "MAX CURRENT      :");
-        itoa(stats.max_current, buff, 10);
+        displayWrite(osdDisplayPort, statNameX, top, "MAX CURRENT/POWER:");
+        osdFormatCentiNumber(buff, stats.max_current * 100, 0, 0, 0, 3);
         strcat(buff, "A");
-        displayWrite(osdDisplayPort, statValuesX, top++, buff);
-
-        displayWrite(osdDisplayPort, statNameX, top, "MAX POWER        :");
-        itoa(stats.max_power, buff, 10);
+        osdLeftAlignString(buff);
+        strcat(buff, "/");
+        displayWrite(osdDisplayPort, statValuesX, top, buff);
+        osdFormatCentiNumber(buff, stats.max_power * 100, 0, 0, 0, 4);
         strcat(buff, "W");
-        displayWrite(osdDisplayPort, statValuesX, top++, buff);
+        osdLeftAlignString(buff);
+        displayWrite(osdDisplayPort, statValuesX+5, top++, buff);
 
         if (osdConfig()->stats_energy_unit == OSD_STATS_ENERGY_UNIT_MAH) {
             displayWrite(osdDisplayPort, statNameX, top, "USED MAH         :");

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -185,7 +185,7 @@ static bool osdDisplayHasCanvas;
 
 #define AH_MAX_PITCH_DEFAULT 20 // Specify default maximum AHI pitch value displayed (degrees)
 
-PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 14);
+PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 15);
 PG_REGISTER_WITH_RESET_FN(osdLayoutsConfig_t, osdLayoutsConfig, PG_OSD_LAYOUTS_CONFIG, 0);
 
 static int digitCount(int32_t value)
@@ -2965,8 +2965,13 @@ static void osdShowStats(void)
     osdFormatAltitudeStr(buff, stats.max_altitude);
     displayWrite(osdDisplayPort, statValuesX, top++, buff);
 
-    displayWrite(osdDisplayPort, statNameX, top, "MIN BATTERY VOLT :");
-    osdFormatCentiNumber(buff, stats.min_voltage, 0, osdConfig()->main_voltage_decimals, 0, osdConfig()->main_voltage_decimals + 2);
+    if (osdConfig()->stats_min_voltage_unit == OSD_STATS_MIN_VOLTAGE_UNIT_BATTERY){
+        displayWrite(osdDisplayPort, statNameX, top, "MIN BATTERY VOLT :");
+        osdFormatCentiNumber(buff, stats.min_voltage, 0, osdConfig()->main_voltage_decimals, 0, osdConfig()->main_voltage_decimals + 2);
+    } else {
+        displayWrite(osdDisplayPort, statNameX, top, "MIN CELL VOLT    :");
+        osdFormatCentiNumber(buff, stats.min_voltage / getBatteryCellCount(), 0, 2, 0, 3);
+    }
     strcat(buff, "V");
     osdLeftAlignString(buff);
     displayWrite(osdDisplayPort, statValuesX, top++, buff);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2968,23 +2968,23 @@ static void osdShowStats(void)
     if (osdConfig()->stats_min_voltage_unit == OSD_STATS_MIN_VOLTAGE_UNIT_BATTERY){
         displayWrite(osdDisplayPort, statNameX, top, "MIN BATTERY VOLT :");
         osdFormatCentiNumber(buff, stats.min_voltage, 0, osdConfig()->main_voltage_decimals, 0, osdConfig()->main_voltage_decimals + 2);
-        strcat(buff, "V/");
+        strcat(buff, "V(");
         osdLeftAlignString(buff);
         int8_t lengthValues = strlen(buff);
         displayWrite(osdDisplayPort, statValuesX, top, buff);
         osdFormatCentiNumber(buff, getBatteryRawVoltage(), 0, osdConfig()->main_voltage_decimals, 0, osdConfig()->main_voltage_decimals + 2);
-        strcat(buff, "V");
+        strcat(buff, "V)");
         osdLeftAlignString(buff);
         displayWrite(osdDisplayPort, statValuesX + lengthValues, top++, buff);
     } else {
         displayWrite(osdDisplayPort, statNameX, top, "MIN CELL VOLT    :");
         osdFormatCentiNumber(buff, stats.min_voltage / getBatteryCellCount(), 0, 2, 0, 3);
-        strcat(buff, "V/");
+        strcat(buff, "V(");
         osdLeftAlignString(buff);
         int8_t lengthValues = strlen(buff);
         displayWrite(osdDisplayPort, statValuesX, top, buff);
-        osdFormatCentiNumber(buff, getBatteryAverageCellVoltage(), 0, 2, 0, 3);
-        strcat(buff, "V");
+        osdFormatCentiNumber(buff, getBatteryRawAverageCellVoltage(), 0, 2, 0, 3);
+        strcat(buff, "V)");
         osdLeftAlignString(buff);
         displayWrite(osdDisplayPort, statValuesX + lengthValues, top++, buff);
     }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2968,25 +2968,25 @@ static void osdShowStats(void)
     if (osdConfig()->stats_min_voltage_unit == OSD_STATS_MIN_VOLTAGE_UNIT_BATTERY){
         displayWrite(osdDisplayPort, statNameX, top, "MIN BATTERY VOLT :");
         osdFormatCentiNumber(buff, stats.min_voltage, 0, osdConfig()->main_voltage_decimals, 0, osdConfig()->main_voltage_decimals + 2);
-        strcat(buff, "V");
+        strcat(buff, "V/");
         osdLeftAlignString(buff);
-        strcat(buff, "/");
+        int8_t lengthValues = strlen(buff);
         displayWrite(osdDisplayPort, statValuesX, top, buff);
         osdFormatCentiNumber(buff, getBatteryRawVoltage(), 0, osdConfig()->main_voltage_decimals, 0, osdConfig()->main_voltage_decimals + 2);
         strcat(buff, "V");
         osdLeftAlignString(buff);
-        displayWrite(osdDisplayPort, statValuesX + 4 + osdConfig()->main_voltage_decimals, top++, buff);
+        displayWrite(osdDisplayPort, statValuesX + lengthValues, top++, buff);
     } else {
         displayWrite(osdDisplayPort, statNameX, top, "MIN CELL VOLT    :");
         osdFormatCentiNumber(buff, stats.min_voltage / getBatteryCellCount(), 0, 2, 0, 3);
-        strcat(buff, "V");
+        strcat(buff, "V/");
         osdLeftAlignString(buff);
-        strcat(buff, "/");
+        int8_t lengthValues = strlen(buff);
         displayWrite(osdDisplayPort, statValuesX, top, buff);
         osdFormatCentiNumber(buff, getBatteryAverageCellVoltage(), 0, 2, 0, 3);
         strcat(buff, "V");
         osdLeftAlignString(buff);
-        displayWrite(osdDisplayPort, statValuesX + 5, top++, buff);
+        displayWrite(osdDisplayPort, statValuesX + lengthValues, top++, buff);
     }
     
     displayWrite(osdDisplayPort, statNameX, top, "MIN RSSI         :");
@@ -2996,15 +2996,21 @@ static void osdShowStats(void)
 
     if (feature(FEATURE_CURRENT_METER)) {
         displayWrite(osdDisplayPort, statNameX, top, "MAX CURRENT/POWER:");
-        osdFormatCentiNumber(buff, stats.max_current * 100, 0, 0, 0, 3);
-        strcat(buff, "A");
+        int8_t currentDigits = 1;
+        if (stats.max_current >= 100){
+            currentDigits = 3;
+        } else if (stats.max_current >= 10){
+            currentDigits = 2;
+        }
+        osdFormatCentiNumber(buff, stats.max_current * 100, 0, 0, 0, currentDigits);
+        strcat(buff, "A/");
         osdLeftAlignString(buff);
-        strcat(buff, "/");
+        int8_t lengthValues = strlen(buff);
         displayWrite(osdDisplayPort, statValuesX, top, buff);
         osdFormatCentiNumber(buff, stats.max_power * 100, 0, 0, 0, 4);
         strcat(buff, "W");
         osdLeftAlignString(buff);
-        displayWrite(osdDisplayPort, statValuesX+5, top++, buff);
+        displayWrite(osdDisplayPort, statValuesX + lengthValues, top++, buff);
 
         if (osdConfig()->stats_energy_unit == OSD_STATS_ENERGY_UNIT_MAH) {
             displayWrite(osdDisplayPort, statNameX, top, "USED MAH         :");

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2938,7 +2938,7 @@ static void osdShowStats(void)
     const char * disarmReasonStr[DISARM_REASON_COUNT] = { "UNKNOWN", "TIMEOUT", "STICKS", "SWITCH", "SWITCH", "KILLSW", "FAILSAFE", "NAV SYS" };
     uint8_t top = 1;    /* first fully visible line */
     const uint8_t statNameX = 1;
-    const uint8_t statValuesX = 20;
+    const uint8_t statValuesX = 19;
     char buff[10];
 
     displayBeginTransaction(osdDisplayPort, DISPLAY_TRANSACTION_OPT_RESET_DRAWING);

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -236,6 +236,11 @@ typedef enum {
 } osd_stats_energy_unit_e;
 
 typedef enum {
+    OSD_STATS_MIN_VOLTAGE_UNIT_BATTERY,
+    OSD_STATS_MIN_VOLTAGE_UNIT_CELL,
+} osd_stats_min_voltage_unit_e;
+
+typedef enum {
     OSD_CROSSHAIRS_STYLE_DEFAULT,
     OSD_CROSSHAIRS_STYLE_AIRCRAFT,
     OSD_CROSSHAIRS_STYLE_TYPE3,
@@ -308,6 +313,7 @@ typedef struct osdConfig_s {
 
     // Preferences
     uint8_t main_voltage_decimals;
+
     uint8_t ahi_reverse_roll;
     uint8_t ahi_max_pitch;
     uint8_t crosshairs_style; // from osd_crosshairs_style_e
@@ -331,6 +337,7 @@ typedef struct osdConfig_s {
 
     uint8_t units; // from osd_unit_e
     uint8_t stats_energy_unit; // from osd_stats_energy_unit_e
+    uint8_t stats_min_voltage_unit; // from osd_stats_min_voltage_unit_e
 
     bool    estimations_wind_compensation; // use wind compensation for estimated remaining flight/distance
     uint8_t coordinate_digits;


### PR DESCRIPTION
Changes:
- Max current and max power are now shown on the same line since they measure the same thing. 
- Using `osd_stats_min_voltage_unit = CELL`, the average min cell voltage is shown instead of the total battery voltage. The default is `BATTERY` which is the current behavior.
- After the minimum battery or cell voltage, the current battery or cell voltage is shown. This follows the above setting. I find myself wanting to see the battery voltage directly after disarming, but this requires dismissing the stats. This change solves that issue.

I do not fully understand all the `buff` and `statValuesX` stuff but I managed to throw this together. There are a couple things I'm not yet happy with:
1. It would look nicer if max power was aligned more to the left when max current is less that 3 digits. The way I pasted these strings together feels a little janky to me. Is there a better way to do this?
2. When using 2 main battery voltage decimals the minimum voltage runs onto the `/` separating it from the current voltage. I tried accounting for this using `displayWrite(osdDisplayPort, statValuesX + 4 + osdConfig()->main_voltage_decimals, top++, buff);` but this doesn't work. Again it would be nicer to paste the strings together based on their actual length instead of some fixed number of characters.

I will later add the configurator side of this PR (also for `osd_stats_energy_unit`).