### PR TITLE
Fix the timer and DMA conflicts in the target, resolves #6303

### DIFF
--- a/src/main/target/DALRCF405/target.c
+++ b/src/main/target/DALRCF405/target.c
@@ -28,9 +28,9 @@ const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM8, CH1, PC6,  TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO, 0, 0),   // S2 (2,2)
     DEF_TIM(TIM1, CH3, PA10, TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO, 0, 0),   // S3 (2,6)
     DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO, 0, 1),   // S4 (2,1)  (2.3 2.6)
-    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO, 0, 0),   // S5 (2,4)  (2.2)
-    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO, 0, 0),   // S6 (1,2)
-    DEF_TIM(TIM3, CH2, PC7,  TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO, 0, 0),   // S7 (1,5)
+    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO, 0, 1),   // S5 (2,4)  (2.2)
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MC_MOTOR |                    TIM_USE_FW_MOTOR, 0, 0),   // S6 (1,2)
+    DEF_TIM(TIM8, CH2, PC7,  TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO, 0, 1),   // S7 (2,3)
     DEF_TIM(TIM8, CH4, PC9,  TIM_USE_MC_MOTOR |                    TIM_USE_FW_SERVO, 0, 0),   // S8 (2,7)
     DEF_TIM(TIM4, CH1, PB6,  TIM_USE_LED,                                            0, 0),     // LED STRIP(1,0)
 


### PR DESCRIPTION
Update target.c file for DALRCF405. Fix the timer and DMA conflicts in the target, resolves #6303