### PR TITLE
fixed mavlink rssi range

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -497,8 +497,9 @@ void mavlinkSendRCChannelsAndRSSI(void)
         GET_CHANNEL_VALUE(6),
         // chan8_raw RC channel 8 value, in microseconds
         GET_CHANNEL_VALUE(7),
-        // rssi Receive signal strength indicator, 0: 0%, 255: 100%
-        scaleRange(getRSSI(), 0, 1023, 0, 255));
+        // rssi Receive signal strength indicator, 0: 0%, 254: 100%
+		//https://github.com/mavlink/mavlink/issues/1027
+        scaleRange(getRSSI(), 0, 1023, 0, 254));
 #undef GET_CHANNEL_VALUE
 
     mavlinkSendMessage();


### PR DESCRIPTION
According to current Mavlink documentation, rssi field should containt number in range 0...254, 255 is invalid:
https://mavlink.io/en/messages/common.html#RC_CHANNELS_RAW
>rssi | uint8_t |Receive signal strength indicator in device-dependent units/scale. Values: [0-254], UINT8_MAX: invalid/unknown.

Also see discussion:
https://github.com/mavlink/mavlink/issues/1027