### PR TITLE
Fix compiler warnings when #define use_lights, fix F3 targets compilation

### DIFF
--- a/src/main/drivers/lights_io.c
+++ b/src/main/drivers/lights_io.c
@@ -10,7 +10,7 @@
 
 static IO_t lightsIO = DEFIO_IO(NONE);
 
-bool lightsHardwareInit()
+bool lightsHardwareInit(void)
 {
     lightsIO = IOGetByTag(IO_TAG(LIGHTS_PIN));
 

--- a/src/main/drivers/lights_io.h
+++ b/src/main/drivers/lights_io.h
@@ -4,7 +4,7 @@
 #ifdef USE_LIGHTS
 
 
-bool lightsHardwareInit();
+bool lightsHardwareInit(void);
 void lightsHardwareSetStatus(bool status);
 
 #endif /* USE_LIGHTS */

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -401,7 +401,9 @@ void disarm(disarmReason_t disarmReason)
 
         statsOnDisarm();
         logicConditionReset();
+#ifdef USE_PROGRAMMING_FRAMEWORK	    
         programmingPidReset();
+#endif	    
         beeper(BEEPER_DISARMING);      // emit disarm tone
     }
 }
@@ -492,7 +494,9 @@ void tryArm(void)
         //It is required to inform the mixer that arming was executed and it has to switch to the FORWARD direction
         ENABLE_STATE(SET_REVERSIBLE_MOTORS_FORWARD);
         logicConditionReset();
+#ifdef USE_PROGRAMMING_FRAMEWORK	    
         programmingPidReset();
+#endif	    
         headFreeModeHold = DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 
         resetHeadingHoldTarget(DECIDEGREES_TO_DEGREES(attitude.values.yaw));

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -494,6 +494,7 @@ void tryArm(void)
         //It is required to inform the mixer that arming was executed and it has to switch to the FORWARD direction
         ENABLE_STATE(SET_REVERSIBLE_MOTORS_FORWARD);
         logicConditionReset();
+	    
 #ifdef USE_PROGRAMMING_FRAMEWORK	    
         programmingPidReset();
 #endif	    

--- a/src/main/io/lights.c
+++ b/src/main/io/lights.c
@@ -72,7 +72,7 @@ void lightsUpdate(timeUs_t currentTimeUs)
         lightsSetStatus(IS_RC_MODE_ACTIVE(BOXLIGHTS), currentTimeUs);
 }
 
-void lightsInit()
+void lightsInit(void)
 {
     lightsHardwareInit();
 }

--- a/src/main/io/lights.h
+++ b/src/main/io/lights.h
@@ -33,6 +33,6 @@ typedef struct lightsConfig_s {
 PG_DECLARE(lightsConfig_t, lightsConfig);
 
 void lightsUpdate(timeUs_t currentTimeUs);
-void lightsInit();
+void lightsInit(void);
 
 #endif /* USE_LIGHTS */


### PR DESCRIPTION
Changed () to (void) to fix 2 function prototypes.

Fixed compilation for F3 targets by adding #ifdef USE_PROGRAMMING_FRAMEWORK