### PR TITLE
Fix throttle percentage scaling

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -604,7 +604,7 @@ void FAST_CODE mixTable()
 
 int16_t getThrottlePercent(void)
 {
-    int16_t thr = (constrain(rcCommand[THROTTLE], PWM_RANGE_MIN, PWM_RANGE_MAX ) - getThrottleIdleValue()) * 100 / (motorConfig()->maxthrottle - getThrottleIdleValue());
+    int16_t thr = scaleRange(constrain(rcCommand[THROTTLE], getThrottleIdleValue(), motorConfig()->maxthrottle), getThrottleIdleValue(), motorConfig()->maxthrottle, 0, 100);
     return thr;
 }
 


### PR DESCRIPTION
Closes https://github.com/iNavFlight/inav/issues/7357 and https://github.com/iNavFlight/inav/issues/6478.

I am not 100% sure `rcCommand[THROTTLE]` is limited to `motorConfig()->maxthrottle` (it looks that way though). If it is not, then this will not work when throttle is manually controlled. Needs testing to confirm.