### PR TITLE
Give options on the method to use for SmartAudio over SoftSerial

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -5712,6 +5712,16 @@ VTX RF power level to use. The exact number of mw depends on the VTX hardware.
 
 ---
 
+### vtx_smartaudio_alternate_softserial_method
+
+Enable the alternate softserial method. This is the method used in iNav 3.0 and ealier.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| ON |  |  |
+
+---
+
 ### vtx_smartaudio_early_akk_workaround
 
 Enable workaround for early AKK SAudio-enabled VTX bug.

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3601,6 +3601,11 @@ groups:
         default_value: ON
         field: smartAudioEarlyAkkWorkaroundEnable
         type: bool
+      - name: vtx_smartaudio_alternate_softserial_method
+        description: "Enable the alternate softserial method. This is the method used in iNav 3.0 and ealier."
+        default_value: ON
+        field: smartAudioAltSoftSerialMethod
+        type: bool
 
   - name: PG_VTX_SETTINGS_CONFIG
     type: vtxSettingsConfig_t

--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -45,6 +45,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(vtxConfig_t, vtxConfig, PG_VTX_CONFIG, 3);
 PG_RESET_TEMPLATE(vtxConfig_t, vtxConfig,
       .halfDuplex = SETTING_VTX_HALFDUPLEX_DEFAULT,
       .smartAudioEarlyAkkWorkaroundEnable = SETTING_VTX_SMARTAUDIO_EARLY_AKK_WORKAROUND_DEFAULT,
+      .smartAudioAltSoftSerialMethod = SETTING_VTX_SMARTAUDIO_ALTERNATE_SOFTSERIAL_METHOD_DEFAULT,
 );
 
 static uint8_t locked = 0;

--- a/src/main/io/vtx_control.h
+++ b/src/main/io/vtx_control.h
@@ -32,6 +32,7 @@ typedef struct vtxConfig_s {
     vtxChannelActivationCondition_t vtxChannelActivationConditions[MAX_CHANNEL_ACTIVATION_CONDITION_COUNT];
     uint8_t halfDuplex;
     uint8_t smartAudioEarlyAkkWorkaroundEnable;
+    bool    smartAudioAltSoftSerialMethod;
 } vtxConfig_t;
 
 PG_DECLARE(vtxConfig_t, vtxConfig);

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -492,9 +492,13 @@ static void saReceiveFramer(uint8_t c)
 
 static void saSendFrame(uint8_t *buf, int len)
 {
-    // TBS SA definition requires that the line is low before frame is sent
-    // (for both soft and hard serial). It can be done by sending first 0x00
-    serialWrite(smartAudioSerialPort, 0x00);
+    if ( (vtxConfig()->smartAudioAltSoftSerialMethod && 
+          (smartAudioSerialPort->identifier == SERIAL_PORT_SOFTSERIAL1 || smartAudioSerialPort->identifier == SERIAL_PORT_SOFTSERIAL2))
+         == false) {
+        // TBS SA definition requires that the line is low before frame is sent
+        // (for both soft and hard serial). It can be done by sending first 0x00
+        serialWrite(smartAudioSerialPort, 0x00);
+    }
 
     for (int i = 0 ; i < len ; i++) {
         serialWrite(smartAudioSerialPort, buf[i]);


### PR DESCRIPTION
The change of SmartAudio over SoftSerial (#7470)  broke compatibility with some VTxs, including the Unify HV. This PR reverts the code, but also allows the option of using the correct TBS SA definition.

There is a new CLI option `vtx_smartaudio_alternate_softserial_method`
- **ON** uses the method currently in the release versions of iNav 3.0 and earlier. I have set this as the default option, so that it doesn't break working setups.
- **OFF** uses the new version, which follows TBS' SA definition, and sends 0x00 before communication to set the line low.