### PR TITLE
Fix bug in GPS weight for vertical velocity calculation

### DIFF
--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -569,7 +569,7 @@ static bool estimationCalculateCorrection_Z(estimationContext_t * ctx)
         if (ctx->newFlags & EST_GPS_Z_VALID) {
             // Trust GPS velocity only if residual/error is less than 2.5 m/s, scale weight according to gaussian distribution
             const float gpsRocResidual = posEstimator.gps.vel.z - posEstimator.est.vel.z;
-            const float gpsRocScaler = bellCurve(gpsRocResidual, 2.5f);
+            const float gpsRocScaler = bellCurve(gpsRocResidual, 250.0f);
             ctx->estVelCorr.z += gpsRocResidual * positionEstimationConfig()->w_z_gps_v * gpsRocScaler * ctx->dt;
         }
 


### PR DESCRIPTION
If I understand correctly, `posEstimator.gps.vel.z` and `posEstimator.est.vel.z` are both in cm/s. But that means that `bellCurve()` leaves very little weight on the GPS velocity when `curveWidth` is 2.5, even for very small errors (for example, 37% for 10cm/s error).  I think this is a mistake and it should be 250.