### PR TITLE
[cli.c] Fix external Flash Memory

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2248,6 +2248,11 @@ static void cliFlashInfo(char *cmdline)
     UNUSED(cmdline);
 
     const flashGeometry_t *layout = flashGetGeometry();
+    
+    if (layout->totalSize == 0) {
+        cliPrintLine("Flash not available");
+        return;
+    }
 
     cliPrintLinef("Flash sectors=%u, sectorSize=%u, pagesPerSector=%u, pageSize=%u, totalSize=%u",
             layout->sectors, layout->sectorSize, layout->pagesPerSector, layout->pageSize, layout->totalSize);
@@ -2277,6 +2282,13 @@ static void cliFlashErase(char *cmdline)
 {
     UNUSED(cmdline);
 
+    const flashGeometry_t *layout = flashGetGeometry();
+    
+    if (layout->totalSize == 0) {
+        cliPrintLine("Flash not available");
+        return;
+    }
+    
     cliPrintLine("Erasing...");
     flashfsEraseCompletely();
 


### PR DESCRIPTION
When the external flash memory, or the SD card is not present in the FC, give the command `flash_erase` and `flash_info`, makes the machine cycle lock, and can only be restored by turning the FC off and on again. Tested on Mamba F405 MK2 and Matek F405