### PR TITLE
Add T-Motor F7 target.

### DIFF
--- a/src/main/target/TMOTORF7/CMakeLists.txt
+++ b/src/main/target/TMOTORF7/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_stm32f722xe(TMOTORF7)
+target_stm32f722xe(TMOTORF7HD)

--- a/src/main/target/TMOTORF7/target.c
+++ b/src/main/target/TMOTORF7/target.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/sensor.h"
+
+// BUSDEV_REGISTER_SPI_TAG(busdev_mpu6000,     DEVHW_MPU6000,      MPU6000_SPI_BUS,    MPU6000_CS_PIN,     MPU6000_EXTI_PIN,       0,  DEVFLAGS_NONE,  IMU_MPU6000_ALIGN);
+// BUSDEV_REGISTER_SPI_TAG(busdev_mpu6500,     DEVHW_MPU6500,      MPU6500_SPI_BUS,    MPU6500_CS_PIN,     MPU6500_EXTI_PIN,       1,  DEVFLAGS_NONE,  IMU_MPU6500_ALIGN);
+
+const timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM8,  CH1,  PC6,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 1),
+    DEF_TIM(TIM8,  CH2,  PC7,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 1),
+    DEF_TIM(TIM3,  CH3,  PB0,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),
+    DEF_TIM(TIM3,  CH4,  PB1,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),
+
+    DEF_TIM(TIM4,  CH1,  PB6,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),
+    DEF_TIM(TIM4,  CH3,  PB8,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),
+
+    DEF_TIM(TIM2,  CH1,  PA15, TIM_USE_PPM,                 0, 0),
+    DEF_TIM(TIM11, CH1,  PB9,  TIM_USE_ANY,                 0, 0),
+
+    DEF_TIM(TIM1,  CH1,  PA8,  TIM_USE_LED,                 0, 0)
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/TMOTORF7/target.h
+++ b/src/main/target/TMOTORF7/target.h
@@ -1,0 +1,169 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#ifdef TMOTORF7
+#define TARGET_BOARD_IDENTIFIER "TMR7"
+#define USBD_PRODUCT_STRING     "TMOTORF7"
+#endif
+#ifdef TMOTORF7HD
+#define TARGET_BOARD_IDENTIFIER "TMR7HD"
+#define USBD_PRODUCT_STRING     "TMOTORF7HD"
+#endif
+
+#define LED0                    PB2
+
+#define BEEPER                  PC13
+#define BEEPER_INVERTED
+
+// *************** SPI1 Gyro & ACC *******************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_IMU_MPU6000
+#define IMU_MPU6000_ALIGN       CW0_DEG
+#define MPU6000_CS_PIN          PA4
+#define MPU6000_SPI_BUS         BUS_SPI1
+#define MPU6000_EXTI_PIN        PC4
+
+#define USE_EXTI
+#define USE_MPU_DATA_READY_SIGNAL
+
+// *************** I2C Mag *********************
+#define USE_I2C
+#define USE_I2C_DEVICE_2
+#define I2C2_SCL                PB10
+#define I2C2_SDA                PB11
+
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C2
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_DPS310
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C2
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define USE_MAG_AK8975
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define USE_MAG_IST8310
+#define USE_MAG_IST8308
+#define USE_MAG_MAG3110
+#define USE_MAG_LIS3MDL
+
+// *************** SPI2 OSD ***********************
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_OSD
+
+#ifndef TMOTORF7HD
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          PB12
+#endif
+
+// *************** SPI3 BARO & BLACKBOX*******************
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_SPI_BUS          BUS_SPI3
+#define M25P16_CS_PIN           PC8
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+#define USE_BARO
+#define USE_BARO_BMP280
+#define USE_BARO_SPI_BMP280
+#define BMP280_SPI_BUS          BUS_SPI3
+#define BMP280_CS_PIN           PC15
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define USE_UART3
+#define UART3_TX_PIN            PC10
+#define UART3_RX_PIN            PC11
+
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1
+     
+#define USE_UART5
+#define UART5_TX_PIN            PC12
+#define UART5_RX_PIN            PD2
+
+#define USE_ESCSERIAL
+#define ESCSERIAL_TIMER_TX_PIN  PA15
+
+#define SERIAL_PORT_COUNT       6
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART5
+#define SBUS_TELEMETRY_UART     SERIAL_PORT_USART1
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream0
+
+#define ADC_CHANNEL_1_PIN           PC1
+#define ADC_CHANNEL_2_PIN           PC2
+#define ADC_CHANNEL_3_PIN           PC3
+
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_3
+
+// *************** LEDSTRIP ************************
+#define USE_LED_STRIP
+#define WS2811_PIN                  PA8
+
+#define DEFAULT_FEATURES                (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT |  FEATURE_BLACKBOX)
+#define CURRENT_METER_SCALE     179
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0x0004
+
+#define MAX_PWM_OUTPUT_PORTS        8
+#define USE_DSHOT
+#define USE_ESC_SENSOR


### PR DESCRIPTION
This PR adds support for the T-Motor F7 target.

I have successfully compiled and flashed the board. Next to test it in a quad.

Sources:
 * MATEKF722 target.
 * MAMBAF722 target.
 * [BetaFlight target definition](https://github.com/betaflight/betaflight/tree/master/src/main/target/TMOTORF7).
 * [BetaFlight board documentation](https://github.com/betaflight/betaflight/blob/master/docs/boards/Board%20-%20TMOTORF7.md).
 * https://github.com/iNavFlight/inav/issues/5377