### PR TITLE
Modify library to supress warnings when combining HAL and LL drivers

### DIFF
--- a/lib/main/STM32H7/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_exti.c
+++ b/lib/main/STM32H7/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_exti.c
@@ -20,11 +20,6 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32h7xx_ll_exti.h"
-#ifdef  USE_FULL_ASSERT
-#include "stm32_assert.h"
-#else
-#define assert_param(expr) ((void)0U)
-#endif
 
 /** @addtogroup STM32H7xx_LL_Driver
   * @{

--- a/lib/main/STM32H7/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_i2c.c
+++ b/lib/main/STM32H7/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_i2c.c
@@ -21,11 +21,6 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32h7xx_ll_i2c.h"
 #include "stm32h7xx_ll_bus.h"
-#ifdef  USE_FULL_ASSERT
-#include "stm32_assert.h"
-#else
-#define assert_param(expr) ((void)0U)
-#endif
 
 /** @addtogroup STM32H7xx_LL_Driver
   * @{


### PR DESCRIPTION
@bkleiner @digitalentity Not pretty but I can't find a better solution for now