### PR TITLE
Disable fw level trim when any stick is deflected instead of just pitch

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1327,11 +1327,16 @@ void updateFixedWingLevelTrim(timeUs_t currentTimeUs)
      */
     pidControllerFlags_e flags = PID_LIMIT_INTEGRATOR;
 
-    //Iterm should freeze when pitch stick is deflected
+    //Iterm should freeze when sticks are deflected
+    bool areSticksDeflected = false;
+    for (int stick = ROLL; stick <= YAW; stick++) {
+        areSticksDeflected = areSticksDeflected ||
+            rxGetChannelValue(stick) > (PWM_RANGE_MIDDLE + pidProfile()->fixedWingLevelTrimDeadband) ||
+            rxGetChannelValue(stick) < (PWM_RANGE_MIDDLE - pidProfile()->fixedWingLevelTrimDeadband);
+    }
     if (
         !IS_RC_MODE_ACTIVE(BOXAUTOLEVEL) ||
-        rxGetChannelValue(PITCH) > (PWM_RANGE_MIDDLE + pidProfile()->fixedWingLevelTrimDeadband) ||
-        rxGetChannelValue(PITCH) < (PWM_RANGE_MIDDLE - pidProfile()->fixedWingLevelTrimDeadband) ||
+        areSticksDeflected ||
         (!FLIGHT_MODE(ANGLE_MODE) && !FLIGHT_MODE(HORIZON_MODE)) ||
         navigationIsControllingAltitude()
     ) {


### PR DESCRIPTION
When flying in angle mode and giving only roll input, the plane will lose altitude. In this situation it is not desirable to adjust the pitch level trim because we are not actually trying to fly level.