### PR TITLE
fix incorrect sdmmc_sdio_f4xx error state

### DIFF
--- a/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c
+++ b/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c
@@ -1081,7 +1081,7 @@ SD_Error_t SD_GetStatus(void)
         }
     }
     else {
-        ErrorState = SD_CARD_ERROR;
+        ErrorState = SD_ERROR;
     }
 
     return ErrorState;


### PR DESCRIPTION
Repeat of #6257 for F4.  Prerequisite for #6747 