### PR TITLE
Remove the OPFLOW_PMW3901 opflow hardware option

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -13,7 +13,7 @@ tables:
     values: ["NONE", "AUTO", "HMC5883", "AK8975", "GPSMAG", "MAG3110", "AK8963", "IST8310", "QMC5883", "MPU9250", "IST8308", "LIS3MDL", "MSP", "FAKE"]
     enum: magSensor_e
   - name: opflow_hardware
-    values: ["NONE", "PMW3901", "CXOF", "MSP", "FAKE"]
+    values: ["NONE", "CXOF", "MSP", "FAKE"]
     enum: opticalFlowSensor_e
   - name: baro_hardware
     values: ["NONE", "AUTO", "BMP085", "MS5611", "BMP280", "MS5607", "LPS25H", "SPL06", "BMP388", "DPS310", "MSP", "FAKE"]

--- a/src/main/sensors/opflow.c
+++ b/src/main/sensors/opflow.c
@@ -75,7 +75,7 @@ static float opflowCalibrationFlowAcc;
 #define OPFLOW_UPDATE_TIMEOUT_US        200000  // At least 5Hz updates required
 #define OPFLOW_CALIBRATE_TIME_MS        30000   // 30 second calibration time
 
-PG_REGISTER_WITH_RESET_TEMPLATE(opticalFlowConfig_t, opticalFlowConfig, PG_OPFLOW_CONFIG, 1);
+PG_REGISTER_WITH_RESET_TEMPLATE(opticalFlowConfig_t, opticalFlowConfig, PG_OPFLOW_CONFIG, 2);
 
 PG_RESET_TEMPLATE(opticalFlowConfig_t, opticalFlowConfig,
     .opflow_hardware = OPFLOW_NONE,

--- a/src/main/sensors/opflow.h
+++ b/src/main/sensors/opflow.h
@@ -30,10 +30,9 @@
 
 typedef enum {
     OPFLOW_NONE         = 0,
-    OPFLOW_PMW3901      = 1,
-    OPFLOW_CXOF         = 2,
-    OPFLOW_MSP          = 3,
-    OPFLOW_FAKE         = 4,
+    OPFLOW_CXOF         = 1,
+    OPFLOW_MSP          = 2,
+    OPFLOW_FAKE         = 3,
 } opticalFlowSensor_e;
 
 typedef enum {


### PR DESCRIPTION
The PMW3901 driver has never been implemented. Quote from @digitalentity: "It's using very weird SPI timings, won't be compatible with our scheduling"