### PR TITLE
Updated UK units to be correct for the UK

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -64,7 +64,7 @@ tables:
   - name: nav_rth_alt_mode
     values: ["CURRENT", "EXTRA", "FIXED", "MAX", "AT_LEAST", "AT_LEAST_LINEAR_DESCENT"]
   - name: osd_unit
-    values: ["IMPERIAL", "METRIC", "UK"]
+    values: ["IMPERIAL", "METRIC", "METRIC MPH", "UK"]
     enum: osd_unit_e
   - name: osd_stats_energy_unit
     values: ["MAH", "WH"]

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -64,7 +64,7 @@ tables:
   - name: nav_rth_alt_mode
     values: ["CURRENT", "EXTRA", "FIXED", "MAX", "AT_LEAST", "AT_LEAST_LINEAR_DESCENT"]
   - name: osd_unit
-    values: ["IMPERIAL", "METRIC", "METRIC MPH", "UK"]
+    values: ["IMPERIAL", "METRIC", "METRIC_MPH", "UK"]
     enum: osd_unit_e
   - name: osd_stats_energy_unit
     values: ["MAH", "WH"]

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -238,7 +238,8 @@ typedef enum {
 typedef enum {
     OSD_UNIT_IMPERIAL,
     OSD_UNIT_METRIC,
-    OSD_UNIT_UK, // Show speed in mp/h, other values in metric
+    OSD_UNIT_METRIC_MPH, // Old UK units, all metric except speed in mph
+    OSD_UNIT_UK, // Show everything in imperial, temperature in C
 
     OSD_UNIT_MAX = OSD_UNIT_UK,
 } osd_unit_e;

--- a/src/main/io/osd_canvas.c
+++ b/src/main/io/osd_canvas.c
@@ -502,9 +502,11 @@ static int32_t osdCanvasSidebarGetValue(osd_sidebar_scroll_e scroll)
             break;
         case OSD_SIDEBAR_SCROLL_ALTITUDE:
             switch ((osd_unit_e)osdConfig()->units) {
+                case OSD_UNIT_UK:
+                    FALLTHROUGH;
                 case OSD_UNIT_IMPERIAL:
                     return CENTIMETERS_TO_CENTIFEET(osdGetAltitude());
-                case OSD_UNIT_UK:
+                case OSD_UNIT_METRIC_MPH:
                     FALLTHROUGH;
                 case OSD_UNIT_METRIC:
                     return osdGetAltitude();
@@ -516,6 +518,8 @@ static int32_t osdCanvasSidebarGetValue(osd_sidebar_scroll_e scroll)
                 int speed = osdGetSpeedFromSelectedSource();
                 switch ((osd_unit_e)osdConfig()->units) {
                     case OSD_UNIT_UK:
+                        FALLTHROUGH;
+                    case OSD_UNIT_METRIC_MPH:
                         FALLTHROUGH;
                     case OSD_UNIT_IMPERIAL:
                         // cms/s to (mi/h) * 100
@@ -530,9 +534,11 @@ static int32_t osdCanvasSidebarGetValue(osd_sidebar_scroll_e scroll)
         case OSD_SIDEBAR_SCROLL_HOME_DISTANCE:
 #if defined(USE_GPS)
             switch ((osd_unit_e)osdConfig()->units) {
+                case OSD_UNIT_UK:
+                    FALLTHROUGH;
                 case OSD_UNIT_IMPERIAL:
                     return CENTIMETERS_TO_CENTIFEET(GPS_distanceToHome * 100);
-                case OSD_UNIT_UK:
+                case OSD_UNIT_METRIC_MPH:
                     FALLTHROUGH;
                 case OSD_UNIT_METRIC:
                     return GPS_distanceToHome * 100;
@@ -575,13 +581,15 @@ static void osdCanvasSidebarGetUnit(osdUnit_t *unit, uint16_t *countsPerStep, os
             break;
         case OSD_SIDEBAR_SCROLL_ALTITUDE:
             switch ((osd_unit_e)osdConfig()->units) {
+                case OSD_UNIT_UK:
+                    FALLTHROUGH;
                 case OSD_UNIT_IMPERIAL:
                     unit->symbol = SYM_ALT_FT;
                     unit->divisor = FEET_PER_KILOFEET;
                     unit->divided_symbol = SYM_ALT_KFT;
                     *countsPerStep = 50;
                     break;
-                case OSD_UNIT_UK:
+                case OSD_UNIT_METRIC_MPH:
                     FALLTHROUGH;
                 case OSD_UNIT_METRIC:
                     unit->symbol = SYM_ALT_M;
@@ -594,6 +602,8 @@ static void osdCanvasSidebarGetUnit(osdUnit_t *unit, uint16_t *countsPerStep, os
         case OSD_SIDEBAR_SCROLL_SPEED:
             switch ((osd_unit_e)osdConfig()->units) {
                 case OSD_UNIT_UK:
+                    FALLTHROUGH;
+                case OSD_UNIT_METRIC_MPH:
                     FALLTHROUGH;
                 case OSD_UNIT_IMPERIAL:
                     unit->symbol = SYM_MPH;
@@ -611,13 +621,15 @@ static void osdCanvasSidebarGetUnit(osdUnit_t *unit, uint16_t *countsPerStep, os
             break;
         case OSD_SIDEBAR_SCROLL_HOME_DISTANCE:
             switch ((osd_unit_e)osdConfig()->units) {
+                case OSD_UNIT_UK:
+                    FALLTHROUGH;
                 case OSD_UNIT_IMPERIAL:
                     unit->symbol = SYM_FT;
                     unit->divisor = FEET_PER_MILE;
                     unit->divided_symbol = SYM_MI;
                     *countsPerStep = 300;
                     break;
-                case OSD_UNIT_UK:
+                case OSD_UNIT_METRIC_MPH:
                     FALLTHROUGH;
                 case OSD_UNIT_METRIC:
                     unit->symbol = SYM_M;

--- a/src/main/io/osd_dji_hd.c
+++ b/src/main/io/osd_dji_hd.c
@@ -652,10 +652,10 @@ static int32_t osdConvertVelocityToUnit(int32_t vel)
     switch (osdConfig()->units) {
         case OSD_UNIT_UK:
             FALLTHROUGH;
-
+        case OSD_UNIT_METRIC_MPH:
+            FALLTHROUGH;
         case OSD_UNIT_IMPERIAL:
             return (vel * 224) / 10000; // Convert to mph
-
         case OSD_UNIT_METRIC:
             return (vel * 36) / 1000;   // Convert to kmh
     }
@@ -692,6 +692,8 @@ void osdDJIFormatVelocityStr(char* buff)
     switch (osdConfig()->units) {
         case OSD_UNIT_UK:
             FALLTHROUGH;
+        case OSD_UNIT_METRIC_MPH:
+            FALLTHROUGH;
         case OSD_UNIT_IMPERIAL:
             tfp_sprintf(buff, "%s %3d MPH", sourceBuf, (int)osdConvertVelocityToUnit(vel));
             break;
@@ -719,6 +721,8 @@ static void osdDJIFormatDistanceStr(char *buff, int32_t dist)
     int32_t centifeet;
 
     switch (osdConfig()->units) {
+        case OSD_UNIT_UK:
+            FALLTHROUGH;
         case OSD_UNIT_IMPERIAL:
             centifeet = CENTIMETERS_TO_CENTIFEET(dist);
             if (abs(centifeet) < FEET_PER_MILE * 100 / 2) {
@@ -731,7 +735,7 @@ static void osdDJIFormatDistanceStr(char *buff, int32_t dist)
                 (abs(centifeet) % (100 * FEET_PER_MILE)) / FEET_PER_MILE, "Mi");
             }
             break;
-        case OSD_UNIT_UK:
+        case OSD_UNIT_METRIC_MPH:
             FALLTHROUGH;
         case OSD_UNIT_METRIC:
             if (abs(dist) < METERS_PER_KILOMETER * 100) {


### PR DESCRIPTION
The units used as **UK** were incorrect. We use imperial for distance, altitude, and speed. Check out our road signs as an example, speeds are in MPH, distances are in miles etc. To correct this, I have added a new units set called **Metric + MPH**.

## Metric + MPH
**Metric + MPH** is the old **UK** units set. Anyone who used the old **UK** setting would use **Metric + MPH** going forward. As in, if you had **UK** before, did an update to a version with this system, you would now be on **Metric + MPH**. The transition is seamless to the pilot. Effectively **UK** has just been renamed at this point.

Function | Units
----------|------
Speed | MPH
Altitude | Metres
Vario |Metres/sec
Distance | Metres/Kilometres
Economy | Mah/Km or Wh/Km
Temperature | Celcius

![iNav 3 1 OSD - Metric + MPH](https://user-images.githubusercontent.com/17590174/123512935-19179300-d682-11eb-9493-ea64cdf3b8f5.png)
![image](https://user-images.githubusercontent.com/17590174/123513207-bc1cdc80-d683-11eb-9b33-e294228fb811.png)
![image](https://user-images.githubusercontent.com/17590174/123513214-c212bd80-d683-11eb-90e9-63784ed1f400.png)

## UK
**UK** is basically the new units set. It uses imperial for everything, except the temperature which is in degrees C.

Function | Units
----------|------
Speed | MPH
Altitude | Miles
Vario |Feet/sec
Distance | Feet/Miles
Economy | Mah/Mile or Wh/Mile
Temperature | Celcius

![iNav 3 1 OSD - UK](https://user-images.githubusercontent.com/17590174/123512939-23d22800-d682-11eb-9529-a063bb776552.png)
![image](https://user-images.githubusercontent.com/17590174/123513181-998ac380-d683-11eb-840f-0906d74f59db.png)
![image](https://user-images.githubusercontent.com/17590174/123513190-a14a6800-d683-11eb-8e39-852701277b92.png)

## Additional
Requires Configurator update https://github.com/iNavFlight/inav-configurator/pull/1309
Fixes #7191 