### PR TITLE
Compensate AHI for fw_level_pitch_trim

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -625,22 +625,8 @@ static void pidLevel(pidState_t *pidState, flight_dynamics_index_t axis, float h
          * Positive fixedWingLevelTrim means nose should point upwards
          * Negative fixedWingLevelTrim means nose should point downwards
          */
-        angleTarget -= fixedWingLevelTrim;   
-        DEBUG_SET(DEBUG_AUTOLEVEL, 3, angleTarget * 10);
-    }
-
-        //PITCH trim applied by a AutoLevel flight mode and manual pitch trimming
-    if (axis == FD_PITCH && STATE(AIRPLANE)) {
-        /* 
-         * fixedWingLevelTrim has opposite sign to rcCommand.
-         * Positive rcCommand means nose should point downwards
-         * Negative rcCommand mean nose should point upwards
-         * This is counter intuitive and a natural way suggests that + should mean UP
-         * This is why fixedWingLevelTrim has opposite sign to rcCommand
-         * Positive fixedWingLevelTrim means nose should point upwards
-         * Negative fixedWingLevelTrim means nose should point downwards
-         */
         angleTarget -= DEGREES_TO_DECIDEGREES(fixedWingLevelTrim);   
+        DEBUG_SET(DEBUG_AUTOLEVEL, 3, angleTarget * 10);
     }
 
 #ifdef USE_SECONDARY_IMU

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1341,3 +1341,8 @@ void updateFixedWingLevelTrim(timeUs_t currentTimeUs)
 
     previousArmingState = !!ARMING_FLAG(ARMED);
 }
+
+float getFixedWingLevelTrim(void)
+{
+    return STATE(AIRPLANE) ? fixedWingLevelTrim : 0;
+}

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -233,3 +233,4 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
 pidType_e pidIndexGetType(pidIndex_e pidIndex);
 
 void updateFixedWingLevelTrim(timeUs_t currentTimeUs);
+float getFixedWingLevelTrim(void);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2031,6 +2031,7 @@ static bool osdDrawSingleElement(uint8_t item)
             pitchAngle = DECIDEGREES_TO_RADIANS(attitude.values.pitch);
 #endif
             pitchAngle -= DEGREES_TO_RADIANS(osdConfig()->camera_uptilt);
+            pitchAngle += DEGREES_TO_RADIANS(pidProfile()->fixedWingLevelTrim);
             if (osdConfig()->ahi_reverse_roll) {
                 rollAngle = -rollAngle;
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2031,7 +2031,7 @@ static bool osdDrawSingleElement(uint8_t item)
             pitchAngle = DECIDEGREES_TO_RADIANS(attitude.values.pitch);
 #endif
             pitchAngle -= DEGREES_TO_RADIANS(osdConfig()->camera_uptilt);
-            pitchAngle += DEGREES_TO_RADIANS(pidProfile()->fixedWingLevelTrim);
+            pitchAngle += DEGREES_TO_RADIANS(getFixedWingLevelTrim());
             if (osdConfig()->ahi_reverse_roll) {
                 rollAngle = -rollAngle;
             }


### PR DESCRIPTION
Closes https://github.com/iNavFlight/inav/issues/7000, although right now it only compensates the AHI, not the pitch attitude osd element or HUD elements, telemetry, blackbox, logic conditions or pitch angle displayed in the configurator (did I forget anything?). Whether those should also be compensated as well depends on how you look at `fw_level_pitch_trim`. 

The author of the feature request (https://github.com/iNavFlight/inav/issues/6561, @fernandodlc) argued that there is a fundamental difference between "level" (meaning 0 degrees AoA) and the attitude needed for maintaining altitude. Some planes have a shelve or other place specifically designed to mount a flight controller and these are often level when the plane is sitting flat on the desk and the wings are at 0 degrees AoA. You then add a few degrees of pitch up to maintain altitude. From that perspective, no further changes are necessary because you actually pitch up during "level" flight. 

On the other hand, you could say the angle of the plane on the ground is irrelevant and we want to equate 0 degrees pitch with maintaining altitude. In that case, the other pitch related displays also need to be adjusted. 