### PR TITLE
h7: enable DPS310

### DIFF
--- a/src/main/target/MATEKH743/target.h
+++ b/src/main/target/MATEKH743/target.h
@@ -146,6 +146,7 @@
 #define BARO_I2C_BUS            BUS_I2C2
 #define USE_BARO_BMP280
 #define USE_BARO_MS5611
+#define USE_BARO_DPS310
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1


### PR DESCRIPTION
baro appears to be working. i dont have any other i2c devices at hand to test