### PR TITLE
Don't overflow TX buffer in serialpassthrough

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -543,6 +543,8 @@ void serialPassthrough(serialPort_t *left, serialPort_t *right, serialConsumer
         if (serialRxBytesWaiting(left)) {
             LED0_ON;
             uint8_t c = serialRead(left);
+            // Make sure there is space in the tx buffer
+            while (!serialTxBytesFree(right));
             serialWrite(right, c);
             leftC(c);
             LED0_OFF;
@@ -550,6 +552,8 @@ void serialPassthrough(serialPort_t *left, serialPort_t *right, serialConsumer
          if (serialRxBytesWaiting(right)) {
              LED0_ON;
              uint8_t c = serialRead(right);
+             // Make sure there is space in the tx buffer
+             while (!serialTxBytesFree(left));
              serialWrite(left, c);
              rightC(c);
              LED0_OFF;


### PR DESCRIPTION
I'm using serialpassthrough as a mechanism for flashing receiver firmware while the RX is still connected to iNav. I've run into a bit of a problem with the ROM bootloader on the target device (ESP8285) where there are bytes getting lost on passthrough. Removing the receiver I can flash it 100% of the time directly connected, but flashing through serialpassthrough it works rarely (and requires removing the receiver to recover).

This PR fixes the issue I am seeing by busywaiting for free TX buffer space (using `serialTxBytesFree`)  before doing a `serialWrite()`. This fixes the serialpassthrough for my scenario and I believe it is the right thing to do for everyone.

I've created the PR against the master branch but it also applies cleanly to the 2.6.1 tag, so I am sure it can be applied anywhere. Let me know if you'd like it rebased against another branch instead. I've tested this on the OMNIBUSF4PRO target and another tester experiencing the same passthrough lost bytes has tested it on the BETAFLIGHTF4 target.