### PR TITLE
SDIO initialization delay for SDIO

### DIFF
--- a/src/main/drivers/sdcard/sdmmc_sdio_f7xx.c
+++ b/src/main/drivers/sdcard/sdmmc_sdio_f7xx.c
@@ -1385,14 +1385,19 @@ bool SD_Init(void)
     // Initialize SDMMC1 peripheral interface with default configuration for SD card initialization
     MODIFY_REG(SDMMC1->CLKCR, CLKCR_CLEAR_MASK, (uint32_t) SDMMC_INIT_CLK_DIV);
 
+    delay(100);
+
     // Identify card operating voltage
     if ((ErrorState = SD_PowerON()) == SD_OK) {
+        delay(100);
         // Initialize the present card and put them in idle state
         if ((ErrorState = SD_InitializeCard()) == SD_OK) {
+            delay(100);
             // Read CSD/CID MSD registers
             if ((ErrorState = SD_GetCardInfo()) == SD_OK) {
                 // Select the Card - Send CMD7 SDMMC_SEL_DESEL_CARD
                 ErrorState = SD_TransmitCommand((SD_CMD_SEL_DESEL_CARD | SD_CMD_RESPONSE_SHORT), SD_CardRCA, 1);
+                delay(100);
                 MODIFY_REG(SDMMC1->CLKCR, CLKCR_CLEAR_MASK, (uint32_t) SDMMC_CLK_DIV); // Configure SDMMC1 peripheral interface
             }
         }
@@ -1400,12 +1405,14 @@ bool SD_Init(void)
 
     // Configure SD Bus width
     if (ErrorState == SD_OK) {
+        delay(100);
         // Enable wide operation
 #ifdef SDCARD_SDIO_4BIT
         ErrorState = SD_WideBusOperationConfig(SD_BUS_WIDE_4B);
 #else
         ErrorState = SD_WideBusOperationConfig(SD_BUS_WIDE_1B);
 #endif
+        delay(100);
     }
 
     // Configure the SDCARD device


### PR DESCRIPTION
MatekF765 and MatekF765SE are the only F7 targets that use SDIO.
When MatekF765 WSE has SD card inserted, it fails to boot in 60% of the times. There is no pattern, it just does not boot, is stuck on the SD card initialization.

This PR adds delays to the process of SDcard with SDIO initialization that apparently fixes the problem. In 10 tries board booted 10 times without any problems. 

The exact reason is unknown to me. My far fetched suspicion is that SDIO requires delay and if SD card does not respond fast enough during initialization, it's stuck. Race condition

Tested with multiple SD card manufacturers