### PR TITLE
Improved CRSF RSSI and SNR display

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1887,9 +1887,9 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_CRSF_SNR_DB:
         {
             static pt1Filter_t snrFilterState;
-            static timeUs_t snrUpdated = 0;
-            int16_t snrFiltered = pt1FilterApply4(&snrFilterState, rxLinkStatistics.uplinkSNR, 1, US2S(micros() - snrUpdated));
-            snrUpdated = micros();
+            static timeMs_t snrUpdated = 0;
+            int16_t snrFiltered = pt1FilterApply4(&snrFilterState, rxLinkStatistics.uplinkSNR, 1, MS2S(millis() - snrUpdated));
+            snrUpdated = millis();
 
             const char* showsnr = "-20";
             const char* hidesnr = "     ";

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1850,8 +1850,13 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_CRSF_RSSI_DBM:
         {
             int16_t rssi = rxLinkStatistics.uplinkRSSI;
+            // Remove empty space when RSSI > -100, only switch back to compact notation when RSSI > -95
+            static bool fourDigits = false;
+            if (rssi <= -100) fourDigits = true;
+            if (rssi >= -95) fourDigits = false;
+            
             buff[0] = (rxLinkStatistics.activeAnt == 0) ? SYM_RSSI : SYM_2RSS; // Separate symbols for each antenna
-            tfp_sprintf(buff + 1, (rssi <= -100 ? "%4d%c" : "%3d%c"), rssi, SYM_DBM);
+            tfp_sprintf(buff + 1, (fourDigits ? "%4d%c" : "%3d%c"), rssi, SYM_DBM);
             if (!failsafeIsReceivingRxData()){
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1856,7 +1856,7 @@ static bool osdDrawSingleElement(uint8_t item)
             if (rssi >= -95) fourDigits = false;
             
             buff[0] = (rxLinkStatistics.activeAnt == 0) ? SYM_RSSI : SYM_2RSS; // Separate symbols for each antenna
-            if (fourdigits) {
+            if (fourDigits) {
                 tfp_sprintf(buff + 1, "%4d%c", rssi, SYM_DBM);
             } else {
                 tfp_sprintf(buff + 1, "%3d%c%c", rssi, SYM_DBM, ' ');

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1856,7 +1856,11 @@ static bool osdDrawSingleElement(uint8_t item)
             if (rssi >= -95) fourDigits = false;
             
             buff[0] = (rxLinkStatistics.activeAnt == 0) ? SYM_RSSI : SYM_2RSS; // Separate symbols for each antenna
-            tfp_sprintf(buff + 1, (fourDigits ? "%4d%c" : "%3d%c"), rssi, SYM_DBM);
+            if (fourdigits) {
+                tfp_sprintf(buff + 1, "%4d%c", rssi, SYM_DBM);
+            } else {
+                tfp_sprintf(buff + 1, "%3d%c%c", rssi, SYM_DBM, ' ');
+            }
             if (!failsafeIsReceivingRxData()){
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1894,7 +1894,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             static pt1Filter_t snrFilterState;
             static timeMs_t snrUpdated = 0;
-            int16_t snrFiltered = pt1FilterApply4(&snrFilterState, rxLinkStatistics.uplinkSNR, 1, MS2S(millis() - snrUpdated));
+            int8_t snrFiltered = pt1FilterApply4(&snrFilterState, rxLinkStatistics.uplinkSNR, 0.5f, MS2S(millis() - snrUpdated));
             snrUpdated = millis();
 
             const char* showsnr = "-20";

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1894,8 +1894,8 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             const char* showsnr = "-20";
             const char* hidesnr = "     ";
-            int16_t osdSNR_Alarm = rxLinkStatistics.uplinkSNR;
-            if (osdSNR_Alarm > osdConfig()->snr_alarm) {
+            int16_t osdSNR = rxLinkStatistics.uplinkSNR;
+            if (osdSNR > osdConfig()->snr_alarm) {
                 if (cmsInMenu) {
                     buff[0] = SYM_SNR;
                     tfp_sprintf(buff + 1, "%s%c", showsnr, SYM_DB);
@@ -1903,9 +1903,13 @@ static bool osdDrawSingleElement(uint8_t item)
                     buff[0] = SYM_BLANK;
                     tfp_sprintf(buff + 1, "%s%c", hidesnr, SYM_BLANK);
                 }
-            } else if (osdSNR_Alarm <= osdConfig()->snr_alarm) {
+            } else if (osdSNR <= osdConfig()->snr_alarm) {
                 buff[0] = SYM_SNR;
-                tfp_sprintf(buff + 1, "%3d%c", rxLinkStatistics.uplinkSNR, SYM_DB);
+                if (osdSNR <= -10) {
+                    tfp_sprintf(buff + 1, "%3d%c", osdSNR, SYM_DB);
+                } else {
+                    tfp_sprintf(buff + 1, "%2d%c%c", osdSNR, SYM_DB, ' ');
+                }
             }
             break;
         }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1886,10 +1886,15 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_CRSF_SNR_DB:
         {
+            static pt1Filter_t snrFilterState;
+            static timeUs_t snrUpdated = 0;
+            int16_t snrFiltered = pt1FilterApply4(&snrFilterState, rxLinkStatistics.uplinkSNR, 1, US2S(micros() - snrUpdated));
+            snrUpdated = micros();
+
             const char* showsnr = "-20";
             const char* hidesnr = "     ";
-            int16_t osdSNR_Alarm = rxLinkStatistics.uplinkSNR;
-            if (osdSNR_Alarm > osdConfig()->snr_alarm) {
+
+            if (snrFiltered > osdConfig()->snr_alarm) {
                 if (cmsInMenu) {
                     buff[0] = SYM_SNR;
                     tfp_sprintf(buff + 1, "%s%c", showsnr, SYM_DB);
@@ -1897,9 +1902,9 @@ static bool osdDrawSingleElement(uint8_t item)
                     buff[0] = SYM_BLANK;
                     tfp_sprintf(buff + 1, "%s%c", hidesnr, SYM_BLANK);
                 }
-            } else if (osdSNR_Alarm <= osdConfig()->snr_alarm) {
+            } else if (snrFiltered <= osdConfig()->snr_alarm) {
                 buff[0] = SYM_SNR;
-                tfp_sprintf(buff + 1, "%3d%c", rxLinkStatistics.uplinkSNR, SYM_DB);
+                tfp_sprintf(buff + 1, "%3d%c", snrFiltered, SYM_DB);
             }
             break;
         }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1850,13 +1850,8 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_CRSF_RSSI_DBM:
         {
             int16_t rssi = rxLinkStatistics.uplinkRSSI;
-            // Remove empty space when RSSI > -100, only switch back to compact notation when RSSI > -95
-            static bool fourDigits = false;
-            if (rssi <= -100) fourDigits = true;
-            if (rssi >= -95) fourDigits = false;
-            
             buff[0] = (rxLinkStatistics.activeAnt == 0) ? SYM_RSSI : SYM_2RSS; // Separate symbols for each antenna
-            if (fourDigits) {
+            if (rssi <= -100) {
                 tfp_sprintf(buff + 1, "%4d%c", rssi, SYM_DBM);
             } else {
                 tfp_sprintf(buff + 1, "%3d%c%c", rssi, SYM_DBM, ' ');

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1849,18 +1849,11 @@ static bool osdDrawSingleElement(uint8_t item)
 #if defined(USE_SERIALRX_CRSF)
     case OSD_CRSF_RSSI_DBM:
         {
-            if (rxLinkStatistics.activeAnt == 0) {
-              buff[0] = SYM_RSSI;
-              tfp_sprintf(buff + 1, "%4d%c", rxLinkStatistics.uplinkRSSI, SYM_DBM);
-              if (!failsafeIsReceivingRxData()){
-                  TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
-              }
-            } else {
-              buff[0] = SYM_2RSS;
-              tfp_sprintf(buff + 1, "%4d%c", rxLinkStatistics.uplinkRSSI, SYM_DBM);
-              if (!failsafeIsReceivingRxData()){
-                  TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
-              }
+            int16_t rssi = rxLinkStatistics.uplinkRSSI;
+            buff[0] = (rxLinkStatistics.activeAnt == 0) ? SYM_RSSI : SYM_2RSS; // Separate symbols for each antenna
+            tfp_sprintf(buff + 1, (rssi <= -100 ? "%4d%c" : "%3d%c"), rssi, SYM_DBM);
+            if (!failsafeIsReceivingRxData()){
+                TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
             }
             break;
         }


### PR DESCRIPTION
Most of the time, RSSI is above -100dBm, and I find the empty space between the RSSI symbol and the value not visually pleasing:
![image](https://user-images.githubusercontent.com/880421/117873941-abb1cd80-b2a0-11eb-9232-4e1939240c98.png)

This PR shifts the value and the dBm symbol one character to the left when RSSI > -100dBm:
![image](https://user-images.githubusercontent.com/880421/117874623-7c4f9080-b2a1-11eb-92fc-149e5b1d34a7.png)

The downside is that the value and dBm symbol will jump around when RSSI fluctuates around -100. I personally think it's still an improvement.