### PR TITLE
Fix H7 timer def: TIM15 CH2 is PA3 not PA2

### DIFF
--- a/src/main/drivers/timer_def_stm32h7xx.h
+++ b/src/main/drivers/timer_def_stm32h7xx.h
@@ -138,7 +138,7 @@
 
 #define DEF_TIM_AF__PA1__TCH_TIM15_CH1N   D(4, 15)
 #define DEF_TIM_AF__PA2__TCH_TIM15_CH1    D(4, 15)
-#define DEF_TIM_AF__PA2__TCH_TIM15_CH2    D(4, 15)
+#define DEF_TIM_AF__PA3__TCH_TIM15_CH2    D(4, 15)
 
 //PORTB
 #define DEF_TIM_AF__PB0__TCH_TIM1_CH2N    D(1, 1)


### PR DESCRIPTION
Same as in betaflight/betaflight#10845