### PR TITLE
Add support for RX5 on MATEKF765 target

### DIFF
--- a/src/main/target/MATEKF765/target.h
+++ b/src/main/target/MATEKF765/target.h
@@ -154,7 +154,7 @@
 #define SOFTSERIAL_1_RX_PIN      PC6  //TX6 pad
 
 
-#define SERIAL_PORT_COUNT       9
+#define SERIAL_PORT_COUNT       10
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_SBUS

--- a/src/main/target/MATEKF765/target.h
+++ b/src/main/target/MATEKF765/target.h
@@ -131,6 +131,11 @@
 #define UART4_TX_PIN            PD1
 #define UART4_RX_PIN            PD0
 
+#define USE_UART5
+#define UART5_TX_PIN            NONE
+#define UART5_RX_PIN            PB8
+#define UART5_AF                7
+
 #define USE_UART6
 #define UART6_TX_PIN            PC6
 #define UART6_RX_PIN            PC7


### PR DESCRIPTION
MATEKF765 exposes RX5 pad, however it's not enabled in the target configuration because it's not on a "standard" pin and therefore needs a different AF. This PR fixes that.