### PR TITLE
WP mission RTH failsafe fix

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -378,7 +378,7 @@ static bool failsafeCheckStickMotion(void)
 
 static failsafeProcedure_e failsafeChooseFailsafeProcedure(void)
 {
-    if (FLIGHT_MODE(NAV_WP_MODE) && !failsafeConfig()->failsafe_mission) {
+    if ((FLIGHT_MODE(NAV_WP_MODE) || isWaypointMissionRTHActive()) && !failsafeConfig()->failsafe_mission) {
         return FAILSAFE_PROCEDURE_NONE;
     }
 


### PR DESCRIPTION
Ensures `failsafe_mission = OFF` also works during the RTH phase of a WP mission. Only an issue if the FS happens when the RTH phase is already active so a rare case.