### PR TITLE
Docker build script shebang fix and extended usage notes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,9 +7,15 @@ Usage syntax: ./build.sh <TARGET>
 
 Notes:
   * You can specify multiple targets.
-  * If no targets are specified, *all* of them will be built.
+    ./build.sh <TARGET_1> <TARGET_2> <TARGET_N>
+  * To get a list of all targets use \"help\". Hint: pipe the output through a pager.
+    ./build.sh help | less
+  * To build all targets use \"all\"
+    ./build.sh all
   * To clean a target prefix it with \"clean_\".
-  * To clean all targets just use \"clean\"."
+    ./build.sh clean_MATEKF405SE
+  * To clean all targets just use \"clean\".
+    ./build.sh clean"
   exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e
 
 if [[ $# == 0 ]]; then

--- a/docs/development/Building in Docker.md
+++ b/docs/development/Building in Docker.md
@@ -20,6 +20,12 @@ Where `<TARGET>` must be replaced with the name of the target that you want to b
 ./build.sh MATEKF405SE
 ```
 
+Run the script with no arguments to get more details on its usage:
+
+```
+./build.sh
+```
+
 ## Windows 10
 
 Docker on Windows requires full paths for mounting volumes in `docker run` commands. For example: `c:\Users\pspyc\Documents\Projects\inav` becomes `//c/Users/pspyc/Documents/Projects/inav` .


### PR DESCRIPTION
This PR doesn't change the behavior / functionality of the Docker build script. It only adds the missing Bash shebang (`#!`) that prevents the script from running on non-Bash shells (e.g. `zsh`). Also some basic usage notes/examples are added similar to the ones in the native build docs.
