### PR TITLE
h7: fix vcp on cold boot & dfu reset

### DIFF
--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -216,6 +216,12 @@ void usbVcpInitHardware(void)
 
     /* Start Device Process */
     USBD_Start(&USBD_Device);
+    
+#ifdef STM32H7
+    HAL_PWREx_EnableUSBVoltageDetector();
+    delay(100); // Cold boot failures observed without this, even when USB cable is not connected
+#endif
+
 #else
     Set_System();
     Set_USBClock();

--- a/src/main/drivers/system_stm32h7xx.c
+++ b/src/main/drivers/system_stm32h7xx.c
@@ -51,10 +51,13 @@ bool isMPUSoftReset(void)
         return false;
 }
 
-#define SYSMEMBOOT_VECTOR_TABLE ((uint32_t *)0x1ff09800)
 uint32_t systemBootloaderAddress(void)
 {
-    return SYSMEMBOOT_VECTOR_TABLE[1];
+#if defined(STM32H743xx) || defined(STM32H750xx) || defined(STM32H723xx) || defined(STM32H725xx)
+    return 0x1ff09800;
+#else
+#error Unknown MCU
+#endif
 }
 
 void systemClockSetup(uint8_t cpuUnderclock)


### PR DESCRIPTION
H7 needs to have usb voltage detect explicitly enabled
reference in betaflight https://github.com/betaflight/betaflight/blob/master/src/main/drivers/serial_usb_vcp.c#L266
should fix the usb not coming up on a cold boot.

Fixes the address given to the bootloader check