### PR TITLE
Detect launch on gps speed

### DIFF
--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -318,7 +318,7 @@ static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_WAIT_DETECTION(timeU
 
     const bool isBungeeLaunched = isForwardAccelerationHigh && isAircraftAlmostLevel;
     const bool isSwingLaunched = (swingVelocity > navConfig()->fw.launch_velocity_thresh) && (imuMeasuredAccelBF.x > 0);
-    const bool isForwardLaunched = isGPSHeadingValid() && (imuMeasuredAccelBF.x > 0);
+    const bool isForwardLaunched = isGPSHeadingValid() && (gpsSol.groundSpeed > navConfig()->fw.launch_velocity_thresh) && (imuMeasuredAccelBF.x > 0);
 
     applyThrottleIdleLogic(false);
 

--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -316,7 +316,7 @@ static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_WAIT_DETECTION(timeU
 
     const bool isBungeeLaunched = isForwardAccelerationHigh && isAircraftAlmostLevel;
     const bool isSwingLaunched = (swingVelocity > navConfig()->fw.launch_velocity_thresh) && (imuMeasuredAccelBF.x > 0);
-    const bool isForwardLaunched = (gpsSol.groundSpeed > navConfig()->fw.launch_velocity_thresh);
+    const bool isForwardLaunched = (gpsSol.groundSpeed > navConfig()->fw.launch_velocity_thresh) && (imuMeasuredAccelBF.x > 0);
 
     applyThrottleIdleLogic(false);
 

--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -48,6 +48,8 @@
 #include "navigation/navigation.h"
 #include "navigation/navigation_private.h"
 
+#include "io/gps.h"
+
 #define SWING_LAUNCH_MIN_ROTATION_RATE      DEGREES_TO_RADIANS(100)     // expect minimum 100dps rotation rate
 #define LAUNCH_MOTOR_IDLE_SPINUP_TIME 1500                              // ms
 #define UNUSED(x) ((void)(x))
@@ -316,7 +318,7 @@ static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_WAIT_DETECTION(timeU
 
     const bool isBungeeLaunched = isForwardAccelerationHigh && isAircraftAlmostLevel;
     const bool isSwingLaunched = (swingVelocity > navConfig()->fw.launch_velocity_thresh) && (imuMeasuredAccelBF.x > 0);
-    const bool isForwardLaunched = (gpsSol.groundSpeed > navConfig()->fw.launch_velocity_thresh) && (imuMeasuredAccelBF.x > 0);
+    const bool isForwardLaunched = isGPSHeadingValid() && (imuMeasuredAccelBF.x > 0);
 
     applyThrottleIdleLogic(false);
 

--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -316,10 +316,11 @@ static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_WAIT_DETECTION(timeU
 
     const bool isBungeeLaunched = isForwardAccelerationHigh && isAircraftAlmostLevel;
     const bool isSwingLaunched = (swingVelocity > navConfig()->fw.launch_velocity_thresh) && (imuMeasuredAccelBF.x > 0);
+    const bool isForwardLaunched = (gpsSol.groundSpeed > navConfig()->fw.launch_velocity_thresh);
 
     applyThrottleIdleLogic(false);
 
-    if (isBungeeLaunched || isSwingLaunched) {
+    if (isBungeeLaunched || isSwingLaunched || isForwardLaunched) {
         if (currentStateElapsedMs(currentTimeUs) > navConfig()->fw.launch_time_thresh) {
             return FW_LAUNCH_EVENT_SUCCESS; // the launch is detected now, go to FW_LAUNCH_STATE_DETECTED
         }


### PR DESCRIPTION
There have been a couple of reports ([here](https://youtu.be/d9C8OW6k-DI?t=36) and [here](https://youtu.be/YMHEx3TwhrY?t=39), and I believe also one in the Telegram group) where launch was not detected but the configured idle throttle was sufficient to sustain flight. When the throttle is raised but before launch is detected, you cannot exit auto launch by wiggling the stick so if you don't think of putting the throttle back to zero you'll have zero control. 

This PR adds an explicit check on the gps speed to detect launch, which should make it impossible for this to happen. 