### PR TITLE
+Added JHEF411 target (GHF412AIO). Optional: Software Serial on LED pin

### DIFF
--- a/src/main/target/JHEF411/CMakeLists.txt
+++ b/src/main/target/JHEF411/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_stm32f411xe(JHEF411)
+target_stm32f411xe(JHEF411_SS)

--- a/src/main/target/JHEF411/target.c
+++ b/src/main/target/JHEF411/target.c
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/bus.h"
+#include "drivers/pwm_mapping.h"
+
+
+const timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM9, CH1, PA2,   TIM_USE_PPM,   0, 0), // PPM IN
+
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 1), // S1_OUT 2,1
+    DEF_TIM(TIM1, CH2, PA9,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 1), // S2_OUT 2,2
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO,  0, 1), // S3_OUT 2,6
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR,  0, 0), // S4_OUT 1,7
+
+    //DEF_TIM(TIM4, CH3, PB1,  TIM_USE_ANY,   0, 0), //  RSSI   1,2
+    DEF_TIM(TIM5, CH4, PA3,  TIM_USE_ANY,   0, 1), //  RX2    1,0
+#if defined(JHEF411_SS)
+    DEF_TIM(TIM2, CH1, PA15, TIM_USE_ANY,   0, 0), //  SS 1,5
+#else
+    DEF_TIM(TIM2, CH1, PA15, TIM_USE_LED,   0, 0), //  LED 1,5
+#endif
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/JHEF411/target.h
+++ b/src/main/target/JHEF411/target.h
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "JH41"
+#define USBD_PRODUCT_STRING     "JHEF411"
+
+#define LED0                    PC13
+
+#define BEEPER                  PC14
+#define BEEPER_INVERTED
+
+
+// *************** SPI **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN           PA5
+#define SPI1_MISO_PIN   	   PA6
+#define SPI1_MOSI_PIN   	   PA7
+
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN           PB13
+#define SPI2_MISO_PIN  		   PB14
+#define SPI2_MOSI_PIN  		   PB15
+
+
+// *************** SPI Gyro & ACC **********************
+
+#define USE_IMU_MPU6000
+#define MPU6000_CS_PIN          PA4
+#define MPU6000_SPI_BUS         BUS_SPI1
+#define IMU_MPU6000_ALIGN       CW180_DEG
+
+#define USE_IMU_ICM20689
+#define ICM20689_CS_PIN         PA4
+#define ICM20689_SPI_BUS        BUS_SPI1
+#define IMU_ICM20689_ALIGN      CW180_DEG
+
+#define USE_EXTI
+#define GYRO_INT_EXTI           PB3
+
+#define USE_MPU_DATA_READY_SIGNAL
+
+// *************** Baro *****************************
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+
+#define USE_BARO
+#define BARO_I2C_BUS		    BUS_I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+
+#define BNO055_I2C_BUS          BUS_I2C1
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define USE_MAG_IST8310
+#define USE_MAG_IST8308
+#define USE_MAG_MAG3110
+#define USE_MAG_LIS3MDL
+
+// *************** SPI OSD *****************************
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          PB12
+
+// *************** SPI FLASH **************************
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN           PB2
+#define M25P16_SPI_BUS          BUS_SPI2
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PB6
+#define UART1_RX_PIN            PB7
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#if defined(JHEF411_SS)
+#define USE_SOFTSERIAL1
+#define SOFTSERIAL_1_TX_PIN     PA15     // Instead of LED
+#define SOFTSERIAL_1_RX_PIN     PA15
+
+#define SERIAL_PORT_COUNT       4        // VCP, USART1, USART2, SS1
+#else
+#define SERIAL_PORT_COUNT       3        // VCP, USART1, USART2
+#endif
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE                    ADC1
+#define ADC_CHANNEL_1_PIN               PA1
+#define ADC_CHANNEL_2_PIN               PA0
+#define ADC_CHANNEL_3_PIN               PB1
+
+#define CURRENT_METER_ADC_CHANNEL       ADC_CHN_1
+#define VBAT_ADC_CHANNEL                ADC_CHN_2
+#define RSSI_ADC_CHANNEL                ADC_CHN_3
+
+// *************** LED2812 ************************
+#if !defined(JHEF411_SS)
+#define USE_LED_STRIP
+#define WS2811_PIN                      PA15
+#endif
+
+// ***************  OTHERS *************************
+#define DEFAULT_FEATURES                (FEATURE_TX_PROF_SEL | FEATURE_OSD | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_SOFTSERIAL)
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+#define USE_SERIALSHOT
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD        (BIT(2))
+
+#define MAX_PWM_OUTPUT_PORTS    4


### PR DESCRIPTION
Target for this AIO hardware from JHEMCU: GHF412AIO

https://www.aliexpress.com/item/1005003134128488.html
https://www.banggood.com/25_5x25_5mm-JHEMCU-GHF412AIO-F4-Flight-Controller-AIO-12A-BLheli_S-2-6S-4in1-Brushless-ESC-for-RC-Drone-FPV-Racing-p-1881146.html

Fixed issue with DShot on 3th ESC.
Two targets: the regualr (all mapping according manufacturer) and with Software Serial on LED pin (usefull for SA of Tramp)

Tested with GPS on UART1 + Mag on I2C, CRSF on UART2, Tramp on SS. and DShot600