### PR TITLE
CRSF RSSI% and LQ fix

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3527,12 +3527,13 @@ static void osdUpdateStats(void)
     if (stats.min_rssi > value)
         stats.min_rssi = value;
 
-    value = osdGetCrsfLQ(); {
+    value = osdGetCrsfLQ();
     if (stats.min_lq > value)
         stats.min_lq = value;
+
     if (!failsafeIsReceivingRxData())
         stats.min_lq = 0;
-    }
+
     value = osdGetCrsfdBm();
     if (stats.min_rssi_dbm > value)
         stats.min_rssi_dbm = value;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2079,7 +2079,10 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_CRSF_TX_POWER:
         {
-            tfp_sprintf(buff, "%4d%c", rxLinkStatistics.uplinkTXPower, SYM_MW);
+            if (!failsafeIsReceivingRxData())
+                tfp_sprintf(buff, "%s%c", "    ", SYM_BLANK);
+            else
+                tfp_sprintf(buff, "%4d%c", rxLinkStatistics.uplinkTXPower, SYM_MW);
             break;
         }
 #endif

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2025,11 +2025,12 @@ static bool osdDrawSingleElement(uint8_t item)
                     } else {
                         tfp_sprintf(buff+1, "%3d", rxLinkStatistics.uplinkLQ);
                     }
+                    break;
                 case OSD_CRSF_LQ_TYPE2:
                     if (!failsafeIsReceivingRxData()) {
                         tfp_sprintf(buff+1, "%s:%3d", " ", 0);
                     } else {
-                    tfp_sprintf(buff+1, "%d:%3d", rxLinkStatistics.rfMode, rxLinkStatistics.uplinkLQ);
+                        tfp_sprintf(buff+1, "%d:%3d", rxLinkStatistics.rfMode, rxLinkStatistics.uplinkLQ);
                     }
                     break;
                 case OSD_CRSF_LQ_TYPE3:

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -241,7 +241,11 @@ STATIC_UNIT_TESTED uint8_t crsfFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
             rxLinkStatistics.uplinkTXPower = crsfPowerStates[linkStats->uplinkTXPower];
             rxLinkStatistics.activeAnt = linkStats->activeAntenna;
 
-            lqTrackerSet(rxRuntimeConfig->lqTracker, scaleRange(constrain(rxLinkStatistics.uplinkRSSI, -120, -30), -120, -30, 0, RSSI_MAX_VALUE));
+            if (rxLinkStatistics.uplinkLQ > 0) {
+                lqTrackerSet(rxRuntimeConfig->lqTracker, scaleRange(constrain(rxLinkStatistics.uplinkRSSI, -120, -30), -120, -30, 0, RSSI_MAX_VALUE));
+            } else {
+                lqTrackerSet(rxRuntimeConfig->lqTracker, 0);
+            }
 
             // This is not RC channels frame, update channel value but don't indicate frame completion
             return RX_FRAME_PENDING;

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -241,11 +241,10 @@ STATIC_UNIT_TESTED uint8_t crsfFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
             rxLinkStatistics.uplinkTXPower = crsfPowerStates[linkStats->uplinkTXPower];
             rxLinkStatistics.activeAnt = linkStats->activeAntenna;
 
-            if (rxLinkStatistics.uplinkLQ > 0) {
+            if (rxLinkStatistics.uplinkLQ > 0)
                 lqTrackerSet(rxRuntimeConfig->lqTracker, scaleRange(constrain(rxLinkStatistics.uplinkRSSI, -120, -30), -120, -30, 0, RSSI_MAX_VALUE));
-            } else {
+            else
                 lqTrackerSet(rxRuntimeConfig->lqTracker, 0);
-            }
 
             // This is not RC channels frame, update channel value but don't indicate frame completion
             return RX_FRAME_PENDING;


### PR DESCRIPTION
This initializes and sets RSSI% and LQ to zero when there's no connection. Fixes issue with setup page of the Configurator and disarm stats too.