### PR TITLE
Add "prearm was reset" flag to prevent rearming without resetting prearm & add prearm timeout

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -426,6 +426,7 @@
 | pitot_scale |  |  |
 | platform_type | "MULTIROTOR" | Defines UAV platform type. Allowed values: "MULTIROTOR", "AIRPLANE", "HELICOPTER", "TRICOPTER", "ROVER", "BOAT". Currently only MULTIROTOR, AIRPLANE and TRICOPTER types are implemented |
 | pos_hold_deadband | 20 | Stick deadband in [r/c points], applied after r/c deadband and expo |
+| prearm_timeout | 10000 | Duration (ms) for which Prearm being activated is valid. after this, Prearm needs to be reset. 0 means Prearm does not timeout. |
 | rangefinder_hardware | NONE | Selection of rangefinder hardware. |
 | rangefinder_median_filter | OFF | 3-point median filtering for rangefinder readouts |
 | rate_accel_limit_roll_pitch | 0 | Limits acceleration of ROLL/PITCH rotation speed that can be requested by stick input. In degrees-per-second-squared. Small and powerful UAV flies great with high acceleration limit ( > 5000 dps^2 and even > 10000 dps^2). Big and heavy multirotors will benefit from low acceleration limit (~ 360 dps^2). When set correctly, it greatly improves stopping performance. Value of 0 disables limiting. |

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -130,7 +130,9 @@ static bool isRXDataNew;
 static uint32_t gyroSyncFailureCount;
 static disarmReason_t lastDisarmReason = DISARM_NONE;
 static emergencyArmingState_t emergencyArming;
+
 static bool prearmWasReset = false; // Prearm must be reset (RC Mode not active) before arming is possible
+static timeMs_t prearmActivationTime = 0;
 
 bool isCalibrating(void)
 {
@@ -298,13 +300,14 @@ static void updateArmingStatus(void)
 
         if (isModeActivationConditionPresent(BOXPREARM)) {
             if (IS_RC_MODE_ACTIVE(BOXPREARM)) {
-                if (prearmWasReset) {
+                if (prearmWasReset && (armingConfig()->prearmTimeoutMs == 0 || millis() - prearmActivationTime < armingConfig()->prearmTimeoutMs)) {
                     DISABLE_ARMING_FLAG(ARMING_DISABLED_NO_PREARM);
                 } else {
                     ENABLE_ARMING_FLAG(ARMING_DISABLED_NO_PREARM);
                 }
             } else {
                 prearmWasReset = true;
+                prearmActivationTime = millis();
                 ENABLE_ARMING_FLAG(ARMING_DISABLED_NO_PREARM);
             }
         } else {

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -130,6 +130,7 @@ static bool isRXDataNew;
 static uint32_t gyroSyncFailureCount;
 static disarmReason_t lastDisarmReason = DISARM_NONE;
 static emergencyArmingState_t emergencyArming;
+static bool prearmWasReset = false; // Prearm must be reset (RC Mode not active) before arming is possible
 
 bool isCalibrating(void)
 {
@@ -297,8 +298,13 @@ static void updateArmingStatus(void)
 
         if (isModeActivationConditionPresent(BOXPREARM)) {
             if (IS_RC_MODE_ACTIVE(BOXPREARM)) {
-                DISABLE_ARMING_FLAG(ARMING_DISABLED_NO_PREARM);
+                if (prearmWasReset) {
+                    DISABLE_ARMING_FLAG(ARMING_DISABLED_NO_PREARM);
+                } else {
+                    ENABLE_ARMING_FLAG(ARMING_DISABLED_NO_PREARM);
+                }
             } else {
+                prearmWasReset = true;
                 ENABLE_ARMING_FLAG(ARMING_DISABLED_NO_PREARM);
             }
         } else {
@@ -410,6 +416,8 @@ void disarm(disarmReason_t disarmReason)
         programmingPidReset();
 #endif	    
         beeper(BEEPER_DISARMING);      // emit disarm tone
+
+        prearmWasReset = false;
     }
 }
 

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -64,12 +64,13 @@
 #define AIRMODE_DEADBAND 25
 #define MIN_RC_TICK_INTERVAL_MS             20
 #define DEFAULT_RC_SWITCH_DISARM_DELAY_MS   250     // Wait at least 250ms before disarming via switch
+#define DEFAULT_PREARM_TIMEOUT              10000   // Prearm is invalidated after 10 seconds
 
 stickPositions_e rcStickPositions;
 
 FASTRAM int16_t rcCommand[4];           // interval [1000;2000] for THROTTLE and [-500;+500] for ROLL/PITCH/YAW
 
-PG_REGISTER_WITH_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 1);
+PG_REGISTER_WITH_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 2);
 
 PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
     .deadband = 5,
@@ -87,6 +88,7 @@ PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
     .fixed_wing_auto_arm = 0,
     .disarm_kill_switch = 1,
     .switchDisarmDelayMs = DEFAULT_RC_SWITCH_DISARM_DELAY_MS,
+    .prearmTimeoutMs = DEFAULT_PREARM_TIMEOUT,
 );
 
 bool areSticksInApModePosition(uint16_t ap_mode)

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -97,6 +97,7 @@ typedef struct armingConfig_s {
     uint8_t fixed_wing_auto_arm;            // Auto-arm fixed wing aircraft on throttle up and never disarm
     uint8_t disarm_kill_switch;             // allow disarm via AUX switch regardless of throttle value
     uint16_t switchDisarmDelayMs;           // additional delay between ARM box going off and actual disarm
+    uint16_t prearmTimeoutMs;               // duration for which Prearm being activated is valid. after this, Prearm needs to be reset. 0 means Prearm does not timeout.
 } armingConfig_t;
 
 PG_DECLARE(armingConfig_t, armingConfig);

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1236,6 +1236,12 @@ groups:
         field: switchDisarmDelayMs
         min: 0
         max: 1000
+      - name: prearm_timeout
+        description: "Duration (ms) for which Prearm being activated is valid. after this, Prearm needs to be reset. 0 means Prearm does not timeout."
+        default_value: "0"
+        field: prearmTimeoutMs
+        min: 0
+        max: 10000
 
   - name: PG_GENERAL_SETTINGS
     headers: ["config/general_settings.h"]

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1238,7 +1238,7 @@ groups:
         max: 1000
       - name: prearm_timeout
         description: "Duration (ms) for which Prearm being activated is valid. after this, Prearm needs to be reset. 0 means Prearm does not timeout."
-        default_value: "0"
+        default_value: "10000"
         field: prearmTimeoutMs
         min: 0
         max: 10000


### PR DESCRIPTION
Fixes #6730. Alternative to #6731.

This fixes an oversight in my implementation of Prearm: Once prearm is held, you can toggle the arm switch on and off all day. So if a non-momentary prearm is used and the quad is disarmed without resetting the prearm, it can be armed again with the single arm switch, which defeats the prearm.

This PR adds a simple flag to track whether the prearm has been reset (not engaged / RC mode not active) since the last disarm.

This **also** adds an optional setting called `prearm_timeout` that invalidates the prearm activation after a set duration. This means that you have to arm within a certain time window after pressing prearm, or the craft won't arm. This is a configurable value between 0 and 10 seconds. Setting it to 0 disables the timeout.