### PR TITLE
Add average speed to OSD stats

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of Cleanflight
+ * This file is part of Cleanflight.
  *
  * Cleanflight is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -459,7 +459,7 @@ void osdFormatVelocityStr(char* buff, int32_t vel, bool _3D, bool _max)
 /**
  * Returns the average velocity. This always uses stats, so can be called as an OSD element later if wanted, to show a real time average
  */
-void osdFormatAverageVelocityStr(char* buff) {
+void osdGenerateAverageVelocityStr(char* buff) {
     uint32_t cmPerSec = getTotalTravelDistance() / getFlightTime();
     osdFormatVelocityStr(buff, cmPerSec, false, false);
 }
@@ -3552,7 +3552,7 @@ static void osdShowStatsPage1(void)
         displayWrite(osdDisplayPort, statValuesX, top++, buff);
 
         displayWrite(osdDisplayPort, statNameX, top, "AVG SPEED        :");
-        osdFormatAverageVelocityStr(buff);
+        osdGenerateAverageVelocityStr(buff);
         osdLeftAlignString(buff);
         displayWrite(osdDisplayPort, statValuesX, top++, buff);
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -459,7 +459,7 @@ void osdFormatVelocityStr(char* buff, int32_t vel, bool _3D, bool _max)
 /**
  * Returns the average velocity. This always uses stats, so can be called as an OSD element later if wanted, to show a real time average
  */
-void osdGenerateAverageVelocityStr(char* buff) {
+static void osdGenerateAverageVelocityStr(char* buff) {
     uint32_t cmPerSec = getTotalTravelDistance() / getFlightTime();
     osdFormatVelocityStr(buff, cmPerSec, false, false);
 }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -421,7 +421,9 @@ static int32_t osdConvertVelocityToUnit(int32_t vel)
 
 /**
  * Converts velocity into a string based on the current unit system.
- * @param alt Raw velocity (i.e. as taken from gpsSol.groundSpeed in centimeters/seconds)
+ * @param vel Raw velocity (i.e. as taken from gpsSol.groundSpeed in centimeters/seconds)
+ * @param _3D is a 3D velocity
+ * @param _max is a maximum velocity
  */
 void osdFormatVelocityStr(char* buff, int32_t vel, bool _3D, bool _max)
 {
@@ -452,6 +454,14 @@ void osdFormatVelocityStr(char* buff, int32_t vel, bool _3D, bool _max)
         }
         break;
     }
+}
+
+/**
+ * Returns the average velocity. This always uses stats, so can be called as an OSD element later if wanted, to show a real time average
+ */
+void osdFormatAverageVelocityStr(char* buff) {
+    uint32_t cmPerSec = getTotalTravelDistance() / getFlightTime();
+    osdFormatVelocityStr(buff, cmPerSec, false, false);
 }
 
 /**
@@ -3538,6 +3548,11 @@ static void osdShowStatsPage1(void)
     if (feature(FEATURE_GPS)) {
         displayWrite(osdDisplayPort, statNameX, top, "MAX SPEED        :");
         osdFormatVelocityStr(buff, stats.max_3D_speed, true, false);
+        osdLeftAlignString(buff);
+        displayWrite(osdDisplayPort, statValuesX, top++, buff);
+
+        displayWrite(osdDisplayPort, statNameX, top, "AVG SPEED        :");
+        osdFormatAverageVelocityStr(buff);
         osdLeftAlignString(buff);
         displayWrite(osdDisplayPort, statValuesX, top++, buff);
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of Cleanflight.
+ * This file is part of Cleanflight
  *
  * Cleanflight is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -416,7 +416,6 @@ void osdCrosshairPosition(uint8_t *x, uint8_t *y);
 bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int maxDecimals, int maxScaledDecimals, int length);
 void osdFormatAltitudeSymbol(char *buff, int32_t alt);
 void osdFormatVelocityStr(char* buff, int32_t vel, bool _3D, bool _max);
-void osdGenerateAverageVelocityStr(char* buff);
 // Returns a heading angle in degrees normalized to [0, 360).
 int osdGetHeadingAngle(int angle);
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -416,7 +416,7 @@ void osdCrosshairPosition(uint8_t *x, uint8_t *y);
 bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int maxDecimals, int maxScaledDecimals, int length);
 void osdFormatAltitudeSymbol(char *buff, int32_t alt);
 void osdFormatVelocityStr(char* buff, int32_t vel, bool _3D, bool _max);
-void osdFormatAverageVelocityStr(char* buff);
+void osdGenerateAverageVelocityStr(char* buff);
 // Returns a heading angle in degrees normalized to [0, 360).
 int osdGetHeadingAngle(int angle);
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -416,6 +416,7 @@ void osdCrosshairPosition(uint8_t *x, uint8_t *y);
 bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int maxDecimals, int maxScaledDecimals, int length);
 void osdFormatAltitudeSymbol(char *buff, int32_t alt);
 void osdFormatVelocityStr(char* buff, int32_t vel, bool _3D, bool _max);
+void osdFormatAverageVelocityStr(char* buff);
 // Returns a heading angle in degrees normalized to [0, 360).
 int osdGetHeadingAngle(int angle);
 


### PR DESCRIPTION
**REQUIRES TESTING**

This should work, but I've not tested in the field yet.

Fixes #7413

Added the osdGenerateAverageVelocityStr() function to get the average speed. This could be called at any time to get the current average speed for the flight. Just in case anyone wanted an OSD element in the future.

I also fixed the param comments for the osdFormatVelocityStr while I was there.