### PR TITLE
Passing elemAttr instead of NULL to osdFormatThrottlePosition()

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1994,7 +1994,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_THROTTLE_POS:
     {
-        osdFormatThrottlePosition(buff, false, NULL);
+        osdFormatThrottlePosition(buff, false, &elemAttr);
         break;
     }
 

--- a/src/test/cmake/CMakeListsGTest.txt.in
+++ b/src/test/cmake/CMakeListsGTest.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Fixes #7593 

Passing NULL and then setting (1<<0) bit in it causes HardFault