### PR TITLE
Don't change P, I and D during FW autotune

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1152,26 +1152,6 @@ D-Series telemetry only: Set to 1 to send raw VBat value in 0.1V resolution for 
 
 ---
 
-### fw_autotune_ff_to_i_tc
-
-FF to I time (defines time for I to reach the same level of response as FF) [ms]
-
-| Default | Min | Max |
-| --- | --- | --- |
-| 600 | 100 | 5000 |
-
----
-
-### fw_autotune_ff_to_p_gain
-
-FF to P gain (strength relationship) [%]
-
-| Default | Min | Max |
-| --- | --- | --- |
-| 10 | 0 | 100 |
-
----
-
 ### fw_autotune_max_rate_deflection
 
 The target percentage of maximum mixer output used for determining the rates in `AUTO` and `LIMIT`.
@@ -1189,16 +1169,6 @@ Minimum stick input [%], after applying deadband and expo, to start recording th
 | Default | Min | Max |
 | --- | --- | --- |
 | 50 | 0 | 100 |
-
----
-
-### fw_autotune_p_to_d_gain
-
-P to D gain (strength relationship) [%]
-
-| Default | Min | Max |
-| --- | --- | --- |
-| 0 | 0 | 200 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2263,24 +2263,6 @@ groups:
         field: fw_min_stick
         min: 0
         max: 100
-      - name: fw_autotune_ff_to_p_gain
-        description: "FF to P gain (strength relationship) [%]"
-        default_value: 10
-        field: fw_ff_to_p_gain
-        min: 0
-        max: 100
-      - name: fw_autotune_p_to_d_gain
-        description: "P to D gain (strength relationship) [%]"
-        default_value: 0
-        field: fw_p_to_d_gain
-        min: 0
-        max: 200
-      - name: fw_autotune_ff_to_i_tc
-        description: "FF to I time (defines time for I to reach the same level of response as FF) [ms]"
-        default_value: 600
-        field: fw_ff_to_i_time_constant
-        min: 100
-        max: 5000
       - name: fw_autotune_rate_adjustment
         description: "`AUTO` and `LIMIT` adjust the rates to match the capabilities of the airplane, with `LIMIT` they are never increased above the starting rates setting. `FIXED` does not adjust the rates. Rates are not changed when tuning in `ANGLE` mode."
         default_value: "AUTO"

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -72,9 +72,6 @@ typedef enum {
 } pidAutotuneState_e;
 
 typedef struct {
-    float   gainP;
-    float   gainI;
-    float   gainD;
     float   gainFF;
     float   rate;
     float   initialRate;
@@ -95,9 +92,6 @@ static timeMs_t             lastGainsUpdateTime;
 void autotuneUpdateGains(pidAutotuneData_t * data)
 {
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        pidBankMutable()->pid[axis].P = lrintf(data[axis].gainP);
-        pidBankMutable()->pid[axis].I = lrintf(data[axis].gainI);
-        pidBankMutable()->pid[axis].D = lrintf(data[axis].gainD);
         pidBankMutable()->pid[axis].FF = lrintf(data[axis].gainFF);
         ((controlRateConfig_t *)currentControlRateProfile)->stabilized.rates[axis] = lrintf(data[axis].rate/10.0f);
     }
@@ -121,9 +115,6 @@ void autotuneCheckUpdateGains(void)
 void autotuneStart(void)
 {
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        tuneCurrent[axis].gainP = pidBank()->pid[axis].P;
-        tuneCurrent[axis].gainI = pidBank()->pid[axis].I;
-        tuneCurrent[axis].gainD = pidBank()->pid[axis].D;
         tuneCurrent[axis].gainFF = pidBank()->pid[axis].FF;
         tuneCurrent[axis].rate = currentControlRateProfile->stabilized.rates[axis] * 10.0f;
         tuneCurrent[axis].initialRate = currentControlRateProfile->stabilized.rates[axis] * 10.0f;

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -46,6 +46,8 @@
 
 #include "flight/pid.h"
 
+#define AUTOTUNE_FIXED_WING_MIN_FF              10
+#define AUTOTUNE_FIXED_WING_MAX_FF              255
 #define AUTOTUNE_FIXED_WING_MIN_ROLL_PITCH_RATE 40
 #define AUTOTUNE_FIXED_WING_MIN_YAW_RATE        10
 #define AUTOTUNE_FIXED_WING_MAX_RATE            720

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -46,8 +46,6 @@
 
 #include "flight/pid.h"
 
-#define AUTOTUNE_FIXED_WING_MIN_FF              10
-#define AUTOTUNE_FIXED_WING_MAX_FF              255
 #define AUTOTUNE_FIXED_WING_MIN_ROLL_PITCH_RATE 40
 #define AUTOTUNE_FIXED_WING_MIN_YAW_RATE        10
 #define AUTOTUNE_FIXED_WING_MAX_RATE            720

--- a/src/main/flight/pid_autotune.c
+++ b/src/main/flight/pid_autotune.c
@@ -60,9 +60,6 @@ PG_REGISTER_WITH_RESET_TEMPLATE(pidAutotuneConfig_t, pidAutotuneConfig, PG_PID_A
 
 PG_RESET_TEMPLATE(pidAutotuneConfig_t, pidAutotuneConfig,
     .fw_min_stick = SETTING_FW_AUTOTUNE_MIN_STICK_DEFAULT,
-    .fw_ff_to_p_gain = SETTING_FW_AUTOTUNE_FF_TO_P_GAIN_DEFAULT,
-    .fw_ff_to_i_time_constant = SETTING_FW_AUTOTUNE_FF_TO_I_TC_DEFAULT,
-    .fw_p_to_d_gain = SETTING_FW_AUTOTUNE_P_TO_D_GAIN_DEFAULT,
     .fw_rate_adjustment = SETTING_FW_AUTOTUNE_RATE_ADJUSTMENT_DEFAULT,
     .fw_max_rate_deflection = SETTING_FW_AUTOTUNE_MAX_RATE_DEFLECTION_DEFAULT,
 );
@@ -246,16 +243,6 @@ void autotuneFixedWingUpdate(const flight_dynamics_index_t axis, float desiredRa
     }
 
     if (gainsUpdated) {
-        // Set P-gain to 10% of FF gain (quite agressive - FIXME)
-        tuneCurrent[axis].gainP = tuneCurrent[axis].gainFF * (pidAutotuneConfig()->fw_ff_to_p_gain / 100.0f);
-        tuneCurrent[axis].gainP = constrainf(tuneCurrent[axis].gainP, 1.0f, 20.0f);
-
-        // Set D-gain relative to P-gain (0 for now)
-        tuneCurrent[axis].gainD = tuneCurrent[axis].gainP * (pidAutotuneConfig()->fw_p_to_d_gain / 100.0f);
-
-        // Set integrator gain to reach the same response as FF gain in 0.667 second
-        tuneCurrent[axis].gainI = (tuneCurrent[axis].gainFF / FP_PID_RATE_FF_MULTIPLIER) * (1000.0f / pidAutotuneConfig()->fw_ff_to_i_time_constant) * FP_PID_RATE_I_MULTIPLIER;
-        tuneCurrent[axis].gainI = constrainf(tuneCurrent[axis].gainI, 2.0f, 30.0f);
         autotuneUpdateGains(tuneCurrent);
 
         switch (axis) {


### PR DESCRIPTION
Autotune is really only about setting the correct rates and FF so that the rotation rate roughly matches the rate command. It does a decent job of figuring out the correct values but on most flying wings this means low pitch rates and conversely high FF. We currently don't have a real way of tuning P, I, and D so these are set relative to FF. However, with these high FF gains, this means very high P and I, making flights rather bumpy and stiff. 

INAV's fixed-wing defaults for P and I are safe for basically all planes, so it is better to just leave them as they are during autotune and let the user tune them manually if he so desires. Once rates and FF are set correctly, P and I are mostly a personal preference thing and not something that needs to be set to a correct value to keep the plane in the air. 

I'm still thinking about a way to tune P, I, and D independently but until then I think it is better to just not change them.