### PR TITLE
Added targets for Hifionrc F7 (AIO/FC) and Flywoo GN745 AIO

### DIFF
--- a/src/main/target/FLYWOOF745/CMakeLists.txt
+++ b/src/main/target/FLYWOOF745/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f745xg(FLYWOOF745)

--- a/src/main/target/FLYWOOF745/target.c
+++ b/src/main/target/FLYWOOF745/target.c
@@ -1,0 +1,44 @@
+/*
+ * This file is part of INAV.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/bus.h"
+
+const timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM1, CH3, PE13, TIM_USE_PPM,                                               0, 1), // PPM, DMA2_ST6
+
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR,                       0, 0), // M1 , DMA1_ST7
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR,                       0, 0), // M2 , DMA1_ST2
+    DEF_TIM(TIM1, CH1, PE9,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,                       0, 2), // M3 , DMA2_ST2
+    DEF_TIM(TIM1, CH2, PE11, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,                       0, 1), // M4 , DMA2_ST4
+    DEF_TIM(TIM8, CH4, PC9,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO | TIM_USE_MC_SERVO,    0, 0), // M5 , DMA2_ST7
+    DEF_TIM(TIM5, CH4, PA3,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO | TIM_USE_MC_SERVO,    0, 0), // M6 , DMA1_ST1
+
+    DEF_TIM(TIM4, CH1, PD12, TIM_USE_LED,                                               0, 0), // LED_STRIP, DMA1_ST0
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/FLYWOOF745/target.h
+++ b/src/main/target/FLYWOOF745/target.h
@@ -1,0 +1,164 @@
+/*
+ * This file is part of INAV.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "FLWO"
+#define USBD_PRODUCT_STRING "Flywoo GN745"
+
+
+#define LED0                PA2
+
+#define BEEPER              PD15
+#define BEEPER_INVERTED
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+
+#define USE_MPU_DATA_READY_SIGNAL
+#define USE_EXTI
+
+#define USE_IMU_MPU6000
+#define IMU_MPU6000_ALIGN       CW270_DEG
+#define GYRO_INT_EXTI           PE1
+#define MPU6000_CS_PIN          SPI4_NSS_PIN
+#define MPU6000_SPI_BUS         BUS_SPI4
+
+
+#define USB_IO
+#define USE_VCP
+#define VBUS_SENSING_ENABLED
+#define VBUS_SENSING_PIN          PA8
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PD5
+#define UART2_RX_PIN            PD6
+
+#define USE_UART3
+#define UART3_TX_PIN            PB10
+#define UART3_RX_PIN            PB11
+
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1
+
+#define USE_UART5
+#define UART5_TX_PIN            PC12
+#define UART5_RX_PIN            PD2
+
+#define USE_UART6
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+#define USE_UART7
+#define UART7_TX_PIN            PE8
+#define UART7_RX_PIN            PE7
+
+#define SERIAL_PORT_COUNT 8 //VCP,UART1,UART2,UART3,UART4,UART6,UART7
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1   //SPI Flash
+#define USE_SPI_DEVICE_2   //OSD
+#define USE_SPI_DEVICE_4   //MPU6000
+
+#define SPI1_NSS_PIN            PA4
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define SPI4_NSS_PIN            PE4
+#define SPI4_SCK_PIN            PE2
+#define SPI4_MISO_PIN           PE5
+#define SPI4_MOSI_PIN           PE6
+
+#define USE_OSD
+
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          SPI2_NSS_PIN
+
+
+
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN           SPI1_NSS_PIN
+#define M25P16_SPI_BUS          BUS_SPI1
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+
+#define USE_BARO
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define BARO_I2C_BUS            BUS_I2C1
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_HMC5883
+#define MAG_HMC5883_ALIGN       CW180_DEG
+#define USE_MAG_QMC5883
+#define USE_MAG_MAG3110
+#define USE_MAG_IST8310
+#define USE_MAG_IST8308
+#define USE_MAG_LIS3MDL
+
+#define TEMPERATURE_I2C_BUS     BUS_I2C1
+
+#define RANGEFINDER_I2C_BUS     BUS_I2C1
+
+#define USE_ADC
+#define ADC_CHANNEL_1_PIN           PC2
+#define ADC_CHANNEL_2_PIN           PC3
+#define ADC_CHANNEL_3_PIN           PC5
+
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_1
+#define VBAT_ADC_CHANNEL            ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_3
+
+
+#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_TELEMETRY | FEATURE_OSD | FEATURE_VBAT | FEATURE_CURRENT_METER | FEATURE_BLACKBOX)
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_UART           SERIAL_PORT_USART6
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+
+#define USE_LED_STRIP
+#define WS2811_PIN                      PD12   //TIM4_CH1
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0xffff
+#define TARGET_IO_PORTE 0xffff
+
+#define MAX_PWM_OUTPUT_PORTS       6

--- a/src/main/target/HIFIONRCF722/CMakeLists.txt
+++ b/src/main/target/HIFIONRCF722/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f722xe(HIFIONRCF722)

--- a/src/main/target/HIFIONRCF722/config.c
+++ b/src/main/target/HIFIONRCF722/config.c
@@ -1,0 +1,57 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+//this is Part of INAV Sourcecode, more exactly target.h for MAMBAF722, modified by LTwin8 to fit HIFIONRCF7 AIO and HIFIONRCF7 PRO
+
+//Used resources are the INAV-Code and the Betaflight unified target file https://raw.githubusercontent.com/betaflight/unified-targets/master/configs/default/HFOR-HIFIONRCF7.config
+
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "common/axis.h"
+
+#include "config/config_master.h"
+#include "config/feature.h"
+
+#include "drivers/sensor.h"
+#include "drivers/pwm_esc_detect.h"
+#include "drivers/pwm_output.h"
+#include "drivers/serial.h"
+
+#include "fc/rc_controls.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+
+#include "rx/rx.h"
+
+#include "io/serial.h"
+
+#include "sensors/battery.h"
+#include "sensors/sensors.h"
+
+#include "telemetry/telemetry.h"
+
+void targetConfiguration(void)
+{
+   //no hardwired UARTs, no Softserial
+}

--- a/src/main/target/HIFIONRCF722/target.c
+++ b/src/main/target/HIFIONRCF722/target.c
@@ -1,0 +1,50 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//this is Part of INAV Sourcecode, more exactly target.h for MAMBAF722, modified by LTwin8 to fit HIFIONRCF7 AIO and HIFIONRCF7 PRO
+
+//Used resources are the INAV-Code and the Betaflight unified target file https://raw.githubusercontent.com/betaflight/unified-targets/master/configs/default/HFOR-HIFIONRCF7.config
+
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+#include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/bus.h"
+
+const timerHardware_t timerHardware[] = {
+   /* //DEF_TIM(TIM11,  CH1,  PB9,   TIM_USE_PPM,       0, 0 ),     // PPM IN
+
+    DEF_TIM(TIM3,   CH3,  PB0,   TIM_USE_MC_MOTOR,  1, 0 ),     // S1_OUT – D(2, 4, 7)
+    DEF_TIM(TIM3,   CH3,  PB1,   TIM_USE_MC_MOTOR,  1, 0 ),     // S2_OUT – D(2, 7, 7)
+    DEF_TIM(TIM3,   CH1,  PB4,   TIM_USE_MC_MOTOR,  0, 0 ),     // S3_OUT – D(2, 1, 6)
+    DEF_TIM(TIM2,   CH2,  PB3,   TIM_USE_MC_MOTOR,  0, 0 ),     // S4_OUT – D(2, 2, 6)
+
+    DEF_TIM(TIM1,   CH1,  PA8,   TIM_USE_LED,       0, 2 ),     // LED_STRIP – D(1, 6, 3)
+/*/
+    
+    
+    DEF_TIM(TIM3, CH3, PB0,   TIM_USE_MC_MOTOR, 0, 0),   // S1   UP1-2
+    DEF_TIM(TIM3, CH4, PB1,   TIM_USE_MC_MOTOR, 0, 0),   // S2   UP1-2
+    DEF_TIM(TIM3, CH1, PB4,   TIM_USE_MC_MOTOR, 0, 0),   // S3   UP1-2
+    DEF_TIM(TIM2, CH2, PB3,   TIM_USE_MC_MOTOR, 0, 0),   // S4   UP1-7
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_LED, 0, 2),   // LED DMA2-3
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/HIFIONRCF722/target.h
+++ b/src/main/target/HIFIONRCF722/target.h
@@ -1,0 +1,176 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//this is Part of INAV Sourcecode, more exactly target.h for MAMBAF722, modified by LTwin8 to fit HIFIONRCF7 AIO and HIFIONRCF7 PRO
+
+//Used resources are the INAV-Code and the Betaflight unified target file https://raw.githubusercontent.com/betaflight/unified-targets/master/configs/default/HFOR-HIFIONRCF7.config
+
+#pragma once
+
+#define USE_TARGET_CONFIG
+
+#define TARGET_BOARD_IDENTIFIER         "HFOR"
+#define USBD_PRODUCT_STRING             "HIFIONRCF722"
+
+// ******** Board LEDs  **********************
+#define LED0                            PA15                            //taken from unified target
+//#define LED1                            PC14                          //No 2nd LED defined in unified target
+
+// ******* Beeper ***********
+#define BEEPER                          PC15                             //taken from unified target
+#define BEEPER_INVERTED
+
+
+// ******* GYRO and ACC ********
+#define USE_EXTI
+#define GYRO_INT_EXTI                   PC3                             //taken from unified target, Gyro 2
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define MPU6000_CS_PIN                  SPI1_NSS_PIN                    //B02 & A04, taken from unified target
+#define MPU6000_SPI_BUS                 BUS_SPI1
+
+#define USE_IMU_MPU6000
+#define IMU_MPU6000_ALIGN               CW90_DEG                        //taken from unified target
+
+// *************** Baro **************************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define USE_I2C_PULLUP
+#define I2C1_SCL                        PB6        // SCL pad TX3       //taken from unified target
+#define I2C1_SDA                        PB7        // SDA pad RX3       //taken from unified target
+#define DEFAULT_I2C_BUS                 BUS_I2C1
+
+#define USE_BARO
+#define BARO_I2C_BUS                    DEFAULT_I2C_BUS
+
+#define USE_BARO_BMP280
+#define USE_BARO_BMP085
+#define USE_BARO_MS5611
+
+//*********** Magnetometer / Compass *************
+//#define USE_MAG
+//#define MAG_I2C_BUS                     DEFAULT_I2C_BUS               //taken from unified target, no mag onboard
+
+//#define USE_MAG_HMC5883
+//#define USE_MAG_QMC5883
+//#define USE_MAG_LIS3MDL
+
+// ******* SERIAL ********
+#define USE_VCP
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_UART4
+#define USE_UART5
+#define USE_UART6
+//#define USE_SOFTSERIAL1
+//SoftSerial not needed, 6 full UARTs available, for example: GPS, ESC-telemetry, S.Port, VTX (TBS, IRC or DJI), Bluetooth, 1 free UART left, 2 free UARTS left if using only one uart for RC&telemetry (F.Port or CRSF for example)
+
+#define UART1_TX_PIN                    PA9                             //taken from unified target
+#define UART1_RX_PIN                    PA10                            //taken from unified target
+
+#define UART2_TX_PIN                    PA2                             //taken from unified target
+#define UART2_RX_PIN                    PA3                             //taken from unified target
+
+#define UART3_TX_PIN                    PB10                            //taken from unified target
+#define UART3_RX_PIN                    PB11                            //taken from unified target
+
+#define UART4_TX_PIN                    PA0                             //taken from unified target
+#define UART4_RX_PIN                    PA1                             //taken from unified target
+
+#define UART5_TX_PIN                    PC12                            //taken from unified target
+#define UART5_RX_PIN                    PD2                             //taken from unified target
+
+#define UART6_TX_PIN                    PC6                             //taken from unified target
+#define UART6_RX_PIN                    PC7                             //taken from unified target
+/*
+#define SOFTSERIAL_1_TX_PIN             PA2                             //dont need this, we have 6 UARTs in HW
+#define SOFTSERIAL_1_RX_PIN             PA2
+*/
+#define SERIAL_PORT_COUNT               6
+
+// ******* SPI ********
+#define USE_SPI
+
+#define USE_SPI_DEVICE_1                                                //taken from unified target //MPU6000
+#define SPI1_NSS_PIN                    PA4                             //taken from unified target //Gyro CS 2
+#define SPI1_SCK_PIN                    PA5                             //taken from unified target
+#define SPI1_MISO_PIN                   PA6                             //taken from unified target
+#define SPI1_MOSI_PIN                   PA7                             //taken from unified target
+
+#define USE_SPI_DEVICE_2                                                //taken from unified target //OSD Chip
+#define SPI2_NSS_PIN                    PB12                            //taken from unified target
+#define SPI2_SCK_PIN                    PB13                            //taken from unified target
+#define SPI2_MISO_PIN                   PB14                            //taken from unified target
+#define SPI2_MOSI_PIN                   PB15                            //taken from unified target
+
+#define USE_SPI_DEVICE_3                                                //taken from unified target // BlackBox Flash
+#define SPI3_NSS_PIN                    PC13                            //taken from unified target
+#define SPI3_SCK_PIN                    PC10                            //taken from unified target
+#define SPI3_MISO_PIN                   PC11                            //taken from unified target
+#define SPI3_MOSI_PIN                   PB5                             //taken from unified target
+
+// ******* ADC ********
+#define USE_ADC
+#define ADC_CHANNEL_1_PIN               PC2                             //taken from unified target
+#define ADC_CHANNEL_2_PIN               PC0                             //taken from unified target
+#define ADC_CHANNEL_3_PIN               PC1                             //taken from unified target
+
+#define VBAT_ADC_CHANNEL                ADC_CHN_1
+#define RSSI_ADC_CHANNEL                ADC_CHN_2
+#define CURRENT_METER_ADC_CHANNEL       ADC_CHN_3
+
+#define VBAT_SCALE_DEFAULT              1100
+
+// ******* OSD ********
+#define USE_OSD                                                         //matches unified target
+#define USE_MAX7456
+#define MAX7456_SPI_BUS                 BUS_SPI2
+#define MAX7456_CS_PIN                  SPI2_NSS_PIN
+
+//******* FLASH ********
+#define USE_FLASHFS                                                     //matches unified target, exact chip type not known yet, but seems right, the 30.5mm HIFIONRC has 16MB BB
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN                   SPI3_NSS_PIN
+#define M25P16_SPI_BUS                  BUS_SPI3
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT                  //yes, no SD Card
+
+//************ LEDSTRIP *****************
+#define USE_LED_STRIP
+#define WS2811_PIN                      PA8                             //taken from unified target
+
+// ******* FEATURES ********
+#define DEFAULT_RX_FEATURE              FEATURE_RX_SERIAL
+#define SERIALRX_UART                   SERIAL_PORT_USART2              //taken from Product Page
+#define SERIALRX_PROVIDER               SERIALRX_SBUS
+
+#define DEFAULT_FEATURES                (FEATURE_OSD | FEATURE_TELEMETRY) //no SoftSerial
+
+#define TARGET_IO_PORTA                 0xffff                          //not sure
+#define TARGET_IO_PORTB                 0xffff                          //not sure
+#define TARGET_IO_PORTC                 0xffff                          //not sure
+#define TARGET_IO_PORTD                 (BIT(2))                        //not sure
+
+#define MAX_PWM_OUTPUT_PORTS            8                               //not sure, would guess 4, because its aiming towards quadcopters
+#define TARGET_MOTOR_COUNT              4                               //taken from unified target, Motors 1,2,3,4 are located on PB0, PB1, PB4, PB3
+
+// ESC-related features
+#define USE_DSHOT
+#define USE_SERIALSHOT
+#define USE_ESC_SENSOR
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE

--- a/src/main/target/HIFIONRCF722/target.h
+++ b/src/main/target/HIFIONRCF722/target.h
@@ -101,7 +101,7 @@
 #define SOFTSERIAL_1_TX_PIN             PA2                             //dont need this, we have 6 UARTs in HW
 #define SOFTSERIAL_1_RX_PIN             PA2
 */
-#define SERIAL_PORT_COUNT               6
+#define SERIAL_PORT_COUNT               8
 
 // ******* SPI ********
 #define USE_SPI

--- a/src/main/target/HIFIONRCF722_AIO/CMakeLists.txt
+++ b/src/main/target/HIFIONRCF722_AIO/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f722xe(HIFIONRCF722_AIO)

--- a/src/main/target/HIFIONRCF722_AIO/config.c
+++ b/src/main/target/HIFIONRCF722_AIO/config.c
@@ -1,0 +1,57 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+//this is Part of INAV Sourcecode, more exactly target.h for MAMBAF722, modified by LTwin8 to fit HIFIONRCF7 AIO and HIFIONRCF7 PRO
+
+//Used resources are the INAV-Code and the Betaflight unified target file https://raw.githubusercontent.com/betaflight/unified-targets/master/configs/default/HFOR-HIFIONRCF7.config
+
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "common/axis.h"
+
+#include "config/config_master.h"
+#include "config/feature.h"
+
+#include "drivers/sensor.h"
+#include "drivers/pwm_esc_detect.h"
+#include "drivers/pwm_output.h"
+#include "drivers/serial.h"
+
+#include "fc/rc_controls.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+
+#include "rx/rx.h"
+
+#include "io/serial.h"
+
+#include "sensors/battery.h"
+#include "sensors/sensors.h"
+
+#include "telemetry/telemetry.h"
+
+void targetConfiguration(void)
+{
+   //no hardwired UARTs, no Softserial
+}

--- a/src/main/target/HIFIONRCF722_AIO/target.c
+++ b/src/main/target/HIFIONRCF722_AIO/target.c
@@ -1,0 +1,50 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//this is Part of INAV Sourcecode, more exactly target.h for MAMBAF722, modified by LTwin8 to fit HIFIONRCF7 AIO and HIFIONRCF7 PRO
+
+//Used resources are the INAV-Code and the Betaflight unified target file https://raw.githubusercontent.com/betaflight/unified-targets/master/configs/default/HFOR-HIFIONRCF7.config
+
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+#include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/bus.h"
+
+const timerHardware_t timerHardware[] = {
+   /* //DEF_TIM(TIM11,  CH1,  PB9,   TIM_USE_PPM,       0, 0 ),     // PPM IN
+
+    DEF_TIM(TIM3,   CH3,  PB0,   TIM_USE_MC_MOTOR,  1, 0 ),     // S1_OUT – D(2, 4, 7)
+    DEF_TIM(TIM3,   CH3,  PB1,   TIM_USE_MC_MOTOR,  1, 0 ),     // S2_OUT – D(2, 7, 7)
+    DEF_TIM(TIM3,   CH1,  PB4,   TIM_USE_MC_MOTOR,  0, 0 ),     // S3_OUT – D(2, 1, 6)
+    DEF_TIM(TIM2,   CH2,  PB3,   TIM_USE_MC_MOTOR,  0, 0 ),     // S4_OUT – D(2, 2, 6)
+
+    DEF_TIM(TIM1,   CH1,  PA8,   TIM_USE_LED,       0, 2 ),     // LED_STRIP – D(1, 6, 3)
+/*/
+    
+    
+    DEF_TIM(TIM3, CH3, PB0,   TIM_USE_MC_MOTOR, 0, 0),   // S1   UP1-2
+    DEF_TIM(TIM3, CH4, PB1,   TIM_USE_MC_MOTOR, 0, 0),   // S2   UP1-2
+    DEF_TIM(TIM3, CH1, PB4,   TIM_USE_MC_MOTOR, 0, 0),   // S3   UP1-2
+    DEF_TIM(TIM2, CH2, PB3,   TIM_USE_MC_MOTOR, 0, 0),   // S4   UP1-7
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_LED, 0, 2),   // LED DMA2-3
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/HIFIONRCF722_AIO/target.h
+++ b/src/main/target/HIFIONRCF722_AIO/target.h
@@ -24,7 +24,7 @@
 #define USE_TARGET_CONFIG
 
 #define TARGET_BOARD_IDENTIFIER         "HFOR"
-#define USBD_PRODUCT_STRING             "HIFIONRCF722_I2C_TX3SDA_RX3SCL"
+#define USBD_PRODUCT_STRING             "HIFIONRCF722_AIO"
 
 // ******** Board LEDs  **********************
 #define LED0                            PA15                            //taken from unified target
@@ -50,8 +50,8 @@
 #define USE_I2C
 #define USE_I2C_DEVICE_1
 #define USE_I2C_PULLUP
-#define I2C1_SCL                        PB6        //taken from unified target
-#define I2C1_SDA                        PB7        //taken from unified target
+#define I2C1_SCL                        PB10        // SCL pad TX3       //taken from unified target
+#define I2C1_SDA                        PB11        // SDA pad RX3       //taken from unified target
 #define DEFAULT_I2C_BUS                 BUS_I2C1
 
 #define USE_BARO
@@ -73,7 +73,7 @@
 #define USE_VCP
 #define USE_UART1
 #define USE_UART2
-#define USE_UART3
+//#define USE_UART3
 #define USE_UART4
 #define USE_UART5
 #define USE_UART6
@@ -85,10 +85,10 @@
 
 #define UART2_TX_PIN                    PA2                             //taken from unified target
 #define UART2_RX_PIN                    PA3                             //taken from unified target
-
+/*
 #define UART3_TX_PIN                    PB10                            //taken from unified target
 #define UART3_RX_PIN                    PB11                            //taken from unified target
-
+*/
 #define UART4_TX_PIN                    PA0                             //taken from unified target
 #define UART4_RX_PIN                    PA1                             //taken from unified target
 

--- a/src/main/target/JHEF7DUAL/CMakeLists.txt
+++ b/src/main/target/JHEF7DUAL/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f722xe(JHEF7DUAL)

--- a/src/main/target/JHEF7DUAL/config.c
+++ b/src/main/target/JHEF7DUAL/config.c
@@ -1,0 +1,56 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "common/axis.h"
+
+#include "config/config_master.h"
+#include "config/feature.h"
+
+#include "drivers/sensor.h"
+#include "drivers/pwm_esc_detect.h"
+#include "drivers/pwm_output.h"
+#include "drivers/serial.h"
+
+#include "fc/rc_controls.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+
+#include "rx/rx.h"
+
+#include "io/serial.h"
+
+#include "sensors/battery.h"
+#include "sensors/sensors.h"
+
+#include "telemetry/telemetry.h"
+
+void targetConfiguration(void)
+{
+    // RX6 is hard-wired to ESC-telemetry
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART6)].functionMask = FUNCTION_ESCSERIAL;
+
+    // Built-in bluetooth on SERIAL4
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].functionMask = FUNCTION_MSP;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].msp_baudrateIndex = BAUD_19200;
+}

--- a/src/main/target/JHEF7DUAL/target.c
+++ b/src/main/target/JHEF7DUAL/target.c
@@ -1,0 +1,50 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//this is Part of INAV Sourcecode, more exactly target.h for MAMBAF722, modified by LTwin8 to fit HIFIONRCF7 AIO and HIFIONRCF7 PRO
+
+//Used resources are the INAV-Code and the Betaflight unified target file https://raw.githubusercontent.com/betaflight/unified-targets/master/configs/default/JHEF-JHEF7DUAL.config
+
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+#include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/bus.h"
+
+const timerHardware_t timerHardware[] = {
+   /* //DEF_TIM(TIM11,  CH1,  PB9,   TIM_USE_PPM,       0, 0 ),     // PPM IN
+
+    DEF_TIM(TIM3,   CH3,  PB0,   TIM_USE_MC_MOTOR,  1, 0 ),     // S1_OUT – D(2, 4, 7)
+    DEF_TIM(TIM3,   CH3,  PB1,   TIM_USE_MC_MOTOR,  1, 0 ),     // S2_OUT – D(2, 7, 7)
+    DEF_TIM(TIM3,   CH1,  PB4,   TIM_USE_MC_MOTOR,  0, 0 ),     // S3_OUT – D(2, 1, 6)
+    DEF_TIM(TIM2,   CH2,  PB3,   TIM_USE_MC_MOTOR,  0, 0 ),     // S4_OUT – D(2, 2, 6)
+
+    DEF_TIM(TIM1,   CH1,  PA8,   TIM_USE_LED,       0, 2 ),     // LED_STRIP – D(1, 6, 3)
+/*/
+    
+    
+    DEF_TIM(TIM3, CH3, PB0,   TIM_USE_MC_MOTOR, 0, 0),   // S1   UP1-2
+    DEF_TIM(TIM3, CH4, PB1,   TIM_USE_MC_MOTOR, 0, 0),   // S2   UP1-2
+    DEF_TIM(TIM3, CH1, PB4,   TIM_USE_MC_MOTOR, 0, 0),   // S3   UP1-2
+    DEF_TIM(TIM2, CH2, PB3,   TIM_USE_MC_MOTOR, 0, 0),   // S4   UP1-7
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_LED, 0, 2),   // LED DMA2-3
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/JHEF7DUAL/target.h
+++ b/src/main/target/JHEF7DUAL/target.h
@@ -1,0 +1,176 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//this is Part of INAV Sourcecode, more exactly target.h for MAMBAF722, modified by LTwin8 to fit HIFIONRCF7 AIO and HIFIONRCF7 PRO
+
+//Used resources are the INAV-Code and the Betaflight unified target file https://raw.githubusercontent.com/betaflight/unified-targets/master/configs/default/JHEF-JHEF7DUAL.config
+
+#pragma once
+
+#define USE_TARGET_CONFIG
+
+#define TARGET_BOARD_IDENTIFIER         "JHEF"
+#define USBD_PRODUCT_STRING             "JHEF7DUAL"
+
+// ******** Board LEDs  **********************
+#define LED0                            PA15                            //taken from unified target
+//#define LED1                            PC14                          //No 2nd LED defined in unified target
+
+// ******* Beeper ***********
+#define BEEPER                          PC15                             //taken from unified target
+#define BEEPER_INVERTED
+
+
+// ******* GYRO and ACC ********
+#define USE_EXTI
+#define GYRO_INT_EXTI                   PC3                             //taken from unified target, additional Interrupt available on C03
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define MPU6000_CS_PIN                  SPI1_NSS_PIN                    //B02 & A04, taken from unified target
+#define MPU6000_SPI_BUS                 BUS_SPI1
+
+#define USE_IMU_MPU6000
+#define IMU_MPU6000_ALIGN               CW90_DEG                        //taken from unified target
+
+// *************** Baro **************************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define USE_I2C_PULLUP
+#define I2C1_SCL                        PB6        // SCL pad TX3       //taken from unified target
+#define I2C1_SDA                        PB7        // SDA pad RX3       //taken from unified target
+#define DEFAULT_I2C_BUS                 BUS_I2C1
+
+#define USE_BARO
+#define BARO_I2C_BUS                    DEFAULT_I2C_BUS
+
+#define USE_BARO_BMP280
+#define USE_BARO_BMP085
+#define USE_BARO_MS5611
+
+//*********** Magnetometer / Compass *************
+//#define USE_MAG
+//#define MAG_I2C_BUS                     DEFAULT_I2C_BUS               //taken from unified target, no mag onboard
+
+//#define USE_MAG_HMC5883
+//#define USE_MAG_QMC5883
+//#define USE_MAG_LIS3MDL
+
+// ******* SERIAL ********
+#define USE_VCP
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_UART4
+#define USE_UART5
+#define USE_UART6
+//#define USE_SOFTSERIAL1
+//SoftSerial not needed, 6 full UARTs available, for example: GPS, ESC-telemetry, S.Port, VTX (TBS, IRC or DJI), Bluetooth, 1 free UART left, 2 free UARTS left if using only one uart for RC&telemetry (F.Port or CRSF for example)
+
+#define UART1_TX_PIN                    PA9                             //taken from unified target
+#define UART1_RX_PIN                    PA10                            //taken from unified target
+
+#define UART2_TX_PIN                    PA2                             //taken from unified target
+#define UART2_RX_PIN                    PA3                             //taken from unified target
+
+#define UART3_TX_PIN                    PB10                            //taken from unified target
+#define UART3_RX_PIN                    PB11                            //taken from unified target
+
+#define UART4_TX_PIN                    PA0                             //taken from unified target
+#define UART4_RX_PIN                    PA1                             //taken from unified target
+
+#define UART5_TX_PIN                    PC12                            //taken from unified target
+#define UART5_RX_PIN                    PD2                             //taken from unified target
+
+#define UART6_TX_PIN                    PC6                             //taken from unified target
+#define UART6_RX_PIN                    PC7                             //taken from unified target
+/*
+#define SOFTSERIAL_1_TX_PIN             PA2                             //dont need this, we have 6 UARTs in HW
+#define SOFTSERIAL_1_RX_PIN             PA2
+*/
+#define SERIAL_PORT_COUNT               6
+
+// ******* SPI ********
+#define USE_SPI
+
+#define USE_SPI_DEVICE_1                                                //taken from unified target //MPU6000
+#define SPI1_NSS_PIN                    PA4                             //taken from unified target //Gyro CS 2
+#define SPI1_SCK_PIN                    PA5                             //taken from unified target
+#define SPI1_MISO_PIN                   PA6                             //taken from unified target
+#define SPI1_MOSI_PIN                   PA7                             //taken from unified target
+
+#define USE_SPI_DEVICE_2                                                //taken from unified target //OSD Chip
+#define SPI2_NSS_PIN                    PB12                            //taken from unified target
+#define SPI2_SCK_PIN                    PB13                            //taken from unified target
+#define SPI2_MISO_PIN                   PB14                            //taken from unified target
+#define SPI2_MOSI_PIN                   PB15                            //taken from unified target
+
+#define USE_SPI_DEVICE_3                                                //taken from unified target // BlackBox Flash
+#define SPI3_NSS_PIN                    PC13                            //taken from unified target
+#define SPI3_SCK_PIN                    PC10                            //taken from unified target
+#define SPI3_MISO_PIN                   PC11                            //taken from unified target
+#define SPI3_MOSI_PIN                   PB5                             //taken from unified target
+
+// ******* ADC ********
+#define USE_ADC
+#define ADC_CHANNEL_1_PIN               PC2                             //taken from unified target
+#define ADC_CHANNEL_2_PIN               PC0                             //taken from unified target
+#define ADC_CHANNEL_3_PIN               PC1                             //taken from unified target
+
+#define VBAT_ADC_CHANNEL                ADC_CHN_1
+#define RSSI_ADC_CHANNEL                ADC_CHN_2
+#define CURRENT_METER_ADC_CHANNEL       ADC_CHN_3
+
+#define VBAT_SCALE_DEFAULT              1100
+
+// ******* OSD ********
+#define USE_OSD                                                         //matches unified target
+#define USE_MAX7456
+#define MAX7456_SPI_BUS                 BUS_SPI2
+#define MAX7456_CS_PIN                  SPI2_NSS_PIN
+
+//******* FLASH ********
+#define USE_FLASHFS                                                     //matches unified target, exact chip type not known yet, but seems right, the 30.5mm HIFIONRC has 16MB BB
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN                   SPI3_NSS_PIN
+#define M25P16_SPI_BUS                  BUS_SPI3
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT                  //yes, no SD Card
+
+//************ LEDSTRIP *****************
+#define USE_LED_STRIP
+#define WS2811_PIN                      PA8                             //taken from unified target
+
+// ******* FEATURES ********
+#define DEFAULT_RX_FEATURE              FEATURE_RX_SERIAL
+#define SERIALRX_UART                   SERIAL_PORT_USART2              //taken from Product Page
+#define SERIALRX_PROVIDER               SERIALRX_SBUS
+
+#define DEFAULT_FEATURES                (FEATURE_OSD | FEATURE_TELEMETRY) //no SoftSerial
+
+#define TARGET_IO_PORTA                 0xffff                          //not sure
+#define TARGET_IO_PORTB                 0xffff                          //not sure
+#define TARGET_IO_PORTC                 0xffff                          //not sure
+#define TARGET_IO_PORTD                 (BIT(2))                        //not sure
+
+#define MAX_PWM_OUTPUT_PORTS            8                               //not sure, would guess 4, because its aiming towards quadcopters
+#define TARGET_MOTOR_COUNT              4                               //taken from unified target, Motors 1,2,3,4 are located on PB0, PB1, PB4, PB3
+
+// ESC-related features
+#define USE_DSHOT
+#define USE_SERIALSHOT
+#define USE_ESC_SENSOR
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE

--- a/src/main/target/JHEF7DUAL/target.h
+++ b/src/main/target/JHEF7DUAL/target.h
@@ -15,7 +15,7 @@
  * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//this is Part of INAV Sourcecode, more exactly target.h for MAMBAF722, modified by LTwin8 to fit HIFIONRCF7 AIO and HIFIONRCF7 PRO
+//this is Part of INAV Sourcecode, more exactly target.h for MAMBAF722, modified by LTwin8 to fit JHEF7
 
 //Used resources are the INAV-Code and the Betaflight unified target file https://raw.githubusercontent.com/betaflight/unified-targets/master/configs/default/JHEF-JHEF7DUAL.config
 

--- a/src/main/target/JHEF7DUAL/target.h
+++ b/src/main/target/JHEF7DUAL/target.h
@@ -101,7 +101,7 @@
 #define SOFTSERIAL_1_TX_PIN             PA2                             //dont need this, we have 6 UARTs in HW
 #define SOFTSERIAL_1_RX_PIN             PA2
 */
-#define SERIAL_PORT_COUNT               6
+#define SERIAL_PORT_COUNT               8
 
 // ******* SPI ********
 #define USE_SPI


### PR DESCRIPTION
Added targets for Hifionrc F7 Pro (standard), hifionfrc F7 AIO (whoop), Flywoo GN745 AIO (Whoop) 