### PR TITLE
WP Mission Landing Elevation Setting

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1915,7 +1915,10 @@ static fpVector3_t * rthGetHomeTargetPosition(rthTargetMode_e mode)
         case RTH_HOME_FINAL_LAND:
             // if WP mission p2 > 0 use p2 value as landing elevation (in meters !) (otherwise default to takeoff home elevation)
             if (FLIGHT_MODE(NAV_WP_MODE) && posControl.waypointList[posControl.activeWaypointIndex].action == NAV_WP_ACTION_LAND && posControl.waypointList[posControl.activeWaypointIndex].p2 != 0) {
-                posControl.rthState.homeTmpWaypoint.z = posControl.waypointList[posControl.activeWaypointIndex].p2 * 100;
+                posControl.rthState.homeTmpWaypoint.z = posControl.waypointList[posControl.activeWaypointIndex].p2 * 100;   // 100 -> m to cm
+                if (waypointMissionAltConvMode(posControl.waypointList[posControl.activeWaypointIndex].p3) == GEO_ALT_ABSOLUTE) {
+                    posControl.rthState.homeTmpWaypoint.z -= posControl.gpsOrigin.alt;  // correct to relative if absolute SL altitude datum used
+                }
             }
             break;
     }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1913,9 +1913,9 @@ static fpVector3_t * rthGetHomeTargetPosition(rthTargetMode_e mode)
             break;
 
         case RTH_HOME_FINAL_LAND:
-            // if WP mission p1 > 0 use P1 value as landing elevation (cm) (otherwise default to takeoff home elevation)
-            if (FLIGHT_MODE(NAV_WP_MODE) && posControl.waypointList[posControl.activeWaypointIndex].action == NAV_WP_ACTION_LAND && posControl.waypointList[posControl.activeWaypointIndex].p1 != 0) {
-                posControl.rthState.homeTmpWaypoint.z = posControl.waypointList[posControl.activeWaypointIndex].p1;
+            // if WP mission p2 > 0 use p2 value as landing elevation (in meters !) (otherwise default to takeoff home elevation)
+            if (FLIGHT_MODE(NAV_WP_MODE) && posControl.waypointList[posControl.activeWaypointIndex].action == NAV_WP_ACTION_LAND && posControl.waypointList[posControl.activeWaypointIndex].p2 != 0) {
+                posControl.rthState.homeTmpWaypoint.z = posControl.waypointList[posControl.activeWaypointIndex].p2 * 100;
             }
             break;
     }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1913,6 +1913,10 @@ static fpVector3_t * rthGetHomeTargetPosition(rthTargetMode_e mode)
             break;
 
         case RTH_HOME_FINAL_LAND:
+            // if WP mission p1 > 0 use P1 value as landing elevation (cm) (otherwise default to takeoff home elevation)
+            if (FLIGHT_MODE(NAV_WP_MODE) && posControl.waypointList[posControl.activeWaypointIndex].action == NAV_WP_ACTION_LAND && posControl.waypointList[posControl.activeWaypointIndex].p1 != 0) {
+                posControl.rthState.homeTmpWaypoint.z = posControl.waypointList[posControl.activeWaypointIndex].p1;
+            }
             break;
     }
 

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -295,8 +295,7 @@ typedef struct {
     int32_t lat;
     int32_t lon;
     int32_t alt;
-    int32_t p1;
-    int16_t p2, p3;
+    int16_t p1, p2, p3;
     uint8_t flag;
 } navWaypoint_t;
 

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -295,7 +295,8 @@ typedef struct {
     int32_t lat;
     int32_t lon;
     int32_t alt;
-    int16_t p1, p2, p3;
+    int32_t p1;
+    int16_t p2, p3;
     uint8_t flag;
 } navWaypoint_t;
 


### PR DESCRIPTION
WP mission Landing currently assumes the landing elevation is the same as takeoff elevation which may not be the case for remote landings. If the remote landing elevation is different then landing vertical velocity scaling will be incorrect. This is more of an issue if the landing elevation is higher than takeoff elevation because the ground will appear sooner than INAV is expecting.

This PR provides the ability to define a different landing elevation to the default takeoff home elevation by setting Landing WP P1 as the landing elevation. Uses an elevation in cm which requires P1 to be changed to int32_t. Could maintain the current int16_t if the elevation was set in meters instead. This would be accurate enough for landing elevation but inconsistent with the altitude setting in cm leading to potential confusion with the settings.