### PR TITLE
Fixing the missing commands to ESC

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -60,7 +60,7 @@ FILE_COMPILE_FOR_SPEED
 
 #define DSHOT_DMA_BUFFER_SIZE   18 /* resolution + frame reset (2us) */
 
-#define DSHOT_COMMAND_INTERVAL_US 1000
+#define DSHOT_COMMAND_INTERVAL_US 10000
 #define DSHOT_COMMAND_QUEUE_LENGTH 8
 #define DHSOT_COMMAND_QUEUE_SIZE   DSHOT_COMMAND_QUEUE_LENGTH * sizeof(dshotCommands_e)
 #endif
@@ -373,12 +373,14 @@ static void executeDShotCommands(void){
         const int isTherePendingCommands = !circularBufferIsEmpty(&commandsCircularBuffer);
 
         if (isTherePendingCommands) {
+            timeUs_t lastCommandSent = micros() + DSHOT_COMMAND_INTERVAL_US;
             //Load the command
             dshotCommands_e cmd;
             circularBufferPopHead(&commandsCircularBuffer, (uint8_t *) &cmd);
 
             currentExecutingCommand.cmd = cmd;
             currentExecutingCommand.remainingRepeats = getDShotCommandRepeats(cmd);
+            while (lastCommandSent - micros() > 0);
         }
         else {
             return;


### PR DESCRIPTION
After using the turtle mode, depending on the configuration of the hardware, not all commands are apparently completely transferred to the ESCs. This means that some motors still have the wrong direction of rotation, even though the turtle mode has been deactivated. This queue addresses these issues.
The mentioned error has thus been eliminated
and i couldn't see any disadvantages, but i'm not a developer and grateful for any other better solution.