### PR TITLE
Autotune: add sane limits for P and I

### DIFF
--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -248,13 +248,14 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
     if (gainsUpdated) {
         // Set P-gain to 10% of FF gain (quite agressive - FIXME)
         tuneCurrent[axis].gainP = tuneCurrent[axis].gainFF * (pidAutotuneConfig()->fw_ff_to_p_gain / 100.0f);
+        tuneCurrent[axis].gainP = constrainf(tuneCurrent[axis].gainP, 1.0f, 20.0f);
 
         // Set D-gain relative to P-gain (0 for now)
         tuneCurrent[axis].gainD = tuneCurrent[axis].gainP * (pidAutotuneConfig()->fw_p_to_d_gain / 100.0f);
 
         // Set integrator gain to reach the same response as FF gain in 0.667 second
         tuneCurrent[axis].gainI = (tuneCurrent[axis].gainFF / FP_PID_RATE_FF_MULTIPLIER) * (1000.0f / pidAutotuneConfig()->fw_ff_to_i_time_constant) * FP_PID_RATE_I_MULTIPLIER;
-        tuneCurrent[axis].gainI = constrainf(tuneCurrent[axis].gainI, 2.0f, 50.0f);
+        tuneCurrent[axis].gainI = constrainf(tuneCurrent[axis].gainI, 2.0f, 30.0f);
         autotuneUpdateGains(tuneCurrent);
 
         switch (axis) {


### PR DESCRIPTION
On planes with low pitch rates and high FF, P and I are set way too high.