### PR TITLE
Fix compilation when USE_SECONDARY_IMU not defined

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -3344,7 +3344,11 @@ static void cliStatus(char *cmdline)
         hardwareSensorStatusNames[getHwRangefinderStatus()],
         hardwareSensorStatusNames[getHwOpticalFlowStatus()],
         hardwareSensorStatusNames[getHwGPSStatus()],
+#ifdef USE_SECONDARY_IMU
         hardwareSensorStatusNames[getHwSecondaryImuStatus()]
+#else
+        hardwareSensorStatusNames[0]
+#endif
     );
 
 #ifdef USE_ESC_SENSOR

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -425,7 +425,11 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         sbufWriteU8(dst, getHwRangefinderStatus());
         sbufWriteU8(dst, getHwPitotmeterStatus());
         sbufWriteU8(dst, getHwOpticalFlowStatus());
+#ifdef USE_SECONDARY_IMU
         sbufWriteU8(dst, getHwSecondaryImuStatus());
+#else
+        sbufWriteU8(dst, 0);
+#endif
         break;
 
     case MSP_ACTIVEBOXES:

--- a/src/main/flight/secondary_imu.c
+++ b/src/main/flight/secondary_imu.c
@@ -22,6 +22,9 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
+#include "platform.h"
+#ifdef USE_SECONDARY_IMU
+
 #include "stdint.h"
 
 #include "build/debug.h"
@@ -257,3 +260,5 @@ hardwareSensorStatus_e getHwSecondaryImuStatus(void)
     return HW_SENSOR_NONE;
 #endif
 }
+
+#endif

--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -227,7 +227,11 @@ bool isHardwareHealthy(void)
     const hardwareSensorStatus_e pitotStatus = getHwPitotmeterStatus();
     const hardwareSensorStatus_e gpsStatus = getHwGPSStatus();
     const hardwareSensorStatus_e opflowStatus = getHwOpticalFlowStatus();
+#ifdef USE_SECONDARY_IMU
     const hardwareSensorStatus_e imu2Status = getHwSecondaryImuStatus();
+#else
+    const hardwareSensorStatus_e imu2Status = HW_SENSOR_NONE;
+#endif
 
     // Sensor is considered failing if it's either unavailable (selected but not detected) or unhealthy (returning invalid readings)
     if (gyroStatus == HW_SENSOR_UNAVAILABLE || gyroStatus == HW_SENSOR_UNHEALTHY)


### PR DESCRIPTION
Code wasn't compiling unless `USE_SECONDARY_IMU` is defined