### PR TITLE
Reversible ESC's for rovers: Don't start motor with high throttle in the mid of the stick

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -541,7 +541,7 @@ void FAST_CODE mixTable()
         motorValueWhenStopped = getReversibleMotorsThrottleDeadband();
         mixerThrottleCommand = constrain(rcCommand[THROTTLE], throttleRangeMin, throttleRangeMax);
 
-        #ifdef USE_DSHOT
+#ifdef USE_DSHOT
         if(isMotorProtocolDigital() && feature(FEATURE_REVERSIBLE_MOTORS) && reversibleMotorsThrottleState == MOTOR_DIRECTION_BACKWARD) {
             /*
              * We need to start the throttle output from stick input to start in the middle of the stick at the low and.
@@ -550,7 +550,7 @@ void FAST_CODE mixTable()
             int throttleDistanceToMax = throttleRangeMax - rcCommand[THROTTLE];
             mixerThrottleCommand = throttleRangeMin + throttleDistanceToMax;
         }
-        #endif
+#endif
     } else {
         mixerThrottleCommand = rcCommand[THROTTLE];
         throttleRangeMin = throttleIdleValue;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -541,6 +541,7 @@ void FAST_CODE mixTable()
         motorValueWhenStopped = getReversibleMotorsThrottleDeadband();
         mixerThrottleCommand = constrain(rcCommand[THROTTLE], throttleRangeMin, throttleRangeMax);
 
+        #ifdef USE_DSHOT
         if(isMotorProtocolDigital() && feature(FEATURE_REVERSIBLE_MOTORS) && reversibleMotorsThrottleState == MOTOR_DIRECTION_BACKWARD) {
             /*
              * We need to start the throttle output from stick input to start in the middle of the stick at the low and.
@@ -549,6 +550,7 @@ void FAST_CODE mixTable()
             int throttleDistanceToMax = throttleRangeMax - rcCommand[THROTTLE];
             mixerThrottleCommand = throttleRangeMin + throttleDistanceToMax;
         }
+        #endif
     } else {
         mixerThrottleCommand = rcCommand[THROTTLE];
         throttleRangeMin = throttleIdleValue;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -540,6 +540,15 @@ void FAST_CODE mixTable()
 
         motorValueWhenStopped = getReversibleMotorsThrottleDeadband();
         mixerThrottleCommand = constrain(rcCommand[THROTTLE], throttleRangeMin, throttleRangeMax);
+
+        if(feature(FEATURE_REVERSIBLE_MOTORS) && reversibleMotorsThrottleState == MOTOR_DIRECTION_BACKWARD) {
+            /*
+             * We need to start the throttle output from stick input to start in the middle of the stick at the low and.
+             * Without this, it's starting at the high side.
+             */
+            int throttleDistanceToMax = throttleRangeMax - rcCommand[THROTTLE];
+            mixerThrottleCommand = throttleRangeMin + throttleDistanceToMax;
+        }
     } else {
         mixerThrottleCommand = rcCommand[THROTTLE];
         throttleRangeMin = throttleIdleValue;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -541,7 +541,7 @@ void FAST_CODE mixTable()
         motorValueWhenStopped = getReversibleMotorsThrottleDeadband();
         mixerThrottleCommand = constrain(rcCommand[THROTTLE], throttleRangeMin, throttleRangeMax);
 
-        if(feature(FEATURE_REVERSIBLE_MOTORS) && reversibleMotorsThrottleState == MOTOR_DIRECTION_BACKWARD) {
+        if(isMotorProtocolDigital() && feature(FEATURE_REVERSIBLE_MOTORS) && reversibleMotorsThrottleState == MOTOR_DIRECTION_BACKWARD) {
             /*
              * We need to start the throttle output from stick input to start in the middle of the stick at the low and.
              * Without this, it's starting at the high side.


### PR DESCRIPTION
Hey, 
that's my very very first PR I'm creating so I'm very pleased about any hints ;)
Using reversible ESCs required a bit of workarounds. See https://github.com/iNavFlight/inav/issues/5767#issuecomment-635799400.
Reversible motors turning into one direction started from the high speed end at the center of the stick to the low speed end at the end of the throttle stick. 
This PR was tested by me with HAKRC_35A ESCs.