### PR TITLE
Camera uptilt AHI compensation

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1917,7 +1917,7 @@ static bool osdDrawSingleElement(uint8_t item)
             rollAngle = DECIDEGREES_TO_RADIANS(attitude.values.roll);
             pitchAngle = DECIDEGREES_TO_RADIANS(attitude.values.pitch);
 #endif
-
+            pitchAngle -= DEGREES_TO_RADIANS(osdConfig()->camera_uptilt);
             if (osdConfig()->ahi_reverse_roll) {
                 rollAngle = -rollAngle;
             }


### PR DESCRIPTION
On a quad, I would like to have the artificial horizon in the middle of the osd when the camera is level with the ground, not when the quad is level. I'm actually surprised this feature doesn't already exist. 

This PR uses the existing `osd_camera_uptilt` cli command from the HUD feature to shift the AHI according to camera uptilt. However, it doesn't work yet. Increasing `osd_camera_uptilt` correctly shifts down the AHI, but far from enough. I can probably figure it out eventually, but if someone can point me in the right direction then that would be great.

