### PR TITLE
Add support for GHST GPS Telemetry

### DIFF
--- a/src/main/rx/ghst_protocol.h
+++ b/src/main/rx/ghst_protocol.h
@@ -65,6 +65,8 @@ typedef enum {
     GHST_DL_LINK_STAT           = 0x21,
     GHST_DL_VTX_STAT            = 0x22,
     GHST_DL_PACK_STAT           = 0x23,     // Battery (Pack) Status
+    GHST_DL_GPS_PRIMARY         = 0x25,     // Primary GPS data (position)
+    GHST_DL_GPS_SECONDARY       = 0x26      // Secondary GPS data (auxiliary)
 } ghstDl_e;
 
 #define GHST_RC_CTR_VAL_12BIT       0x7C0   // servo center for 12 bit values (0x3e0 << 1)
@@ -72,9 +74,12 @@ typedef enum {
 
 #define GHST_FRAME_SIZE             14      // including addr, type, len, crc, and payload
 
-#define GHST_PAYLOAD_SIZE_MAX           14
+#define GHST_PAYLOAD_SIZE_MAX       14
 
-#define GHST_FRAME_SIZE_MAX             24
+#define GHST_FRAME_SIZE_MAX         24
+
+#define GPS_FLAGS_FIX               0x01
+#define GPS_FLAGS_FIX_HOME          0x02
 
 typedef struct ghstFrameDef_s {
     uint8_t addr;

--- a/src/main/telemetry/ghst.c
+++ b/src/main/telemetry/ghst.c
@@ -130,7 +130,7 @@ void ghstFrameGpsPrimaryTelemetry(sbuf_t *dst)
     // constrain alt. from -32,000m to +32,000m, units of meters
     const int16_t altitude = (constrain(getEstimatedActualPosition(Z), -32000 * 100, 32000 * 100) / 100);
     sbufWriteU16(dst, altitude);
-.}
+}
 
 // GPS data, secondary, auxiliary data
 void ghstFrameGpsSecondaryTelemetry(sbuf_t *dst)


### PR DESCRIPTION
Add two new telemetry packets to the GHST telemetry implementation.
One for primary GPS position data, one for auxiliary GPS data (speed/course/etc.)
Will require v1.0.3.0 of the GHST firmware to pass this telemetry through to OpenTx.