### PR TITLE
FW: limit max climb angle relative to max throttle in AH

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -894,7 +894,9 @@ void taskMainPidLoop(timeUs_t currentTimeUs)
     }
 
 #ifdef USE_POWER_LIMITS
-    powerLimiterApply(&rcCommand[THROTTLE]);
+    if (!STATE(AIRPLANE) || !navigationInAutomaticThrottleMode()) {  // power limits are applied in navigation_fixedwing.c for fixed wings
+        powerLimiterApply(&rcCommand[THROTTLE]);
+    }
 #endif
 
     // Calculate stabilisation


### PR DESCRIPTION
Prevent stalling when the throttle is limited to less than `nav_fw_climb_angle * nav_fw_pitch2thr` either because of `max_throttle` or the power limiter