### PR TITLE
Decrease acc and mag P-gains in AHRS

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1948,7 +1948,7 @@ Inertial Measurement Unit KP Gain for accelerometer measurements
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 2500 |  | 65535 |
+| 1000 |  | 65535 |
 
 ---
 
@@ -1958,7 +1958,7 @@ Inertial Measurement Unit KP Gain for compass measurements
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 10000 |  | 65535 |
+| 5000 |  | 65535 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1493,7 +1493,7 @@ groups:
     members:
       - name: imu_dcm_kp
         description: "Inertial Measurement Unit KP Gain for accelerometer measurements"
-        default_value: 2500
+        default_value: 1000
         field: dcm_kp_acc
         max: UINT16_MAX
       - name: imu_dcm_ki
@@ -1503,7 +1503,7 @@ groups:
         max: UINT16_MAX
       - name: imu_dcm_kp_mag
         description: "Inertial Measurement Unit KP Gain for compass measurements"
-        default_value: 10000
+        default_value: 5000
         field: dcm_kp_mag
         max: UINT16_MAX
       - name: imu_dcm_ki_mag


### PR DESCRIPTION
I get more accurate attitude estimation and lower probability of toilet bowling by decreasing the P gains of the accelerometer and magnetometer in the Mahoney AHRS. This should be safe on all but the noisiest of setups so I suggest making these the defaults.