### PR TITLE
Increase the number or mode ranges

### DIFF
--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -74,6 +74,7 @@ typedef enum {
 // type to hold enough bits for CHECKBOX_ITEM_COUNT. Struct used for value-like behavior
 typedef struct boxBitmask_s { BITARRAY_DECLARE(bits, CHECKBOX_ITEM_COUNT); } boxBitmask_t;
 
+#define MAX_MODE_ACTIVATION_CONDITION_COUNT 40
 
 #define CHANNEL_RANGE_MIN 900
 #define CHANNEL_RANGE_MAX 2100

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -74,7 +74,6 @@ typedef enum {
 // type to hold enough bits for CHECKBOX_ITEM_COUNT. Struct used for value-like behavior
 typedef struct boxBitmask_s { BITARRAY_DECLARE(bits, CHECKBOX_ITEM_COUNT); } boxBitmask_t;
 
-#define MAX_MODE_ACTIVATION_CONDITION_COUNT 20
 
 #define CHANNEL_RANGE_MIN 900
 #define CHANNEL_RANGE_MAX 2100


### PR DESCRIPTION
Updated the number of modes ranges to 40. More features are being added that require switching, and we have limited RC channels. The extra ranges will allow for some tricks to get multiple independent switches on  a single channel. This is working on the CLI and modes pages in configurator.

I did look, but couldn't see any documentation that needed updating with regards to the number.