### PR TITLE
fix array overflow with 11S-14S battery in Mavlink

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -664,7 +664,7 @@ void mavlinkSendHUDAndHeartbeat(void)
     }
 #endif
 
-    
+
     int16_t thr = rxGetChannelValue(THROTTLE);
     if (navigationIsControllingThrottle()) {
         thr = rcCommand[THROTTLE];
@@ -777,7 +777,7 @@ void mavlinkSendBatteryTemperatureStatusText(void)
                 if (cell < MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN) {
                     batteryVoltages[cell] = getBatteryAverageCellVoltage() * 10;
                 } else {
-                    batteryVoltagesExt[cell] = getBatteryAverageCellVoltage() * 10;
+                    batteryVoltagesExt[cell-MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN] = getBatteryAverageCellVoltage() * 10;
                 }
             }
         }


### PR DESCRIPTION
Smashing the stack considered harmful, so let's avoid it. 

```
/home/jrh/Projects/fc/inav/src/main/telemetry/mavlink.c:780:39: error: array subscript 10 is above array bounds of 'uint16_t[4]' {aka 'short unsigned int[4]'} [-Werror=array-bounds]
  780 |                     batteryVoltagesExt[cell] = getBatteryAverageCellVoltage() * 10;
      |                     ~~~~~~~~~~~~~~~~~~^~~~~~
```

For all those power fiends on 11S - 14S batteries.