### PR TITLE
Ignore roll in AHI drift mitigation

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -504,7 +504,7 @@ static float imuCalculateAccelerometerWeight(const float dT)
     float accWeight_RateIgnore = 1.0f;
 
     if (ARMING_FLAG(ARMED) && STATE(FIXED_WING_LEGACY) && imuConfig()->acc_ignore_rate) {
-        const float rotRateMagnitude = sqrtf(vectorNormSquared(&imuMeasuredRotationBF));
+        const float rotRateMagnitude = sqrtf(sq(imuMeasuredRotationBF.y) + sq(imuMeasuredRotationBF.z));
         const float rotRateMagnitudeFiltered = pt1FilterApply4(&rotRateFilter, rotRateMagnitude, IMU_CENTRIFUGAL_LPF, dT);
 
         if (imuConfig()->acc_ignore_slope) {


### PR DESCRIPTION
A pure rotation around the longitudinal axis (roll) does not generate centrifugal forces and thus does not contribute to the AHI drift problem. Some planes, especially smaller wings such as the Dart 250, are quite bumpy on the roll axis when there's turbulence. This makes it necessary to set a higher `imu_acc_ignore_rate` to avoid never trusting the accelerometer for gyro drift compensation. With this change, `imu_acc_ignore_rate` on these planes can be decreased to (hopefully) better mitigate AHI drift while still using the accelerometer when flying straight ahead in turbulent conditions. 

Not tested yet.