### PR TITLE
Arming screen changes

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1199,7 +1199,7 @@ static void osdDisplayFlightPIDValues(uint8_t elemPosX, uint8_t elemPosY, const 
     if ((isAdjustmentFunctionSelected(adjFuncD)) || (((adjFuncD == ADJUSTMENT_ROLL_D) || (adjFuncD == ADJUSTMENT_PITCH_D)) && (isAdjustmentFunctionSelected(ADJUSTMENT_PITCH_ROLL_D))))
         TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
     displayWriteWithAttr(osdDisplayPort, elemPosX + 12, elemPosY, buff, elemAttr);
-    
+
     elemAttr = TEXT_ATTRIBUTES_NONE;
     tfp_sprintf(buff, "%3d", pid->FF);
     if ((isAdjustmentFunctionSelected(adjFuncFF)) || (((adjFuncFF == ADJUSTMENT_ROLL_FF) || (adjFuncFF == ADJUSTMENT_PITCH_FF)) && (isAdjustmentFunctionSelected(ADJUSTMENT_PITCH_ROLL_FF))))
@@ -2238,17 +2238,17 @@ static bool osdDrawSingleElement(uint8_t item)
         }
     case OSD_DEBUG:
         {
-            /* 
-             * Longest representable string is -2147483648 does not fit in the screen. 
+            /*
+             * Longest representable string is -2147483648 does not fit in the screen.
              * Only 7 digits for negative and 8 digits for positive values allowed
              */
             for (uint8_t bufferIndex = 0; bufferIndex < DEBUG32_VALUE_COUNT; ++elemPosY, bufferIndex += 2) {
                 tfp_sprintf(
-                    buff, 
-                    "[%u]=%8ld [%u]=%8ld", 
-                    bufferIndex, 
-                    constrain(debug[bufferIndex], -9999999, 99999999), 
-                    bufferIndex+1, 
+                    buff,
+                    "[%u]=%8ld [%u]=%8ld",
+                    bufferIndex,
+                    constrain(debug[bufferIndex], -9999999, 99999999),
+                    bufferIndex+1,
                     constrain(debug[bufferIndex+1], -9999999, 99999999)
                 );
                 displayWrite(osdDisplayPort, elemPosX, elemPosY, buff);
@@ -3117,8 +3117,8 @@ static void osdShowArmed(void)
     char versionBuf[30];
     char *date;
     char *time;
-    // We need 12 visible rows
-    uint8_t y = MIN((osdDisplayPort->rows / 2) - 1, osdDisplayPort->rows - 12 - 1);
+    // We need 12 visible rows, start row never < first fully visible row 1
+    uint8_t y = osdDisplayPort->rows > 13 ? (osdDisplayPort->rows - 12) / 2 : 1;
 
     displayClearScreen(osdDisplayPort);
     displayWrite(osdDisplayPort, 12, y, "ARMED");
@@ -3127,8 +3127,13 @@ static void osdShowArmed(void)
     if (strlen(systemConfig()->name) > 0) {
         osdFormatCraftName(craftNameBuf);
         displayWrite(osdDisplayPort, (osdDisplayPort->cols - strlen(systemConfig() -> name)) / 2, y, craftNameBuf );
-        y += 2;
+        y += 1;
     }
+
+    if (posControl.waypointListValid && posControl.waypointCount > 0) {
+        displayWrite(osdDisplayPort, 7, y, "*MISSION LOADED*");
+    }
+    y += 1;
 
 #if defined(USE_GPS)
     if (feature(FEATURE_GPS)) {


### PR DESCRIPTION
Addresses https://github.com/iNavFlight/inav/issues/6702. The current logic for setting the starting row doesn't appear to work if the intention is the 12 rows of info are centred in the middle of the screen.

PR also adds a message after the craft name to show if a WP Mission is loaded which is useful given there is no other indication available other than discovering WP Mode selection in flight goes into RTH mode requiring a landing to fix the problem.