### PR TITLE
Improved MS4525 I2C probing

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2904,7 +2904,7 @@ Output frequency (in Hz) for motor pins. Default is 400Hz for motor with motor_p
 
 ### ms4525_i2c_address
 
-3 possible MS4525 I2C addresses (0 = 0x28, 1 = 0x36 or 2 = 0x46)
+3 possible I2C addresses for AirSpeed ​​MS4525 (0 = 0x28, 1 = 0x36 or 2 = 0x46)
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2902,6 +2902,16 @@ Output frequency (in Hz) for motor pins. Default is 400Hz for motor with motor_p
 
 ---
 
+### ms4525_i2c_address
+
+3 possible MS4525 I2C addresses (0 = 0x28, 1 = 0x36 or 2 = 0x46)
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | 0 | 2 |
+
+---
+
 ### msp_override_channels
 
 Mask of RX channels that may be overridden by MSP `SET_RAW_RC`. Note that this requires custom firmware with `USE_RX_MSP` and `USE_MSP_RC_OVERRIDE` compile options and the `MSP RC Override` flight mode.

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2902,7 +2902,7 @@ Output frequency (in Hz) for motor pins. Default is 400Hz for motor with motor_p
 
 ---
 
-### ms4525_i2c_address
+### ms4525_address
 
 3 possible I2C addresses for AirSpeed ​​MS4525 (0 = 0x28, 1 = 0x36 or 2 = 0x46)
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -212,6 +212,16 @@ ADC channel to use for analog pitot tube (airspeed) sensor. If board doesn't hav
 
 ---
 
+### airspeed_address
+
+3 possible I2C addresses for AirSpeed ​​MS4525 (0 = 0x28, 1 = 0x36 or 2 = 0x46)
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | 0 | 2 |
+
+---
+
 ### align_acc
 
 When running on non-default hardware or adding support for new sensors/sensor boards, these values are used for sensor orientation. When carefully understood, these values can also be used to rotate (in 90deg steps) or flip the board. Possible values are: DEFAULT, CW0_DEG, CW90_DEG, CW180_DEG, CW270_DEG, CW0_DEG_FLIP, CW90_DEG_FLIP, CW180_DEG_FLIP, CW270_DEG_FLIP.
@@ -2899,16 +2909,6 @@ Output frequency (in Hz) for motor pins. Default is 400Hz for motor with motor_p
 | Default | Min | Max |
 | --- | --- | --- |
 | 400 | 50 | 32000 |
-
----
-
-### ms4525_address
-
-3 possible I2C addresses for AirSpeed ​​MS4525 (0 = 0x28, 1 = 0x36 or 2 = 0x46)
-
-| Default | Min | Max |
-| --- | --- | --- |
-| 0 | 0 | 2 |
 
 ---
 

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -144,9 +144,9 @@ typedef enum {
     DEVHW_US42,
 
     /* Other hardware */
-    DEVHW_MS4525_0,     // Pitot meter
-    DEVHW_MS4525_1,     // Pitot meter
-    DEVHW_MS4525_2,     // Pitot meter
+    DEVHW_MS4525_0,     // Pitot meter 0x28
+    DEVHW_MS4525_1,     // Pitot meter 0x36
+    DEVHW_MS4525_2,     // Pitot meter 0x46
     DEVHW_PCA9685,      // PWM output device
     DEVHW_M25P16,       // SPI NOR flash
     DEVHW_UG2864,       // I2C OLED display

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -144,7 +144,9 @@ typedef enum {
     DEVHW_US42,
 
     /* Other hardware */
-    DEVHW_MS4525,       // Pitot meter
+    DEVHW_MS4525_ADDR1, // Pitot meter
+    DEVHW_MS4525_ADDR2, // Pitot meter
+    DEVHW_MS4525_ADDR3, // Pitot meter
     DEVHW_PCA9685,      // PWM output device
     DEVHW_M25P16,       // SPI NOR flash
     DEVHW_UG2864,       // I2C OLED display

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -144,9 +144,9 @@ typedef enum {
     DEVHW_US42,
 
     /* Other hardware */
-    DEVHW_MS4525_ADDR1, // Pitot meter
-    DEVHW_MS4525_ADDR2, // Pitot meter
-    DEVHW_MS4525_ADDR3, // Pitot meter
+    DEVHW_MS4525_0,     // Pitot meter
+    DEVHW_MS4525_1,     // Pitot meter
+    DEVHW_MS4525_2,     // Pitot meter
     DEVHW_PCA9685,      // PWM output device
     DEVHW_M25P16,       // SPI NOR flash
     DEVHW_UG2864,       // I2C OLED display

--- a/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
@@ -128,8 +128,7 @@ bool ms4525Detect(pitotDev_t * pitot)
     } else if (found_sensor == DEVHW_MS4525_ADDR3) {
         pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_ADDR3, 0, OWNER_AIRSPEED);
     }
-    
-    pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525, 0, OWNER_AIRSPEED);
+
     if (pitot->busDev == NULL) {
         return false;
     }

--- a/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
@@ -26,7 +26,6 @@
 #include "drivers/bus_i2c.h"
 #include "drivers/time.h"
 #include "drivers/pitotmeter/pitotmeter.h"
-#include "sensors/pitotmeter.h"
 
 // MS4525, Standard address 0x28
 #define MS4525_ADDR                 0x28
@@ -109,12 +108,12 @@ static void ms4525_calculate(pitotDev_t * pitot, float *pressure, float *tempera
     }
 }
 
-bool ms4525Detect(pitotDev_t * pitot)
+bool ms4525Detect(pitotDev_t * pitot, uint8_t parse_i2c_addr_config)
 {
     uint8_t rxbuf[4];
     bool ack = false;
 
-    pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_0 + pitotmeterConfig()->ms4525_i2c_address, 0, OWNER_AIRSPEED);
+    pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_0 + parse_i2c_addr_config, 0, OWNER_AIRSPEED);
 
     if (pitot->busDev == NULL) {
         return false;

--- a/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
@@ -112,7 +112,7 @@ bool ms4525Detect(pitotDev_t * pitot)
 {
     uint8_t rxbuf[4];
     bool ack = false;
-     uint8_t found_sensor = DEVHW_MS4525_ADDR1;
+    uint8_t found_sensor = DEVHW_MS4525_ADDR1;
     
     //search the sensor with 3 different addresses
     if (found_sensor == DEVHW_MS4525_ADDR1) {

--- a/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
@@ -112,7 +112,23 @@ bool ms4525Detect(pitotDev_t * pitot)
 {
     uint8_t rxbuf[4];
     bool ack = false;
-
+     uint8_t found_sensor = DEVHW_MS4525_ADDR1;
+    
+    //search the sensor with 3 different addresses
+    if (found_sensor == DEVHW_MS4525_ADDR1) {
+        pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_ADDR1, 0, OWNER_AIRSPEED);
+        if (pitot->busDev == NULL) {
+            found_sensor = DEVHW_MS4525_ADDR2;
+        }
+    } else if (found_sensor == DEVHW_MS4525_ADDR2) {
+        pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_ADDR2, 0, OWNER_AIRSPEED);
+        if (pitot->busDev == NULL) {
+            found_sensor = DEVHW_MS4525_ADDR3;
+        }
+    } else if (found_sensor == DEVHW_MS4525_ADDR3) {
+        pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_ADDR3, 0, OWNER_AIRSPEED);
+    }
+    
     pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525, 0, OWNER_AIRSPEED);
     if (pitot->busDev == NULL) {
         return false;

--- a/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
@@ -112,21 +112,13 @@ bool ms4525Detect(pitotDev_t * pitot)
 {
     uint8_t rxbuf[4];
     bool ack = false;
-    uint8_t found_sensor = DEVHW_MS4525_ADDR1;
-    
-    //search the sensor with 3 different addresses
-    if (found_sensor == DEVHW_MS4525_ADDR1) {
-        pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_ADDR1, 0, OWNER_AIRSPEED);
-        if (pitot->busDev == NULL) {
-            found_sensor = DEVHW_MS4525_ADDR2;
+
+    for (uint8_t index = 0; index < 3; ++index) {
+        delay(10); //don't do it so fast
+        pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_0 + index, 0, OWNER_AIRSPEED);
+        if (pitot->busDev != NULL) { //sensor found
+            break;
         }
-    } else if (found_sensor == DEVHW_MS4525_ADDR2) {
-        pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_ADDR2, 0, OWNER_AIRSPEED);
-        if (pitot->busDev == NULL) {
-            found_sensor = DEVHW_MS4525_ADDR3;
-        }
-    } else if (found_sensor == DEVHW_MS4525_ADDR3) {
-        pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_ADDR3, 0, OWNER_AIRSPEED);
     }
 
     if (pitot->busDev == NULL) {

--- a/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_ms4525.c
@@ -26,6 +26,7 @@
 #include "drivers/bus_i2c.h"
 #include "drivers/time.h"
 #include "drivers/pitotmeter/pitotmeter.h"
+#include "sensors/pitotmeter.h"
 
 // MS4525, Standard address 0x28
 #define MS4525_ADDR                 0x28
@@ -113,13 +114,7 @@ bool ms4525Detect(pitotDev_t * pitot)
     uint8_t rxbuf[4];
     bool ack = false;
 
-    for (uint8_t index = 0; index < 3; ++index) {
-        delay(10); //don't do it so fast
-        pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_0 + index, 0, OWNER_AIRSPEED);
-        if (pitot->busDev != NULL) { //sensor found
-            break;
-        }
-    }
+    pitot->busDev = busDeviceInit(BUSTYPE_I2C, DEVHW_MS4525_0 + pitotmeterConfig()->ms4525_i2c_address, 0, OWNER_AIRSPEED);
 
     if (pitot->busDev == NULL) {
         return false;

--- a/src/main/drivers/pitotmeter/pitotmeter_ms4525.h
+++ b/src/main/drivers/pitotmeter/pitotmeter_ms4525.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-bool ms4525Detect(pitotDev_t *pitot);
+bool ms4525Detect(pitotDev_t *pitot, uint8_t parse_i2c_addr_config);

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -694,7 +694,7 @@ groups:
         max: 100
         default_value: 1.0
       - name: ms4525_i2c_address
-        description: "3 possible MS4525 I2C addresses (0 = 0x28, 1 = 0x36 or 2 = 0x46)"
+        description: "3 possible I2C addresses for AirSpeed ​​MS4525 (0 = 0x28, 1 = 0x36 or 2 = 0x46)"
         min: 0
         max: 2
         default_value: 0

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -693,6 +693,11 @@ groups:
         min: 0
         max: 100
         default_value: 1.0
+      - name: ms4525_i2c_address
+        description: "3 possible MS4525 I2C addresses (0 = 0x28, 1 = 0x36 or 2 = 0x46)"
+        min: 0
+        max: 2
+        default_value: 0
 
   - name: PG_RX_CONFIG
     type: rxConfig_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -693,7 +693,7 @@ groups:
         min: 0
         max: 100
         default_value: 1.0
-      - name: ms4525_i2c_address
+      - name: ms4525_address
         description: "3 possible I2C addresses for AirSpeed ​​MS4525 (0 = 0x28, 1 = 0x36 or 2 = 0x46)"
         min: 0
         max: 2

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -693,7 +693,7 @@ groups:
         min: 0
         max: 100
         default_value: 1.0
-      - name: ms4525_address
+      - name: airspeed_address
         description: "3 possible I2C addresses for AirSpeed ​​MS4525 (0 = 0x28, 1 = 0x36 or 2 = 0x46)"
         min: 0
         max: 2

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -61,7 +61,8 @@ PG_REGISTER_WITH_RESET_TEMPLATE(pitotmeterConfig_t, pitotmeterConfig, PG_PITOTME
 PG_RESET_TEMPLATE(pitotmeterConfig_t, pitotmeterConfig,
     .pitot_hardware = SETTING_PITOT_HARDWARE_DEFAULT,
     .pitot_lpf_milli_hz = SETTING_PITOT_LPF_MILLI_HZ_DEFAULT,
-    .pitot_scale = SETTING_PITOT_SCALE_DEFAULT
+    .pitot_scale = SETTING_PITOT_SCALE_DEFAULT,
+    .ms4525_i2c_address = SETTING_MS4525_I2C_ADDRESS_DEFAULT
 );
 
 bool pitotDetect(pitotDev_t *dev, uint8_t pitotHardwareToUse)

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -74,7 +74,7 @@ bool pitotDetect(pitotDev_t *dev, uint8_t pitotHardwareToUse)
         case PITOT_AUTODETECT:
         case PITOT_MS4525:
 #ifdef USE_PITOT_MS4525
-            if (ms4525Detect(dev)) {
+            if (ms4525Detect(dev, pitotmeterConfig()->ms4525_i2c_address)) {
                 pitotHardware = PITOT_MS4525;
                 break;
             }

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -62,7 +62,7 @@ PG_RESET_TEMPLATE(pitotmeterConfig_t, pitotmeterConfig,
     .pitot_hardware = SETTING_PITOT_HARDWARE_DEFAULT,
     .pitot_lpf_milli_hz = SETTING_PITOT_LPF_MILLI_HZ_DEFAULT,
     .pitot_scale = SETTING_PITOT_SCALE_DEFAULT,
-    .airspeed_address = SETTING_MS4525_I2C_ADDRESS_DEFAULT
+    .airspeed_address = SETTING_AIRSPEED_ADDRESS_DEFAULT
 );
 
 bool pitotDetect(pitotDev_t *dev, uint8_t pitotHardwareToUse)

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -62,7 +62,7 @@ PG_RESET_TEMPLATE(pitotmeterConfig_t, pitotmeterConfig,
     .pitot_hardware = SETTING_PITOT_HARDWARE_DEFAULT,
     .pitot_lpf_milli_hz = SETTING_PITOT_LPF_MILLI_HZ_DEFAULT,
     .pitot_scale = SETTING_PITOT_SCALE_DEFAULT,
-    .ms4525_i2c_address = SETTING_MS4525_I2C_ADDRESS_DEFAULT
+    .ms4525_address = SETTING_MS4525_I2C_ADDRESS_DEFAULT
 );
 
 bool pitotDetect(pitotDev_t *dev, uint8_t pitotHardwareToUse)
@@ -74,7 +74,7 @@ bool pitotDetect(pitotDev_t *dev, uint8_t pitotHardwareToUse)
         case PITOT_AUTODETECT:
         case PITOT_MS4525:
 #ifdef USE_PITOT_MS4525
-            if (ms4525Detect(dev, pitotmeterConfig()->ms4525_i2c_address)) {
+            if (ms4525Detect(dev, pitotmeterConfig()->ms4525_address)) {
                 pitotHardware = PITOT_MS4525;
                 break;
             }

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -62,7 +62,7 @@ PG_RESET_TEMPLATE(pitotmeterConfig_t, pitotmeterConfig,
     .pitot_hardware = SETTING_PITOT_HARDWARE_DEFAULT,
     .pitot_lpf_milli_hz = SETTING_PITOT_LPF_MILLI_HZ_DEFAULT,
     .pitot_scale = SETTING_PITOT_SCALE_DEFAULT,
-    .ms4525_address = SETTING_MS4525_I2C_ADDRESS_DEFAULT
+    .airspeed_address = SETTING_MS4525_I2C_ADDRESS_DEFAULT
 );
 
 bool pitotDetect(pitotDev_t *dev, uint8_t pitotHardwareToUse)
@@ -74,7 +74,7 @@ bool pitotDetect(pitotDev_t *dev, uint8_t pitotHardwareToUse)
         case PITOT_AUTODETECT:
         case PITOT_MS4525:
 #ifdef USE_PITOT_MS4525
-            if (ms4525Detect(dev, pitotmeterConfig()->ms4525_address)) {
+            if (ms4525Detect(dev, pitotmeterConfig()->airspeed_address)) {
                 pitotHardware = PITOT_MS4525;
                 break;
             }

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -49,7 +49,7 @@
 
 pitot_t pitot;
 
-PG_REGISTER_WITH_RESET_TEMPLATE(pitotmeterConfig_t, pitotmeterConfig, PG_PITOTMETER_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(pitotmeterConfig_t, pitotmeterConfig, PG_PITOTMETER_CONFIG, 3);
 
 #define PITOT_HARDWARE_TIMEOUT_MS   500     // Accept 500ms of non-responsive sensor, report HW failure otherwise
 

--- a/src/main/sensors/pitotmeter.h
+++ b/src/main/sensors/pitotmeter.h
@@ -40,7 +40,7 @@ typedef struct pitotmeterConfig_s {
     uint8_t pitot_hardware;                 // Pitotmeter hardware to use
     uint16_t pitot_lpf_milli_hz;            // additional LPF to reduce pitot noise in [0.001Hz]
     float pitot_scale;                      // scale value
-    uint8_t ms4525_address;                 // i2c address
+    uint8_t airspeed_address;               // i2c address
 } pitotmeterConfig_t;
 
 PG_DECLARE(pitotmeterConfig_t, pitotmeterConfig);

--- a/src/main/sensors/pitotmeter.h
+++ b/src/main/sensors/pitotmeter.h
@@ -40,7 +40,7 @@ typedef struct pitotmeterConfig_s {
     uint8_t pitot_hardware;                 // Pitotmeter hardware to use
     uint16_t pitot_lpf_milli_hz;            // additional LPF to reduce pitot noise in [0.001Hz]
     float pitot_scale;                      // scale value
-    uint8_t ms4525_i2c_address;             // i2c address
+    uint8_t ms4525_address;                 // i2c address
 } pitotmeterConfig_t;
 
 PG_DECLARE(pitotmeterConfig_t, pitotmeterConfig);

--- a/src/main/sensors/pitotmeter.h
+++ b/src/main/sensors/pitotmeter.h
@@ -40,6 +40,7 @@ typedef struct pitotmeterConfig_s {
     uint8_t pitot_hardware;                 // Pitotmeter hardware to use
     uint16_t pitot_lpf_milli_hz;            // additional LPF to reduce pitot noise in [0.001Hz]
     float pitot_scale;                      // scale value
+    uint8_t ms4525_i2c_address;             // i2c address
 } pitotmeterConfig_t;
 
 PG_DECLARE(pitotmeterConfig_t, pitotmeterConfig);

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -336,9 +336,9 @@
 #endif
 
 #if defined(USE_PITOT_MS4525) && defined(MS4525_I2C_BUS)
-    BUSDEV_REGISTER_I2C(busdev_ms5425_0,      DEVHW_MS4525_ADDR1,       MS4525_I2C_BUS,     0x28,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
-    BUSDEV_REGISTER_I2C(busdev_ms5425_1,      DEVHW_MS4525_ADDR2,       MS4525_I2C_BUS,     0x36,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
-    BUSDEV_REGISTER_I2C(busdev_ms5425_2,      DEVHW_MS4525_ADDR3,       MS4525_I2C_BUS,     0x46,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
+    BUSDEV_REGISTER_I2C(busdev_ms5425_0,      DEVHW_MS4525_0,       MS4525_I2C_BUS,     0x28,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
+    BUSDEV_REGISTER_I2C(busdev_ms5425_1,      DEVHW_MS4525_1,       MS4525_I2C_BUS,     0x36,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
+    BUSDEV_REGISTER_I2C(busdev_ms5425_2,      DEVHW_MS4525_2,       MS4525_I2C_BUS,     0x46,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
 #endif
 
 

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -336,7 +336,9 @@
 #endif
 
 #if defined(USE_PITOT_MS4525) && defined(MS4525_I2C_BUS)
-    BUSDEV_REGISTER_I2C(busdev_ms5425,      DEVHW_MS4525,       MS4525_I2C_BUS,     0x28,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
+    BUSDEV_REGISTER_I2C(busdev_ms5425,      DEVHW_MS4525_ADDR1,       MS4525_I2C_BUS,     0x28,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
+    BUSDEV_REGISTER_I2C(busdev_ms5425,      DEVHW_MS4525_ADDR2,       MS4525_I2C_BUS,     0x36,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
+    BUSDEV_REGISTER_I2C(busdev_ms5425,      DEVHW_MS4525_ADDR3,       MS4525_I2C_BUS,     0x46,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
 #endif
 
 

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -336,9 +336,9 @@
 #endif
 
 #if defined(USE_PITOT_MS4525) && defined(MS4525_I2C_BUS)
-    BUSDEV_REGISTER_I2C(busdev_ms5425,      DEVHW_MS4525_ADDR1,       MS4525_I2C_BUS,     0x28,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
-    BUSDEV_REGISTER_I2C(busdev_ms5425,      DEVHW_MS4525_ADDR2,       MS4525_I2C_BUS,     0x36,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
-    BUSDEV_REGISTER_I2C(busdev_ms5425,      DEVHW_MS4525_ADDR3,       MS4525_I2C_BUS,     0x46,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
+    BUSDEV_REGISTER_I2C(busdev_ms5425_0,      DEVHW_MS4525_ADDR1,       MS4525_I2C_BUS,     0x28,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
+    BUSDEV_REGISTER_I2C(busdev_ms5425_1,      DEVHW_MS4525_ADDR2,       MS4525_I2C_BUS,     0x36,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
+    BUSDEV_REGISTER_I2C(busdev_ms5425_2,      DEVHW_MS4525_ADDR3,       MS4525_I2C_BUS,     0x46,               NONE,           DEVFLAGS_USE_RAW_REGISTERS,  0);    // Requires 0xFF to passthrough
 #endif
 
 


### PR DESCRIPTION
AirSpeed:

- Adds probing for all 3 possible MS4525 I2C addresses.