### PR TITLE
BMI270: Fix acc alignment

### DIFF
--- a/src/main/drivers/accgyro/accgyro_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_bmi270.c
@@ -274,8 +274,8 @@ static bool bmi270AccReadScratchpad(accDev_t *acc)
     bmi270ContextData_t * ctx = busDeviceGetScratchpadMemory(acc->busDev);
 
     if (ctx->lastReadStatus) {
-        acc->ADCRaw[X] = -(int16_t)((ctx->accRaw[1] << 8) | ctx->accRaw[0]);
-        acc->ADCRaw[Y] = -(int16_t)((ctx->accRaw[3] << 8) | ctx->accRaw[2]);
+        acc->ADCRaw[X] = (int16_t)((ctx->accRaw[1] << 8) | ctx->accRaw[0]);
+        acc->ADCRaw[Y] = (int16_t)((ctx->accRaw[3] << 8) | ctx->accRaw[2]);
         acc->ADCRaw[Z] = (int16_t)((ctx->accRaw[5] << 8) | ctx->accRaw[4]);
         return true;
     }
@@ -323,6 +323,7 @@ bool bmi270AccDetect(accDev_t *acc)
 
     acc->initFn = bmi270AccInit;
     acc->readFn = bmi270AccReadScratchpad;
+    acc->accAlign = acc->busDev->param;
 
     return true;
 }


### PR DESCRIPTION
The acc alignment wasn't set for the BMI270, so it was only working correctly when the BMI270 was mounted 0 deg rotated. 

In #7662 the X and Y axes were inverted to make it work with the MAMBA H743, which has the BMI270 mounted 180 degree rotated. But this made it no longer work for other orientations.

This fixes it by setting the `accAlign`, so it works for any orientation.