### PR TITLE
fix problem with smartaudio on softserial

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -492,14 +492,9 @@ static void saReceiveFramer(uint8_t c)
 
 static void saSendFrame(uint8_t *buf, int len)
 {
-    switch (smartAudioSerialPort->identifier) {
-        case SERIAL_PORT_SOFTSERIAL1:
-        case SERIAL_PORT_SOFTSERIAL2:
-            break;
-        default:
-            serialWrite(smartAudioSerialPort, 0x00); // Generate 1st start bit
-            break;
-    }
+    // TBS SA definition requires that the line is low before frame is sent
+    // (for both soft and hard serial). It can be done by sending first 0x00
+    serialWrite(smartAudioSerialPort, 0x00);
 
     for (int i = 0 ; i < len ; i++) {
         serialWrite(smartAudioSerialPort, buf[i]);


### PR DESCRIPTION
Fix for SA for VTXs which strictly follow the protocol definition. Tested using fc Omnibus F4 V3 with vtx Holybro Atlatl HV V2.
Related issue #7455.