### PR TITLE
Renamed OSD SW and LEDLOW to OSD/LEDS OFF

### DIFF
--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -58,9 +58,9 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXNAVPOSHOLD, "NAV POSHOLD", 11 },     // old GPS HOLD
     { BOXMANUAL, "MANUAL", 12 },
     { BOXBEEPERON, "BEEPER", 13 },
-    { BOXLEDLOW, "LEDLOW", 15 },
+    { BOXLEDLOW, "LEDS OFF", 15 },
     { BOXLIGHTS, "LIGHTS", 16 },
-    { BOXOSD, "OSD SW", 19 },
+    { BOXOSD, "OSD OFF", 19 },
     { BOXTELEMETRY, "TELEMETRY", 20 },
     { BOXAUTOTUNE, "AUTO TUNE", 21 },
     { BOXBLACKBOX, "BLACKBOX", 26 },


### PR DESCRIPTION
These 2 labels tend to confuse people. So I have renamed them to make it more obvious to people.

Requires https://github.com/iNavFlight/inav-configurator/pull/1229
Fixes https://github.com/iNavFlight/inav-configurator/issues/1136