### PR TITLE
canvas: Honor ahi_max_pitch when drawing the horizon line

### DIFF
--- a/src/main/io/osd_canvas.c
+++ b/src/main/io/osd_canvas.c
@@ -381,7 +381,7 @@ static bool osdCanvasDrawArtificialHorizonWidget(displayPort_t *display, display
         // so that's 135degs each direction. Map that to the configured limit.
         const float halfRange = 135.0f;
         const float limit = halfRange / 180.0f * M_PIf;
-        float multiplier = halfRange / osdConfig()->ahi_max_pitch;
+        float multiplier = osdConfig()->osd_ahi_style == OSD_AHI_STYLE_DEFAULT ? 1.0f : halfRange / osdConfig()->ahi_max_pitch;
         widgetAHIData_t data = {
             .pitch = constrainf(pitchAngle * multiplier, -limit, limit),
             .roll = rollAngle,

--- a/src/main/io/osd_canvas.c
+++ b/src/main/io/osd_canvas.c
@@ -377,8 +377,13 @@ static bool osdCanvasDrawArtificialHorizonWidget(displayPort_t *display, display
             }
             configured = true;
         }
+        // The widget displays 270degs before fixing the bar at the top/bottom
+        // so that's 135degs each direction. Map that to the configured limit.
+        const float halfRange = 135.0f;
+        const float limit = halfRange / 180.0f * M_PIf;
+        float multiplier = halfRange / osdConfig()->ahi_max_pitch;
         widgetAHIData_t data = {
-            .pitch = pitchAngle,
+            .pitch = constrainf(pitchAngle * multiplier, -limit, limit),
             .roll = rollAngle,
         };
         if (displayWidgetsDrawAHI(&widgets, instance, &data)) {


### PR DESCRIPTION
Map our real pitch to a value that causes the specified limit in
the setting to place the horizon bar at the top (or bottom)
when ahi_max_pitch is reached.
