### PR TITLE
FW Launch idle throttle motor start time delay

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -306,7 +306,7 @@
 | nav_fw_launch_climb_angle | 18 | 5 | 45 | Climb angle (attitude of model, not climb slope) for launch sequence (degrees), is also restrained by global max_angle_inclination_pit |
 | nav_fw_launch_detect_time | 40 | 10 | 1000 | Time for which thresholds have to breached to consider launch happened [ms] |
 | nav_fw_launch_end_time | 3000 | 0 | 5000 | Time for the transition of throttle and pitch angle, between the launch state and the subsequent flight mode [ms] |
-| nav_fw_launch_idle_motor_delay | 0 | 0 | 20000 | Delay between raising throttle and motor starting at idle throttle (ms) |
+| nav_fw_launch_idle_motor_delay | 0 | 0 | 60000 | Delay between raising throttle and motor starting at idle throttle (ms) |
 | nav_fw_launch_idle_thr | 1000 | 1000 | 2000 | Launch idle throttle - throttle to be set before launch sequence is initiated. If set below minimum throttle it will force motor stop or at idle throttle (depending if the MOTOR_STOP is enabled). If set above minimum throttle it will force throttle to this value (if MOTOR_STOP is enabled it will be handled according to throttle stick position) |
 | nav_fw_launch_max_altitude | 0 | 0 | 60000 | Altitude (centimeters) at which LAUNCH mode will be turned off and regular flight mode will take over [0-60000]. |
 | nav_fw_launch_max_angle | 45 | 5 | 180 | Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg] |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -306,6 +306,7 @@
 | nav_fw_launch_climb_angle | 18 | 5 | 45 | Climb angle (attitude of model, not climb slope) for launch sequence (degrees), is also restrained by global max_angle_inclination_pit |
 | nav_fw_launch_detect_time | 40 | 10 | 1000 | Time for which thresholds have to breached to consider launch happened [ms] |
 | nav_fw_launch_end_time | 3000 | 0 | 5000 | Time for the transition of throttle and pitch angle, between the launch state and the subsequent flight mode [ms] |
+| nav_fw_launch_idle_motor_delay | 0 | 0 | 20000 | Delay between raising throttle and motor starting at idle throttle (ms) |
 | nav_fw_launch_idle_thr | 1000 | 1000 | 2000 | Launch idle throttle - throttle to be set before launch sequence is initiated. If set below minimum throttle it will force motor stop or at idle throttle (depending if the MOTOR_STOP is enabled). If set above minimum throttle it will force throttle to this value (if MOTOR_STOP is enabled it will be handled according to throttle stick position) |
 | nav_fw_launch_max_altitude | 0 | 0 | 60000 | Altitude (centimeters) at which LAUNCH mode will be turned off and regular flight mode will take over [0-60000]. |
 | nav_fw_launch_max_angle | 45 | 5 | 180 | Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg] |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -77,7 +77,7 @@ tables:
     enum: videoSystem_e
   - name: osd_telemetry
     values: ["OFF", "ON","TEST"]
-    enum: osd_telemetry_e    
+    enum: osd_telemetry_e
   - name: osd_alignment
     values: ["LEFT", "RIGHT"]
     enum: osd_alignment_e
@@ -2670,6 +2670,12 @@ groups:
         field: fw.launch_idle_throttle
         min: 1000
         max: 2000
+      - name: nav_fw_launch_idle_motor_delay
+        description: "Delay between raising throttle and motor starting at idle throttle (ms)"
+        default_value: 0
+        field: fw.launch_idle_motor_timer
+        min: 0
+        max: 20000
       - name: nav_fw_launch_motor_delay
         description: "Delay between detected launch and launch sequence start and throttling up (ms)"
         default_value: 500

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2675,7 +2675,7 @@ groups:
         default_value: 0
         field: fw.launch_idle_motor_timer
         min: 0
-        max: 20000
+        max: 60000
       - name: nav_fw_launch_motor_delay
         description: "Delay between detected launch and launch sequence start and throttling up (ms)"
         default_value: 500

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -132,6 +132,10 @@ static const uint8_t beep_launchModeBeep[] = {
 static const uint8_t beep_launchModeLowThrottleBeep[] = {
     5, 5, 5, 5, 3, 100, BEEPER_COMMAND_STOP
 };
+// 4 short beeps and a pause. Warning motor about to start at idle throttle
+static const uint8_t beep_launchModeIdleStartBeep[] = {
+    5, 5, 5, 5, 5, 5, 5, 80, BEEPER_COMMAND_STOP
+};
 // short beeps
 static const uint8_t beep_hardwareFailure[] = {
     10, 10, BEEPER_COMMAND_STOP
@@ -196,11 +200,12 @@ typedef struct beeperTableEntry_s {
     { BEEPER_ENTRY(BEEPER_USB,                      18, NULL,                           "ON_USB") },
     { BEEPER_ENTRY(BEEPER_LAUNCH_MODE_ENABLED,      19, beep_launchModeBeep,            "LAUNCH_MODE") },
     { BEEPER_ENTRY(BEEPER_LAUNCH_MODE_LOW_THROTTLE, 20, beep_launchModeLowThrottleBeep, "LAUNCH_MODE_LOW_THROTTLE") },
-    { BEEPER_ENTRY(BEEPER_CAM_CONNECTION_OPEN,      21, beep_camOpenBeep,               "CAM_CONNECTION_OPEN") },
-    { BEEPER_ENTRY(BEEPER_CAM_CONNECTION_CLOSE,     22, beep_camCloseBeep,              "CAM_CONNECTION_CLOSED") },
+    { BEEPER_ENTRY(BEEPER_LAUNCH_MODE_IDLE_START,   21, beep_launchModeIdleStartBeep,   "LAUNCH_MODE_IDLE_START") },
+    { BEEPER_ENTRY(BEEPER_CAM_CONNECTION_OPEN,      22, beep_camOpenBeep,               "CAM_CONNECTION_OPEN") },
+    { BEEPER_ENTRY(BEEPER_CAM_CONNECTION_CLOSE,     23, beep_camCloseBeep,              "CAM_CONNECTION_CLOSED") },
 
-    { BEEPER_ENTRY(BEEPER_ALL,                      23, NULL,                           "ALL") },
-    { BEEPER_ENTRY(BEEPER_PREFERENCE,               24, NULL,                           "PREFERED") },
+    { BEEPER_ENTRY(BEEPER_ALL,                      24, NULL,                           "ALL") },
+    { BEEPER_ENTRY(BEEPER_PREFERENCE,               25, NULL,                           "PREFERED") },
 };
 
 static const beeperTableEntry_t *currentBeeperEntry = NULL;

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -44,6 +44,7 @@ typedef enum {
     BEEPER_USB,                         // Some boards have beeper powered USB connected
     BEEPER_LAUNCH_MODE_ENABLED,         // Fixed-wing launch mode enabled
     BEEPER_LAUNCH_MODE_LOW_THROTTLE,    // Fixed-wing launch mode enabled, but throttle is low
+    BEEPER_LAUNCH_MODE_IDLE_START,      // Fixed-wing launch mode enabled, motor about to start at idle after set delay
     BEEPER_CAM_CONNECTION_OPEN,         // When the 5 key simulation stated
     BEEPER_CAM_CONNECTION_CLOSE,        // When the 5 key simulation stop
 

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -185,6 +185,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .launch_throttle = SETTING_NAV_FW_LAUNCH_THR_DEFAULT,
         .launch_idle_throttle = SETTING_NAV_FW_LAUNCH_IDLE_THR_DEFAULT,         // Motor idle or MOTOR_STOP
         .launch_motor_timer = SETTING_NAV_FW_LAUNCH_MOTOR_DELAY_DEFAULT,        // ms
+        .launch_idle_motor_timer = SETTING_NAV_FW_LAUNCH_IDLE_MOTOR_DELAY_DEFAULT,   // ms
         .launch_motor_spinup_time = SETTING_NAV_FW_LAUNCH_SPINUP_TIME_DEFAULT,  // ms, time to gredually increase throttle from idle to launch
         .launch_end_time = SETTING_NAV_FW_LAUNCH_END_TIME_DEFAULT,              // ms, time to gradually decrease/increase throttle and decrease pitch angle from launch to the current flight mode
         .launch_min_time = SETTING_NAV_FW_LAUNCH_MIN_TIME_DEFAULT,              // ms, min time in launch mode
@@ -2578,11 +2579,11 @@ void updateClimbRateToAltitudeController(float desiredClimbRate, climbRateToAlti
     }
     else {
 
-        /* 
+        /*
          * If max altitude is set, reset climb rate if altitude is reached and climb rate is > 0
          * In other words, when altitude is reached, allow it only to shrink
          */
-        if (navConfig()->general.max_altitude > 0 && 
+        if (navConfig()->general.max_altitude > 0 &&
             altitudeToUse >= navConfig()->general.max_altitude &&
             desiredClimbRate > 0
         ) {

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -263,6 +263,7 @@ typedef struct navConfig_s {
         uint16_t launch_idle_throttle;       // Throttle to keep at launch idle
         uint16_t launch_throttle;            // Launch throttle
         uint16_t launch_motor_timer;         // Time to wait before setting launch_throttle (ms)
+        uint16_t launch_idle_motor_timer;    // Time to wait before motor starts at_idle throttle (ms)
         uint16_t launch_motor_spinup_time;   // Time to speed-up motors from idle to launch_throttle (ESC desync prevention)
         uint16_t launch_end_time;            // Time to make the transition from launch angle to leveled and throttle transition from launch throttle to the stick position
         uint16_t launch_min_time;	           // Minimum time in launch mode to prevent possible bump of the sticks from leaving launch mode early


### PR DESCRIPTION
Resolves https://github.com/iNavFlight/inav/issues/6873.

Provides a time delay between raising throttle and the motor starting at idle of between 0 (default) and 60s.