### PR TITLE
Add 50mW CRSF tx power level

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -58,8 +58,8 @@ static timeUs_t crsfFrameStartAt = 0;
 static uint8_t telemetryBuf[CRSF_FRAME_SIZE_MAX];
 static uint8_t telemetryBufLen = 0;
 
-// The power levels represented by uplinkTXPower above in mW (250mW added to full TX in v4.00 firmware)
-const uint16_t crsfPowerStates[] = {0, 10, 25, 100, 500, 1000, 2000, 250};
+// The power levels represented by uplinkTXPower above in mW (250mW added to full TX in v4.00 firmware, 50mW added for ExpressLRS)
+const uint16_t crsfPowerStates[] = {0, 10, 25, 100, 500, 1000, 2000, 250, 50};
 
 /*
  * CRSF protocol


### PR DESCRIPTION
ExpressLRS supports transmit power of 50mW which is currently not part of the CRSF protocol. This PR adds it as the 8th power level so it can be shown on the OSD.

Requires merging of https://github.com/ExpressLRS/ExpressLRS/pull/821 to send TX power OTA and https://github.com/ExpressLRS/ExpressLRS/pull/854 to add the 50mW power level.