### PR TITLE
fix docker build under windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,4 +10,4 @@
 Makefile text
 *.bat eol=crlf
 *.txt text
-*.sh text
+*.sh text eol=lf

--- a/docs/development/Building in Docker.md
+++ b/docs/development/Building in Docker.md
@@ -23,12 +23,14 @@ Where `<TARGET>` must be replaced with the name of the target that you want to b
 ## Windows 10
 
 Docker on Windows requires full paths for mounting volumes in `docker run` commands. For example: `c:\Users\pspyc\Documents\Projects\inav` becomes `//c/Users/pspyc/Documents/Projects/inav` .
+If you are getting error "standard_init_linux.go:219: exec user process caused: no such file or directory", make sure `\cmake\docker.sh` has lf (not crlf) line endings.
 
 You'll have to manually execute the same steps that the build script does:
 
 1. `docker build -t inav-build .`
    + This step is only needed the first time.
-2. `docker run --rm -it -v <PATH_TO_REPO>:/src inav-build <TARGET>`
+2. `docker run --rm -it -u root -v <PATH_TO_REPO>:/src inav-build <TARGET>`
    + Where `<PATH_TO_REPO>` must be replaced with the absolute path of where you cloned this repo (see above), and `<TARGET>` with the name of the target that you want to build.
+   + Note that on Windows/WSL 2 mounted /src folder is writeable for root user only. You have to run build under root user. You can achieve this by using `-u root` option in the command line above, or by removing "USER inav" line from the .\DockerFile before building image.   
 
 Refer to the [Linux](#Linux) instructions or the [build script](/build.sh) for more details.


### PR DESCRIPTION
Docker build does not work under Windows 10, WSL 2

1) \cmake\build.sh has CRLF line endings, should have LF line endings.
Solution: added option to .gitattibutes.

2) docker documentation states that mounted folder is assigned write permissions for active user.
In practice, only root user has writing permissions.
Solution: run docker container with 'root' user instead of 'inav' user: -u root. 
Updated documentation.