### PR TITLE
Fix WSL build

### DIFF
--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -33,7 +33,7 @@ function(enable_settings exe name)
     add_custom_command(
         OUTPUT ${output}
         COMMAND
-            ${CMAKE_COMMAND} -E env CFLAGS="${cflags}" TARGET=${name} PATH=$ENV{PATH} SETTINGS_CXX=${args_SETTINGS_CXX}
+            ${CMAKE_COMMAND} -E env CFLAGS="${cflags}" TARGET=${name} PATH="$ENV{PATH}" SETTINGS_CXX=${args_SETTINGS_CXX}
             ${RUBY_EXECUTABLE} ${SETTINGS_GENERATOR} ${MAIN_DIR} ${SETTINGS_FILE} -o "${dir}"
         DEPENDS ${SETTINGS_GENERATOR} ${SETTINGS_FILE}
     )

--- a/cmake/stm32.cmake
+++ b/cmake/stm32.cmake
@@ -189,7 +189,7 @@ endfunction()
 
 function(add_hex_target name exe hex)
     add_custom_target(${name} ALL
-        cmake -E env PATH=$ENV{PATH}
+        cmake -E env PATH="$ENV{PATH}"
         # TODO: Overriding the start address with --set-start 0x08000000
         # seems to be required due to some incorrect assumptions about .hex
         # files in the configurator. Verify wether that's the case and fix
@@ -201,7 +201,7 @@ endfunction()
 
 function(add_bin_target name exe bin)
     add_custom_target(${name}
-        cmake -E env PATH=$ENV{PATH}
+        cmake -E env PATH="$ENV{PATH}"
         ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${exe}> ${bin}
         BYPRODUCTS ${bin}
     )


### PR DESCRIPTION
WSL by default appends windows path to PATH and it contains parentheses which results in invalid shell syntax without quotes