### PR TITLE
h7: enable uart RCC

### DIFF
--- a/src/main/drivers/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/serial_uart_stm32h7xx.c
@@ -331,6 +331,10 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_t mode, 
 
     s->Handle.Instance = uart->dev;
 
+    if (uart->rcc) {
+        RCC_ClockCmd(uart->rcc, ENABLE);
+    }
+
     IO_t tx = IOGetByTag(uart->tx);
     IO_t rx = IOGetByTag(uart->rx);
 


### PR DESCRIPTION
as far as i can tell this is the only thing we are missing. i have stick output in the configurator with a dsm rx on uart1