### PR TITLE
Flip over after crash aka TURTLE MODE

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -101,6 +101,7 @@
 | failsafe_throttle_low_delay | 100 | If failsafe activated when throttle is low for this much time - bypass failsafe and disarm, in 10th of seconds. 0 = No timeout |
 | fixed_wing_auto_arm | OFF | Auto-arm fixed wing aircraft on throttle above min_check, and disarming with stick commands are disabled, so power cycle is required to disarm. Requires enabled motorstop and no arm switch configured. |
 | flaperon_throw_offset | 200 | Defines throw range in us for both ailerons that will be passed to servo mixer via input source 14 (`FEATURE FLAPS`) when FLAPERON mode is activated. |
+| flip_over_after_crash_power_factor | 65 | flip over after crash power factor |
 | fpv_mix_degrees |  |  |
 | frsky_coordinates_format | 0 | D-Series telemetry only: FRSKY_FORMAT_DMS (default), FRSKY_FORMAT_NMEA |
 | frsky_default_latitude | 0.000 | D-Series telemetry only: OpenTX needs a valid set of coordinates to show compass value. A fake value defined in this setting is sent while no fix is acquired. |

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -48,6 +48,8 @@ main_sources(COMMON_SRC
     common/typeconversion.h
     common/uvarint.c
     common/uvarint.h
+    common/circular_queue.c
+    common/circular_queue.h
 
     config/config_eeprom.c
     config/config_eeprom.h

--- a/src/main/common/circular_queue.c
+++ b/src/main/common/circular_queue.c
@@ -1,0 +1,42 @@
+#include "circular_queue.h"
+
+void circularBufferInit(circularBuffer_t *circular_buffer, uint8_t *buffer, size_t buffer_size,
+                          size_t buffer_element_size) {
+    circular_buffer->buffer = buffer;
+    circular_buffer->bufferSize = buffer_size;
+    circular_buffer->elementSize = buffer_element_size;
+    circular_buffer->head = 0;
+    circular_buffer->tail = 0;
+    circular_buffer->size = 0;
+}
+
+void circularBufferPushElement(circularBuffer_t *circularBuffer, uint8_t *element) {
+    if (circularBufferIsFull(circularBuffer))
+        return;
+
+    memcpy(circularBuffer->buffer + circularBuffer->tail, element, circularBuffer->elementSize);
+
+    circularBuffer->tail += circularBuffer->elementSize;
+    circularBuffer->tail %= circularBuffer->bufferSize;
+    circularBuffer->size += 1;
+}
+
+void circularBufferPopHead(circularBuffer_t *circularBuffer, uint8_t *element) {
+    memcpy(element, circularBuffer->buffer + circularBuffer->head, circularBuffer->elementSize);
+
+    circularBuffer->head += circularBuffer->elementSize;
+    circularBuffer->head %= circularBuffer->bufferSize;
+    circularBuffer->size -= 1;
+}
+
+uint8_t circularBufferIsFull(circularBuffer_t *circularBuffer) {
+    return circularBufferCountElements(circularBuffer) * circularBuffer->elementSize == circularBuffer->bufferSize;
+}
+
+uint8_t circularBufferIsEmpty(circularBuffer_t *circularBuffer) {
+    return circularBufferCountElements(circularBuffer) == 0;
+}
+
+size_t circularBufferCountElements(circularBuffer_t *circularBuffer) {
+    return circularBuffer->size;
+}

--- a/src/main/common/circular_queue.c
+++ b/src/main/common/circular_queue.c
@@ -1,3 +1,27 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
 #include "circular_queue.h"
 
 void circularBufferInit(circularBuffer_t *circular_buffer, uint8_t *buffer, size_t buffer_size,
@@ -29,12 +53,12 @@ void circularBufferPopHead(circularBuffer_t *circularBuffer, uint8_t *element) {
     circularBuffer->size -= 1;
 }
 
-uint8_t circularBufferIsFull(circularBuffer_t *circularBuffer) {
+int circularBufferIsFull(circularBuffer_t *circularBuffer) {
     return circularBufferCountElements(circularBuffer) * circularBuffer->elementSize == circularBuffer->bufferSize;
 }
 
-uint8_t circularBufferIsEmpty(circularBuffer_t *circularBuffer) {
-    return circularBufferCountElements(circularBuffer) == 0;
+int circularBufferIsEmpty(circularBuffer_t *circularBuffer) {
+    return circularBuffer==NULL || circularBufferCountElements(circularBuffer) == 0;
 }
 
 size_t circularBufferCountElements(circularBuffer_t *circularBuffer) {

--- a/src/main/common/circular_queue.h
+++ b/src/main/common/circular_queue.h
@@ -1,3 +1,27 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
 #ifndef INAV_CIRCULAR_QUEUE_H
 #define INAV_CIRCULAR_QUEUE_H
 
@@ -16,8 +40,8 @@ typedef struct circularBuffer_s{
 void    circularBufferInit(circularBuffer_t * circularBuffer, uint8_t * buffer, size_t bufferSize, size_t bufferElementSize);
 void    circularBufferPushElement(circularBuffer_t * circularBuffer, uint8_t * element);
 void    circularBufferPopHead(circularBuffer_t * circularBuffer, uint8_t * element);
-uint8_t circularBufferIsFull(circularBuffer_t * circularBuffer);
-uint8_t circularBufferIsEmpty(circularBuffer_t *circularBuffer);
+int     circularBufferIsFull(circularBuffer_t * circularBuffer);
+int     circularBufferIsEmpty(circularBuffer_t *circularBuffer);
 size_t  circularBufferCountElements(circularBuffer_t * circularBuffer);
 
 #endif //INAV_CIRCULAR_QUEUE_H

--- a/src/main/common/circular_queue.h
+++ b/src/main/common/circular_queue.h
@@ -1,0 +1,23 @@
+#ifndef INAV_CIRCULAR_QUEUE_H
+#define INAV_CIRCULAR_QUEUE_H
+
+#include "stdint.h"
+#include "string.h"
+
+typedef struct circularBuffer_s{
+    size_t head;
+    size_t tail;
+    size_t bufferSize;
+    uint8_t * buffer;
+    size_t elementSize;
+    size_t size;
+}circularBuffer_t;
+
+void    circularBufferInit(circularBuffer_t * circularBuffer, uint8_t * buffer, size_t bufferSize, size_t bufferElementSize);
+void    circularBufferPushElement(circularBuffer_t * circularBuffer, uint8_t * element);
+void    circularBufferPopHead(circularBuffer_t * circularBuffer, uint8_t * element);
+uint8_t circularBufferIsFull(circularBuffer_t * circularBuffer);
+uint8_t circularBufferIsEmpty(circularBuffer_t *circularBuffer);
+size_t  circularBufferCountElements(circularBuffer_t * circularBuffer);
+
+#endif //INAV_CIRCULAR_QUEUE_H

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -88,6 +88,8 @@
 #define _ABS_I(x, var) _ABS_II(x, var)
 #define ABS(x) _ABS_I(x, _CHOOSE_VAR(_abs, __COUNTER__))
 
+#define power3(x) ((x)*(x)*(x))
+
 // Floating point Euler angles.
 typedef struct fp_angles {
     float roll;

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -582,7 +582,6 @@ void changeDshotSpinRotation(dshotDirectionCommands_e directionSpin) {
             pwmRequestMotorTelemetry(i);
             pwmWriteMotor(i, directionSpin);
         }
-        delayMicroseconds(DSHOT_COMMAND_DELAY_US);
         pwmCompleteMotorUpdate();
 
     }

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -67,7 +67,7 @@ FILE_COMPILE_FOR_SPEED
 typedef void (*pwmWriteFuncPtr)(uint8_t index, uint16_t value);  // function pointer used to write motors
 
 typedef struct {
-    TCH_t *tch;
+    TCH_t * tch;
     bool configured;
     uint16_t value;
 
@@ -83,19 +83,19 @@ typedef struct {
 } pwmOutputPort_t;
 
 typedef struct {
-    pwmOutputPort_t *pwmPort;        // May be NULL if motor doesn't use the PWM port
-    uint16_t value;          // Used to keep track of last motor value
-    bool requestTelemetry;
+    pwmOutputPort_t *   pwmPort;        // May be NULL if motor doesn't use the PWM port
+    uint16_t            value;          // Used to keep track of last motor value
+    bool                requestTelemetry;
 } pwmOutputMotor_t;
 
 static pwmOutputPort_t pwmOutputPorts[MAX_PWM_OUTPUT_PORTS];
 
-static pwmOutputMotor_t motors[MAX_MOTORS];
+static pwmOutputMotor_t        motors[MAX_MOTORS];
 static motorPwmProtocolTypes_e initMotorProtocol;
-static pwmWriteFuncPtr motorWritePtr = NULL;    // Function to write value to motors
+static pwmWriteFuncPtr         motorWritePtr = NULL;    // Function to write value to motors
 
-static pwmOutputPort_t *servos[MAX_SERVOS];
-static pwmWriteFuncPtr servoWritePtr = NULL;    // Function to write value to motors
+static pwmOutputPort_t *       servos[MAX_SERVOS];
+static pwmWriteFuncPtr         servoWritePtr = NULL;    // Function to write value to motors
 
 #if defined(USE_DSHOT) || defined(USE_SERIALSHOT)
 static timeUs_t digitalMotorUpdateIntervalUs = 0;
@@ -112,7 +112,8 @@ static uint8_t allocatedOutputPortCount = 0;
 
 static bool pwmMotorsEnabled = true;
 
-static void pwmOutConfigTimer(pwmOutputPort_t *p, TCH_t *tch, uint32_t hz, uint16_t period, uint16_t value) {
+static void pwmOutConfigTimer(pwmOutputPort_t * p, TCH_t * tch, uint32_t hz, uint16_t period, uint16_t value)
+{
     p->tch = tch;
 
     timerConfigBase(p->tch, period, hz);
@@ -125,7 +126,8 @@ static void pwmOutConfigTimer(pwmOutputPort_t *p, TCH_t *tch, uint32_t hz, uint1
     *p->ccr = 0;
 }
 
-static pwmOutputPort_t *pwmOutAllocatePort(void) {
+static pwmOutputPort_t *pwmOutAllocatePort(void)
+{
     if (allocatedOutputPortCount >= MAX_PWM_OUTPUT_PORTS) {
         LOG_E(PWM, "Attempt to allocate PWM output beyond MAX_PWM_OUTPUT_PORTS");
         return NULL;
@@ -139,10 +141,10 @@ static pwmOutputPort_t *pwmOutAllocatePort(void) {
     return p;
 }
 
-static pwmOutputPort_t *
-pwmOutConfigMotor(const timerHardware_t *timHw, uint32_t hz, uint16_t period, uint16_t value, bool enableOutput) {
+static pwmOutputPort_t *pwmOutConfigMotor(const timerHardware_t *timHw, uint32_t hz, uint16_t period, uint16_t value, bool enableOutput)
+{
     // Attempt to allocate TCH
-    TCH_t *tch = timerGetTCH(timHw);
+    TCH_t * tch = timerGetTCH(timHw);
     if (tch == NULL) {
         return NULL;
     }
@@ -158,7 +160,8 @@ pwmOutConfigMotor(const timerHardware_t *timHw, uint32_t hz, uint16_t period, ui
 
     if (enableOutput) {
         IOConfigGPIOAF(io, IOCFG_AF_PP, timHw->alternateFunction);
-    } else {
+    }
+    else {
         // If PWM outputs are disabled - configure as GPIO and drive low
         IOConfigGPIO(io, IOCFG_OUT_OD);
         IOLo(io);
@@ -168,25 +171,28 @@ pwmOutConfigMotor(const timerHardware_t *timHw, uint32_t hz, uint16_t period, ui
     return p;
 }
 
-static void pwmWriteNull(uint8_t index, uint16_t value) {
-    (void) index;
-    (void) value;
+static void pwmWriteNull(uint8_t index, uint16_t value)
+{
+    (void)index;
+    (void)value;
 }
 
-static void pwmWriteStandard(uint8_t index, uint16_t value) {
+static void pwmWriteStandard(uint8_t index, uint16_t value)
+{
     if (motors[index].pwmPort) {
-        *(motors[index].pwmPort->ccr) = lrintf(
-                (value * motors[index].pwmPort->pulseScale) + motors[index].pwmPort->pulseOffset);
+        *(motors[index].pwmPort->ccr) = lrintf((value * motors[index].pwmPort->pulseScale) + motors[index].pwmPort->pulseOffset);
     }
 }
 
-void pwmWriteMotor(uint8_t index, uint16_t value) {
+void pwmWriteMotor(uint8_t index, uint16_t value)
+{
     if (motorWritePtr && index < MAX_MOTORS && pwmMotorsEnabled) {
         motorWritePtr(index, value);
     }
 }
 
-void pwmShutdownPulsesForAllMotors(uint8_t motorCount) {
+void pwmShutdownPulsesForAllMotors(uint8_t motorCount)
+{
     for (int index = 0; index < motorCount; index++) {
         // Set the compare register to 0, which stops the output pulsing if the timer overflows
         if (motors[index].pwmPort) {
@@ -195,27 +201,29 @@ void pwmShutdownPulsesForAllMotors(uint8_t motorCount) {
     }
 }
 
-void pwmDisableMotors(void) {
+void pwmDisableMotors(void)
+{
     pwmMotorsEnabled = false;
 }
 
-void pwmEnableMotors(void) {
+void pwmEnableMotors(void)
+{
     pwmMotorsEnabled = true;
 }
 
-bool isMotorBrushed(uint16_t motorPwmRateHz) {
+bool isMotorBrushed(uint16_t motorPwmRateHz)
+{
     return (motorPwmRateHz > 500);
 }
 
-static pwmOutputPort_t *
-motorConfigPwm(const timerHardware_t *timerHardware, float sMin, float sLen, uint32_t motorPwmRateHz,
-               bool enableOutput) {
+static pwmOutputPort_t * motorConfigPwm(const timerHardware_t *timerHardware, float sMin, float sLen, uint32_t motorPwmRateHz, bool enableOutput)
+{
     const uint32_t baseClockHz = timerGetBaseClockHW(timerHardware);
     const uint32_t prescaler = ((baseClockHz / motorPwmRateHz) + 0xffff) / 0x10000; /* rounding up */
     const uint32_t timerHz = baseClockHz / prescaler;
     const uint32_t period = timerHz / motorPwmRateHz;
 
-    pwmOutputPort_t *port = pwmOutConfigMotor(timerHardware, timerHz, period, 0, enableOutput);
+    pwmOutputPort_t * port = pwmOutConfigMotor(timerHardware, timerHz, period, 0, enableOutput);
 
     if (port) {
         port->pulseScale = ((sLen == 0) ? period : (sLen * timerHz)) / 1000.0f;
@@ -227,24 +235,25 @@ motorConfigPwm(const timerHardware_t *timerHardware, float sMin, float sLen, uin
 }
 
 #ifdef USE_DSHOT
-
-uint32_t getDshotHz(motorPwmProtocolTypes_e pwmProtocolType) {
+uint32_t getDshotHz(motorPwmProtocolTypes_e pwmProtocolType)
+{
     switch (pwmProtocolType) {
-        case (PWM_TYPE_DSHOT1200):
+        case(PWM_TYPE_DSHOT1200):
             return MOTOR_DSHOT1200_HZ;
-        case (PWM_TYPE_DSHOT600):
+        case(PWM_TYPE_DSHOT600):
             return MOTOR_DSHOT600_HZ;
-        case (PWM_TYPE_DSHOT300):
+        case(PWM_TYPE_DSHOT300):
             return MOTOR_DSHOT300_HZ;
         default:
-        case (PWM_TYPE_DSHOT150):
+        case(PWM_TYPE_DSHOT150):
             return MOTOR_DSHOT150_HZ;
     }
 }
 
-static pwmOutputPort_t *motorConfigDshot(const timerHardware_t *timerHardware, uint32_t dshotHz, bool enableOutput) {
+static pwmOutputPort_t * motorConfigDshot(const timerHardware_t * timerHardware, uint32_t dshotHz, bool enableOutput)
+{
     // Try allocating new port
-    pwmOutputPort_t *port = pwmOutConfigMotor(timerHardware, dshotHz, DSHOT_MOTOR_BITLENGTH, 0, enableOutput);
+    pwmOutputPort_t * port = pwmOutConfigMotor(timerHardware, dshotHz, DSHOT_MOTOR_BITLENGTH, 0, enableOutput);
 
     if (!port) {
         return NULL;
@@ -260,21 +269,23 @@ static pwmOutputPort_t *motorConfigDshot(const timerHardware_t *timerHardware, u
     return port;
 }
 
-static void loadDmaBufferDshot(timerDMASafeType_t *dmaBuffer, uint16_t packet) {
+static void loadDmaBufferDshot(timerDMASafeType_t *dmaBuffer, uint16_t packet)
+{
     for (int i = 0; i < 16; i++) {
         dmaBuffer[i] = (packet & 0x8000) ? DSHOT_MOTOR_BIT_1 : DSHOT_MOTOR_BIT_0;  // MSB first
         packet <<= 1;
     }
 }
 
-static uint16_t prepareDshotPacket(const uint16_t value, bool requestTelemetry) {
+static uint16_t prepareDshotPacket(const uint16_t value, bool requestTelemetry)
+{
     uint16_t packet = (value << 1) | (requestTelemetry ? 1 : 0);
 
     // compute checksum
     int csum = 0;
     int csum_data = packet;
     for (int i = 0; i < 3; i++) {
-        csum ^= csum_data;   // xor data by nibbles
+        csum ^=  csum_data;   // xor data by nibbles
         csum_data >>= 4;
     }
     csum &= 0xf;
@@ -284,37 +295,41 @@ static uint16_t prepareDshotPacket(const uint16_t value, bool requestTelemetry) 
 
     return packet;
 }
-
 #endif
 
 #if defined(USE_DSHOT) || defined(USE_SERIALSHOT)
-
-static void motorConfigDigitalUpdateInterval(uint16_t motorPwmRateHz) {
+static void motorConfigDigitalUpdateInterval(uint16_t motorPwmRateHz)
+{
     digitalMotorUpdateIntervalUs = 1000000 / motorPwmRateHz;
     digitalMotorLastUpdateUs = 0;
 }
 
-static void pwmWriteDigital(uint8_t index, uint16_t value) {
+static void pwmWriteDigital(uint8_t index, uint16_t value)
+{
     // Just keep track of motor value, actual update happens in pwmCompleteMotorUpdate()
     // DSHOT and some other digital protocols use 11-bit throttle range [0;2047]
     motors[index].value = constrain(value, 0, 2047);
 }
 
-bool isMotorProtocolDshot(void) {
+bool isMotorProtocolDshot(void)
+{
     // We look at cached `initMotorProtocol` to make sure we are consistent with the initialized config
     // motorConfig()->motorPwmProtocol may change at run time which will cause uninitialized structures to be used
     return getMotorProtocolProperties(initMotorProtocol)->isDSHOT;
 }
 
-bool isMotorProtocolSerialShot(void) {
+bool isMotorProtocolSerialShot(void)
+{
     return getMotorProtocolProperties(initMotorProtocol)->isSerialShot;
 }
 
-bool isMotorProtocolDigital(void) {
+bool isMotorProtocolDigital(void)
+{
     return isMotorProtocolDshot() || isMotorProtocolSerialShot();
 }
 
-void pwmRequestMotorTelemetry(int motorIndex) {
+void pwmRequestMotorTelemetry(int motorIndex)
+{
     if (!isMotorProtocolDigital()) {
         return;
     }
@@ -327,7 +342,8 @@ void pwmRequestMotorTelemetry(int motorIndex) {
     }
 }
 
-void pwmCompleteMotorUpdate(void) {
+void pwmCompleteMotorUpdate(void)
+{
     // This only makes sense for digital motor protocols
     if (!isMotorProtocolDigital()) {
         return;
@@ -337,8 +353,7 @@ void pwmCompleteMotorUpdate(void) {
     timeUs_t currentTimeUs = micros();
 
     // Enforce motor update rate
-    if ((digitalMotorUpdateIntervalUs == 0) ||
-        ((currentTimeUs - digitalMotorLastUpdateUs) <= digitalMotorUpdateIntervalUs)) {
+    if ((digitalMotorUpdateIntervalUs == 0) || ((currentTimeUs - digitalMotorLastUpdateUs) <= digitalMotorUpdateIntervalUs)) {
         return;
     }
 
@@ -386,7 +401,8 @@ void pwmRequestMotorTelemetry(int motorIndex)
 
 #endif
 
-void pwmMotorPreconfigure(void) {
+void pwmMotorPreconfigure(void)
+{
     // Keep track of initial motor protocol
     initMotorProtocol = motorConfig()->motorPwmProtocol;
 
@@ -429,86 +445,84 @@ void pwmMotorPreconfigure(void) {
     }
 }
 
-bool pwmMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, bool enableOutput) {
+bool pwmMotorConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, bool enableOutput)
+{
     switch (initMotorProtocol) {
-        case PWM_TYPE_BRUSHED:
-            motors[motorIndex].pwmPort = motorConfigPwm(timerHardware, 0.0f, 0.0f, motorConfig()->motorPwmRate,
-                                                        enableOutput);
-            break;
+    case PWM_TYPE_BRUSHED:
+        motors[motorIndex].pwmPort = motorConfigPwm(timerHardware, 0.0f, 0.0f, motorConfig()->motorPwmRate, enableOutput);
+        break;
 
-        case PWM_TYPE_ONESHOT125:
-            motors[motorIndex].pwmPort = motorConfigPwm(timerHardware, 125e-6f, 125e-6f, motorConfig()->motorPwmRate,
-                                                        enableOutput);
-            break;
+    case PWM_TYPE_ONESHOT125:
+        motors[motorIndex].pwmPort = motorConfigPwm(timerHardware, 125e-6f, 125e-6f, motorConfig()->motorPwmRate, enableOutput);
+        break;
 
-        case PWM_TYPE_ONESHOT42:
-            motors[motorIndex].pwmPort = motorConfigPwm(timerHardware, 42e-6f, 42e-6f, motorConfig()->motorPwmRate,
-                                                        enableOutput);
-            break;
+    case PWM_TYPE_ONESHOT42:
+        motors[motorIndex].pwmPort = motorConfigPwm(timerHardware, 42e-6f, 42e-6f, motorConfig()->motorPwmRate, enableOutput);
+        break;
 
-        case PWM_TYPE_MULTISHOT:
-            motors[motorIndex].pwmPort = motorConfigPwm(timerHardware, 5e-6f, 20e-6f, motorConfig()->motorPwmRate,
-                                                        enableOutput);
-            break;
+    case PWM_TYPE_MULTISHOT:
+        motors[motorIndex].pwmPort = motorConfigPwm(timerHardware, 5e-6f, 20e-6f, motorConfig()->motorPwmRate, enableOutput);
+        break;
 
 #ifdef USE_DSHOT
-        case PWM_TYPE_DSHOT1200:
-        case PWM_TYPE_DSHOT600:
-        case PWM_TYPE_DSHOT300:
-        case PWM_TYPE_DSHOT150:
-            motors[motorIndex].pwmPort = motorConfigDshot(timerHardware, getDshotHz(initMotorProtocol), enableOutput);
-            break;
+    case PWM_TYPE_DSHOT1200:
+    case PWM_TYPE_DSHOT600:
+    case PWM_TYPE_DSHOT300:
+    case PWM_TYPE_DSHOT150:
+        motors[motorIndex].pwmPort = motorConfigDshot(timerHardware, getDshotHz(initMotorProtocol), enableOutput);
+        break;
 #endif
 
-        case PWM_TYPE_STANDARD:
-            motors[motorIndex].pwmPort = motorConfigPwm(timerHardware, 1e-3f, 1e-3f, motorConfig()->motorPwmRate,
-                                                        enableOutput);
-            break;
+    case PWM_TYPE_STANDARD:
+        motors[motorIndex].pwmPort = motorConfigPwm(timerHardware, 1e-3f, 1e-3f, motorConfig()->motorPwmRate, enableOutput);
+        break;
 
-        default:
-            motors[motorIndex].pwmPort = NULL;
-            break;
+    default:
+        motors[motorIndex].pwmPort = NULL;
+        break;
     }
 
     return (motors[motorIndex].pwmPort != NULL);
 }
 
 // Helper function for ESC passthrough
-ioTag_t pwmGetMotorPinTag(int motorIndex) {
+ioTag_t pwmGetMotorPinTag(int motorIndex)
+{
     if (motors[motorIndex].pwmPort) {
         return motors[motorIndex].pwmPort->tch->timHw->tag;
-    } else {
+    }
+    else {
         return IOTAG_NONE;
     }
 }
 
-static void pwmServoWriteStandard(uint8_t index, uint16_t value) {
+static void pwmServoWriteStandard(uint8_t index, uint16_t value)
+{
     if (servos[index]) {
         *servos[index]->ccr = value;
     }
 }
 
 #ifdef USE_SERVO_SBUS
-
-static void sbusPwmWriteStandard(uint8_t index, uint16_t value) {
+static void sbusPwmWriteStandard(uint8_t index, uint16_t value)
+{
     pwmServoWriteStandard(index, value);
     sbusServoUpdate(index, value);
 }
-
 #endif
 
 #ifdef USE_PWM_SERVO_DRIVER
-
-static void pwmServoWriteExternalDriver(uint8_t index, uint16_t value) {
+static void pwmServoWriteExternalDriver(uint8_t index, uint16_t value)
+{
     // If PCA9685 is not detected, we do not want to write servo output anywhere
     if (STATE(PWM_DRIVER_AVAILABLE)) {
         pwmDriverSetPulse(index, value);
     }
 }
-
 #endif
 
-void pwmServoPreconfigure(void) {
+void pwmServoPreconfigure(void)
+{
     // Protocol-specific configuration
     switch (servoConfig()->servo_protocol) {
         default:
@@ -537,10 +551,9 @@ void pwmServoPreconfigure(void) {
     }
 }
 
-bool pwmServoConfig(const timerHardware_t *timerHardware, uint8_t servoIndex, uint16_t servoPwmRate,
-                    uint16_t servoCenterPulse, bool enableOutput) {
-    pwmOutputPort_t *port = pwmOutConfigMotor(timerHardware, PWM_TIMER_HZ, PWM_TIMER_HZ / servoPwmRate,
-                                              servoCenterPulse, enableOutput);
+bool pwmServoConfig(const timerHardware_t *timerHardware, uint8_t servoIndex, uint16_t servoPwmRate, uint16_t servoCenterPulse, bool enableOutput)
+{
+    pwmOutputPort_t * port = pwmOutConfigMotor(timerHardware, PWM_TIMER_HZ, PWM_TIMER_HZ / servoPwmRate, servoCenterPulse, enableOutput);
 
     if (port) {
         servos[servoIndex] = port;
@@ -550,7 +563,8 @@ bool pwmServoConfig(const timerHardware_t *timerHardware, uint8_t servoIndex, ui
     return false;
 }
 
-void pwmWriteServo(uint8_t index, uint16_t value) {
+void pwmWriteServo(uint8_t index, uint16_t value)
+{
     if (servoWritePtr && index < MAX_SERVOS) {
         servoWritePtr(index, value);
     }

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -28,6 +28,7 @@ void pwmWriteMotor(uint8_t index, uint16_t value);
 void pwmShutdownPulsesForAllMotors(uint8_t motorCount);
 void pwmCompleteMotorUpdate(void);
 bool isMotorProtocolDigital(void);
+bool isMotorProtocolDshot(void);
 
 void pwmWriteServo(uint8_t index, uint16_t value);
 

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -25,6 +25,11 @@ typedef enum {
     DSHOT_CMD_SPIN_DIRECTION_REVERSED = 21,
 } dshotCommands_e;
 
+typedef struct {
+    dshotCommands_e cmd;
+    int remainingRepeats;
+} currentExecutingCommand_t;
+
 void pwmRequestMotorTelemetry(int motorIndex);
 
 ioTag_t pwmGetMotorPinTag(int motorIndex);

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -20,6 +20,11 @@
 #include "drivers/io_types.h"
 #include "drivers/time.h"
 
+typedef enum {
+    DSHOT_CMD_SPIN_DIRECTION_NORMAL = 20,
+    DSHOT_CMD_SPIN_DIRECTION_REVERSED = 21,
+} dshotDirectionCommands_e;
+
 void pwmRequestMotorTelemetry(int motorIndex);
 
 ioTag_t pwmGetMotorPinTag(int motorIndex);
@@ -43,3 +48,5 @@ void pwmServoPreconfigure(void);
 bool pwmServoConfig(const struct timerHardware_s *timerHardware, uint8_t servoIndex, uint16_t servoPwmRate, uint16_t servoCenterPulse, bool enableOutput);
 void pwmWriteBeeper(bool onoffBeep);
 void beeperPwmInit(ioTag_t tag, uint16_t frequency);
+
+void changeDshotSpinRotation(dshotDirectionCommands_e directionSpin);

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -23,7 +23,7 @@
 typedef enum {
     DSHOT_CMD_SPIN_DIRECTION_NORMAL = 20,
     DSHOT_CMD_SPIN_DIRECTION_REVERSED = 21,
-} dshotDirectionCommands_e;
+} dshotCommands_e;
 
 void pwmRequestMotorTelemetry(int motorIndex);
 
@@ -49,4 +49,5 @@ bool pwmServoConfig(const struct timerHardware_s *timerHardware, uint8_t servoIn
 void pwmWriteBeeper(bool onoffBeep);
 void beeperPwmInit(ioTag_t tag, uint16_t frequency);
 
-void changeDshotSpinRotation(dshotDirectionCommands_e directionSpin);
+void sendDShotCommand(dshotCommands_e directionSpin);
+void initDShotCommands(void);

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -65,7 +65,6 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *instance)
 
             .misc = {
                 .fpvCamAngleDegrees = 0,
-                .flipOverAfterPowerFactor = 65
             }
         );
     }

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -64,7 +64,8 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *instance)
             },
 
             .misc = {
-                .fpvCamAngleDegrees = 0
+                .fpvCamAngleDegrees = 0,
+                .flipOverAfterPowerFactor = 65
             }
         );
     }

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -64,7 +64,6 @@ typedef struct controlRateConfig_s {
 
     struct {
         uint8_t fpvCamAngleDegrees;             // Camera angle to treat as "forward" base axis in ACRO (Roll and Yaw sticks will command rotation considering this axis)
-        uint8_t flipOverAfterPowerFactor;
     } misc;
 
 } controlRateConfig_t;

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -64,6 +64,7 @@ typedef struct controlRateConfig_s {
 
     struct {
         uint8_t fpvCamAngleDegrees;             // Camera angle to treat as "forward" base axis in ACRO (Roll and Yaw sticks will command rotation considering this axis)
+        uint8_t flipOverAfterPowerFactor;
     } misc;
 
 } controlRateConfig_t;

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -400,7 +400,7 @@ void disarm(disarmReason_t disarmReason)
 #endif
 #ifdef USE_DSHOT
         if (FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)) {
-            changeDshotSpinRotation(DSHOT_CMD_SPIN_DIRECTION_NORMAL);
+            sendDShotCommand(DSHOT_CMD_SPIN_DIRECTION_NORMAL);
             DISABLE_FLIGHT_MODE(FLIP_OVER_AFTER_CRASH);
         }
 #endif
@@ -471,8 +471,7 @@ void tryArm(void)
             !ARMING_FLAG(ARMING_DISABLED_THROTTLE) &&
             !FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)
             ) {
-
-        changeDshotSpinRotation(DSHOT_CMD_SPIN_DIRECTION_REVERSED);
+        sendDShotCommand(DSHOT_CMD_SPIN_DIRECTION_REVERSED);
         ENABLE_ARMING_FLAG(ARMED);
         enableFlightMode(FLIP_OVER_AFTER_CRASH);
         return;

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -399,6 +399,7 @@ void disarm(disarmReason_t disarmReason)
         }
 #endif
         if (FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)) {
+            changeDshotSpinRotation(DSHOT_CMD_SPIN_DIRECTION_NORMAL);
             DISABLE_FLIGHT_MODE(FLIP_OVER_AFTER_CRASH);
         }
 
@@ -469,6 +470,8 @@ void tryArm(void)
             !ARMING_FLAG(ARMING_DISABLED_THROTTLE) &&
             !FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)
             ) {
+
+        changeDshotSpinRotation(DSHOT_CMD_SPIN_DIRECTION_REVERSED);
         ENABLE_ARMING_FLAG(ARMED);
         enableFlightMode(FLIP_OVER_AFTER_CRASH);
         return;

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -467,8 +467,8 @@ void tryArm(void)
     if (
             STATE(MULTIROTOR) &&
             IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) &&
+            emergencyArmingCanOverrideArmingDisabled() &&
             isMotorProtocolDshot() &&
-            !ARMING_FLAG(ARMING_DISABLED_THROTTLE) &&
             !FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)
             ) {
         sendDShotCommand(DSHOT_CMD_SPIN_DIRECTION_REVERSED);

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -398,11 +398,12 @@ void disarm(disarmReason_t disarmReason)
             blackboxFinish();
         }
 #endif
+#ifdef USE_DSHOT
         if (FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)) {
             changeDshotSpinRotation(DSHOT_CMD_SPIN_DIRECTION_NORMAL);
             DISABLE_FLIGHT_MODE(FLIP_OVER_AFTER_CRASH);
         }
-
+#endif
         statsOnDisarm();
         logicConditionReset();
         programmingPidReset();

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -398,6 +398,9 @@ void disarm(disarmReason_t disarmReason)
             blackboxFinish();
         }
 #endif
+        if (FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)) {
+            DISABLE_FLIGHT_MODE(FLIP_OVER_AFTER_CRASH);
+        }
 
         statsOnDisarm();
         logicConditionReset();
@@ -457,6 +460,20 @@ void releaseSharedTelemetryPorts(void) {
 void tryArm(void)
 {
     updateArmingStatus();
+
+#ifdef USE_DSHOT
+    if (
+            STATE(MULTIROTOR) &&
+            IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) &&
+            isMotorProtocolDshot() &&
+            !ARMING_FLAG(ARMING_DISABLED_THROTTLE) &&
+            !FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)
+            ) {
+        ENABLE_ARMING_FLAG(ARMED);
+        enableFlightMode(FLIP_OVER_AFTER_CRASH);
+        return;
+    }
+#endif
 #ifdef USE_PROGRAMMING_FRAMEWORK
     if (
         !isArmingDisabled() || 

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -673,6 +673,10 @@ void init(void)
     rcdeviceInit();
 #endif // USE_RCDEVICE
 
+#ifdef USE_DSHOT
+    initDShotCommands();
+#endif
+
     // Latch active features AGAIN since some may be modified by init().
     latchActiveFeatures();
     motorControlEnable = true;

--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -309,7 +309,8 @@ void initActiveBoxIds(void)
 #endif
 
 #ifdef USE_DSHOT
-    activeBoxIds[activeBoxIdCount++] = BOXFLIPOVERAFTERCRASH;
+    if(STATE(MULTIROTOR))
+        activeBoxIds[activeBoxIdCount++] = BOXFLIPOVERAFTERCRASH;
 #endif
 }
 

--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -87,6 +87,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXLOITERDIRCHN, "LOITER CHANGE", 49 },
     { BOXMSPRCOVERRIDE, "MSP RC OVERRIDE", 50 },
     { BOXPREARM, "PREARM", 51 },
+    { BOXFLIPOVERAFTERCRASH, "TURTLE", 52 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -305,6 +306,10 @@ void initActiveBoxIds(void)
 
 #if defined(USE_RX_MSP) && defined(USE_MSP_RC_OVERRIDE)
     activeBoxIds[activeBoxIdCount++] = BOXMSPRCOVERRIDE;
+#endif
+
+#ifdef USE_DSHOT
+    activeBoxIds[activeBoxIdCount++] = BOXFLIPOVERAFTERCRASH;
 #endif
 }
 

--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -33,6 +33,8 @@
 
 #include "io/osd.h"
 
+#include "drivers/pwm_output.h"
+
 #include "sensors/diagnostics.h"
 #include "sensors/sensors.h"
 
@@ -309,7 +311,7 @@ void initActiveBoxIds(void)
 #endif
 
 #ifdef USE_DSHOT
-    if(STATE(MULTIROTOR))
+    if(STATE(MULTIROTOR) && isMotorProtocolDshot())
         activeBoxIds[activeBoxIdCount++] = BOXFLIPOVERAFTERCRASH;
 #endif
 }

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -69,6 +69,7 @@ typedef enum {
     BOXLOITERDIRCHN  = 40,
     BOXMSPRCOVERRIDE = 41,
     BOXPREARM        = 42,
+    BOXFLIPOVERAFTERCRASH = 43,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -97,6 +97,7 @@ typedef enum {
     NAV_CRUISE_MODE = (1 << 12),
     FLAPERON        = (1 << 13),
     TURN_ASSISTANT  = (1 << 14),
+    FLIP_OVER_AFTER_CRASH = (1 << 15),
 } flightModeFlags_e;
 
 extern uint32_t flightModeFlags;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -726,6 +726,7 @@ groups:
         field: flipOverAfterPowerFactor
         default_value: "65"
         description: "flip over after crash power factor"
+        condition: "USE_DSHOT"
         min: 0
         max: 100
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1157,6 +1157,12 @@ groups:
         field: misc.fpvCamAngleDegrees
         min: 0
         max: 50
+      - name: flip_over_after_crash_power_factor
+        field: misc.flipOverAfterPowerFactor
+        default_value: "65"
+        description: "flip over after crash power factor"
+        min: 0
+        max: 100
 
   - name: PG_SERIAL_CONFIG
     type: serialConfig_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -722,6 +722,12 @@ groups:
         default_value: "14"
         min: 4
         max: 255
+      - name: flip_over_after_crash_power_factor
+        field: flipOverAfterPowerFactor
+        default_value: "65"
+        description: "flip over after crash power factor"
+        min: 0
+        max: 100
 
   - name: PG_FAILSAFE_CONFIG
     type: failsafeConfig_t
@@ -1159,12 +1165,6 @@ groups:
         field: misc.fpvCamAngleDegrees
         min: 0
         max: 50
-      - name: flip_over_after_crash_power_factor
-        field: misc.flipOverAfterPowerFactor
-        default_value: "65"
-        description: "flip over after crash power factor"
-        min: 0
-        max: 100
 
   - name: PG_SERIAL_CONFIG
     type: serialConfig_t

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -100,7 +100,7 @@ PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
 
 #define DEFAULT_MAX_THROTTLE    1850
 
-PG_REGISTER_WITH_RESET_TEMPLATE(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 6);
+PG_REGISTER_WITH_RESET_TEMPLATE(motorConfig_t, motorConfig, PG_MOTOR_CONFIG, 7);
 
 PG_RESET_TEMPLATE(motorConfig_t, motorConfig,
     .motorPwmProtocol = DEFAULT_PWM_PROTOCOL,
@@ -111,7 +111,8 @@ PG_RESET_TEMPLATE(motorConfig_t, motorConfig,
     .motorDecelTimeMs = 0,
     .throttleIdle = 15.0f,
     .throttleScale = 1.0f,
-    .motorPoleCount = 14            // Most brushless motors that we use are 14 poles
+    .motorPoleCount = 14,           // Most brushless motors that we use are 14 poles
+    .flipOverAfterPowerFactor = 65
 );
 
 PG_REGISTER_ARRAY(motorMixer_t, MAX_SUPPORTED_MOTORS, primaryMotorMixer, PG_MOTOR_MIXER, 0);
@@ -326,7 +327,7 @@ static uint16_t handleOutputScaling(
 static void applyFlipOverAfterCrashModeToMotors(void) {
 
     if (ARMING_FLAG(ARMED)) {
-        const float flipPowerFactor = ((float)currentControlRateProfile->misc.flipOverAfterPowerFactor/100.0f);
+        const float flipPowerFactor = ((float)motorConfig()->flipOverAfterPowerFactor)/100.0f;
         const float stickDeflectionPitchAbs = ABS(((float) rcCommand[PITCH]) / 500.0f);
         const float stickDeflectionRollAbs = ABS(((float) rcCommand[ROLL]) / 500.0f);
         const float stickDeflectionYawAbs = ABS(((float) rcCommand[YAW]) / 500.0f);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -399,19 +399,6 @@ static void applyFlipOverAfterCrashModeToMotors(void) {
                     motorOutput - CRASH_FLIP_DEADBAND);
 
             motor[i] = motorOutput;
-
-            motorValue = handleOutputScaling(
-                    motorOutput,
-                    throttleIdleValue,
-                    DSHOT_DISARM_COMMAND,
-                    motorConfig()->mincommand,
-                    motorConfig()->maxthrottle,
-                    DSHOT_MIN_THROTTLE,
-                    DSHOT_3D_DEADBAND_LOW,
-                    false
-            );
-
-            pwmWriteMotor(i,motorValue);
         }
     } else {
         // Disarmed mode

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -529,10 +529,12 @@ static int getReversibleMotorsThrottleDeadband(void)
 
 void FAST_CODE mixTable(const float dT)
 {
+#ifdef USE_DSHOT
     if (FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)) {
         applyFlipOverAfterCrashModeToMotors();
         return;
     }
+#endif
 
     int16_t input[3];   // RPY, range [-500:+500]
     // Allow direct stick input to motors in passthrough mode on airplanes

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -92,6 +92,7 @@ typedef struct motorConfig_s {
     float throttleIdle;                     // Throttle IDLE value based on min_command, max_throttle, in percent
     float throttleScale;                    // Scaling factor for throttle.
     uint8_t motorPoleCount;                 // Magnetic poles in the motors for calculating actual RPM from eRPM provided by ESC telemetry
+    uint8_t flipOverAfterPowerFactor;       // Power factor from 0 to 100% of flip over after crash
 } motorConfig_t;
 
 PG_DECLARE(motorConfig_t, motorConfig);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1609,6 +1609,8 @@ static bool osdDrawSingleElement(uint8_t item)
                 p = "ANGL";
             else if (FLIGHT_MODE(HORIZON_MODE))
                 p = "HOR ";
+            else if (FLIGHT_MODE(FLIP_OVER_AFTER_CRASH))
+                p = "TURT";
 
             displayWrite(osdDisplayPort, elemPosX, elemPosY, p);
             return true;

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -27,6 +27,8 @@ set_property(SOURCE telemetry_hott_unittest.cc PROPERTY depends
 
 set_property(SOURCE time_unittest.cc PROPERTY depends "drivers/time.c")
 
+set_property(SOURCE circular_queue_unittest.cc PROPERTY depends "common/circular_queue.c")
+
 function(unit_test src)
     get_filename_component(basename ${src} NAME)
     string(REPLACE ".cc" "" name ${basename} )

--- a/src/test/unit/circular_queue_unittest.cc
+++ b/src/test/unit/circular_queue_unittest.cc
@@ -1,0 +1,166 @@
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+#include <stdint.h>
+
+#include <stdlib.h>
+#include <time.h>
+
+extern "C" {
+    #include "common/circular_queue.h"
+}
+#include <queue>
+#include <climits>
+
+
+TEST(CircularQueue, ElementsAreCorrect){
+    srand (time(NULL));
+
+    circularBuffer_t buffer;
+
+    const size_t bufferSize = 16;
+    uint8_t buff[bufferSize];
+
+    circularBufferInit(&buffer, buff, bufferSize, sizeof(char));
+
+    const uint8_t testBurst = 3;
+
+    const uint8_t dataToInsertSize[testBurst] = {5, 10, 3};
+    const uint8_t dataToRemoveSize[testBurst] = {3, 7, 2};
+
+    std::queue <uint8_t>queue;
+
+    for(uint8_t j=0; j<testBurst; j++){
+
+        for(uint8_t i = 0;i < dataToInsertSize[j]; i++)
+        {
+            uint8_t value = rand() % 255;
+            queue.push(value);
+            circularBufferPushElement(&buffer, &value);
+        }
+        for(uint8_t i = 0;i < dataToRemoveSize[j]; i++)
+        {
+            uint8_t value;
+            circularBufferPopHead(&buffer, &value);
+            EXPECT_EQ(queue.front(),value);
+            queue.pop();
+        }
+        EXPECT_EQ(circularBufferCountElements(&buffer),queue.size());
+    }
+
+    EXPECT_EQ(circularBufferIsEmpty(&buffer),queue.empty());
+
+}
+
+TEST(CircularQueue, CheckIsEmptyAndIsFull16){ //check with uint16_t
+    srand (time(NULL));
+
+    circularBuffer_t buffer;
+
+    typedef uint16_t tested_type;
+
+    const size_t bufferSize = 16 * sizeof(tested_type);
+    uint8_t buff[bufferSize];
+
+    circularBufferInit(&buffer, buff, bufferSize, sizeof(tested_type));
+
+    const int testBurst = 3;
+
+    const int dataToInsertSize[testBurst] = {10, 8, 4};
+    const int dataToRemoveSize[testBurst] = {3, 3, 0};
+    //At the end we have 0 elements
+
+    std::queue <tested_type>queue;
+
+    EXPECT_EQ(circularBufferIsEmpty(&buffer),true);
+    EXPECT_EQ(circularBufferIsFull(&buffer),false);
+
+    for(uint8_t j=0; j<testBurst; j++){
+
+        for(uint8_t i = 0;i < dataToInsertSize[j]; i++)
+        {
+            tested_type value = rand() % SHRT_MAX;
+            queue.push(value);
+            circularBufferPushElement(&buffer, (uint8_t*)&value);
+        }
+        for(uint8_t i = 0;i < dataToRemoveSize[j]; i++)
+        {
+            tested_type value;
+            circularBufferPopHead(&buffer, (uint8_t*)&value);
+            EXPECT_EQ(queue.front(),value);
+            queue.pop();
+        }
+        EXPECT_EQ(circularBufferCountElements(&buffer),queue.size());
+    }
+
+    EXPECT_EQ(circularBufferIsFull(&buffer),true);
+
+    //Remove all elements
+    while(!circularBufferIsEmpty(&buffer))
+    {
+        tested_type value;
+        circularBufferPopHead(&buffer, (uint8_t*)&value);
+        EXPECT_EQ(queue.front(),value);
+        queue.pop();
+    }
+
+    EXPECT_EQ(circularBufferIsFull(&buffer),false);
+    EXPECT_EQ(circularBufferIsEmpty(&buffer),true);
+    EXPECT_EQ(circularBufferIsEmpty(&buffer),queue.empty());
+}
+
+TEST(CircularQueue, CheckIsEmptyAndIsFull32){  //check with uint32_t
+    srand (time(NULL));
+
+    circularBuffer_t buffer;
+
+    typedef uint32_t tested_type;
+
+    const size_t bufferSize =  16 * sizeof(tested_type);
+    uint8_t buff[bufferSize];
+
+    circularBufferInit(&buffer, buff, bufferSize, sizeof(tested_type));
+
+    const int testBurst = 3;
+
+    const int dataToInsertSize[testBurst] = {10, 8, 4};
+    const int dataToRemoveSize[testBurst] = {3, 3, 0};
+    //At the end we have 0 elements
+
+    std::queue <tested_type>queue;
+
+    EXPECT_EQ(circularBufferIsEmpty(&buffer),true);
+    EXPECT_EQ(circularBufferIsFull(&buffer),false);
+
+    for(uint8_t j=0; j<testBurst; j++){
+
+        for(uint8_t i = 0;i < dataToInsertSize[j]; i++)
+        {
+            tested_type value = rand() % INT_MAX;
+            queue.push(value);
+            circularBufferPushElement(&buffer, (uint8_t*)&value);
+        }
+        for(uint8_t i = 0;i < dataToRemoveSize[j]; i++)
+        {
+            tested_type value;
+            circularBufferPopHead(&buffer, (uint8_t*)&value);
+            EXPECT_EQ(queue.front(),value);
+            queue.pop();
+        }
+    EXPECT_EQ(circularBufferCountElements(&buffer),queue.size());
+    }
+
+    EXPECT_EQ(circularBufferIsFull(&buffer),true);
+
+    //Remove all elements
+    while(!circularBufferIsEmpty(&buffer))
+    {
+        tested_type value;
+        circularBufferPopHead(&buffer, (uint8_t*)&value);
+        EXPECT_EQ(queue.front(),value);
+        queue.pop();
+    }
+
+    EXPECT_EQ(circularBufferIsFull(&buffer),false);
+    EXPECT_EQ(circularBufferIsEmpty(&buffer),true);
+    EXPECT_EQ(circularBufferIsEmpty(&buffer),queue.empty());
+}


### PR DESCRIPTION
Since there are many users that require this feature, included me, i decide to implement it https://github.com/iNavFlight/inav/issues/5126 

This feature is a must have for bando pilots, so maybe they will use also iNav.

The main function applyFlipOverAfterCrashModeToMotors is taken by betaflight with some edits and i have write a function to send dshot commands to the ESCs, using the same protocol used by betaflight, send the packet 10 times with the telemetry flag active with an interval 1000 uS between a packet and the next. 
I have not found an official DSHOT command manual so i've based my implementation on what betaflight does.

On OSD and on iNav configurator this mode is called respectively TURT and TURTLE to avoid to use the longer name "Flip over after crash"

The power factor of 0.65 is fine for my 5", but i have not way to try this on another quads


