### PR TITLE
RTH Sanity Checking Fix

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -819,7 +819,6 @@ static const navigationFSMStateDescriptor_t navFSM[NAV_STATE_COUNT] = {
             [NAV_FSM_EVENT_ERROR]                          = NAV_STATE_IDLE,
             [NAV_FSM_EVENT_SWITCH_TO_IDLE]                 = NAV_STATE_IDLE,
             [NAV_FSM_EVENT_SWITCH_TO_ALTHOLD]              = NAV_STATE_ALTHOLD_INITIALIZE,
-            [NAV_FSM_EVENT_SWITCH_TO_RTH]                  = NAV_STATE_RTH_INITIALIZE,
             [NAV_FSM_EVENT_SWITCH_TO_WAYPOINT]             = NAV_STATE_WAYPOINT_INITIALIZE,
         }
     },
@@ -837,7 +836,6 @@ static const navigationFSMStateDescriptor_t navFSM[NAV_STATE_COUNT] = {
             [NAV_FSM_EVENT_SUCCESS]                        = NAV_STATE_EMERGENCY_LANDING_FINISHED,
             [NAV_FSM_EVENT_SWITCH_TO_IDLE]                 = NAV_STATE_IDLE,
             [NAV_FSM_EVENT_SWITCH_TO_ALTHOLD]              = NAV_STATE_ALTHOLD_INITIALIZE,
-            [NAV_FSM_EVENT_SWITCH_TO_RTH]                  = NAV_STATE_RTH_INITIALIZE,
             [NAV_FSM_EVENT_SWITCH_TO_WAYPOINT]             = NAV_STATE_WAYPOINT_INITIALIZE,
         }
     },


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/iNavFlight/inav/pull/7421 which breaks RTH Sanity Checking. This is caused by RTH reinitialising immediately after an Emergency Landing is triggered by Sanity Checking. This will reset the Sanity distance start point to the current position so the craft never has a chance to emergency land.

PR simply removes RTH from the Emergency Landing mode event switching preventing RTH from reinitialising. Only consequence is RTH will not automatically restart during an Emergency Landing caused by position sensor loss if the sensors start working again. More of a problem for Failsafe RTH rather then a switched RTH (where an Emergency Landing can be stopped by deselecting RTH).

This is a quick fix pending a better solution that allows RTH to restart automatically if sensors recover.

Not yet tested.