### PR TITLE
Adjust pitch angle by fixedWingLevelTrim instead of adding to target pitch angle

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -462,7 +462,7 @@ STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
 {
     /* Compute pitch/roll angles */
     attitude.values.roll = RADIANS_TO_DECIDEGREES(atan2_approx(rMat[2][1], rMat[2][2]));
-    attitude.values.pitch = RADIANS_TO_DECIDEGREES((0.5f * M_PIf) - acos_approx(-rMat[2][0]));
+    attitude.values.pitch = RADIANS_TO_DECIDEGREES((0.5f * M_PIf) - acos_approx(-rMat[2][0])) + DEGREES_TO_DECIDEGREES(getFixedWingLevelTrim());
     attitude.values.yaw = RADIANS_TO_DECIDEGREES(-atan2_approx(rMat[1][0], rMat[0][0]));
 
     if (attitude.values.yaw < 0)

--- a/src/main/flight/secondary_imu.c
+++ b/src/main/flight/secondary_imu.c
@@ -40,6 +40,7 @@
 #include "fc/settings.h"
 
 #include "flight/secondary_imu.h"
+#include "flight/pid.h"
 
 #include "sensors/boardalignment.h"
 #include "sensors/compass.h"
@@ -140,7 +141,7 @@ void secondaryImuProcess(void) {
     rotated.z = ((int32_t)(rotated.z + secondaryImuConfig()->yawDeciDegrees)) % 3600;
 
     secondaryImuState.eulerAngles.values.roll = rotated.x;
-    secondaryImuState.eulerAngles.values.pitch = rotated.y;
+    secondaryImuState.eulerAngles.values.pitch = rotated.y + DEGREES_TO_DECIDEGREES(getFixedWingLevelTrim());
     secondaryImuState.eulerAngles.values.yaw = rotated.z;
 
     DEBUG_SET(DEBUG_IMU2, 0, secondaryImuState.eulerAngles.values.roll);

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -507,7 +507,7 @@ void processContinuousServoAutotrim(const float dT)
             const bool planeIsFlyingStraight = rotRateMagnitudeFiltered <= DEGREES_TO_RADIANS(servoConfig()->servo_autotrim_rotation_limit);
             const bool noRotationCommanded = targetRateMagnitudeFiltered <= servoConfig()->servo_autotrim_rotation_limit;
             const bool sticksAreCentered = !areSticksDeflected();
-            const bool planeIsFlyingLevel = ABS(attitude.values.pitch + DEGREES_TO_DECIDEGREES(getFixedWingLevelTrim())) <= SERVO_AUTOTRIM_ATIITUDE_LIMIT 
+            const bool planeIsFlyingLevel = ABS(attitude.values.pitch) <= SERVO_AUTOTRIM_ATIITUDE_LIMIT 
                                             && ABS(attitude.values.roll) <= SERVO_AUTOTRIM_ATIITUDE_LIMIT;
             if (
                 planeIsFlyingStraight && 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2073,7 +2073,6 @@ static bool osdDrawSingleElement(uint8_t item)
             pitchAngle = DECIDEGREES_TO_RADIANS(attitude.values.pitch);
 #endif
             pitchAngle -= osdConfig()->ahi_camera_uptilt_comp ? DEGREES_TO_RADIANS(osdConfig()->camera_uptilt) : 0;
-            pitchAngle += DEGREES_TO_RADIANS(getFixedWingLevelTrim());
             if (osdConfig()->ahi_reverse_roll) {
                 rollAngle = -rollAngle;
             }


### PR DESCRIPTION
The current approach of adding `fixedWingLevelTrim` degrees to the target pitch angle creates a lot of apparent inconsistencies such as the telemetry script and OSD pitch indicator showing consistent pitch up in level flight and cruise throttle being offset by `fixedWingLevelTrim`*`pitch2throttle`. You could argue that the plane _is_ pitching up so the indicated pitch angle is correct but this depends on how your fc is mounted and it's different from the previous behavior so it can create some confusion.

Instead of changing the target pitch angle, this PR changes the pitch attitude by the same amount in the opposite direction. The effect in angle mode is exactly the same but now level flight is indicated as 0 degrees pitch throughout the project.

While typing this I realize that neither this PR nor the existing `fixedWingLevelTrim` is exactly equivalent to the old approach of adjusting the board alignment because they only create a pitch offset and don't properly rotate the body reference frame. How to do this is a bit beyond me at the moment. With modest pitch trim angles between -10 and +10 degrees, the effect is probably negligible. @digitalentity, do you have any suggestions on how to approach this?