### PR TITLE
Updated CRSF LQ formatting

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -402,7 +402,7 @@
 | osd_camera_uptilt | 0 | -40 | 80 | Set the camera uptilt for the FPV camera in degres, positive is up, negative is down, relative to the horizontal |
 | osd_coordinate_digits | 9 | 8 | 11 |  |
 | osd_crosshairs_style | DEFAULT |  |  | To set the visual type for the crosshair |
-| osd_crsf_lq_format | TYPE3 |  |  | To select LQ format |
+| osd_crsf_lq_format | TYPE1 |  |  | To select LQ format |
 | osd_current_alarm | 0 | 0 | 255 | Value above which the OSD current consumption element will start blinking. Measured in full Amperes. |
 | osd_dist_alarm | 1000 | 0 | 50000 | Value above which to make the OSD distance from home indicator blink (meters) |
 | osd_esc_temp_alarm_max | 900 | -550 | 1500 | Temperature above which the IMU temperature OSD element will start blinking (decidegrees centigrade) |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -402,7 +402,7 @@
 | osd_camera_uptilt | 0 | -40 | 80 | Set the camera uptilt for the FPV camera in degres, positive is up, negative is down, relative to the horizontal |
 | osd_coordinate_digits | 9 | 8 | 11 |  |
 | osd_crosshairs_style | DEFAULT |  |  | To set the visual type for the crosshair |
-| osd_crsf_lq_format | TYPE1 |  |  | To select LQ format |
+| osd_crsf_lq_format | TYPE3 |  |  | To select LQ format |
 | osd_current_alarm | 0 | 0 | 255 | Value above which the OSD current consumption element will start blinking. Measured in full Amperes. |
 | osd_dist_alarm | 1000 | 0 | 50000 | Value above which to make the OSD distance from home indicator blink (meters) |
 | osd_esc_temp_alarm_max | 900 | -550 | 1500 | Temperature above which the IMU temperature OSD element will start blinking (decidegrees centigrade) |

--- a/src/main/drivers/osd_symbols.h
+++ b/src/main/drivers/osd_symbols.h
@@ -35,7 +35,7 @@
 #define SYM_AH_MI                 0x09 // 009 Ah/mi
 #define SYM_MAH_MI_0              0x0A // 010 mAh/mi left
 #define SYM_MAH_MI_1              0x0B // 010 mAh/mi left
-//                                0x0C // 012 -
+#define SYM_LQ                    0x0C // 012 LQ
 
 #define SYM_TEMP_F                0x0D // 013 °F
 #define SYM_TEMP_C                0x0E // 014 °C

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3136,7 +3136,7 @@ groups:
         type: uint8_t
       - name: osd_crsf_lq_format
         description: "To select LQ format"
-        default_value: "TYPE1"
+        default_value: "TYPE3"
         field: crsf_lq_format
         table: osd_crsf_lq_format
         type: uint8_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -156,7 +156,7 @@ tables:
     values: ["AUTO", "ON", "OFF"]
   - name: osd_crsf_lq_format
     enum: osd_crsf_lq_format_e
-    values: ["TYPE1", "TYPE2"]
+    values: ["TYPE1", "TYPE2", "TYPE3"]
   - name: off_on
     values: ["OFF", "ON"]
   - name: djiOsdTempSource

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3136,7 +3136,7 @@ groups:
         type: uint8_t
       - name: osd_crsf_lq_format
         description: "To select LQ format"
-        default_value: "TYPE3"
+        default_value: "TYPE1"
         field: crsf_lq_format
         table: osd_crsf_lq_format
         type: uint8_t

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -539,11 +539,17 @@ static uint16_t osdGetCrsfLQ(void)
 {
     int16_t statsLQ = rxLinkStatistics.uplinkLQ;
     int16_t scaledLQ = scaleRange(constrain(statsLQ, 0, 100), 0, 100, 170, 300);
-    if (rxLinkStatistics.rfMode == 2) {
-        return scaledLQ;
-    } else {
-        return statsLQ;
+    int16_t displayedLQ;
+    switch (osdConfig()->crsf_lq_format) {
+        case OSD_CRSF_LQ_TYPE1:
+            displayedLQ = rxLinkStatistics.rfMode >= 2 ? scaledLQ : statsLQ;
+            break;
+        case OSD_CRSF_LQ_TYPE2:
+        case OSD_CRSF_LQ_TYPE3:
+            displayedLQ = statsLQ;
+            break;
     }
+    return displayedLQ;
 }
 
 static int16_t osdGetCrsfdBm(void)
@@ -1866,10 +1872,13 @@ static bool osdDrawSingleElement(uint8_t item)
             switch (osdConfig()->crsf_lq_format) {
                 case OSD_CRSF_LQ_TYPE1:
                     tfp_sprintf(buff+1, "%3d", rxLinkStatistics.rfMode >= 2 ? scaledLQ : rxLinkStatistics.uplinkLQ);
+                    break;
                 case OSD_CRSF_LQ_TYPE2:
                     tfp_sprintf(buff+1, "%d:%3d", rxLinkStatistics.rfMode, rxLinkStatistics.uplinkLQ);
+                    break;
                 case OSD_CRSF_LQ_TYPE3:
                     tfp_sprintf(buff+1, "%3d", rxLinkStatistics.uplinkLQ);
+                    break;
             }
             if (!failsafeIsReceivingRxData()){
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1860,22 +1860,16 @@ static bool osdDrawSingleElement(uint8_t item)
         }
     case OSD_CRSF_LQ:
         {
-            buff[0] = SYM_BLANK;
+            buff[0] = SYM_LQ;
             int16_t statsLQ = rxLinkStatistics.uplinkLQ;
             int16_t scaledLQ = scaleRange(constrain(statsLQ, 0, 100), 0, 100, 170, 300);
             switch (osdConfig()->crsf_lq_format) {
                 case OSD_CRSF_LQ_TYPE1:
-                    if (rxLinkStatistics.rfMode >= 2) {
-                        tfp_sprintf(buff, "%3d%s", scaledLQ, "%");
-                    } else {
-                        tfp_sprintf(buff, "%3d%s", rxLinkStatistics.uplinkLQ, "%");
-                    }
-
+                    tfp_sprintf(buff+1, "%3d", rxLinkStatistics.rfMode >= 2 ? scaledLQ : rxLinkStatistics.uplinkLQ);
                 case OSD_CRSF_LQ_TYPE2:
-                    tfp_sprintf(buff, "%d:%3d%s", rxLinkStatistics.rfMode, rxLinkStatistics.uplinkLQ, "%");
-
+                    tfp_sprintf(buff+1, "%d:%3d", rxLinkStatistics.rfMode, rxLinkStatistics.uplinkLQ);
                 case OSD_CRSF_LQ_TYPE3:
-                    tfp_sprintf(buff, "%3d%s", rxLinkStatistics.uplinkLQ, "%");
+                    tfp_sprintf(buff+1, "%3d", rxLinkStatistics.uplinkLQ);
             }
             if (!failsafeIsReceivingRxData()){
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -542,11 +542,11 @@ static uint16_t osdGetCrsfLQ(void)
     int16_t displayedLQ;
     switch (osdConfig()->crsf_lq_format) {
         case OSD_CRSF_LQ_TYPE1:
-            displayedLQ = rxLinkStatistics.rfMode >= 2 ? scaledLQ : statsLQ;
-            break;
         case OSD_CRSF_LQ_TYPE2:
-        case OSD_CRSF_LQ_TYPE3:
             displayedLQ = statsLQ;
+            break;
+        case OSD_CRSF_LQ_TYPE3:
+            displayedLQ = rxLinkStatistics.rfMode >= 2 ? scaledLQ : statsLQ;
             break;
     }
     return displayedLQ;
@@ -1871,13 +1871,13 @@ static bool osdDrawSingleElement(uint8_t item)
             int16_t scaledLQ = scaleRange(constrain(statsLQ, 0, 100), 0, 100, 170, 300);
             switch (osdConfig()->crsf_lq_format) {
                 case OSD_CRSF_LQ_TYPE1:
-                    tfp_sprintf(buff+1, "%3d", rxLinkStatistics.rfMode >= 2 ? scaledLQ : rxLinkStatistics.uplinkLQ);
+                    tfp_sprintf(buff+1, "%3d", rxLinkStatistics.uplinkLQ);
                     break;
                 case OSD_CRSF_LQ_TYPE2:
                     tfp_sprintf(buff+1, "%d:%3d", rxLinkStatistics.rfMode, rxLinkStatistics.uplinkLQ);
                     break;
                 case OSD_CRSF_LQ_TYPE3:
-                    tfp_sprintf(buff+1, "%3d", rxLinkStatistics.uplinkLQ);
+                    tfp_sprintf(buff+1, "%3d", rxLinkStatistics.rfMode >= 2 ? scaledLQ : rxLinkStatistics.uplinkLQ);
                     break;
             }
             if (!failsafeIsReceivingRxData()){

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1863,18 +1863,19 @@ static bool osdDrawSingleElement(uint8_t item)
             buff[0] = SYM_BLANK;
             int16_t statsLQ = rxLinkStatistics.uplinkLQ;
             int16_t scaledLQ = scaleRange(constrain(statsLQ, 0, 100), 0, 100, 170, 300);
-            if (rxLinkStatistics.rfMode == 2) {
-                if (osdConfig()->crsf_lq_format == OSD_CRSF_LQ_TYPE1) {
-                    tfp_sprintf(buff, "%5d%s", scaledLQ, "%");
-                } else {
+            switch (osdConfig()->crsf_lq_format) {
+                case OSD_CRSF_LQ_TYPE1:
+                    if (rxLinkStatistics.rfMode >= 2) {
+                        tfp_sprintf(buff, "%3d%s", scaledLQ, "%");
+                    } else {
+                        tfp_sprintf(buff, "%3d%s", rxLinkStatistics.uplinkLQ, "%");
+                    }
+
+                case OSD_CRSF_LQ_TYPE2:
                     tfp_sprintf(buff, "%d:%3d%s", rxLinkStatistics.rfMode, rxLinkStatistics.uplinkLQ, "%");
-                }
-            } else {
-                if (osdConfig()->crsf_lq_format == OSD_CRSF_LQ_TYPE1) {
-                    tfp_sprintf(buff, "%5d%s", rxLinkStatistics.uplinkLQ, "%");
-                } else {
-                    tfp_sprintf(buff, "%d:%3d%s", rxLinkStatistics.rfMode, rxLinkStatistics.uplinkLQ, "%");
-                }
+
+                case OSD_CRSF_LQ_TYPE3:
+                    tfp_sprintf(buff, "%3d%s", rxLinkStatistics.uplinkLQ, "%");
             }
             if (!failsafeIsReceivingRxData()){
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -194,7 +194,7 @@ static bool osdDisplayHasCanvas;
 
 #define AH_MAX_PITCH_DEFAULT 20 // Specify default maximum AHI pitch value displayed (degrees)
 
-PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 1);
+PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 2);
 PG_REGISTER_WITH_RESET_FN(osdLayoutsConfig_t, osdLayoutsConfig, PG_OSD_LAYOUTS_CONFIG, 0);
 
 static int digitCount(int32_t value)

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -284,6 +284,7 @@ typedef enum {
 typedef enum {
     OSD_CRSF_LQ_TYPE1,
     OSD_CRSF_LQ_TYPE2,
+    OSD_CRSF_LQ_TYPE3
 } osd_crsf_lq_format_e;
 
 typedef struct osdLayoutsConfig_s {


### PR DESCRIPTION
This PR:
- adds a third CRSF LQ display format that omits RF mode (`TYPE3`). This is useful when using ExpressLRS, which uses the CRSF protocol but does not (currently) support RF mode switching.
- replaces the trailing % sign with a leading LQ symbol (to be added in a separate configurator PR later, thanks @Jetrell!).
- removes blank characters from the LQ formats that take up less space (`TYPE1` and `TYPE3`).

@OptimusTi, any comments?