### PR TITLE
Enable report_cell_voltage support for CRSF telemetry

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -246,7 +246,11 @@ static void crsfFrameBatterySensor(sbuf_t *dst)
     // use sbufWrite since CRC does not include frame length
     sbufWriteU8(dst, CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE + CRSF_FRAME_LENGTH_TYPE_CRC);
     crsfSerialize8(dst, CRSF_FRAMETYPE_BATTERY_SENSOR);
-    crsfSerialize16(dst, getBatteryVoltage() / 10); // vbat is in units of 0.01V
+    if (telemetryConfig()->report_cell_voltage) {
+        crsfSerialize16(dst, getBatteryAverageCellVoltage() / 10);
+    } else {
+        crsfSerialize16(dst, getBatteryVoltage() / 10); // vbat is in units of 0.01V
+    }
     crsfSerialize16(dst, getAmperage() / 10);
     const uint8_t batteryRemainingPercentage = calculateBatteryPercentage();
     crsfSerialize8(dst, (getMAhDrawn() >> 16));


### PR DESCRIPTION
Sorry for the earlier pull request, I'm not sure why the checks failed. This is a small change to enable reporting cell voltage with crossfire telemetry, similar to how it is allowed for with smartport telemetry.