### PR TITLE
make max WP 120

### DIFF
--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -79,7 +79,7 @@
 
 #if (MCU_FLASH_SIZE > 256)
 
-#if defined(MAG_I2C_BUS) || defined(VCM5883_I2C_BUS)    
+#if defined(MAG_I2C_BUS) || defined(VCM5883_I2C_BUS)
 #define USE_MAG_VCM5883
 #endif
 
@@ -190,7 +190,7 @@
 //#define USE_MSP_RC_OVERRIDE
 #define USE_SERIALRX_CRSF
 #define USE_SERIAL_PASSTHROUGH
-#define NAV_MAX_WAYPOINTS       60
+#define NAV_MAX_WAYPOINTS       120
 #define USE_RCDEVICE
 
 //Enable VTX control


### PR DESCRIPTION
We last increased the number of WP probably 5 years ago, for F3.

Following a couple of requests on discord / telegram, this is an ongoing experiment.

* Mission planners may need updating
* Number may not be appropriate for all FCs
* Tested on F405 and (updated) mwp.