### PR TITLE
Add battery symbol in front of battery percentage

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1542,7 +1542,8 @@ static bool osdDrawSingleElement(uint8_t item)
         break;
 
     case OSD_BATTERY_REMAINING_PERCENT:
-        tfp_sprintf(buff, "%3d%%", calculateBatteryPercentage());
+        osdFormatBatteryChargeSymbol(buff);
+        tfp_sprintf(buff + 1, "%3d%%", calculateBatteryPercentage());
         osdUpdateBatteryCapacityOrVoltageTextAttributes(&elemAttr);
         break;
 


### PR DESCRIPTION
This PR adds the battery symbol in front of the battery percentage. Currently the percentage has no indication of what it is for. This PR fixes that.

Requires https://github.com/iNavFlight/inav-configurator/pull/1335

![WIN_20210823_18_34_29_Pro](https://user-images.githubusercontent.com/17590174/130493828-8c26143e-9e20-4640-bf5f-fc71269388e9.jpg)
