### PR TITLE
Fix MSC on windows with F7 and H7

### DIFF
--- a/src/main/drivers/usb_msc_f7xx.c
+++ b/src/main/drivers/usb_msc_f7xx.c
@@ -109,8 +109,6 @@ uint8_t mscStart(void)
 
     USBD_Start(&USBD_Device);
 
-    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
-
     // NVIC configuration for SYSTick
     NVIC_DisableIRQ(SysTick_IRQn);
     NVIC_SetPriority(SysTick_IRQn, 0);

--- a/src/main/drivers/usb_msc_h7xx.c
+++ b/src/main/drivers/usb_msc_h7xx.c
@@ -109,8 +109,6 @@ uint8_t mscStart(void)
 
     USBD_Start(&USBD_Device);
 
-    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
-
     // NVIC configuration for SYSTick
     NVIC_DisableIRQ(SysTick_IRQn);
     NVIC_SetPriority(SysTick_IRQn, 0);


### PR DESCRIPTION
This fixes MSC on Windows platforms on F7 (and hopefully H7) by removing persistent storage call on MSC entry. Tested on F722