### PR TITLE
Increase max gains to 255 and min rate to 40 dps (10 on yaw)

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1138,7 +1138,7 @@ Fixed-wing attitude stabilisation HORIZON transition point
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 75 | 0 | 300 |
+| 75 | 0 | 255 |
 
 ---
 
@@ -1148,7 +1148,7 @@ Fixed wing rate stabilisation D-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0 | 0 | 300 |
+| 0 | 0 | 255 |
 
 ---
 
@@ -1158,7 +1158,7 @@ Fixed wing rate stabilisation D-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0 | 0 | 300 |
+| 0 | 0 | 255 |
 
 ---
 
@@ -1168,7 +1168,7 @@ Fixed wing rate stabilisation D-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0 | 0 | 300 |
+| 0 | 0 | 255 |
 
 ---
 
@@ -1178,7 +1178,7 @@ Fixed-wing rate stabilisation FF-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 50 | 0 | 300 |
+| 50 | 0 | 255 |
 
 ---
 
@@ -1188,7 +1188,7 @@ Fixed-wing rate stabilisation FF-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 50 | 0 | 300 |
+| 50 | 0 | 255 |
 
 ---
 
@@ -1198,7 +1198,7 @@ Fixed-wing rate stabilisation FF-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 60 | 0 | 300 |
+| 60 | 0 | 255 |
 
 ---
 
@@ -1208,7 +1208,7 @@ Fixed-wing attitude stabilisation low-pass filter cutoff
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 5 | 0 | 300 |
+| 5 | 0 | 255 |
 
 ---
 
@@ -1218,7 +1218,7 @@ Fixed-wing rate stabilisation I-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 7 | 0 | 300 |
+| 7 | 0 | 255 |
 
 ---
 
@@ -1228,7 +1228,7 @@ Fixed-wing rate stabilisation I-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 7 | 0 | 300 |
+| 7 | 0 | 255 |
 
 ---
 
@@ -1238,7 +1238,7 @@ Fixed-wing rate stabilisation I-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 10 | 0 | 300 |
+| 10 | 0 | 255 |
 
 ---
 
@@ -1318,7 +1318,7 @@ Fixed-wing attitude stabilisation P-gain
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 20 | 0 | 300 |
+| 20 | 0 | 255 |
 
 ---
 
@@ -1328,7 +1328,7 @@ Fixed-wing rate stabilisation P-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 5 | 0 | 300 |
+| 5 | 0 | 255 |
 
 ---
 
@@ -1338,7 +1338,7 @@ Fixed-wing rate stabilisation P-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 5 | 0 | 300 |
+| 5 | 0 | 255 |
 
 ---
 
@@ -1348,7 +1348,7 @@ Fixed-wing rate stabilisation P-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 6 | 0 | 300 |
+| 6 | 0 | 255 |
 
 ---
 
@@ -2568,7 +2568,7 @@ Multicopter Control Derivative gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 60 | 0 | 300 |
+| 60 | 0 | 255 |
 
 ---
 
@@ -2578,7 +2578,7 @@ Multicopter Control Derivative gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 60 | 0 | 300 |
+| 60 | 0 | 255 |
 
 ---
 
@@ -2588,7 +2588,7 @@ Multicopter Control Derivative gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 60 | 0 | 300 |
+| 60 | 0 | 255 |
 
 ---
 
@@ -2598,7 +2598,7 @@ Multicopter attitude stabilisation HORIZON transition point
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 75 | 0 | 300 |
+| 75 | 0 | 255 |
 
 ---
 
@@ -2608,7 +2608,7 @@ Multicopter rate stabilisation D-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 23 | 0 | 300 |
+| 23 | 0 | 255 |
 
 ---
 
@@ -2618,7 +2618,7 @@ Multicopter rate stabilisation D-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 23 | 0 | 300 |
+| 23 | 0 | 255 |
 
 ---
 
@@ -2628,7 +2628,7 @@ Multicopter rate stabilisation D-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0 | 0 | 300 |
+| 0 | 0 | 255 |
 
 ---
 
@@ -2638,7 +2638,7 @@ Multicopter attitude stabilisation low-pass filter cutoff
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 15 | 0 | 300 |
+| 15 | 0 | 255 |
 
 ---
 
@@ -2648,7 +2648,7 @@ Multicopter rate stabilisation I-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 30 | 0 | 300 |
+| 30 | 0 | 255 |
 
 ---
 
@@ -2658,7 +2658,7 @@ Multicopter rate stabilisation I-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 30 | 0 | 300 |
+| 30 | 0 | 255 |
 
 ---
 
@@ -2668,7 +2668,7 @@ Multicopter rate stabilisation I-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 45 | 0 | 300 |
+| 45 | 0 | 255 |
 
 ---
 
@@ -2698,7 +2698,7 @@ Multicopter attitude stabilisation P-gain
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 20 | 0 | 300 |
+| 20 | 0 | 255 |
 
 ---
 
@@ -2708,7 +2708,7 @@ Multicopter rate stabilisation P-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 40 | 0 | 300 |
+| 40 | 0 | 255 |
 
 ---
 
@@ -2718,7 +2718,7 @@ Multicopter rate stabilisation P-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 40 | 0 | 300 |
+| 40 | 0 | 255 |
 
 ---
 
@@ -2728,7 +2728,7 @@ Multicopter rate stabilisation P-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 85 | 0 | 300 |
+| 85 | 0 | 255 |
 
 ---
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1138,7 +1138,7 @@ Fixed-wing attitude stabilisation HORIZON transition point
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 75 | 0 | 200 |
+| 75 | 0 | 300 |
 
 ---
 
@@ -1148,7 +1148,7 @@ Fixed wing rate stabilisation D-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0 | 0 | 200 |
+| 0 | 0 | 300 |
 
 ---
 
@@ -1158,7 +1158,7 @@ Fixed wing rate stabilisation D-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0 | 0 | 200 |
+| 0 | 0 | 300 |
 
 ---
 
@@ -1168,7 +1168,7 @@ Fixed wing rate stabilisation D-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0 | 0 | 200 |
+| 0 | 0 | 300 |
 
 ---
 
@@ -1178,7 +1178,7 @@ Fixed-wing rate stabilisation FF-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 50 | 0 | 200 |
+| 50 | 0 | 300 |
 
 ---
 
@@ -1188,7 +1188,7 @@ Fixed-wing rate stabilisation FF-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 50 | 0 | 200 |
+| 50 | 0 | 300 |
 
 ---
 
@@ -1198,7 +1198,7 @@ Fixed-wing rate stabilisation FF-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 60 | 0 | 200 |
+| 60 | 0 | 300 |
 
 ---
 
@@ -1208,7 +1208,7 @@ Fixed-wing attitude stabilisation low-pass filter cutoff
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 5 | 0 | 200 |
+| 5 | 0 | 300 |
 
 ---
 
@@ -1218,7 +1218,7 @@ Fixed-wing rate stabilisation I-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 7 | 0 | 200 |
+| 7 | 0 | 300 |
 
 ---
 
@@ -1228,7 +1228,7 @@ Fixed-wing rate stabilisation I-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 7 | 0 | 200 |
+| 7 | 0 | 300 |
 
 ---
 
@@ -1238,7 +1238,7 @@ Fixed-wing rate stabilisation I-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 10 | 0 | 200 |
+| 10 | 0 | 300 |
 
 ---
 
@@ -1318,7 +1318,7 @@ Fixed-wing attitude stabilisation P-gain
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 20 | 0 | 200 |
+| 20 | 0 | 300 |
 
 ---
 
@@ -1328,7 +1328,7 @@ Fixed-wing rate stabilisation P-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 5 | 0 | 200 |
+| 5 | 0 | 300 |
 
 ---
 
@@ -1338,7 +1338,7 @@ Fixed-wing rate stabilisation P-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 5 | 0 | 200 |
+| 5 | 0 | 300 |
 
 ---
 
@@ -1348,7 +1348,7 @@ Fixed-wing rate stabilisation P-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 6 | 0 | 200 |
+| 6 | 0 | 300 |
 
 ---
 
@@ -2568,7 +2568,7 @@ Multicopter Control Derivative gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 60 | 0 | 200 |
+| 60 | 0 | 300 |
 
 ---
 
@@ -2578,7 +2578,7 @@ Multicopter Control Derivative gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 60 | 0 | 200 |
+| 60 | 0 | 300 |
 
 ---
 
@@ -2588,7 +2588,7 @@ Multicopter Control Derivative gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 60 | 0 | 200 |
+| 60 | 0 | 300 |
 
 ---
 
@@ -2598,7 +2598,7 @@ Multicopter attitude stabilisation HORIZON transition point
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 75 | 0 | 200 |
+| 75 | 0 | 300 |
 
 ---
 
@@ -2608,7 +2608,7 @@ Multicopter rate stabilisation D-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 23 | 0 | 200 |
+| 23 | 0 | 300 |
 
 ---
 
@@ -2618,7 +2618,7 @@ Multicopter rate stabilisation D-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 23 | 0 | 200 |
+| 23 | 0 | 300 |
 
 ---
 
@@ -2628,7 +2628,7 @@ Multicopter rate stabilisation D-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0 | 0 | 200 |
+| 0 | 0 | 300 |
 
 ---
 
@@ -2638,7 +2638,7 @@ Multicopter attitude stabilisation low-pass filter cutoff
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 15 | 0 | 200 |
+| 15 | 0 | 300 |
 
 ---
 
@@ -2648,7 +2648,7 @@ Multicopter rate stabilisation I-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 30 | 0 | 200 |
+| 30 | 0 | 300 |
 
 ---
 
@@ -2658,7 +2658,7 @@ Multicopter rate stabilisation I-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 30 | 0 | 200 |
+| 30 | 0 | 300 |
 
 ---
 
@@ -2668,7 +2668,7 @@ Multicopter rate stabilisation I-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 45 | 0 | 200 |
+| 45 | 0 | 300 |
 
 ---
 
@@ -2698,7 +2698,7 @@ Multicopter attitude stabilisation P-gain
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 20 | 0 | 200 |
+| 20 | 0 | 300 |
 
 ---
 
@@ -2708,7 +2708,7 @@ Multicopter rate stabilisation P-gain for PITCH
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 40 | 0 | 200 |
+| 40 | 0 | 300 |
 
 ---
 
@@ -2718,7 +2718,7 @@ Multicopter rate stabilisation P-gain for ROLL
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 40 | 0 | 200 |
+| 40 | 0 | 300 |
 
 ---
 
@@ -2728,7 +2728,7 @@ Multicopter rate stabilisation P-gain for YAW
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 85 | 0 | 200 |
+| 85 | 0 | 300 |
 
 ---
 
@@ -4618,7 +4618,7 @@ Defines rotation rate on PITCH axis that UAV will try to archive on max. stick d
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 20 | 6 | 180 |
+| 20 | 4 | 180 |
 
 ---
 
@@ -4788,7 +4788,7 @@ Defines rotation rate on ROLL axis that UAV will try to archive on max. stick de
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 20 | 6 | 180 |
+| 20 | 4 | 180 |
 
 ---
 
@@ -5628,7 +5628,7 @@ Defines rotation rate on YAW axis that UAV will try to archive on max. stick def
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 20 | 2 | 180 |
+| 20 | 1 | 180 |
 
 ---
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1098,7 +1098,7 @@ The target percentage of maximum mixer output used for determining the rates in 
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 80 | 50 | 100 |
+| 90 | 50 | 100 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -182,12 +182,12 @@ tables:
 
 constants:
   RPYL_PID_MIN: 0
-  RPYL_PID_MAX: 200
+  RPYL_PID_MAX: 300
 
   MANUAL_RATE_MIN: 0
   MANUAL_RATE_MAX: 100
 
-  ROLL_PITCH_RATE_MIN: 6
+  ROLL_PITCH_RATE_MIN: 4
   ROLL_PITCH_RATE_MAX: 180
 
 groups:
@@ -1289,7 +1289,7 @@ groups:
         description: "Defines rotation rate on YAW axis that UAV will try to archive on max. stick deflection. Rates are defined in tens of degrees (deca-degrees) per second [rate = dps/10]. That means, rate 20 represents 200dps rotation speed. Default 20 (200dps) is more less equivalent of old Cleanflight/Baseflight rate 0. Max. 180 (1800dps) is what gyro can measure."
         default_value: 20
         field: stabilized.rates[FD_YAW]
-        min: 2
+        min: 1
         max: 180
       - name: manual_rc_expo
         description: "Exposition value used for the PITCH/ROLL axes by the `MANUAL` flight mode [0-100]"

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2161,7 +2161,7 @@ groups:
         type: uint8_t
       - name: fw_autotune_max_rate_deflection
         description: "The target percentage of maximum mixer output used for determining the rates in `AUTO` and `LIMIT`."
-        default_value: 80
+        default_value: 90
         field: fw_max_rate_deflection
         min: 50
         max: 100

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -182,7 +182,7 @@ tables:
 
 constants:
   RPYL_PID_MIN: 0
-  RPYL_PID_MAX: 300
+  RPYL_PID_MAX: 255
 
   MANUAL_RATE_MIN: 0
   MANUAL_RATE_MAX: 100

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -47,7 +47,7 @@
 #include "flight/pid.h"
 
 #define AUTOTUNE_FIXED_WING_MIN_FF              10
-#define AUTOTUNE_FIXED_WING_MAX_FF              200
+#define AUTOTUNE_FIXED_WING_MAX_FF              300
 #define AUTOTUNE_FIXED_WING_MIN_ROLL_PITCH_RATE 40
 #define AUTOTUNE_FIXED_WING_MIN_YAW_RATE        10
 #define AUTOTUNE_FIXED_WING_MAX_RATE            720

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -53,8 +53,8 @@
 #define AUTOTUNE_FIXED_WING_MAX_RATE            720
 #define AUTOTUNE_FIXED_WING_CONVERGENCE_RATE    10
 #define AUTOTUNE_FIXED_WING_SAMPLE_INTERVAL     20      // ms
-#define AUTOTUNE_FIXED_WING_SAMPLES             1000    // Use averagea over the last 20 seconds
-#define AUTOTUNE_FIXED_WING_MIN_SAMPLES         250     // Start updating tune after 5 seconds
+#define AUTOTUNE_FIXED_WING_SAMPLES             1000    // Use average over the last 20 seconds of hard maneuvers
+#define AUTOTUNE_FIXED_WING_MIN_SAMPLES         250     // Start updating tune after 5 seconds of hard maneuvers
 
 PG_REGISTER_WITH_RESET_TEMPLATE(pidAutotuneConfig_t, pidAutotuneConfig, PG_PID_AUTOTUNE_CONFIG, 2);
 


### PR DESCRIPTION
Some planes are much slower than I thought and the new autotune sets very low rates, especially on yaw. This causes FF to max out. At some point, we should rethink the way we handle rates and gains on fixed-wing but for now, this will somewhat alleviate the issue. I also increased the default autotune target deflection to 90%.