### PR TITLE
[RFC] Migrate to 6bit settings name table

### DIFF
--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -41,11 +41,13 @@ static bool settingGetWord(char *buf, int idx)
 			}
 			char c;
 			if (chr < 27) {
-				c = 'a' + (chr - 1);
-			} else {
-				c = wordSymbols[chr - 27];
-			}
-			*bufPtr++ = c;
+                            c = 'a' + (chr - 1);
+			} else if (chr == 27) {
+                            c = '_';
+                        } else if (chr < 38) {
+                            c = '0' + (chr - 28);
+                        }
+                        *bufPtr++ = c;
 		} else {
 			if (chr == 0) {
 				// Word end

--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -566,6 +566,7 @@ class Generator
             buf << "};\n"
         end
 
+        # Write the tables
         buf << "static const lookupTableEntry_t settingLookupTables[] = {\n"
         table_names.each do |name|
             vn = table_variable_name(name)

--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -555,6 +555,7 @@ class Generator
         end
         buf << "};\n"
 
+        # Write the tables
         table_names = ordered_table_names()
         table_names.each do |name|
             buf << "const char * const #{table_variable_name(name)}[] = {\n"
@@ -566,7 +567,6 @@ class Generator
             buf << "};\n"
         end
 
-        # Write the tables
         buf << "static const lookupTableEntry_t settingLookupTables[] = {\n"
         table_names.each do |name|
             vn = table_variable_name(name)


### PR DESCRIPTION
## Overview

#7254 exposed both the limitations (and benefits) of the extant 5 bit settings names character set (as well as the developer confusion ensuing from the concept of a limited character set).

This **RFC** demonstrates a 6 bit setttings name character set, as follows:
* Fixed character set, providing the (lower case) ISO C naming set 
* NUL, 'a'-'z', '_', '0'-'9'
* Simplifies the encoding and decoding of settings names
* Permits the usage of 0 - 9 digits
* uses 38 of a possible 64 entries
* Increases flash usage by c. 500 bytes (alas)

## Example flash usage:

Extant 5 bit character set [NUL, a-z, _, 1,2,3]
```
[729/732] Linking C executable bin/WINGFC.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      465836 B       896 KB     50.77%
    FLASH_CONFIG:          0 GB       128 KB      0.00%
             RAM:       54836 B       128 KB     41.84%
             CCM:       13140 B        64 KB     20.05%
     BACKUP_SRAM:          0 GB         4 KB      0.00%
       MEMORY_B1:          0 GB         0 GB
[731/732] Linking C executable bin/MATEKF405.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      507324 B       896 KB     55.29%
    FLASH_CONFIG:          0 GB       128 KB      0.00%
             RAM:       78984 B       128 KB     60.26%
             CCM:       17252 B        64 KB     26.32%
     BACKUP_SRAM:          0 GB         4 KB      0.00%
       MEMORY_B1:          0 GB         0 GB
``` 
Example 6bit character set [NUL, a-z, _, 0 - 9]
```
57/358] Linking C executable bin/WINGFC.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      466308 B       896 KB     50.82%
    FLASH_CONFIG:          0 GB       128 KB      0.00%
             RAM:       54836 B       128 KB     41.84%
             CCM:       13140 B        64 KB     20.05%
     BACKUP_SRAM:          0 GB         4 KB      0.00%
       MEMORY_B1:          0 GB         0 GB
[358/358] cd /home/jrh/Projects/fc/ina...ts/fc/inav/build/inav_3.1.0_WINGFC.hex
[jrh@eeyore]$ ninja MATEKF405
[373/374] Linking C executable bin/MATEKF405.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      507812 B       896 KB     55.35%
    FLASH_CONFIG:          0 GB       128 KB      0.00%
             RAM:       78984 B       128 KB     60.26%
             CCM:       17252 B        64 KB     26.32%
     BACKUP_SRAM:          0 GB         4 KB      0.00%
       MEMORY_B1:          0 GB         0 GB
```

More user-friendly settiings names costs c. 500 bytes. Comments solicited.

