### PR TITLE
Let fixed wing autotune set the rates

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -111,7 +111,7 @@
 | fw_autotune_ff_to_i_tc | 600 | FF to I time (defines time for I to reach the same level of response as FF) [ms] |
 | fw_autotune_ff_to_p_gain | 10 | FF to P gain (strength relationship) [%] |
 | fw_autotune_overshoot_time | 100 | Time [ms] to detect sustained overshoot |
-| fw_autotune_rate_adjustment | FIXED | `AUTO` adjusts the rates (both up and down) to match the capabilities of the airplane. `MAX` decreases the rates when the airplane is not able to achieve them, but does not increase the rates. `FIXED` (the default) does not adjust the rates. |
+| fw_autotune_rate_adjustment | FIXED | `AUTO` increases and decreases the rates to match the capabilities of the airplane. `DECREASE_ONLY` only decreases the rates. `FIXED` (the default) does not adjust the rates. |
 | fw_autotune_threshold | 50 | Threshold [%] of max rate to consider overshoot/undershoot detection |
 | fw_autotune_undershoot_time | 200 | Time [ms] to detect sustained undershoot |
 | fw_d_level | 75 | Fixed-wing attitude stabilisation HORIZON transition point |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -111,7 +111,7 @@
 | fw_autotune_ff_to_i_tc | 600 | FF to I time (defines time for I to reach the same level of response as FF) [ms] |
 | fw_autotune_ff_to_p_gain | 10 | FF to P gain (strength relationship) [%] |
 | fw_autotune_overshoot_time | 100 | Time [ms] to detect sustained overshoot |
-| fw_autotune_rate_adjustment | FIXED | `AUTO` increases and decreases the rates to match the capabilities of the airplane. `DECREASE_ONLY` only decreases the rates. `FIXED` (the default) does not adjust the rates. |
+| fw_autotune_rate_adjustment | FIXED | `AUTO` increases and decreases the rates to match the capabilities of the airplane. `DECREASE_ONLY` decreases the rates when they are set too high but never increases them. `FIXED` (the default) does not adjust the rates. |
 | fw_autotune_threshold | 50 | Threshold [%] of max rate to consider overshoot/undershoot detection |
 | fw_autotune_undershoot_time | 200 | Time [ms] to detect sustained undershoot |
 | fw_d_level | 75 | Fixed-wing attitude stabilisation HORIZON transition point |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -107,6 +107,7 @@
 | frsky_pitch_roll | OFF | S.Port and D-Series telemetry: Send pitch and roll degrees*10 instead of raw accelerometer data |
 | frsky_unit | METRIC | Not used? [METRIC/IMPERIAL] |
 | frsky_vfas_precision | 0 | D-Series telemetry only: Set to 1 to send raw VBat value in 0.1V resolution for receivers that can handle it, or 0 (default) to use the standard method |
+| fw_autotune_convergence_rate | 0.5 | How fast autotune will converge. Too high values can cause overshooting of FF and rate targets. |
 | fw_autotune_ff_to_i_tc | 600 | FF to I time (defines time for I to reach the same level of response as FF) [ms] |
 | fw_autotune_ff_to_p_gain | 10 | FF to P gain (strength relationship) [%] |
 | fw_autotune_overshoot_time | 100 | Time [ms] to detect sustained overshoot |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -110,6 +110,7 @@
 | fw_autotune_ff_to_i_tc | 600 | FF to I time (defines time for I to reach the same level of response as FF) [ms] |
 | fw_autotune_ff_to_p_gain | 10 | FF to P gain (strength relationship) [%] |
 | fw_autotune_overshoot_time | 100 | Time [ms] to detect sustained overshoot |
+| fw_autotune_rate_adjustment | FIXED | `AUTO` adjusts the rates (both up and down) to match the capabilities of the airplane. `MAX` decreases the rates when the airplane is not able to achieve them, but does not increase the rates. `FIXED` (the default) does not adjust the rates. |
 | fw_autotune_threshold | 50 | Threshold [%] of max rate to consider overshoot/undershoot detection |
 | fw_autotune_undershoot_time | 200 | Time [ms] to detect sustained undershoot |
 | fw_d_level | 75 | Fixed-wing attitude stabilisation HORIZON transition point |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1921,8 +1921,9 @@ groups:
       - name: fw_autotune_rate_adjustment
         description: "`AUTO` adjusts the rates (both up and down) to match the capabilities of the airplane. `MAX` decreases the rates when the airplane is not able to achieve them, but does not increase the rates. `FIXED` (the default) does not adjust the rates."
         default_value: "FIXED"
-        field: autotune_rate_adjustment
+        field: fw_autotune_rate_adjustment
         table: autotune_rate_adjustment
+        type: uint8_t
 
   - name: PG_POSITION_ESTIMATION_CONFIG
     type: positionEstimationConfig_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1919,7 +1919,7 @@ groups:
         min: 100
         max: 5000
       - name: fw_autotune_rate_adjustment
-        description: "`AUTO` increases and decreases the rates to match the capabilities of the airplane. `DECREASE_ONLY` only decreases the rates. `FIXED` (the default) does not adjust the rates."
+        description: "`AUTO` increases and decreases the rates to match the capabilities of the airplane. `DECREASE_ONLY` decreases the rates when they are set too high but never increases them. `FIXED` (the default) does not adjust the rates."
         default_value: "FIXED"
         field: fw_autotune_rate_adjustment
         table: autotune_rate_adjustment

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -159,7 +159,7 @@ tables:
     values: ["0", "2", "4", "6"]
   - name: autotune_rate_adjustment
     enum: autotune_rate_adjustment_e
-    values: ["FIXED", "MAX", "AUTO"]
+    values: ["FIXED", "DECREASE_ONLY", "AUTO"]
 
 groups:
   - name: PG_GYRO_CONFIG
@@ -1919,7 +1919,7 @@ groups:
         min: 100
         max: 5000
       - name: fw_autotune_rate_adjustment
-        description: "`AUTO` adjusts the rates (both up and down) to match the capabilities of the airplane. `MAX` decreases the rates when the airplane is not able to achieve them, but does not increase the rates. `FIXED` (the default) does not adjust the rates."
+        description: "`AUTO` increases and decreases the rates to match the capabilities of the airplane. `DECREASE_ONLY` only decreases the rates. `FIXED` (the default) does not adjust the rates."
         default_value: "FIXED"
         field: fw_autotune_rate_adjustment
         table: autotune_rate_adjustment

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -157,6 +157,9 @@ tables:
     values: ["OFF_ALWAYS", "OFF", "AUTO_ONLY", "ALL_NAV"]
   - name: osd_plus_code_short
     values: ["0", "2", "4", "6"]
+  - name: autotune_rate_adjustment
+    enum: autotune_rate_adjustment_e
+    values: ["FIXED", "MAX", "AUTO"]
 
 groups:
   - name: PG_GYRO_CONFIG
@@ -1915,6 +1918,11 @@ groups:
         field: fw_ff_to_i_time_constant
         min: 100
         max: 5000
+      - name: fw_autotune_rate_adjustment
+        description: "`AUTO` adjusts the rates (both up and down) to match the capabilities of the airplane. `MAX` decreases the rates when the airplane is not able to achieve them, but does not increase the rates. `FIXED` (the default) does not adjust the rates."
+        default_value: "FIXED"
+        field: autotune_rate_adjustment
+        table: autotune_rate_adjustment
 
   - name: PG_POSITION_ESTIMATION_CONFIG
     type: positionEstimationConfig_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1924,6 +1924,12 @@ groups:
         field: fw_autotune_rate_adjustment
         table: autotune_rate_adjustment
         type: uint8_t
+      - name: fw_autotune_convergence_rate
+        description: "How fast autotune will converge. Too high values can cause overshooting of FF and rate targets."
+        default_value: "0.5"
+        field: fw_convergence_rate
+        min: 0
+        max: 1
 
   - name: PG_POSITION_ESTIMATION_CONFIG
     type: positionEstimationConfig_t

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -160,7 +160,14 @@ typedef struct pidAutotuneConfig_s {
     uint8_t     fw_max_rate_threshold;      // Threshold [%] of max rate to consider autotune detection
     uint8_t     fw_ff_to_p_gain;            // FF to P gain (strength relationship) [%]
     uint16_t    fw_ff_to_i_time_constant;   // FF to I time (defines time for I to reach the same level of response as FF) [ms]
+    uint16_t    fw_target_rate_adjustment;             // Target rate on full stick deflection
 } pidAutotuneConfig_t;
+
+typedef enum {
+    FIXED,
+    MAX,
+    AUTO
+} autotune_rate_adjustment_e;
 
 PG_DECLARE_PROFILE(pidProfile_t, pidProfile);
 PG_DECLARE(pidAutotuneConfig_t, pidAutotuneConfig);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -166,7 +166,7 @@ typedef struct pidAutotuneConfig_s {
 
 typedef enum {
     FIXED,
-    MAX,
+    DECREASE_ONLY,
     AUTO,
 } fw_autotune_rate_adjustment_e;
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -160,7 +160,7 @@ typedef struct pidAutotuneConfig_s {
     uint8_t     fw_max_rate_threshold;      // Threshold [%] of max rate to consider autotune detection
     uint8_t     fw_ff_to_p_gain;            // FF to P gain (strength relationship) [%]
     uint16_t    fw_ff_to_i_time_constant;   // FF to I time (defines time for I to reach the same level of response as FF) [ms]
-    uint16_t    fw_autotune_rate_adjustment;  // Target rate adjustment on full stick deflection?
+    uint8_t     fw_autotune_rate_adjustment;  // Target rate adjustment on full stick deflection?
 } pidAutotuneConfig_t;
 
 typedef enum {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -160,14 +160,14 @@ typedef struct pidAutotuneConfig_s {
     uint8_t     fw_max_rate_threshold;      // Threshold [%] of max rate to consider autotune detection
     uint8_t     fw_ff_to_p_gain;            // FF to P gain (strength relationship) [%]
     uint16_t    fw_ff_to_i_time_constant;   // FF to I time (defines time for I to reach the same level of response as FF) [ms]
-    uint16_t    fw_target_rate_adjustment;  // Target rate adjustment on full stick deflection?
+    uint16_t    fw_autotune_rate_adjustment;  // Target rate adjustment on full stick deflection?
 } pidAutotuneConfig_t;
 
 typedef enum {
     FIXED,
     MAX,
-    AUTO
-} autotune_rate_adjustment_e;
+    AUTO,
+} fw_autotune_rate_adjustment_e;
 
 PG_DECLARE_PROFILE(pidProfile_t, pidProfile);
 PG_DECLARE(pidAutotuneConfig_t, pidAutotuneConfig);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -161,6 +161,7 @@ typedef struct pidAutotuneConfig_s {
     uint8_t     fw_ff_to_p_gain;            // FF to P gain (strength relationship) [%]
     uint16_t    fw_ff_to_i_time_constant;   // FF to I time (defines time for I to reach the same level of response as FF) [ms]
     uint8_t     fw_autotune_rate_adjustment;  // Target rate adjustment on full stick deflection?
+    float       fw_convergence_rate;        // Convergence rate
 } pidAutotuneConfig_t;
 
 typedef enum {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -160,7 +160,7 @@ typedef struct pidAutotuneConfig_s {
     uint8_t     fw_max_rate_threshold;      // Threshold [%] of max rate to consider autotune detection
     uint8_t     fw_ff_to_p_gain;            // FF to P gain (strength relationship) [%]
     uint16_t    fw_ff_to_i_time_constant;   // FF to I time (defines time for I to reach the same level of response as FF) [ms]
-    uint16_t    fw_target_rate_adjustment;             // Target rate on full stick deflection
+    uint16_t    fw_target_rate_adjustment;  // Target rate adjustment on full stick deflection?
 } pidAutotuneConfig_t;
 
 typedef enum {

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -97,7 +97,7 @@ void autotuneUpdateGains(pidAutotuneData_t * data)
         pidBankMutable()->pid[axis].I = lrintf(data[axis].gainI);
         pidBankMutable()->pid[axis].D = 0;
         pidBankMutable()->pid[axis].FF = lrintf(data[axis].gainFF);
-        currentControlRateProfile->stabilized.rates[axis] = lrintf(data[axis].rate/10.0f);
+        // &controlRateConfig->stabilized.rates[axis] = lrintf(data[axis].rate/10.0f); // Need to figure out how to save the new rates.
     }
     schedulePidGainsUpdate();
 }

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -172,7 +172,7 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
     const float convergenceRate = pidAutotuneConfig()->fw_convergence_rate;
     const float absDesiredRateDps = fabsf(desiredRateDps);
     const float absReachedRateDps = fabsf(reachedRateDps);
-    float maxDesiredRateDps = currentControlRateProfile->stabilized.rates[axis] * 10.0f;
+    float maxDesiredRateDps = tuneCurrent[axis].rate;
     pidAutotuneState_e newState;
 
     // Use different max desired rate in ANGLE for pitch and roll

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -97,6 +97,7 @@ void autotuneUpdateGains(pidAutotuneData_t * data)
         pidBankMutable()->pid[axis].I = lrintf(data[axis].gainI);
         pidBankMutable()->pid[axis].D = 0;
         pidBankMutable()->pid[axis].FF = lrintf(data[axis].gainFF);
+        currentControlRateProfile->stabilized.rates[axis] = lrintf(data[axis].rate/10.0f);
     }
     schedulePidGainsUpdate();
 }
@@ -278,7 +279,7 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
         }
 
         if (ratesUpdated) {
-            // What to do with autotuneUpdateGains(tuneCurrent)?
+            autotuneUpdateGains(tuneCurrent);
 
             switch (axis) {
             case FD_ROLL:

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -219,6 +219,7 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
                         // AUTO mode: we can rotate faster than current max rate setting, so increase max rate
                         // TODO: better calculation of new rate instead of fixed increase
                         // Explicit check for absDesiredRateDps close to maxDesiredRate?
+                        // Also increase rate in MAX if it was previously decreased (tuneCurrent[axis].rate < currentControlRateProfile->stabilized.rates[axis] * 10.0f)?
                         tuneCurrent[axis].rate += 30;
                         if (tuneCurrent[axis].rate > AUTOTUNE_FIXED_WING_MAX_RATE) {
                             tuneCurrent[axis].rate = AUTOTUNE_FIXED_WING_MAX_RATE;

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -174,7 +174,6 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
     const timeMs_t currentTimeMs = millis();
     const float absDesiredRateDps = fabsf(desiredRateDps);
     const float absReachedRateDps = fabsf(reachedRateDps);
-    const float rateError = absReachedRateDps - absDesiredRateDps;
     float maxDesiredRate = currentControlRateProfile->stabilized.rates[axis] * 10.0f;
     pidAutotuneState_e newState;
 
@@ -215,7 +214,7 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
                 break;
             case DEMAND_OVERSHOOT:
                 if (stateTimeMs >= pidAutotuneConfig()->fw_overshoot_time) {
-                    if (pidAutotuneConfig()->autotune_rate_adjustment == AUTO && absReachedRateDps > maxDesiredRate && !tuneCurrent[axis].mixerSaturated) {
+                    if (pidAutotuneConfig()->fw_autotune_rate_adjustment == AUTO && absReachedRateDps > maxDesiredRate && !tuneCurrent[axis].mixerSaturated) {
                         // AUTO mode: we can rotate faster than current max rate setting, so increase max rate
                         // TODO: better calculation of new rate to ensure convergence
                         // Explicit check for absDesiredRateDps close to maxDesiredRate?
@@ -300,7 +299,7 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
         tuneCurrent[axis].state = newState;
         tuneCurrent[axis].stateEnterTime = currentTimeMs;
         tuneCurrent[axis].pidSaturated = false;
-        tuneCurrent[axis].servoSaturated = false;
+        tuneCurrent[axis].mixerSaturated = false;
     }
 }
 #endif

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -207,7 +207,7 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
             case DEMAND_UNDERSHOOT:
                 if (stateTimeMs >= pidAutotuneConfig()->fw_overshoot_time) {
                     if (pidAutotuneConfig()->fw_autotune_rate_adjustment != FIXED) {
-                        /* In AUTO and MAX adjust both rates and FF */
+                        /* In AUTO and DECREASE_ONLY simultaniously adjust both rates and FF */
                         // Target pidSum at 90% deflection
                         const float pidTuneLimit = 0.9f * pidProfile()->pidSumLimit;
 
@@ -217,8 +217,8 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
                         // Calculate rate update and constrain to safe values
                         tuneCurrent[axis].rate += (rate90PercDeflection - maxDesiredRateDps) * convergenceRate;
                         tuneCurrent[axis].rate = constrainf(tuneCurrent[axis].rate, AUTOTUNE_FIXED_WING_MIN_RATE, AUTOTUNE_FIXED_WING_MAX_RATE);
-                        if (pidAutotuneConfig()->fw_autotune_rate_adjustment == MAX) {
-                            // In MAX limit max rate to initial value
+                        if (pidAutotuneConfig()->fw_autotune_rate_adjustment == DECREASE_ONLY) {
+                            // In DECREASE_ONLY limit max rate to initial value
                             tuneCurrent[axis].rate = constrainf(tuneCurrent[axis].rate, AUTOTUNE_FIXED_WING_MIN_RATE, tuneCurrent[axis].initialRate);
                         }
 

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -221,11 +221,15 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
                         // Explicit check for absDesiredRateDps close to maxDesiredRate?
                         // Also increase rate in MAX if it was previously decreased (tuneCurrent[axis].rate < currentControlRateProfile->stabilized.rates[axis] * 10.0f)?
                         tuneCurrent[axis].rate += (absReachedRateDps - maxDesiredRate) * 0.5f;
-                        tuneCurrent[axis].rate = MIN(tuneCurrent[axis].rate, AUTOTUNE_FIXED_WING_MAX_RATE);
+                        if (tuneCurrent[axis].rate > AUTOTUNE_FIXED_WING_MAX_RATE) {
+                            tuneCurrent[axis].rate = AUTOTUNE_FIXED_WING_MAX_RATE;
+                        }
                         ratesUpdated = true;
                     } else {
                         tuneCurrent[axis].gainFF = tuneCurrent[axis].gainFF * (100 - AUTOTUNE_FIXED_WING_DECREASE_STEP) / 100.0f;
-                        tuneCurrent[axis].gainFF = MAX(tuneCurrent[axis].gainFF, AUTOTUNE_FIXED_WING_MIN_FF)
+                        if (tuneCurrent[axis].gainFF < AUTOTUNE_FIXED_WING_MIN_FF) {
+                            tuneCurrent[axis].gainFF = AUTOTUNE_FIXED_WING_MIN_FF;
+                        }
                         gainsUpdated = true;
                     }
                 }
@@ -235,11 +239,15 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
                     if (pidAutotuneConfig()->fw_autotune_rate_adjustment != FIXED && tuneCurrent[axis].mixerSaturated) {
                         // Decrease target rate if not achievable with full servo deflection
                         tuneCurrent[axis].rate -= (maxDesiredRate - absReachedRateDps) * 0.5f;
-                        tuneCurrent[axis].rate = MAX(tuneCurrent[axis].rate, AUTOTUNE_FIXED_WING_MIN_RATE);
+                        if (tuneCurrent[axis].rate < AUTOTUNE_FIXED_WING_MIN_RATE) {
+                            tuneCurrent[axis].rate = AUTOTUNE_FIXED_WING_MIN_RATE;
+                        }
                         ratesUpdated = true;
                     } else {
                         tuneCurrent[axis].gainFF = tuneCurrent[axis].gainFF * (100 + AUTOTUNE_FIXED_WING_INCREASE_STEP) / 100.0f;
-                        tuneCurrent[axis].gainFF = MIN(tuneCurrent[axis].gainFF, AUTOTUNE_FIXED_WING_MAX_FF);
+                        if (tuneCurrent[axis].gainFF > AUTOTUNE_FIXED_WING_MAX_FF) {
+                            tuneCurrent[axis].gainFF = AUTOTUNE_FIXED_WING_MAX_FF;
+                        }
                         gainsUpdated = true;
                     }
                 }


### PR DESCRIPTION
Closes #6025.

This is a WIP improvement to autotune that creates three autotune modes (`fw_autotune_rate_adjustment`): `FIXED` the default and the current behavior where rates are never changed, `MAX` where rates are decreased if not achievable with current mixer weights, and `AUTO` where the rates are increased and decreased according to the airplane's capabilities. Setting to `MAX`, and especially `AUTO`, creates a system where both the setpoint and the gains are changed simultaneously. The current logic should not cause any problems but I am looking for feedback on this.

There are still some things to do, for which I have added comments.

@b14ckyy, is this sort of what you had in mind?