### PR TITLE
Make battery profile count configurable from settings.yaml

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -5558,7 +5558,7 @@ Battery voltage calibration value. 1100 = 11:1 voltage divider (10k:1k) x 100. A
 
 | Default | Min | Max |
 | --- | --- | --- |
-| _target default_ | VBAT_SCALE_MIN | VBAT_SCALE_MAX |
+| _target default_ | 0 | 65535 |
 
 ---
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -242,7 +242,7 @@ main_sources(COMMON_SRC
     drivers/rangefinder/rangefinder_virtual.h
     drivers/rangefinder/rangefinder_us42.c
     drivers/rangefinder/rangefinder_us42.h
-    
+
     drivers/resource.c
     drivers/resource.h
     drivers/rcc.c
@@ -441,6 +441,7 @@ main_sources(COMMON_SRC
     sensors/acceleration.h
     sensors/battery.c
     sensors/battery.h
+    sensors/battery_config_structs.h
     sensors/boardalignment.c
     sensors/boardalignment.h
     sensors/compass.c

--- a/src/main/fc/settings.h
+++ b/src/main/fc/settings.h
@@ -67,9 +67,9 @@ typedef struct {
 
 } __attribute__((packed)) setting_t;
 
-static inline setting_type_e SETTING_TYPE(const setting_t *s) { return s->type &  SETTING_TYPE_MASK; }
-static inline setting_section_e SETTING_SECTION(const setting_t *s) { return s->type & SETTING_SECTION_MASK; }
-static inline setting_mode_e SETTING_MODE(const setting_t *s) { return s->type & SETTING_MODE_MASK; }
+static inline setting_type_e SETTING_TYPE(const setting_t *s) { return (setting_type_e)(s->type &  SETTING_TYPE_MASK); }
+static inline setting_section_e SETTING_SECTION(const setting_t *s) { return (setting_section_e)(s->type & SETTING_SECTION_MASK); }
+static inline setting_mode_e SETTING_MODE(const setting_t *s) { return (setting_mode_e)(s->type & SETTING_MODE_MASK); }
 
 void settingGetName(const setting_t *val, char *buf);
 bool settingNameContains(const setting_t *val, char *buf, const char *cmdline);

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -181,7 +181,7 @@ tables:
     values: ["OFF", "ON", "ON_FW_SPIRAL"]
   - name: djiRssiSource
     values: ["RSSI", "CRSF_LQ"]
-    enum: djiRssiSource_e    
+    enum: djiRssiSource_e
 
 
 constants:
@@ -195,6 +195,8 @@ constants:
   ROLL_PITCH_RATE_MAX: 180
 
   MAX_CONTROL_RATE_PROFILE_COUNT: 3
+  MAX_BATTERY_PROFILE_COUNT: 3
+
 
 groups:
   - name: PG_GYRO_CONFIG
@@ -1005,7 +1007,7 @@ groups:
 
   - name: PG_BATTERY_METERS_CONFIG
     type: batteryMetersConfig_t
-    headers: ["sensors/battery.h"]
+    headers: ["sensors/battery_config_structs.h"]
     members:
       - name: vbat_meter_type
         description: "Vbat voltage source. Possible values: `NONE`, `ADC`, `ESC`. `ESC` required ESC telemetry enebled and running"
@@ -1019,8 +1021,8 @@ groups:
         default_value: :target
         field: voltage.scale
         condition: USE_ADC
-        min: VBAT_SCALE_MIN
-        max: VBAT_SCALE_MAX
+        min: 0
+        max: 65535
       - name: current_meter_scale
         description: "This sets the output voltage to current scaling for the current sensor in 0.1 mV/A steps. 400 is 40mV/A such as the ACS756 sensor outputs. 183 is the setting for the uberdistro with a 0.25mOhm shunt."
         default_value: :target
@@ -1071,7 +1073,7 @@ groups:
 
   - name: PG_BATTERY_PROFILES
     type: batteryProfile_t
-    headers: ["sensors/battery.h"]
+    headers: ["sensors/battery_config_structs.h"]
     value_type: BATTERY_CONFIG_VALUE
     members:
       - name: bat_cells

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -18,13 +18,16 @@
 #pragma once
 
 #include "config/parameter_group.h"
+
 #include "drivers/time.h"
+
+#include "fc/settings.h"
+
+#include "sensors/battery_config_structs.h"
 
 #ifndef VBAT_SCALE_DEFAULT
 #define VBAT_SCALE_DEFAULT 1100
 #endif
-#define VBAT_SCALE_MIN 0
-#define VBAT_SCALE_MAX 65535
 
 #ifndef CURRENT_METER_SCALE
 #define CURRENT_METER_SCALE 400 // for Allegro ACS758LCB-100U (40mV/A)
@@ -35,86 +38,13 @@
 #endif
 
 #ifndef MAX_BATTERY_PROFILE_COUNT
-#define MAX_BATTERY_PROFILE_COUNT 3
+#define MAX_BATTERY_PROFILE_COUNT SETTING_CONSTANT_MAX_BATTERY_PROFILE_COUNT
 #endif
-
-typedef enum {
-    CURRENT_SENSOR_NONE = 0,
-    CURRENT_SENSOR_ADC,
-    CURRENT_SENSOR_VIRTUAL,
-    CURRENT_SENSOR_ESC,
-    CURRENT_SENSOR_MAX = CURRENT_SENSOR_VIRTUAL
-} currentSensor_e;
-
-typedef enum {
-    VOLTAGE_SENSOR_NONE = 0,
-    VOLTAGE_SENSOR_ADC,
-    VOLTAGE_SENSOR_ESC
-} voltageSensor_e;
-
-typedef enum {
-    BAT_CAPACITY_UNIT_MAH,
-    BAT_CAPACITY_UNIT_MWH,
-} batCapacityUnit_e;
 
 typedef struct {
   uint8_t profile_index;
   uint16_t max_voltage;
 } profile_comp_t;
-
-typedef enum {
-    BAT_VOLTAGE_RAW,
-    BAT_VOLTAGE_SAG_COMP
-} batVoltageSource_e;
-
-typedef struct batteryMetersConfig_s {
-
-#ifdef USE_ADC
-    struct {
-        uint16_t scale;
-        voltageSensor_e type;
-    } voltage;
-#endif
-
-    struct {
-        int16_t scale;          // scale the current sensor output voltage to milliamps. Value in 1/10th mV/A
-        int16_t offset;         // offset of the current sensor in millivolt steps
-        currentSensor_e type;   // type of current meter used, either ADC or virtual
-    } current;
-
-    batVoltageSource_e voltageSource;
-
-    uint32_t cruise_power;      // power drawn by the motor(s) at cruise throttle/speed (cW)
-    uint16_t idle_power;        // power drawn by the system when the motor(s) are stopped (cW)
-    uint8_t rth_energy_margin;  // Energy that should be left after RTH (%), used for remaining time/distance before RTH
-
-    float throttle_compensation_weight;
-
-} batteryMetersConfig_t;
-
-typedef struct batteryProfile_s {
-
-#ifdef USE_ADC
-    uint8_t cells;
-
-    struct {
-        uint16_t cellDetect;    // maximum voltage per cell, used for auto-detecting battery cell count in 0.01V units, default is 430 (4.3V)
-        uint16_t cellMax;       // maximum voltage per cell, used for auto-detecting battery voltage in 0.01V units, default is 421 (4.21V)
-        uint16_t cellMin;       // minimum voltage per cell, this triggers battery critical alarm, in 0.01V units, default is 330 (3.3V)
-        uint16_t cellWarning;   // warning voltage per cell, this triggers battery warning alarm, in 0.01V units, default is 350 (3.5V)
-    } voltage;
-#endif
-
-    struct {
-        uint32_t value;         // mAh or mWh (see capacity.unit)
-        uint32_t warning;       // mAh or mWh (see capacity.unit)
-        uint32_t critical;      // mAh or mWh (see capacity.unit)
-        batCapacityUnit_e unit; // Describes unit of capacity.value, capacity.warning and capacity.critical
-    } capacity;
-
-    uint8_t controlRateProfile;
-
-} batteryProfile_t;
 
 PG_DECLARE(batteryMetersConfig_t, batteryMetersConfig);
 PG_DECLARE_ARRAY(batteryProfile_t, MAX_BATTERY_PROFILE_COUNT, batteryProfiles);

--- a/src/main/sensors/battery_config_structs.h
+++ b/src/main/sensors/battery_config_structs.h
@@ -1,0 +1,99 @@
+/*
+ * This file is part of iNav
+ *
+ * iNav free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * iNav distributed in the hope that it
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+typedef enum {
+    CURRENT_SENSOR_NONE = 0,
+    CURRENT_SENSOR_ADC,
+    CURRENT_SENSOR_VIRTUAL,
+    CURRENT_SENSOR_ESC,
+    CURRENT_SENSOR_MAX = CURRENT_SENSOR_VIRTUAL
+} currentSensor_e;
+
+typedef enum {
+    VOLTAGE_SENSOR_NONE = 0,
+    VOLTAGE_SENSOR_ADC,
+    VOLTAGE_SENSOR_ESC
+} voltageSensor_e;
+
+typedef enum {
+    BAT_CAPACITY_UNIT_MAH,
+    BAT_CAPACITY_UNIT_MWH,
+} batCapacityUnit_e;
+
+typedef enum {
+    BAT_VOLTAGE_RAW,
+    BAT_VOLTAGE_SAG_COMP
+} batVoltageSource_e;
+
+typedef struct batteryMetersConfig_s {
+
+#ifdef USE_ADC
+    struct {
+        uint16_t scale;
+        voltageSensor_e type;
+    } voltage;
+#endif
+
+    struct {
+        int16_t scale;          // scale the current sensor output voltage to milliamps. Value in 1/10th mV/A
+        int16_t offset;         // offset of the current sensor in millivolt steps
+        currentSensor_e type;   // type of current meter used, either ADC or virtual
+    } current;
+
+    batVoltageSource_e voltageSource;
+
+    uint32_t cruise_power;      // power drawn by the motor(s) at cruise throttle/speed (cW)
+    uint16_t idle_power;        // power drawn by the system when the motor(s) are stopped (cW)
+    uint8_t rth_energy_margin;  // Energy that should be left after RTH (%), used for remaining time/distance before RTH
+
+    float throttle_compensation_weight;
+
+} batteryMetersConfig_t;
+
+typedef struct batteryProfile_s {
+
+#ifdef USE_ADC
+    uint8_t cells;
+
+    struct {
+        uint16_t cellDetect;    // maximum voltage per cell, used for auto-detecting battery cell count in 0.01V units, default is 430 (4.3V)
+        uint16_t cellMax;       // maximum voltage per cell, used for auto-detecting battery voltage in 0.01V units, default is 421 (4.21V)
+        uint16_t cellMin;       // minimum voltage per cell, this triggers battery critical alarm, in 0.01V units, default is 330 (3.3V)
+        uint16_t cellWarning;   // warning voltage per cell, this triggers battery warning alarm, in 0.01V units, default is 350 (3.5V)
+    } voltage;
+#endif
+
+    struct {
+        uint32_t value;         // mAh or mWh (see capacity.unit)
+        uint32_t warning;       // mAh or mWh (see capacity.unit)
+        uint32_t critical;      // mAh or mWh (see capacity.unit)
+        batCapacityUnit_e unit; // Describes unit of capacity.value, capacity.warning and capacity.critical
+    } capacity;
+
+    uint8_t controlRateProfile;
+
+} batteryProfile_t;


### PR DESCRIPTION
Like #7048 makes the controlrate profile count configurable from `settings.yaml`