### PR TITLE
Change autotune target deflection to 80%

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1158,13 +1158,13 @@ The target percentage of maximum mixer output used for determining the rates in 
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 90 | 50 | 100 |
+| 80 | 50 | 100 |
 
 ---
 
 ### fw_autotune_min_stick
 
-Minimum stick input [%] to consider overshoot/undershoot detection
+Minimum stick input [%], after applying deadband and expo, to start recording the plane's response to stick input.
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2220,7 +2220,7 @@ groups:
     condition: USE_AUTOTUNE_FIXED_WING
     members:
       - name: fw_autotune_min_stick
-        description: "Minimum stick input [%] to consider overshoot/undershoot detection"
+        description: "Minimum stick input [%], after applying deadband and expo, to consider overshoot/undershoot detection"
         default_value: 50
         field: fw_min_stick
         min: 0
@@ -2251,7 +2251,7 @@ groups:
         type: uint8_t
       - name: fw_autotune_max_rate_deflection
         description: "The target percentage of maximum mixer output used for determining the rates in `AUTO` and `LIMIT`."
-        default_value: 90
+        default_value: 80
         field: fw_max_rate_deflection
         min: 50
         max: 100

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2220,7 +2220,7 @@ groups:
     condition: USE_AUTOTUNE_FIXED_WING
     members:
       - name: fw_autotune_min_stick
-        description: "Minimum stick input [%], after applying deadband and expo, to consider overshoot/undershoot detection"
+        description: "Minimum stick input [%], after applying deadband and expo, to start recording the plane's response to stick input."
         default_value: 50
         field: fw_min_stick
         min: 0


### PR DESCRIPTION
It was previously increased to 90% to get higher rates/lower FF but that leaves little room for stabilization, especially when the servo midpoints are not exactly 1500.