### PR TITLE
Added selectable precision to the OSD RPM

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4122,6 +4122,16 @@ Value above which to make the OSD distance from home indicator blink (meters)
 
 ---
 
+### osd_esc_rpm_precision
+
+Number of characters used to display the RPM value.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 3 | 3 | 6 |
+
+---
+
 ### osd_esc_temp_alarm_max
 
 Temperature above which the IMU temperature OSD element will start blinking (decidegrees centigrade)

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3340,7 +3340,6 @@ groups:
         description: "How many navigation waypoints are displayed, set to 0 (zero) to disable. As sample, if set to 2, and you just passed the 3rd waypoint of the mission, you'll see markers for the 4th waypoint (marked 1) and the 5th waypoint (marked 2)"
         default_value: 0
         field: hud_wp_disp
-
         min: 0
         max: 3
       - name: osd_left_sidebar_scroll
@@ -3475,6 +3474,13 @@ groups:
         default_value: 0
         min: -36
         max: 36
+
+      - name: osd_esc_rpm_precision
+        description: Number of characters used to display the RPM value.
+        field: esc_rpm_precision
+        min: 3
+        max: 6
+        default_value: 3
 
   - name: PG_OSD_COMMON_CONFIG
     type: osdCommonConfig_t

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1037,17 +1037,37 @@ static void osdFormatRpm(char *buff, uint32_t rpm)
 {
     buff[0] = SYM_RPM;
     if (rpm) {
-        if (rpm >= 1000) {
-            osdFormatCentiNumber(buff + 1, rpm / 10, 0, 1, 1, 2);
-            buff[3] = 'K';
-            buff[4] = '\0';
+        if ( digitCount(rpm) > osdConfig()->esc_rpm_precision) {
+            uint8_t rpmMaxDecimals = (osdConfig()->esc_rpm_precision - 3);
+            osdFormatCentiNumber(buff + 1, rpm / 10, 0, rpmMaxDecimals, rpmMaxDecimals, osdConfig()->esc_rpm_precision-1);
+            buff[osdConfig()->esc_rpm_precision] = 'K';
+            buff[osdConfig()->esc_rpm_precision+1] = '\0';
         }
         else {
-            tfp_sprintf(buff + 1, "%3lu", rpm);
+            switch(osdConfig()->esc_rpm_precision) {
+                case 6:
+                    tfp_sprintf(buff + 1, "%6lu", rpm);
+                    break;
+                case 5:
+                    tfp_sprintf(buff + 1, "%5lu", rpm);
+                    break;
+                case 4:
+                    tfp_sprintf(buff + 1, "%4lu", rpm);
+                    break;
+                case 3:
+                default:
+                    tfp_sprintf(buff + 1, "%3lu", rpm);
+                    break;
+            }
+
+            
         }
     }
     else {
-        strcpy(buff + 1, "---");
+        uint8_t buffPos = 1;
+        while (buffPos <=( osdConfig()->esc_rpm_precision)) {
+            strcpy(buff + buffPos++, "-");
+        }
     }
 }
 #endif
@@ -3148,6 +3168,7 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .osd_home_position_arm_screen = SETTING_OSD_HOME_POSITION_ARM_SCREEN_DEFAULT,
     .pan_servo_index = SETTING_OSD_PAN_SERVO_INDEX_DEFAULT,
     .pan_servo_pwm2centideg = SETTING_OSD_PAN_SERVO_PWM2CENTIDEG_DEFAULT,
+    .esc_rpm_precision = SETTING_OSD_ESC_RPM_PRECISION_DEFAULT,
 
     .units = SETTING_OSD_UNITS_DEFAULT,
     .main_voltage_decimals = SETTING_OSD_MAIN_VOLTAGE_DECIMALS_DEFAULT,

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -383,6 +383,7 @@ typedef struct osdConfig_s {
     uint8_t crsf_lq_format;
     uint8_t sidebar_height;             // sidebar height in rows, 0 turns off sidebars leaving only level indicator arrows
     uint8_t telemetry; 				    // use telemetry on displayed pixel line 0
+    uint8_t esc_rpm_precision;          // Number of characters used for the RPM numbers.
 
 } osdConfig_t;
 


### PR DESCRIPTION
I've added selectable precision to the ESC RPM, as shown in the OSD. The default is 3, which is the same as the current RPM display.

Can be set in the CLI with `set osd_esc_rpm_precision = 5` for example.

[Here's a demo video](https://youtu.be/AmCPe7T5gAc)

Requires configurator change https://github.com/iNavFlight/inav-configurator/pull/1379