### PR TITLE
DShot beeper fix

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -341,8 +341,7 @@ void beeperUpdate(timeUs_t currentTimeUs)
 #ifdef USE_DSHOT
         if (!areMotorsRunning()
             && beeperConfig()->dshot_beeper_enabled
-            && (currentBeeperEntry->mode == BEEPER_RX_SET || currentBeeperEntry->mode == BEEPER_RX_LOST)
-            && currentTimeUs - getLastDisarmTimeUs() > getDShotBeaconGuardDelayUs())
+            && currentTimeUs - lastDshotBeeperCommandTimeUs > getDShotBeaconGuardDelayUs())
         {
             lastDshotBeeperCommandTimeUs = currentTimeUs;
             sendDShotCommand(beeperConfig()->dshot_beeper_tone);


### PR DESCRIPTION
Fix #6940 so with this PR dshoot bepper works for all beeper modes, as a normal beeper, so on flight mode changing, GPS fix success, ecc...
I has also changed a condition in the activation if

I think that is useless to have a delay after the disarm so i've removed it.

But i've added a delay between the dshoot beeps