### PR TITLE
Include compass in OSD sensors calibration message

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Gaël James
 Gregor Ottmann
 Google LLC
 Hyon Lim
+Hubert Jozwiak
 James Harrison
 Jan Staal
 Jeremy Waters

--- a/src/main/fc/fc_core.h
+++ b/src/main/fc/fc_core.h
@@ -43,7 +43,7 @@ disarmReason_t getDisarmReason(void);
 
 void emergencyArmingUpdate(bool armingSwitchIsOn);
 
-bool isCalibrating(void);
+bool areSensorsCalibrating(void);
 float getFlightTime(void);
 float getArmTime(void);
 

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -329,6 +329,16 @@ bool compassIsReady(void)
     return magUpdatedAtLeastOnce;
 }
 
+bool compassIsCalibrationComplete(void)
+{
+    if (STATE(COMPASS_CALIBRATED)) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
 void compassUpdate(timeUs_t currentTimeUs)
 {
     static sensorCalibrationState_t calState;

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -78,5 +78,6 @@ bool compassInit(void);
 void compassUpdate(timeUs_t currentTimeUs);
 bool compassIsReady(void);
 bool compassIsHealthy(void);
+bool compassIsCalibrationComplete(void);
 
 #endif

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -733,7 +733,7 @@ void mavlinkSendHUDAndHeartbeat(void)
             mavSystemState = MAV_STATE_ACTIVE;
         }
     }
-    else if (isCalibrating()) {
+    else if (areSensorsCalibrating()) {
         mavSystemState = MAV_STATE_CALIBRATING;
     }
     else {


### PR DESCRIPTION
I noticed that when the user calibrates the compass, it doesn't show as the OSD message, so the only way you could tell that calibration is happening is by looking at the MCU's debug LED (or by beeper beeps, which not all users have).
I also changed the function name, so that its name better suits its purpose.