### PR TITLE
Fix the time window calculation problem in zeroCalibration code

### DIFF
--- a/src/main/common/calibration.c
+++ b/src/main/common/calibration.c
@@ -34,7 +34,7 @@ void zeroCalibrationStartS(zeroCalibrationScalar_t * s, timeMs_t window, float t
 {
     // Reset parameters and state
     s->params.state = ZERO_CALIBRATION_IN_PROGRESS;
-    s->params.startTimeMs = millis();
+    s->params.startTimeMs = 0;
     s->params.windowSizeMs = window;
     s->params.stdDevThreshold = threshold;
     s->params.allowFailure = allowFailure;
@@ -58,6 +58,13 @@ void zeroCalibrationAddValueS(zeroCalibrationScalar_t * s, const float v)
 {
     if (s->params.state != ZERO_CALIBRATION_IN_PROGRESS) {
         return;
+    }
+
+    // An unknown delay may have passed between `zeroCalibrationStartS` and first sample acquisition
+    // therefore our window measurement might be incorrect
+    // To account for that we reset the startTimeMs when acquiring the first sample
+    if (s->params.sampleCount == 0 && s->params.startTimeMs == 0) {
+        s->params.startTimeMs = millis();
     }
 
     // Add value


### PR DESCRIPTION
Our zeroCalibration[.+] code measures the calibration time from when the calibration was started, not from when the first sample was acquired. 

While this is not a problem in itself, we might have a large delay between calibration start and first sample acquisition which may lead to calibration completing successfully on a first sample.

This PR improves the time window calculation and fixes #7163