### PR TITLE
Turtle mode issue fix

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -497,20 +497,6 @@ void tryArm(void)
 {
     updateArmingStatus();
 
-#ifdef USE_DSHOT
-    if (
-            STATE(MULTIROTOR) &&
-            IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) &&
-            emergencyArmingCanOverrideArmingDisabled() &&
-            isMotorProtocolDshot() &&
-            !FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)
-            ) {
-        sendDShotCommand(DSHOT_CMD_SPIN_DIRECTION_REVERSED);
-        ENABLE_ARMING_FLAG(ARMED);
-        enableFlightMode(FLIP_OVER_AFTER_CRASH);
-        return;
-    }
-#endif
 #ifdef USE_PROGRAMMING_FRAMEWORK
     if (
         !isArmingDisabled() || 
@@ -526,6 +512,21 @@ void tryArm(void)
         if (ARMING_FLAG(ARMED)) {
             return;
         }
+
+#ifdef USE_DSHOT
+        if (
+                STATE(MULTIROTOR) &&
+                IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) &&
+                emergencyArmingCanOverrideArmingDisabled() &&
+                isMotorProtocolDshot() &&
+                !FLIGHT_MODE(FLIP_OVER_AFTER_CRASH)
+                ) {
+            sendDShotCommand(DSHOT_CMD_SPIN_DIRECTION_REVERSED);
+            ENABLE_ARMING_FLAG(ARMED);
+            enableFlightMode(FLIP_OVER_AFTER_CRASH);
+            return;
+        }
+#endif
 
 #if defined(USE_NAV)
         // If nav_extra_arming_safety was bypassed we always


### PR DESCRIPTION
**IMPORTANT BUG IN TURTLE MODE**

If the turtle mode switch is turned on during the flight, the turtle mode will enter and the motors are stopped so the quad will crash. 

Because the check if the turtle mode have to enter is checked also if the quad is armed.
So i have moved this piece of code in order to check if the turtle mode have to enter only if the quad is armed.