### PR TITLE
Changing the UP and DOWN symbols for the radar relative altitude display

### DIFF
--- a/src/main/io/osd_hud.c
+++ b/src/main/io/osd_hud.c
@@ -205,7 +205,7 @@ void osdHudDrawPoi(uint32_t poiDistance, int16_t poiDirection, int32_t poiAltitu
     if (((millis() / 1000) % 6 == 0) && poiType > 0) { // For Radar and WPs, display the difference in altitude
         altc = ((osd_unit_e)osdConfig()->units == OSD_UNIT_IMPERIAL) ? constrain(CENTIMETERS_TO_FEET(poiAltitude * 100), -99, 99) : constrain(poiAltitude, -99 , 99);
         tfp_sprintf(buff, "%3d", altc);
-        buff[0] = (poiAltitude >= 0) ? SYM_VARIO_UP_2A : SYM_VARIO_DOWN_2A;
+        buff[0] = (poiAltitude >= 0) ? SYM_HUD_ARROWS_U3 : SYM_HUD_ARROWS_D3;
     }
     else { // Display the distance by default 
         if ((osd_unit_e)osdConfig()->units == OSD_UNIT_IMPERIAL) {


### PR DESCRIPTION
The OSD font was changed before the PR was merged, leading to display errors in 4.1