### PR TITLE
Set speed for CXOF from configuration

### DIFF
--- a/src/main/io/opflow_cxof.c
+++ b/src/main/io/opflow_cxof.c
@@ -73,7 +73,7 @@ static bool cxofOpflowInit(void)
         return false;
     }
 
-    flowPort = openSerialPort(portConfig->identifier, FUNCTION_OPTICAL_FLOW, NULL, NULL, baudRates[BAUD_19200], MODE_RX, SERIAL_NOT_INVERTED);
+    flowPort = openSerialPort(portConfig->identifier, FUNCTION_OPTICAL_FLOW, NULL, NULL, baudRates[portConfig->gps_baudrateIndex], MODE_RX, SERIAL_NOT_INVERTED);
     if (!flowPort) {
         return false;
     }


### PR DESCRIPTION
Removed fixed speed for CXOF opflow protocol.

MSP openMV camera program from IDE example not supported. (incompatible MavLink version)

So, this is new version of firmware for openMV Camera to use with Inav with CXOF protocol. (With 115200 speed)

[openMVprogram.zip](https://github.com/iNavFlight/inav/files/7697300/openMVprogram.zip)

Also, you can use any opflow sensors from Aliexpress, with using some nano arduino boards with implemented simple CXOF protocol and connect it to Inav FC.
Tested sensors from Ali Express: 
SERIAL: (CXOF) GL-9306 - low quality, UP-FLOW-LC-302 - bad sensor,
SPI: CJMCU Optical Flow 1.0 - good sensor, CJMCU - 3901 - average sensor, need complex arduino program to implement.



