### PR TITLE
Fix image links in docs/boards/

### DIFF
--- a/docs/boards/AnyFC F7.md
+++ b/docs/boards/AnyFC F7.md
@@ -71,7 +71,7 @@ Airplanes
 
 Buzzer is supported with additional switching MOSFET transistor when connected to PWM Output #9. 
 
-![Buzzer](assets/images/anyfcf7_buzzer_pwm9.png)
+![Buzzer](../assets/images/anyfcf7_buzzer_pwm9.png)
 
 ## SD Card Detection
 

--- a/docs/boards/BetFPVF722.md
+++ b/docs/boards/BetFPVF722.md
@@ -9,4 +9,4 @@ BetFPVF722 does not have I2C pads broken out. I2C is shared with UART3
 
 > I2C and UART3 can not be used at the same time! Connect the serial receiver to a different serial port when I2C device like MAG is used.
 
-![BetaFPVF722 I2C](assets/betafpvf722.png)
+![BetaFPVF722 I2C](../assets/betafpvf722.png)

--- a/docs/boards/Omnibus F4.md
+++ b/docs/boards/Omnibus F4.md
@@ -155,14 +155,14 @@ This board allows for single **SoftwareSerial** port on small soldering pads loc
 Please note that this is *not* the motor PWM5/PWM6 pins, but small surface mount pads CH5/CH6.
 
 ### Omnibus F4 Pro SoftwareSerial Connections
-![Omnibus F4 Pro SoftwareSerial Connections](assets/images/omnibusf4pro_ss.jpg)
+![Omnibus F4 Pro SoftwareSerial Connections](../assets/images/omnibusf4pro_ss.jpg)
 
 | Pad   | SoftwareSerial Role   |
 | ----  | ----                  |
 | CH5   | RX                    |
 | CH6   | TX                    |
 
-![Omnibus F4 Pro SmartPort using SoftwareSerial](assets/images/omnibusf4pro_ss.png)
+![Omnibus F4 Pro SmartPort using SoftwareSerial](../assets/images/omnibusf4pro_ss.png)
 
 ### Omnibus F4 v3/v4/v5 SoftwareSerial Connections
 
@@ -181,22 +181,22 @@ Following diagrams applies to _Pro_ version with integrated current meter and JS
 
 ## Board layout
 
-![Omnibus F4 Pro Board Layout](assets/images/omnibusf4pro.png)
+![Omnibus F4 Pro Board Layout](../assets/images/omnibusf4pro.png)
 
 ## Flying wing motor and servos
 
-![Omnibus F4 Pro Flying Wing Setup](assets/images/omnibusf4pro_flyingwing_setup.png)
+![Omnibus F4 Pro Flying Wing Setup](../assets/images/omnibusf4pro_flyingwing_setup.png)
 
 ## RX setup
 
-![Omnibus F4 Pro RX Setup](assets/images/omnibusf4pro_rx.png)
+![Omnibus F4 Pro RX Setup](../assets/images/omnibusf4pro_rx.png)
 
 ## FPV setup
 
-![Omnibus F4 Pro FPV Setup](assets/images/omnibusf4pro_fpv_setup.png)
+![Omnibus F4 Pro FPV Setup](../assets/images/omnibusf4pro_fpv_setup.png)
 
 ## GPS setup
 
-![Omnibus F4 Pro GPS Setup](assets/images/omnibusf4pro_gps_setup.png)
+![Omnibus F4 Pro GPS Setup](../assets/images/omnibusf4pro_gps_setup.png)
 
 _Diagrams created by Albert Kravcov (skaman82)_


### PR DESCRIPTION
Fix links to images in docs/assets/ which were broken by 95d307a