### PR TITLE
Fixing the missing commands to ESC

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -98,11 +98,6 @@ static pwmWriteFuncPtr         motorWritePtr = NULL;    // Function to write val
 static pwmOutputPort_t *       servos[MAX_SERVOS];
 static pwmWriteFuncPtr         servoWritePtr = NULL;    // Function to write value to motors
 
-#if defined(USE_DSHOT)
-static timeUs_t digitalMotorUpdateIntervalUs = 0;
-static timeUs_t digitalMotorLastUpdateUs;
-#endif
-
 static pwmOutputPort_t  beeperPwmPort;
 static pwmOutputPort_t *beeperPwm;
 static uint16_t beeperFrequency = 0;
@@ -112,6 +107,10 @@ static uint8_t allocatedOutputPortCount = 0;
 static bool pwmMotorsEnabled = true;
 
 #ifdef USE_DSHOT
+static timeUs_t digitalMotorUpdateIntervalUs = 0;
+static timeUs_t digitalMotorLastUpdateUs;
+static timeUs_t lastCommandSent = 0;
+    
 static circularBuffer_t commandsCircularBuffer;
 static uint8_t commandsBuff[DHSOT_COMMAND_QUEUE_SIZE];
 static currentExecutingCommand_t currentExecutingCommand;
@@ -366,13 +365,13 @@ static int getDShotCommandRepeats(dshotCommands_e cmd) {
     return repeats;
 }
 
-timeUs_t lastCommandSent = 0;
-
 static void executeDShotCommands(void){
+    
+    timeUs_t tNow = micros();
 
     if(currentExecutingCommand.remainingRepeats == 0) {
        const int isTherePendingCommands = !circularBufferIsEmpty(&commandsCircularBuffer);
-        if (isTherePendingCommands && (micros() - lastCommandSent > DSHOT_COMMAND_INTERVAL_US)){
+        if (isTherePendingCommands && (tNow - lastCommandSent > DSHOT_COMMAND_INTERVAL_US)){
             //Load the command
             dshotCommands_e cmd;
             circularBufferPopHead(&commandsCircularBuffer, (uint8_t *) &cmd);
@@ -387,7 +386,7 @@ static void executeDShotCommands(void){
          motors[i].value = currentExecutingCommand.cmd;
     }
     currentExecutingCommand.remainingRepeats--; 
-    lastCommandSent = micros();
+    lastCommandSent = tNow;
 }
 #endif
 


### PR DESCRIPTION
After using the turtle mode, depending on the configuration of the hardware, not all commands are apparently completely transferred to the ESCs. This means that some motors still have the wrong direction of rotation, even though the turtle mode has been deactivated. This queue addresses these issues.
The mentioned error has thus been eliminated
and i couldn't see any disadvantages, but i'm not a developer and grateful for any other better solution.