### PR TITLE
Fixes the returns inside bool and integer type functions

### DIFF
--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -140,9 +140,7 @@ static int32_t getTwosComplement(uint32_t raw, uint8_t length)
     if (raw & ((int)1 << (length - 1))) {
         return ((int32_t)raw) - ((int32_t)1 << length);
     }
-    else {
-        return raw;
-    }
+    return raw;
 }
 
 static bool deviceConfigure(busDevice_t * busDev)

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -518,9 +518,7 @@ ioTag_t pwmGetMotorPinTag(int motorIndex)
     if (motors[motorIndex].pwmPort) {
         return motors[motorIndex].pwmPort->tch->timHw->tag;
     }
-    else {
-        return IOTAG_NONE;
-    }
+    return IOTAG_NONE;
 }
 
 static void pwmServoWriteStandard(uint8_t index, uint16_t value)

--- a/src/main/drivers/rangefinder/rangefinder_srf10.c
+++ b/src/main/drivers/rangefinder/rangefinder_srf10.c
@@ -143,9 +143,7 @@ static int32_t srf10_get_distance(rangefinderDev_t *dev)
     if (isSensorResponding) {
         return srf10measurementCm;
     }
-    else {
-        return RANGEFINDER_HARDWARE_FAILURE;
-    }
+    return RANGEFINDER_HARDWARE_FAILURE;
 }
 
 static bool deviceDetect(busDevice_t * busDev)

--- a/src/main/drivers/rangefinder/rangefinder_vl53l0x.c
+++ b/src/main/drivers/rangefinder/rangefinder_vl53l0x.c
@@ -352,9 +352,7 @@ uint16_t encodeTimeout(uint16_t timeout_mclks)
 
         return (ms_byte << 8) | (ls_byte & 0xFF);
     }
-    else {
-        return 0;
-    }
+    return 0;
 }
 
 // Set the return signal rate limit check value in units of MCPS (mega counts
@@ -424,9 +422,7 @@ uint8_t getVcselPulsePeriod(busDevice_t * busDev, vcselPeriodType_e type)
     else if (type == VcselPeriodFinalRange) {
         return decodeVcselPeriod(readReg(busDev, VL53L0X_REG_FINAL_RANGE_CONFIG_VCSEL_PERIOD));
     }
-    else {
-        return 255;
-    }
+    return 255;
 }
 
 // Get sequence step timeouts
@@ -1141,9 +1137,7 @@ int32_t vl53l0x_GetDistance(rangefinderDev_t *dev)
             return RANGEFINDER_NO_NEW_DATA;
         }
     }
-    else {
-        return RANGEFINDER_HARDWARE_FAILURE;
-    }
+    return RANGEFINDER_HARDWARE_FAILURE;
 }
 
 static bool deviceDetect(busDevice_t * busDev)

--- a/src/main/drivers/rangefinder/rangefinder_vl53l1x.c
+++ b/src/main/drivers/rangefinder/rangefinder_vl53l1x.c
@@ -1648,9 +1648,7 @@ int32_t vl53l1x_GetDistance(rangefinderDev_t *dev)
             return RANGEFINDER_NO_NEW_DATA;
         }
     }
-    else {
-        return RANGEFINDER_HARDWARE_FAILURE;
-    }
+    return RANGEFINDER_HARDWARE_FAILURE;
 }
 
 static bool deviceDetect(busDevice_t * busDev)

--- a/src/main/drivers/sdcard/sdcard.c
+++ b/src/main/drivers/sdcard/sdcard.c
@@ -75,9 +75,7 @@ bool sdcard_isInserted(void)
         return result;
 #endif
     }
-    else {
-        return true;
-    }
+    return true;
 }
 
 /**
@@ -102,54 +100,48 @@ bool sdcard_readBlock(uint32_t blockIndex, uint8_t *buffer, sdcard_operationComp
 {
     if (sdcardVTable) {
         return sdcardVTable->readBlock(blockIndex, buffer, callback, callbackData);
-    } else {
-        return false;
     }
+    return false;
 }
 
 sdcardOperationStatus_e sdcard_beginWriteBlocks(uint32_t blockIndex, uint32_t blockCount)
 {
     if (sdcardVTable) {
         return sdcardVTable->beginWriteBlocks(blockIndex, blockCount);
-    } else {
-        return false;
     }
+    return false;
 }
 
 sdcardOperationStatus_e sdcard_writeBlock(uint32_t blockIndex, uint8_t *buffer, sdcard_operationCompleteCallback_c callback, uint32_t callbackData)
 {
     if (sdcardVTable) {
         return sdcardVTable->writeBlock(blockIndex, buffer, callback, callbackData);
-    } else {
-        return false;
-    }
+    } 
+    return false;
 }
 
 bool sdcard_poll(void)
 {
     if (sdcardVTable) {
         return sdcardVTable->poll();
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool sdcard_isFunctional(void)
 {
     if (sdcardVTable) {
         return sdcardVTable->isFunctional();
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool sdcard_isInitialized(void)
 {
     if (sdcardVTable) {
         return sdcardVTable->isInitialized();
-    } else {
-        return false;
-    }
+    } 
+    return false;
 }
 
 const sdcardMetadata_t* sdcard_getMetadata(void)
@@ -157,9 +149,7 @@ const sdcardMetadata_t* sdcard_getMetadata(void)
     if (sdcardVTable) {
         return sdcardVTable->getMetadata();
     }
-    else {
-        return NULL;
-    }
+    return NULL;
 }
 
 #endif

--- a/src/main/drivers/sdcard/sdcard_spi.c
+++ b/src/main/drivers/sdcard/sdcard_spi.c
@@ -236,9 +236,8 @@ static bool sdcardSpi_readOCRRegister(uint32_t *result)
     if (status == 0) {
         *result = (response[0] << 24) | (response[1] << 16) | (response[2] << 8) | response[3];
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 typedef enum {

--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -253,9 +253,8 @@ bool isUartIdle(serialPort_t *instance)
     if(USART_GetFlagStatus(s->USARTx, USART_FLAG_IDLE)) {
         uartClearIdleFlag(s);
         return true;
-    } else {
-        return false;
-    }
+    } 
+    return false;
 }
 
 const struct serialPortVTable uartVTable[] = {

--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -252,9 +252,8 @@ bool isUartIdle(serialPort_t *instance)
     if(__HAL_UART_GET_FLAG(&s->Handle, UART_FLAG_IDLE)) {
         __HAL_UART_CLEAR_IDLEFLAG(&s->Handle);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 const struct serialPortVTable uartVTable[] = {

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -299,9 +299,8 @@ static bool cliDumpPrintLinef(uint8_t dumpMask, bool equalsDefault, const char *
         cliPrintLinefva(format, va);
         va_end(va);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 static void cliWrite(uint8_t ch)
@@ -319,9 +318,8 @@ static bool cliDefaultPrintLinef(uint8_t dumpMask, bool equalsDefault, const cha
         cliPrintLinefva(format, va);
         va_end(va);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 static void cliPrintf(const char *format, ...)

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -329,9 +329,7 @@ static bool failsafeCheckStickMotion(void)
 
         return totalRcDelta >= failsafeConfig()->failsafe_stick_motion_threshold;
     }
-    else {
-        return true;
-    }
+    return true;
 }
 
 static failsafeProcedure_e failsafeChooseFailsafeProcedure(void)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -229,9 +229,7 @@ static float imuGetPGainScaleFactor(void)
     if (imuUseFastGains()) {
         return 10.0f;
     }
-    else {
-        return 1.0f;
-    }
+    return 1.0f;
 }
 
 static void imuResetOrientationQuaternion(const fpVector3_t * accBF)

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -165,9 +165,7 @@ int getServoCount(void)
     if (servoRuleCount) {
         return 1 + maxServoIndex - minServoIndex;
     }
-    else {
-        return 0;
-    }
+    return 0;
 }
 
 void loadCustomServoMixer(void)

--- a/src/main/io/rangefinder_benewake.c
+++ b/src/main/io/rangefinder_benewake.c
@@ -154,9 +154,7 @@ static int32_t benewakeRangefinderGetDistance(void)
         hasNewData = false;
         return (sensorData > 0) ? (sensorData) : RANGEFINDER_OUT_OF_RANGE;
     }
-    else {
-        return RANGEFINDER_NO_NEW_DATA;
-    }
+    return RANGEFINDER_NO_NEW_DATA;
 }
 
 virtualRangefinderVTable_t rangefinderBenewakeVtable = {

--- a/src/main/io/rangefinder_msp.c
+++ b/src/main/io/rangefinder_msp.c
@@ -67,9 +67,7 @@ static int32_t mspRangefinderGetDistance(void)
         hasNewData = false;
         return (sensorData > 0) ? sensorData : RANGEFINDER_OUT_OF_RANGE;
     }
-    else {
-        return RANGEFINDER_NO_NEW_DATA;
-    }
+    return RANGEFINDER_NO_NEW_DATA;
 }
 
 void mspRangefinderReceiveNewData(uint8_t * bufferPtr)

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1635,9 +1635,7 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_WAYPOINT_RTH_LAND(navig
         navOnEnteringState_NAV_STATE_RTH_FINISHING(previousState);
         return NAV_FSM_EVENT_SUCCESS;
     }
-    else {
-        return NAV_FSM_EVENT_NONE;
-    }
+    return NAV_FSM_EVENT_NONE;
 }
 
 static navigationFSMEvent_t navOnEnteringState_NAV_STATE_WAYPOINT_NEXT(navigationFSMState_t previousState)
@@ -2122,9 +2120,7 @@ static bool isWaypointPositionReached(const fpVector3_t * pos, const bool isWayp
         return (posControl.wpDistance <= navConfig()->general.waypoint_radius)
                 || (posControl.wpDistance <= (navConfig()->fw.loiter_radius * 1.10f));  // 10% margin of desired circular loiter radius
     }
-    else {
-        return (posControl.wpDistance <= navConfig()->general.waypoint_radius);
-    }
+    return (posControl.wpDistance <= navConfig()->general.waypoint_radius);
 }
 
 bool isWaypointReached(const navWaypointPosition_t * waypoint, const bool isWaypointHome)
@@ -2652,9 +2648,7 @@ static bool adjustAltitudeFromRCInput(void)
     if (STATE(FIXED_WING_LEGACY)) {
         return adjustFixedWingAltitudeFromRCInput();
     }
-    else {
-        return adjustMulticopterAltitudeFromRCInput();
-    }
+    return adjustMulticopterAltitudeFromRCInput();
 }
 
 /*-----------------------------------------------------------
@@ -2705,9 +2699,7 @@ static bool adjustHeadingFromRCInput(void)
     if (STATE(FIXED_WING_LEGACY)) {
         return adjustFixedWingHeadingFromRCInput();
     }
-    else {
-        return adjustMulticopterHeadingFromRCInput();
-    }
+    return adjustMulticopterHeadingFromRCInput();
 }
 
 /*-----------------------------------------------------------
@@ -3433,9 +3425,7 @@ bool navigationRequiresTurnAssistance(void)
         // For airplanes turn assistant is always required when controlling position
         return (currentState & (NAV_CTL_POS | NAV_CTL_ALT));
     }
-    else {
-        return false;
-    }
+    return false;
 }
 
 /**
@@ -3457,9 +3447,7 @@ int8_t navigationGetHeadingControlState(void)
             return NAV_HEADING_CONTROL_AUTO;
         }
     }
-    else {
-        return NAV_HEADING_CONTROL_NONE;
-    }
+    return NAV_HEADING_CONTROL_NONE;
 }
 
 bool navigationTerrainFollowingEnabled(void)
@@ -3870,9 +3858,7 @@ rthState_e getStateOfForcedRTH(void)
             return RTH_IN_PROGRESS;
         }
     }
-    else {
-        return RTH_IDLE;
-    }
+    return RTH_IDLE;
 }
 
 /*-----------------------------------------------------------

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -254,9 +254,7 @@ bool adjustMulticopterHeadingFromRCInput(void)
 
         return true;
     }
-    else {
-        return false;
-    }
+    return false;
 }
 
 /*-----------------------------------------------------------
@@ -726,9 +724,7 @@ bool isMulticopterLandingDetected(void)
         landingTimer = currentTimeUs;
         return false;
     }
-    else {
-        return ((currentTimeUs - landingTimer) > (navConfig()->mc.auto_disarm_delay * 1000)) ? true : false;
-    }
+    return ((currentTimeUs - landingTimer) > (navConfig()->mc.auto_disarm_delay * 1000)) ? true : false;
 }
 
 /*-----------------------------------------------------------

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -102,9 +102,7 @@ static bool updateTimer(navigationTimer_t * tim, timeUs_t interval, timeUs_t cur
         tim->lastTriggeredTime = currentTimeUs;
         return true;
     }
-    else {
-        return false;
-    }
+    return false;
 }
 
 static bool shouldResetReferenceAltitude(void)

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -362,9 +362,7 @@ bool compassIsCalibrationComplete(void)
     if (STATE(COMPASS_CALIBRATED)) {
         return true;
     }
-    else {
-        return false;
-    }
+    return false;
 }
 
 void compassUpdate(timeUs_t currentTimeUs)

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -89,9 +89,7 @@ static int getTelemetryMotorCount(void)
     if (escSensorConfig()->listenOnly) {
         return 1;
     }
-    else {
-        return getMotorCount();
-    }
+    return getMotorCount();
 }
 
 static void escSensorSelectNextMotor(void)
@@ -201,9 +199,7 @@ escSensorData_t * escSensorGetData(void)
     if (escSensorDataCombined.dataAge >= ESC_DATA_INVALID) {
         return NULL;
     }
-    else {
-        return &escSensorDataCombined;
-    }
+    return &escSensorDataCombined;
 }
 
 bool escSensorInitialize(void)

--- a/src/main/target/ALIENFLIGHTF3/hardware_revision.c
+++ b/src/main/target/ALIENFLIGHTF3/hardware_revision.c
@@ -66,7 +66,5 @@ const extiConfig_t *selectMPUIntExtiConfigByHardwareRevision(void)
     if (hardwareRevision == AFF3_REV_1) {
         return &alienFlightF3V1MPUIntExtiConfig;
     }
-    else {
-        return &alienFlightF3V2MPUIntExtiConfig;
-    }
+    return &alienFlightF3V2MPUIntExtiConfig;
 }


### PR DESCRIPTION
This fixes some return functions. There were few changes, and this PR is easy to review.

example of what it currently looks like:

```
bool get_actual_state (void) {
   if (condition) {
         return true;
   } else {
         return false;
    }
}
```

Changed to:

```
bool get_actual_state (void) {
   if (condition) {
         return true;
   }
    return false;
}
```

Yes, the compiler should complain about that, but it unfortunately doesn't.