### PR TITLE
Don't show autotrim osd message when autotrim feature is enabled

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3867,7 +3867,7 @@ textAttributes_t osdGetSystemMessage(char *buff, size_t buff_size, bool isCenter
                         // by OSD_FLYMODE.
                         messages[messageCount++] = OSD_MESSAGE_STR(OSD_MSG_ALTITUDE_HOLD);
                     }
-                    if (IS_RC_MODE_ACTIVE(BOXAUTOTRIM)) {
+                    if (IS_RC_MODE_ACTIVE(BOXAUTOTRIM) && !feature(FEATURE_FW_AUTOTRIM)) {
                         messages[messageCount++] = OSD_MESSAGE_STR(OSD_MSG_AUTOTRIM);
                     }
                     if (IS_RC_MODE_ACTIVE(BOXAUTOTUNE)) {


### PR DESCRIPTION
Replaces https://github.com/iNavFlight/inav/pull/6989.