### PR TITLE
Feature cut for F411 and F722 boards

### DIFF
--- a/src/main/drivers/io_pca9685.c
+++ b/src/main/drivers/io_pca9685.c
@@ -5,6 +5,8 @@
 
 #include "build/build_config.h"
 
+#ifdef USE_PWM_DRIVER_PCA9685
+
 #include "common/time.h"
 #include "common/maths.h"
 
@@ -141,3 +143,5 @@ bool pca9685Initialize(void)
 
     return true;
 }
+
+#endif

--- a/src/main/io/pwmdriver_i2c.c
+++ b/src/main/io/pwmdriver_i2c.c
@@ -7,6 +7,9 @@
 #include "fc/runtime_config.h"
 
 #include "config/feature.h"
+#include "platform.h"
+
+#ifdef USE_PWM_SERVO_DRIVER
 
 #define PWM_DRIVER_IMPLEMENTATION_COUNT 1
 #define PWM_DRIVER_MAX_CYCLE 4
@@ -63,3 +66,5 @@ void pwmDriverSync(void) {
         cycle = 0;
     }
 }
+
+#endif

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -82,7 +82,6 @@
 #define USE_MR_BRAKING_MODE
 #define USE_PITOT
 #define USE_PITOT_ADC
-#define USE_PITOT_VIRTUAL
 
 #define USE_ALPHA_BETA_GAMMA_FILTER
 #define USE_DYNAMIC_FILTERS
@@ -90,7 +89,6 @@
 #define USE_SMITH_PREDICTOR
 #define USE_RATE_DYNAMICS
 #define USE_EXTENDED_CMS_MENUS
-#define USE_HOTT_TEXTMODE
 
 // NAZA GPS support for F4+ only
 #define USE_GPS_PROTO_NAZA
@@ -126,8 +124,6 @@
 #define DASHBOARD_ARMED_BITMAP
 #define USE_OLED_UG2864
 
-#define USE_PWM_DRIVER_PCA9685
-
 #define USE_OSD
 #define USE_FRSKYOSD
 #define USE_DJI_HD_OSD
@@ -146,14 +142,10 @@
 #define USE_GPS_PROTO_MTK
 
 #define USE_TELEMETRY_SIM
-#define USE_TELEMETRY_HOTT
 #define USE_TELEMETRY_MAVLINK
 #define USE_MSP_OVER_TELEMETRY
 
 #define USE_SERIALRX_SRXL2     // Spektrum SRXL2 protocol
-#define USE_SERIALRX_SUMD
-#define USE_SERIALRX_SUMH
-#define USE_SERIALRX_XBUS
 #define USE_SERIALRX_JETIEXBUS
 #define USE_SERIALRX_MAVLINK
 #define USE_TELEMETRY_SRXL
@@ -193,7 +185,6 @@
 #define USE_RX_MSP
 //#define USE_MSP_RC_OVERRIDE
 #define USE_SERIALRX_CRSF
-#define USE_PWM_SERVO_DRIVER
 #define USE_SERIAL_PASSTHROUGH
 #define NAV_MAX_WAYPOINTS       60
 #define USE_RCDEVICE
@@ -202,7 +193,6 @@
 #define USE_VTX_CONTROL
 #define USE_VTX_SMARTAUDIO
 #define USE_VTX_TRAMP
-#define USE_VTX_FFPV
 
 #ifndef STM32F3 //F3 series does not have enoug RAM to support logic conditions
 #define USE_PROGRAMMING_FRAMEWORK
@@ -217,5 +207,21 @@
 #else // MCU_FLASH_SIZE < 128
 
 #define SKIP_TASK_STATISTICS
+
+#endif
+
+//Designed to free space of F722 and F411 MCUs
+#if (MCU_FLASH_SIZE > 512)
+
+#define USE_VTX_FFPV
+#define USE_PITOT_VIRTUAL
+#define USE_PWM_DRIVER_PCA9685
+#define USE_PWM_SERVO_DRIVER
+
+#define USE_SERIALRX_SUMD
+#define USE_SERIALRX_SUMH
+#define USE_SERIALRX_XBUS
+#define USE_TELEMETRY_HOTT
+#define USE_HOTT_TEXTMODE
 
 #endif

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -58,7 +58,6 @@ extern uint8_t __config_end;
 #undef USE_SERIALRX_SUMH
 #undef USE_SERIALRX_XBUS
 #undef USE_SERIALRX_JETIEXBUS
-#undef USE_PWM_SERVO_DRIVER
 #endif
 
 #ifndef BEEPER_PWM_FREQUENCY


### PR DESCRIPTION
This removed the support for following features on F411 and F722:

* Furious FPV 2.4GHz VTX
* Virtual Pitot
* PCA9685 servo driver
* SUMD RX protocol
* SUMH RX protocol
* XBUS RX protocol
* HOTT telemetry