### PR TITLE
Set manual rc expo to 35%

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2478,7 +2478,7 @@ Exposition value used for the PITCH/ROLL axes by the `MANUAL` flight mode [0-100
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 70 | 0 | 100 |
+| 35 | 0 | 100 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1401,7 +1401,7 @@ groups:
         max: 180
       - name: manual_rc_expo
         description: "Exposition value used for the PITCH/ROLL axes by the `MANUAL` flight mode [0-100]"
-        default_value: 70
+        default_value: 35
         field: manual.rcExpo8
         min: 0
         max: 100


### PR DESCRIPTION
Currently manual RC expo is 70%, which is excessive. This is close to the expo you'd find on 3D planes on high rates.

I have reduced the manual expo to 35%, which should be fine for most planes that people put iNav in.

Multirotors don't use manual, so are unaffected.