### PR TITLE
Make CW270FLIP default MAG alignment

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -301,6 +301,12 @@ void validateAndFixConfig(void)
     // Call target-specific validation function
     validateAndFixTargetConfig();
 
+#ifdef USE_MAG
+    if (compassConfig()->mag_align == ALIGN_DEFAULT) {
+        compassConfigMutable()->mag_align = CW270_DEG_FLIP;
+    }
+#endif
+
     if (settingsValidate(NULL)) {
         DISABLE_ARMING_FLAG(ARMING_DISABLED_INVALID_SETTING);
     } else {

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -95,9 +95,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_QMC5883:
 #ifdef USE_MAG_QMC5883
         if (qmc5883Detect(dev)) {
-#ifdef MAG_QMC5883_ALIGN
-            dev->magAlign.onBoard = MAG_QMC5883_ALIGN;
-#endif
             magHardware = MAG_QMC5883;
             break;
         }
@@ -111,9 +108,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_HMC5883:
 #ifdef USE_MAG_HMC5883
         if (hmc5883lDetect(dev)) {
-#ifdef MAG_HMC5883_ALIGN
-            dev->magAlign.onBoard = MAG_HMC5883_ALIGN;
-#endif
             magHardware = MAG_HMC5883;
             break;
         }
@@ -127,9 +121,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_AK8975:
 #ifdef USE_MAG_AK8975
         if (ak8975Detect(dev)) {
-#ifdef MAG_AK8975_ALIGN
-            dev->magAlign.onBoard = MAG_AK8975_ALIGN;
-#endif
             magHardware = MAG_AK8975;
             break;
         }
@@ -143,9 +134,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_AK8963:
 #ifdef USE_MAG_AK8963
         if (ak8963Detect(dev)) {
-#ifdef MAG_AK8963_ALIGN
-            dev->magAlign.onBoard = MAG_AK8963_ALIGN;
-#endif
             magHardware = MAG_AK8963;
             break;
         }
@@ -159,9 +147,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_GPS:
 #ifdef USE_GPS
         if (gpsMagDetect(dev)) {
-#ifdef MAG_GPS_ALIGN
-            dev->magAlign.onBoard = MAG_GPS_ALIGN;
-#endif
             magHardware = MAG_GPS;
             break;
         }
@@ -175,9 +160,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_MAG3110:
 #ifdef USE_MAG_MAG3110
         if (mag3110detect(dev)) {
-#ifdef MAG_MAG3110_ALIGN
-            dev->magAlign.onBoard = MAG_MAG3110_ALIGN;
-#endif
             magHardware = MAG_MAG3110;
             break;
         }
@@ -191,9 +173,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_IST8310:
 #ifdef USE_MAG_IST8310
         if (ist8310Detect(dev)) {
-#ifdef MAG_IST8310_ALIGN
-            dev->magAlign.onBoard = MAG_IST8310_ALIGN;
-#endif
             magHardware = MAG_IST8310;
             break;
         }
@@ -207,9 +186,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_IST8308:
 #ifdef USE_MAG_IST8308
         if (ist8308Detect(dev)) {
-#ifdef MAG_IST8308_ALIGN
-            dev->magAlign.onBoard = MAG_IST8308_ALIGN;
-#endif
             magHardware = MAG_IST8308;
             break;
         }
@@ -223,9 +199,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_MPU9250:
 #ifdef USE_MAG_MPU9250
         if (mpu9250CompassDetect(dev)) {
-#ifdef MAG_MPU9250_ALIGN
-            dev->magAlign.onBoard = MAG_MPU9250_ALIGN;
-#endif
             magHardware = MAG_MPU9250;
             break;
         }
@@ -235,9 +208,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_LIS3MDL:
 #ifdef USE_MAG_LIS3MDL
         if (lis3mdlDetect(dev)) {
-#ifdef MAG_LIS3MDL_ALIGN
-            dev->magAlign = MAG_LIS3MDL_ALIGN;
-#endif
             magHardware = MAG_LIS3MDL;
             break;
         }
@@ -266,9 +236,6 @@ bool compassDetect(magDev_t *dev, magSensor_e magHardwareToUse)
     case MAG_RM3100:
 #ifdef USE_MAG_RM3100
         if (rm3100MagDetect(dev)) {
-#ifdef MAG_RM3100_ALIGN
-            dev->magAlign.onBoard = MAG_RM3100_ALIGN;
-#endif
             magHardware = MAG_RM3100;
             break;
         }
@@ -344,6 +311,8 @@ bool compassInit(void)
         mag.dev.magAlign.useExternal = false;
         if (compassConfig()->mag_align != ALIGN_DEFAULT) {
             mag.dev.magAlign.onBoard = compassConfig()->mag_align;
+        } else {
+            mag.dev.magAlign.onBoard = CW270_DEG_FLIP;  // The most popular default is 270FLIP for external mags
         }
     }
 

--- a/src/main/target/AIRBOTF4/target.h
+++ b/src/main/target/AIRBOTF4/target.h
@@ -46,7 +46,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
-#define MAG_HMC5883_ALIGN       CW90_DEG
 #define USE_MAG_HMC5883
 #define USE_MAG_AK8963
 #define USE_MAG_AK8975
@@ -127,8 +126,6 @@
 #define WS2811_PIN                      PA1
 
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
-
-#define MAG_GPS_ALIGN           CW180_DEG_FLIP
 
 #define DEFAULT_RX_TYPE         RX_TYPE_PPM
 #define DISABLE_RX_PWM_FEATURE

--- a/src/main/target/ALIENFLIGHTF3/target.h
+++ b/src/main/target/ALIENFLIGHTF3/target.h
@@ -60,7 +60,6 @@
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
 #define USE_MAG_MPU9250
-#define MAG_MPU9250_ALIGN       CW0_DEG
 #define USE_MAG_AK8963
 #define USE_MAG_AK8975
 #define USE_MAG_HMC5883

--- a/src/main/target/ALIENFLIGHTF4/config.c
+++ b/src/main/target/ALIENFLIGHTF4/config.c
@@ -45,6 +45,7 @@
 
 #include "sensors/battery.h"
 #include "sensors/sensors.h"
+#include "sensors/compass.h"
 
 #include "telemetry/telemetry.h"
 
@@ -56,6 +57,8 @@
 // alternative defaults settings for AlienFlight targets
 void targetConfiguration(void)
 {
+    compassConfigMutable()->mag_align = CW90_DEG;
+
     serialConfigMutable()->portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
     batteryMetersConfigMutable()->current.offset = CURRENTOFFSET;
     batteryMetersConfigMutable()->current.scale = CURRENTSCALE;

--- a/src/main/target/ALIENFLIGHTF4/target.h
+++ b/src/main/target/ALIENFLIGHTF4/target.h
@@ -61,8 +61,6 @@
 #define USE_MAG_IST8308
 #define USE_MAG_LIS3MDL
 
-#define MAG_MPU9250_ALIGN       CW0_DEG
-
 #define TEMPERATURE_I2C_BUS     BUS_I2C1
 #define BNO055_I2C_BUS          BUS_I2C1
 

--- a/src/main/target/ALIENFLIGHTNGF7/config.c
+++ b/src/main/target/ALIENFLIGHTNGF7/config.c
@@ -47,6 +47,7 @@
 #include "config/feature.h"
 
 #include "sensors/battery.h"
+#include "sensors/compass.h"
 
 #include "hardware_revision.h"
 
@@ -58,6 +59,8 @@
 // alternative defaults settings for AlienFlight targets
 void targetConfiguration(void)
 {
+    compassConfigMutable()->mag_align = CW90_DEG;
+
     serialConfigMutable()->portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
     batteryMetersConfigMutable()->current.offset = CURRENTOFFSET;
     batteryMetersConfigMutable()->current.scale = CURRENTSCALE;

--- a/src/main/target/ALIENFLIGHTNGF7/target.h
+++ b/src/main/target/ALIENFLIGHTNGF7/target.h
@@ -59,9 +59,6 @@
 #define USE_MAG_IST8308
 #define USE_MAG_LIS3MDL
 
-#define MAG_AK9863_ALIGN        CW0_DEG
-#define MAG_MPU9250_ALIGN       CW0_DEG
-
 #define AK8963_CS_PIN           PC15
 #define AK8963_SPI_BUS          BUS_SPI3
 

--- a/src/main/target/ANYFC/target.h
+++ b/src/main/target/ANYFC/target.h
@@ -47,7 +47,6 @@
 #define USE_MAG_IST8310
 #define USE_MAG_IST8308
 #define USE_MAG_LIS3MDL
-#define MAG_HMC5883_ALIGN       CW270_DEG_FLIP
 
 #define TEMPERATURE_I2C_BUS     BUS_I2C2
 
@@ -103,8 +102,6 @@
 //#define USE_I2C_PULLUP
 
 //#define HIL
-
-#define MAG_GPS_ALIGN           CW180_DEG_FLIP
 
 #define USE_ADC
 #define ADC_CHANNEL_1_PIN               PC0

--- a/src/main/target/ANYFCF7/target.h
+++ b/src/main/target/ANYFCF7/target.h
@@ -40,7 +40,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
-#define MAG_HMC5883_ALIGN       CW270_DEG_FLIP
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883
 #define USE_MAG_IST8310
@@ -141,8 +140,6 @@
 #define USE_I2C
 #define USE_I2C_DEVICE_4
 #define USE_I2C_DEVICE_2
-
-#define MAG_GPS_ALIGN           CW180_DEG_FLIP
 
 #define SENSORS_SET (SENSOR_ACC|SENSOR_MAG|SENSOR_BARO)
 

--- a/src/main/target/ANYFCM7/target.h
+++ b/src/main/target/ANYFCM7/target.h
@@ -40,7 +40,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
-#define MAG_HMC5883_ALIGN       CW270_DEG_FLIP
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883
 #define USE_MAG_IST8310

--- a/src/main/target/BEEROTORF4/target.h
+++ b/src/main/target/BEEROTORF4/target.h
@@ -45,7 +45,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
-#define MAG_HMC5883_ALIGN       CW90_DEG
 #define USE_MAG_HMC5883
 #define USE_MAG_AK8963
 #define USE_MAG_AK8975

--- a/src/main/target/BETAFLIGHTF4/target.h
+++ b/src/main/target/BETAFLIGHTF4/target.h
@@ -119,7 +119,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
-//#define MAG_HMC5883_ALIGN       CW90_DEG
 #define USE_MAG_AK8963
 #define USE_MAG_AK8975
 #define USE_MAG_HMC5883

--- a/src/main/target/CHEBUZZF3/target.h
+++ b/src/main/target/CHEBUZZF3/target.h
@@ -48,7 +48,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
-#define MAG_AK8975_ALIGN        CW90_DEG_FLIP
 #define USE_MAG_AK8975
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883

--- a/src/main/target/CLRACINGF4AIR/config.c
+++ b/src/main/target/CLRACINGF4AIR/config.c
@@ -49,8 +49,6 @@
 #include "sensors/battery.h"
 #include "sensors/compass.h"
 
-#include "hardware_revision.h"
-
 void targetConfiguration(void)
 {
     compassConfigMutable()->mag_align = CW90_DEG;

--- a/src/main/target/CLRACINGF4AIR/config.c
+++ b/src/main/target/CLRACINGF4AIR/config.c
@@ -15,18 +15,43 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
-#include "platform.h"
+
+#include <platform.h>
+
+#include "common/axis.h"
+
+#include "drivers/sensor.h"
+#include "drivers/pwm_esc_detect.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/pwm_output.h"
+#include "drivers/serial.h"
+
+#include "fc/rc_controls.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+
+#include "rx/rx.h"
+
+#include "io/serial.h"
+
+#include "telemetry/telemetry.h"
+
+#include "sensors/battery.h"
+#include "sensors/sensors.h"
+
 #include "config/config_master.h"
 #include "config/feature.h"
-#include "io/serial.h"
+
+#include "sensors/battery.h"
 #include "sensors/compass.h"
 
+#include "hardware_revision.h"
 
 void targetConfiguration(void)
 {
-    compassConfigMutable()->mag_align = CW0_DEG_FLIP;
-    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].functionMask = FUNCTION_GPS;
-    // serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].gps_baudrateIndex = BAUD_115200;
-
+    compassConfigMutable()->mag_align = CW90_DEG;
 }

--- a/src/main/target/CLRACINGF4AIR/target.h
+++ b/src/main/target/CLRACINGF4AIR/target.h
@@ -52,7 +52,6 @@
 
 #define USE_MAG
 #define USE_MAG_MPU9250
-#define MAG_MPU9250_ALIGN       CW90_DEG
 
 // MPU6 interrupts
 #define USE_EXTI

--- a/src/main/target/COLIBRI/config.c
+++ b/src/main/target/COLIBRI/config.c
@@ -20,18 +20,18 @@
 #include "platform.h"
 
 #include "config/feature.h"
-
 #include "fc/config.h"
-
 #include "flight/mixer.h"
-
 #include "io/serial.h"
-
 #include "rx/rx.h"
+#include "sensors/compass.h"
 
 void targetConfiguration(void)
 {
     rxConfigMutable()->serialrx_provider = SERIALRX_SBUS;
     rxConfigMutable()->receiverType = RX_TYPE_SERIAL;
     serialConfigMutable()->portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
+#ifdef QUANTON
+    compassConfigMutable()->mag_align = CW90_DEG;
+#endif
 }

--- a/src/main/target/COLIBRI/target.h
+++ b/src/main/target/COLIBRI/target.h
@@ -60,10 +60,8 @@
 
 #ifdef QUANTON
 #define IMU_MPU6000_ALIGN       CW90_DEG
-#define MAG_HMC5883_ALIGN       CW90_DEG
 #else
 #define IMU_MPU6000_ALIGN       CW270_DEG_FLIP
-#define MAG_HMC5883_ALIGN       CW270_DEG_FLIP
 #endif
 
 #define USE_BARO

--- a/src/main/target/F4BY/config.c
+++ b/src/main/target/F4BY/config.c
@@ -16,17 +16,17 @@
  */
 
 #include <stdint.h>
-#include "platform.h"
-#include "config/config_master.h"
-#include "config/feature.h"
-#include "io/serial.h"
-#include "sensors/compass.h"
 
+#include "platform.h"
+
+#include "config/feature.h"
+#include "fc/config.h"
+#include "flight/mixer.h"
+#include "io/serial.h"
+#include "rx/rx.h"
+#include "sensors/compass.h"
 
 void targetConfiguration(void)
 {
-    compassConfigMutable()->mag_align = CW0_DEG_FLIP;
-    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].functionMask = FUNCTION_GPS;
-    // serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].gps_baudrateIndex = BAUD_115200;
-
+    compassConfigMutable()->mag_align = CW90_DEG;
 }

--- a/src/main/target/F4BY/target.h
+++ b/src/main/target/F4BY/target.h
@@ -47,7 +47,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
-#define MAG_HMC5883_ALIGN       CW90_DEG
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883
 #define USE_MAG_IST8310

--- a/src/main/target/FF_F35_LIGHTNING/config.c
+++ b/src/main/target/FF_F35_LIGHTNING/config.c
@@ -18,21 +18,16 @@
 #include <stdint.h>
 
 #include <platform.h>
-
 #include "config/config_master.h"
-
 #include "flight/mixer.h"
-
 #include "rx/rx.h"
-
 #include "io/serial.h"
-
 #include "telemetry/telemetry.h"
+#include "sensors/compass.h"
 
-// alternative defaults settings for FF_F35_LIGHTNING targets
 void targetConfiguration(void)
 {
-    motorConfigMutable()->maxthrottle = 2000;
+    compassConfigMutable()->mag_align = CW90_DEG;
 
     serialConfigMutable()->portConfigs[1].functionMask = FUNCTION_MSP;
     serialConfigMutable()->portConfigs[1].msp_baudrateIndex = BAUD_57600;

--- a/src/main/target/FF_F35_LIGHTNING/target.h
+++ b/src/main/target/FF_F35_LIGHTNING/target.h
@@ -42,7 +42,6 @@
 
 #define USE_MAG
 #define USE_MAG_MPU9250
-#define MAG_MPU9250_ALIGN       CW90_DEG_FLIP
 
 #define USE_BARO
 #define USE_BARO_BMP280

--- a/src/main/target/FISHDRONEF4/target.h
+++ b/src/main/target/FISHDRONEF4/target.h
@@ -60,7 +60,6 @@
 #define USE_MAG_IST8308
 #define USE_MAG_QMC5883
 #define USE_MAG_LIS3MDL
-#define MAG_IST8310_ALIGN CW270_DEG
 
 // *************** Temperature sensor *****************
 #define TEMPERATURE_I2C_BUS     BUS_I2C1

--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -57,7 +57,6 @@
 #   define USE_MAG
 #   define MAG_I2C_BUS             BUS_I2C1
 #   define USE_MAG_HMC5883
-#   define MAG_HMC5883_ALIGN       CW180_DEG
 #   define USE_MAG_QMC5883
 #   define USE_MAG_MAG3110
 #   define USE_MAG_IST8310

--- a/src/main/target/KAKUTEF7/target.h
+++ b/src/main/target/KAKUTEF7/target.h
@@ -140,7 +140,6 @@
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
 #define USE_MAG_HMC5883
-#define MAG_HMC5883_ALIGN       CW180_DEG
 #define USE_MAG_QMC5883
 #define USE_MAG_MAG3110
 #define USE_MAG_IST8310

--- a/src/main/target/KROOZX/target.h
+++ b/src/main/target/KROOZX/target.h
@@ -41,7 +41,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
-#define MAG_HMC5883_ALIGN       CW270_DEG_FLIP
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883
 #define USE_MAG_IST8310

--- a/src/main/target/MATEKF405CAN/target.h
+++ b/src/main/target/MATEKF405CAN/target.h
@@ -85,7 +85,6 @@
 #define SPI2_MOSI_PIN   	    PB15
 
 #define USE_MAG_RM3100
-#define MAG_RM3100_ALIGN        CW0_DEG_FLIP
 #define RM3100_CS_PIN           PB12
 #define RM3100_SPI_BUS          BUS_SPI2
 

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -90,7 +90,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             I2C_EXT_BUS
-#define MAG_HMC5883_ALIGN       CW90_DEG
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883
 #define USE_MAG_IST8310

--- a/src/main/target/OMNIBUSF7/target.h
+++ b/src/main/target/OMNIBUSF7/target.h
@@ -149,7 +149,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
-#define MAG_HMC5883_ALIGN       CW270_DEG_FLIP
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883
 #define USE_MAG_IST8310

--- a/src/main/target/PIXRACER/config.c
+++ b/src/main/target/PIXRACER/config.c
@@ -16,17 +16,17 @@
  */
 
 #include <stdint.h>
-#include "platform.h"
-#include "config/config_master.h"
-#include "config/feature.h"
-#include "io/serial.h"
-#include "sensors/compass.h"
 
+#include "platform.h"
+
+#include "config/feature.h"
+#include "fc/config.h"
+#include "flight/mixer.h"
+#include "io/serial.h"
+#include "rx/rx.h"
+#include "sensors/compass.h"
 
 void targetConfiguration(void)
 {
-    compassConfigMutable()->mag_align = CW0_DEG_FLIP;
-    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].functionMask = FUNCTION_GPS;
-    // serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].gps_baudrateIndex = BAUD_115200;
-
+    compassConfigMutable()->mag_align = CW90_DEG;
 }

--- a/src/main/target/PIXRACER/target.h
+++ b/src/main/target/PIXRACER/target.h
@@ -44,7 +44,6 @@
 
 #define USE_IMU_MPU9250
 #define IMU_MPU9250_ALIGN       CW180_DEG_FLIP
-#define MAG_MPU9250_ALIGN       CW90_DEG
 
 #define USE_DUAL_GYRO
 

--- a/src/main/target/RADIX/target.h
+++ b/src/main/target/RADIX/target.h
@@ -36,7 +36,6 @@
 
 // #define USE_MAG
 // #define MAG_I2C_BUS             BUS_I2C1
-// #define MAG_HMC5883_ALIGN       CW90_DEG
 // #define USE_MAG_HMC5883
 // #define USE_MAG_QMC5883
 // #define USE_MAG_IST8310

--- a/src/main/target/REVO/config.c
+++ b/src/main/target/REVO/config.c
@@ -16,17 +16,17 @@
  */
 
 #include <stdint.h>
-#include "platform.h"
-#include "config/config_master.h"
-#include "config/feature.h"
-#include "io/serial.h"
-#include "sensors/compass.h"
 
+#include "platform.h"
+
+#include "config/feature.h"
+#include "fc/config.h"
+#include "flight/mixer.h"
+#include "io/serial.h"
+#include "rx/rx.h"
+#include "sensors/compass.h"
 
 void targetConfiguration(void)
 {
-    compassConfigMutable()->mag_align = CW0_DEG_FLIP;
-    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].functionMask = FUNCTION_GPS;
-    // serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].gps_baudrateIndex = BAUD_115200;
-
+    compassConfigMutable()->mag_align = CW90_DEG;
 }

--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -47,7 +47,6 @@
 #define USE_DUAL_MAG
 #define MAG_I2C_BUS_EXT         BUS_I2C2
 #define MAG_I2C_BUS_INT         BUS_I2C1
-#define MAG_HMC5883_ALIGN       CW90_DEG
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883
 #define USE_MAG_IST8310
@@ -130,8 +129,6 @@
 #define WS2811_PIN                      PA1
 
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
-
-#define MAG_GPS_ALIGN           CW180_DEG_FLIP
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX)

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -42,7 +42,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
-#define MAG_AK8975_ALIGN        CW0_DEG
 #define USE_MAG_AK8975
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883

--- a/src/main/target/SPARKY2/config.c
+++ b/src/main/target/SPARKY2/config.c
@@ -16,17 +16,17 @@
  */
 
 #include <stdint.h>
-#include "platform.h"
-#include "config/config_master.h"
-#include "config/feature.h"
-#include "io/serial.h"
-#include "sensors/compass.h"
 
+#include "platform.h"
+
+#include "config/feature.h"
+#include "fc/config.h"
+#include "flight/mixer.h"
+#include "io/serial.h"
+#include "rx/rx.h"
+#include "sensors/compass.h"
 
 void targetConfiguration(void)
 {
-    compassConfigMutable()->mag_align = CW0_DEG_FLIP;
-    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].functionMask = FUNCTION_GPS;
-    // serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].gps_baudrateIndex = BAUD_115200;
-
+    compassConfigMutable()->mag_align = CW0_DEG;
 }

--- a/src/main/target/SPARKY2/target.h
+++ b/src/main/target/SPARKY2/target.h
@@ -42,7 +42,6 @@
 
 #define USE_MAG
 #define USE_MAG_MPU9250
-#define MAG_MPU9250_ALIGN       CW0_DEG
 
 #define MAG_I2C_BUS             BUS_I2C1
 #define USE_MAG_HMC5883

--- a/src/main/target/SPEEDYBEEF4/target.h
+++ b/src/main/target/SPEEDYBEEF4/target.h
@@ -140,7 +140,6 @@
 #define USE_MAG_IST8310						
 #define USE_MAG_MAG3110						
 #define USE_MAG_LIS3MDL						
-#define MAG_HMC5883_ALIGN       CW90_DEG	
 
 /*** ADC ***/
 #define USE_ADC

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -42,7 +42,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
-#define MAG_HMC5883_ALIGN       CW270_DEG
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883
 #define USE_MAG_IST8310

--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -47,7 +47,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
-#define MAG_MPU9250_ALIGN       CW270_DEG
 #define USE_MAG_MPU9250
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -47,7 +47,6 @@
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
-#define MAG_AK8963_ALIGN        CW270_DEG
 #define USE_MAG_AK8963
 #define USE_MAG_HMC5883
 #define USE_MAG_QMC5883

--- a/src/main/target/YUPIF4/target.h
+++ b/src/main/target/YUPIF4/target.h
@@ -64,7 +64,6 @@
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2
 #define USE_MAG_HMC5883
-#define MAG_HMC5883_ALIGN       CW270_DEG_FLIP
 #define USE_MAG_QMC5883
 
 #define TEMPERATURE_I2C_BUS     BUS_I2C2

--- a/src/main/target/YUPIF7/target.h
+++ b/src/main/target/YUPIF7/target.h
@@ -44,7 +44,6 @@
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1
 #define USE_MAG_HMC5883
-#define MAG_HMC5883_ALIGN       CW270_DEG_FLIP
 #define USE_MAG_QMC5883
 #define TEMPERATURE_I2C_BUS     BUS_I2C1
 #define BNO055_I2C_BUS          BUS_I2C1


### PR DESCRIPTION
Current setup for default mag aligment and mag alignment in particular was somehow strange:

- DEFAULT setting was not really a DEFAULT as it was just exposing what MAG chipset returned. The same as CW0
- Per board settings were valid only for boards equipped with internal MAG, which in 2021 is a dead trend. I'm not aware of any modern FC with integrated MAG that is even remotely popular
- 270FLIP is a de-facto standard for all external GPS+MAG modules

This PR makes a 270FLIP a default value is per-board config does not say otherwise. Most probably, it satisfies the needs of 95% of the users. Users with "custom" setups can still manually set MAG orientation