### PR TITLE
h7: fix led strip dma configuration

### DIFF
--- a/src/main/drivers/light_ws2811strip.c
+++ b/src/main/drivers/light_ws2811strip.c
@@ -47,7 +47,7 @@
 #define WS2811_BIT_COMPARE_1 ((WS2811_PERIOD * 2) / 3)
 #define WS2811_BIT_COMPARE_0 (WS2811_PERIOD / 3)
 
-static timerDMASafeType_t ledStripDMABuffer[WS2811_DMA_BUFFER_SIZE];
+static DMA_RAM timerDMASafeType_t ledStripDMABuffer[WS2811_DMA_BUFFER_SIZE];
 
 static IO_t ws2811IO = IO_NONE;
 static TCH_t * ws2811TCH = NULL;

--- a/src/main/target/MATEKH743/target.c
+++ b/src/main/target/MATEKH743/target.c
@@ -47,7 +47,7 @@ const timerHardware_t timerHardware[] = {
     DEF_TIM(TIM15, CH1, PE5, TIM_USE_MC_SERVO | TIM_USE_FW_SERVO, 0, 0),   // S11
     DEF_TIM(TIM15, CH2, PE6, TIM_USE_MC_SERVO | TIM_USE_FW_SERVO, 0, 0),   // S12 DMA_NONE
 
-    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_LED, 0, 0),    // LED_2812
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_LED, 0, 8),    // LED_2812
     DEF_TIM(TIM2,  CH1, PA15, TIM_USE_BEEPER, 0, 0),  // BEEPER PWM
 
     DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_PPM, 0, 0),   // RX6 PPM


### PR DESCRIPTION
fixes #7623
data coherency issue of `ledStripDMABuffer` on h7 by moving it to `DMA_RAM`
assigns LED pin PA8 a dedicated DMA_TAG to avoid conflict with S1 when its configured as dshot