### PR TITLE
Fix i2c errors after 72 min of FC launch

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -87,7 +87,7 @@ typedef struct i2cBusState_s {
     I2CDevice       device;
     bool            initialized;
     i2cState_t      state;
-    uint32_t        timeout;
+    timeUs_t        timeout;
 
     /* Active transfer */
     bool                        allowRawAccess;

--- a/src/main/drivers/bus_i2c_stm32f40x.c
+++ b/src/main/drivers/bus_i2c_stm32f40x.c
@@ -121,7 +121,7 @@ typedef struct i2cBusState_s {
     I2CDevice       device;
     bool            initialized;
     i2cState_t      state;
-    uint32_t        timeout;
+    timeUs_t        timeout;
 
     /* Active transfer */
     bool                        allowRawAccess;


### PR DESCRIPTION
Related to https://github.com/iNavFlight/inav/issues/7211