### PR TITLE
[Fixed-Wing Aircraft] Stall Prevention for Roll axis

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1404,7 +1404,7 @@ Reference airspeed. Set this to airspeed at which PIDs were tuned. Usually shoul
 
 ### fw_stall_prevention
 
-Stops motor when Soaring mode enabled.
+Set to 'ON', the stall prevention system will be activated when the autopilot is also active.
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1342,6 +1342,16 @@ Automatic pitch down angle when throttle is at 0 in angle mode. Progressively ap
 
 ---
 
+### fw_min_vel_speed
+
+Minimum AirSpeed demanded. Beware, low values ​​can cause your aircraft to stall.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 900 | 500 | 10000 |
+
+---
+
 ### fw_p_level
 
 Fixed-wing attitude stabilisation P-gain
@@ -1389,6 +1399,16 @@ Reference airspeed. Set this to airspeed at which PIDs were tuned. Usually shoul
 | Default | Min | Max |
 | --- | --- | --- |
 | 1500 | 300 | 6000 |
+
+---
+
+### fw_stall_prevention
+
+Stops motor when Soaring mode enabled.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| OFF |  |  |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2832,7 +2832,7 @@ groups:
         min: 0
         max: 90
       - name: fw_stall_prevention
-        description: "Stops motor when Soaring mode enabled."
+        description: "Set to 'ON', the stall prevention system will be activated when the autopilot is also active."
         default_value: OFF
         field: fw.stall_prevention
         type: bool

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2731,7 +2731,6 @@ groups:
         field: fw.control_smoothness
         min: 0
         max: 9
-
       - name: nav_fw_land_dive_angle
         description: "Dive angle that airplane will use during final landing phase. During dive phase, motor is stopped or IDLE and roll control is locked to 0 degrees"
         default_value: 2
@@ -2739,7 +2738,6 @@ groups:
         condition: NAV_FIXED_WING_LANDING
         min: -20
         max: 20
-
       - name: nav_fw_launch_velocity
         description: "Forward velocity threshold for swing-launch detection [cm/s]"
         default_value: 300
@@ -2833,6 +2831,17 @@ groups:
         field: fw.yawControlDeadband
         min: 0
         max: 90
+      - name: fw_stall_prevention
+        description: "Stops motor when Soaring mode enabled."
+        default_value: OFF
+        field: fw.stall_prevention
+        type: bool
+      - name: fw_min_vel_speed
+        description: "Minimum AirSpeed demanded. Beware, low values ​​can cause your aircraft to stall."
+        default_value: 900
+        field: fw.airspeed_min
+        min: 500
+        max: 10000
 
   - name: PG_TELEMETRY_CONFIG
     type: telemetryConfig_t

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -116,9 +116,9 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
             .rth_alt_control_override = SETTING_NAV_RTH_ALT_CONTROL_OVERRIDE_DEFAULT,       // Override RTH Altitude and Climb First using Pitch and Roll stick
             .nav_overrides_motor_stop = SETTING_NAV_OVERRIDES_MOTOR_STOP_DEFAULT,
             .safehome_usage_mode = SETTING_SAFEHOME_USAGE_MODE_DEFAULT,
-            .mission_planner_reset = SETTING_NAV_MISSION_PLANNER_RESET_DEFAULT,       // Allow mode switch toggle to reset Mission Planner WPs
-            .waypoint_mission_restart = SETTING_NAV_WP_MISSION_RESTART_DEFAULT,           // WP mission restart action
-            .soaring_motor_stop = SETTING_NAV_FW_SOARING_MOTOR_STOP_DEFAULT,          // stops motor when Saoring mode enabled
+            .mission_planner_reset = SETTING_NAV_MISSION_PLANNER_RESET_DEFAULT,             // Allow mode switch toggle to reset Mission Planner WPs
+            .waypoint_mission_restart = SETTING_NAV_WP_MISSION_RESTART_DEFAULT,             // WP mission restart action
+            .soaring_motor_stop = SETTING_NAV_FW_SOARING_MOTOR_STOP_DEFAULT,                // stops motor when Saoring mode enabled
         },
 
         // General navigation parameters
@@ -170,36 +170,38 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
 
     // Fixed wing
     .fw = {
-        .max_bank_angle = SETTING_NAV_FW_BANK_ANGLE_DEFAULT,                    // degrees
-        .max_climb_angle = SETTING_NAV_FW_CLIMB_ANGLE_DEFAULT,                  // degrees
-        .max_dive_angle = SETTING_NAV_FW_DIVE_ANGLE_DEFAULT,                    // degrees
-        .cruise_speed = SETTING_NAV_FW_CRUISE_SPEED_DEFAULT,                    // cm/s
+        .max_bank_angle = SETTING_NAV_FW_BANK_ANGLE_DEFAULT,                         // degrees
+        .max_climb_angle = SETTING_NAV_FW_CLIMB_ANGLE_DEFAULT,                       // degrees
+        .max_dive_angle = SETTING_NAV_FW_DIVE_ANGLE_DEFAULT,                         // degrees
+        .cruise_speed = SETTING_NAV_FW_CRUISE_SPEED_DEFAULT,                         // cm/s
         .control_smoothness = SETTING_NAV_FW_CONTROL_SMOOTHNESS_DEFAULT,
         .pitch_to_throttle_smooth = SETTING_NAV_FW_PITCH2THR_SMOOTHING_DEFAULT,
-        .pitch_to_throttle_thresh = SETTING_NAV_FW_PITCH2THR_THRESHOLD_DEFAULT,
-        .loiter_radius = SETTING_NAV_FW_LOITER_RADIUS_DEFAULT,                  // 75m
+        .pitch_to_throttle_thresh = SETTING_NAV_FW_PITCH2THR_THRESHOLD_DEFAULT,  
+        .loiter_radius = SETTING_NAV_FW_LOITER_RADIUS_DEFAULT,                       // 75m
 
         //Fixed wing landing
-        .land_dive_angle = SETTING_NAV_FW_LAND_DIVE_ANGLE_DEFAULT,              // 2 degrees dive by default
+        .land_dive_angle = SETTING_NAV_FW_LAND_DIVE_ANGLE_DEFAULT,                   // 2 degrees dive by default
 
         // Fixed wing launch
-        .launch_velocity_thresh = SETTING_NAV_FW_LAUNCH_VELOCITY_DEFAULT,       // 3 m/s
-        .launch_accel_thresh = SETTING_NAV_FW_LAUNCH_ACCEL_DEFAULT,             // cm/s/s (1.9*G)
-        .launch_time_thresh = SETTING_NAV_FW_LAUNCH_DETECT_TIME_DEFAULT,        // 40ms
-        .launch_motor_timer = SETTING_NAV_FW_LAUNCH_MOTOR_DELAY_DEFAULT,        // ms
+        .launch_velocity_thresh = SETTING_NAV_FW_LAUNCH_VELOCITY_DEFAULT,            // 3 m/s
+        .launch_accel_thresh = SETTING_NAV_FW_LAUNCH_ACCEL_DEFAULT,                  // cm/s/s (1.9*G)
+        .launch_time_thresh = SETTING_NAV_FW_LAUNCH_DETECT_TIME_DEFAULT,             // 40ms
+        .launch_motor_timer = SETTING_NAV_FW_LAUNCH_MOTOR_DELAY_DEFAULT,             // ms
         .launch_idle_motor_timer = SETTING_NAV_FW_LAUNCH_IDLE_MOTOR_DELAY_DEFAULT,   // ms
-        .launch_motor_spinup_time = SETTING_NAV_FW_LAUNCH_SPINUP_TIME_DEFAULT,  // ms, time to gredually increase throttle from idle to launch
-        .launch_end_time = SETTING_NAV_FW_LAUNCH_END_TIME_DEFAULT,              // ms, time to gradually decrease/increase throttle and decrease pitch angle from launch to the current flight mode
-        .launch_min_time = SETTING_NAV_FW_LAUNCH_MIN_TIME_DEFAULT,              // ms, min time in launch mode
-        .launch_timeout = SETTING_NAV_FW_LAUNCH_TIMEOUT_DEFAULT,                // ms, timeout for launch procedure
-        .launch_max_altitude = SETTING_NAV_FW_LAUNCH_MAX_ALTITUDE_DEFAULT,      // cm, altitude where to consider launch ended
-        .launch_climb_angle = SETTING_NAV_FW_LAUNCH_CLIMB_ANGLE_DEFAULT,        // 18 degrees
-        .launch_max_angle = SETTING_NAV_FW_LAUNCH_MAX_ANGLE_DEFAULT,            // 45 deg
-        .cruise_yaw_rate  = SETTING_NAV_FW_CRUISE_YAW_RATE_DEFAULT,             // 20dps
+        .launch_motor_spinup_time = SETTING_NAV_FW_LAUNCH_SPINUP_TIME_DEFAULT,       // ms, time to gredually increase throttle from idle to launch
+        .launch_end_time = SETTING_NAV_FW_LAUNCH_END_TIME_DEFAULT,                   // ms, time to gradually decrease/increase throttle and decrease pitch angle from launch to the current flight mode
+        .launch_min_time = SETTING_NAV_FW_LAUNCH_MIN_TIME_DEFAULT,                   // ms, min time in launch mode
+        .launch_timeout = SETTING_NAV_FW_LAUNCH_TIMEOUT_DEFAULT,                     // ms, timeout for launch procedure
+        .launch_max_altitude = SETTING_NAV_FW_LAUNCH_MAX_ALTITUDE_DEFAULT,           // cm, altitude where to consider launch ended
+        .launch_climb_angle = SETTING_NAV_FW_LAUNCH_CLIMB_ANGLE_DEFAULT,             // 18 degrees
+        .launch_max_angle = SETTING_NAV_FW_LAUNCH_MAX_ANGLE_DEFAULT,                 // 45 deg
+        .cruise_yaw_rate  = SETTING_NAV_FW_CRUISE_YAW_RATE_DEFAULT,                  // 20dps
         .allow_manual_thr_increase = SETTING_NAV_FW_ALLOW_MANUAL_THR_INCREASE_DEFAULT,
         .useFwNavYawControl = SETTING_NAV_USE_FW_YAW_CONTROL_DEFAULT,
         .yawControlDeadband = SETTING_NAV_FW_YAW_DEADBAND_DEFAULT,
-        .soaring_pitch_deadband = SETTING_NAV_FW_SOARING_PITCH_DEADBAND_DEFAULT,// pitch angle mode deadband when Saoring mode enabled
+        .soaring_pitch_deadband = SETTING_NAV_FW_SOARING_PITCH_DEADBAND_DEFAULT,     // pitch angle mode deadband when Saoring mode enabled
+        .stall_prevention = SETTING_FW_STALL_PREVENTION_DEFAULT,
+        .airspeed_min = SETTING_FW_MIN_VEL_SPEED_DEFAULT
     }
 );
 

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -97,7 +97,7 @@ STATIC_ASSERT(NAV_MAX_WAYPOINTS < 254, NAV_MAX_WAYPOINTS_exceeded_allowable_rang
 PG_REGISTER_ARRAY(navWaypoint_t, NAV_MAX_WAYPOINTS, nonVolatileWaypointList, PG_WAYPOINT_MISSION_STORAGE, 1);
 #endif
 
-PG_REGISTER_WITH_RESET_TEMPLATE(navConfig_t, navConfig, PG_NAV_CONFIG, 14);
+PG_REGISTER_WITH_RESET_TEMPLATE(navConfig_t, navConfig, PG_NAV_CONFIG, 15);
 
 PG_RESET_TEMPLATE(navConfig_t, navConfig,
     .general = {

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -298,6 +298,8 @@ typedef struct navConfig_s {
         bool     useFwNavYawControl;
         uint8_t  yawControlDeadband;
         uint8_t  soaring_pitch_deadband;     // soaring mode pitch angle deadband (deg)
+        bool stall_prevention;
+        uint16_t airspeed_min;
     } fw;
 } navConfig_t;
 

--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -519,7 +519,7 @@ static int16_t get_stall_prevention(int16_t navigation_roll)
 #ifdef USE_PITOT
     
     if (!pitotIsHealthy()) {
-        return avigation_roll;
+        return navigation_roll;
     }
 
     if (!navConfig()->fw.stall_prevention) {

--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -529,10 +529,10 @@ static int16_t get_stall_prevention(int16_t navigation_roll)
     float max_load_factor = pitot.airSpeed / MAX(navConfig()->fw.airspeed_min, 100);
 
     if (max_load_factor <= 1) { 
-        // air speed is below minimum speed, roll will be limited to 25 degrees
+        // airspeed is below minimum speed, roll will be limited to 25 degrees
         navigation_roll = constrain(navigation_roll, -250, 250);
     } else { 
-        // calculates a new roll limit according to the aerodynamic limit
+        // calculates a new roll limit according to the max load factor
         int32_t roll_limit_deg = RADIANS_TO_DECIDEGREES(acos_approx(sq(1.0f / max_load_factor)));
         if (roll_limit_deg < 250) {
             roll_limit_deg = 250;

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -58,6 +58,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(pitotmeterConfig_t, pitotmeterConfig, PG_PITOTME
 #else
 #define PITOT_HARDWARE_DEFAULT    PITOT_NONE
 #endif
+
 PG_RESET_TEMPLATE(pitotmeterConfig_t, pitotmeterConfig,
     .pitot_hardware = SETTING_PITOT_HARDWARE_DEFAULT,
     .pitot_lpf_milli_hz = SETTING_PITOT_LPF_MILLI_HZ_DEFAULT,


### PR DESCRIPTION
This feature causes the Roll axis to be limited in degrees, the lower the speed of the fuselage in relation to the air, the lower the adjustment limit of the Roll surface.

Requires: Pitot Tube and the autopilot system activated

CLI: 

`fw_min_vel_speed`: Minimum AirSpeed demanded. Beware, low values ​​can cause your aircraft to stall.

`fw_stall_prevention`: Set to "ON", the stall prevention system will be activated when the autopilot is also active.
