### PR TITLE
[Multirotor] New approach to to Throttle compensated by Roll/Pitch angles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/${TOOLCHAIN}-checks.cmake")
 endif()
 
-project(INAV VERSION 4.0.0)
+project(INAV VERSION 5.0.0)
 
 enable_language(ASM)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/${TOOLCHAIN}-checks.cmake")
 endif()
 
-project(INAV VERSION 5.0.0)
+project(INAV VERSION 4.0.0)
 
 enable_language(ASM)
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -5472,6 +5472,16 @@ Throttle value when the stick is set to mid-position. Used in the throttle curve
 
 ---
 
+### throttle_angle_boost
+
+Can be used in ANGLE and HORIZON mode and will automatically boost throttle when banking.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| ON | OFF | ON |
+
+---
+
 ### throttle_idle
 
 The percentage of the throttle range (`max_throttle` - `min_command`) above `min_command` used for minimum / idle throttle.
@@ -5489,16 +5499,6 @@ Throttle scaling factor. `1` means no throttle scaling. `0.5` means throttle sca
 | Default | Min | Max |
 | --- | --- | --- |
 | 1.0 | 0 | 1 |
-
----
-
-### throttle_tilt_comp_str
-
-Can be used in ANGLE and HORIZON mode and will automatically boost throttle when banking. Setting is in percentage, 0=disabled.
-
-| Default | Min | Max |
-| --- | --- | --- |
-| 0 | 0 | 100 |
 
 ---
 
@@ -5708,7 +5708,7 @@ Enable the alternate softserial method. This is the method used in iNav 3.0 and 
 
 | Default | Min | Max |
 | --- | --- | --- |
-| ON |  |  |
+| ON | OFF | ON |
 
 ---
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -119,7 +119,7 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
 #ifdef USE_UNDERCLOCK
     .cpuUnderclock = SETTING_CPU_UNDERCLOCK_DEFAULT,
 #endif
-    .throttle_tilt_compensation_strength = SETTING_THROTTLE_TILT_COMP_STR_DEFAULT,      // 0-100, 0 - disabled
+    .throttle_angle_boost_enabled = SETTING_THROTTLE_ANGLE_BOOST_DEFAULT,
     .name = SETTING_NAME_DEFAULT
 );
 

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -74,7 +74,7 @@ typedef struct systemConfig_s {
 #ifdef USE_UNDERCLOCK
     uint8_t cpuUnderclock;
 #endif
-    uint8_t throttle_tilt_compensation_strength;    // the correction that will be applied at throttle_correction_angle.
+    uint8_t throttle_angle_boost_enabled;
     char name[MAX_NAME_LENGTH + 1];
 } systemConfig_t;
 

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -74,7 +74,7 @@ typedef struct systemConfig_s {
 #ifdef USE_UNDERCLOCK
     uint8_t cpuUnderclock;
 #endif
-    uint8_t throttle_angle_boost_enabled;
+    bool throttle_angle_boost_enabled;
     char name[MAX_NAME_LENGTH + 1];
 } systemConfig_t;
 

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -863,10 +863,12 @@ fpVector3_t *optimizedQuaternionRotateVectorInv(fpVector3_t * result, fpVector3_
     return result;
 }
 
-static void multicopterUpdateThrottleBoosted(float throttle_input)
+static void multicopterUpdateThrottleBoosted(void)
 {
     if (systemConfig()->throttle_angle_boost_enabled) {
         
+        float throttle_input = (float)rcCommand[THROTTLE];
+
         fpVector3_t thrust_vector_up = { .v = { 0.0f, 0.0f, -1.0f } }; // the direction of thrust
         fpVector3_t body_thrust; // current impulse in the inertial frame
    
@@ -921,7 +923,7 @@ void taskMainPidLoop(timeUs_t currentTimeUs)
 
     // Apply throttle boost
     if (!STATE(FIXED_WING_LEGACY)) {
-        multicopterUpdateThrottleBoosted(rcCommand[THROTTLE]);
+        multicopterUpdateThrottleBoosted();
     }
     else {
         // FIXME: throttle pitch comp for FW

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -846,6 +846,10 @@ static void multirotorUpdateThrottleBoosted(void)
         return; // Exit immediately if multirotor mode is not active
     }
 
+    if (!FLIGHT_MODE(ANGLE_MODE) && !FLIGHT_MODE(HORIZON_MODE)) {
+        return; // Exit immediately if acro mode is active
+    }
+    
     if (systemConfig()->throttle_angle_boost_enabled) {
         
         float throttle_input = (float)rcCommand[THROTTLE];

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -391,17 +391,17 @@ void annexCode(float dT)
             rcCommand[PITCH] = rcCommand[PITCH] * currentControlRateProfile->manual.rates[FD_PITCH] / 100L;
             rcCommand[YAW] = rcCommand[YAW] * currentControlRateProfile->manual.rates[FD_YAW] / 100L;
         } else {
-            //DEBUG_SET(DEBUG_RATE_DYNAMICS, 0, rcCommand[ROLL]);
+            DEBUG_SET(DEBUG_RATE_DYNAMICS, 0, rcCommand[ROLL]);
             rcCommand[ROLL] = applyRateDynamics(rcCommand[ROLL], ROLL, dT);
-            //DEBUG_SET(DEBUG_RATE_DYNAMICS, 1, rcCommand[ROLL]);
+            DEBUG_SET(DEBUG_RATE_DYNAMICS, 1, rcCommand[ROLL]);
 
-            //DEBUG_SET(DEBUG_RATE_DYNAMICS, 2, rcCommand[PITCH]);
+            DEBUG_SET(DEBUG_RATE_DYNAMICS, 2, rcCommand[PITCH]);
             rcCommand[PITCH] = applyRateDynamics(rcCommand[PITCH], PITCH, dT);
-            //DEBUG_SET(DEBUG_RATE_DYNAMICS, 3, rcCommand[PITCH]);
+            DEBUG_SET(DEBUG_RATE_DYNAMICS, 3, rcCommand[PITCH]);
 
-            //DEBUG_SET(DEBUG_RATE_DYNAMICS, 4, rcCommand[YAW]);
+            DEBUG_SET(DEBUG_RATE_DYNAMICS, 4, rcCommand[YAW]);
             rcCommand[YAW] = applyRateDynamics(rcCommand[YAW], YAW, dT);
-            //DEBUG_SET(DEBUG_RATE_DYNAMICS, 5, rcCommand[YAW]);
+            DEBUG_SET(DEBUG_RATE_DYNAMICS, 5, rcCommand[YAW]);
 
         }
 

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -840,29 +840,6 @@ void FAST_CODE taskGyro(timeUs_t currentTimeUs) {
 #endif
 }
 
-fpVector3_t *optimizedQuaternionRotateVectorInv(fpVector3_t * result, fpVector3_t * vec, fpQuaternion_t * ref)
-{
-    fpVector3_t vectQuat;
-
-    result->x = vec->x;
-    result->y = vec->y;
-    result->z = vec->z;
-
-    vectQuat.x = ref->q2 * vec->z - ref->q3 * vec->y;
-    vectQuat.y = ref->q3 * vec->x - ref->q1 * vec->z;
-    vectQuat.z = ref->q1 * vec->y - ref->q2 * vec->x;
-
-    vectQuat.x += vectQuat.x;
-    vectQuat.y += vectQuat.y;
-    vectQuat.z += vectQuat.z;
-
-    result->x += ref->q0 * vectQuat.x + ref->q2 * vectQuat.z - ref->q3 * vectQuat.y;
-    result->y += ref->q0 * vectQuat.y + ref->q3 * vectQuat.x - ref->q1 * vectQuat.z;
-    result->z += ref->q0 * vectQuat.z + ref->q1 * vectQuat.y - ref->q2 * vectQuat.x;
-
-    return result;
-}
-
 static void multicopterUpdateThrottleBoosted(void)
 {
     if (systemConfig()->throttle_angle_boost_enabled) {
@@ -872,7 +849,6 @@ static void multicopterUpdateThrottleBoosted(void)
         fpVector3_t thrust_vector_up = { .v = { 0.0f, 0.0f, -1.0f } }; // the direction of thrust
         fpVector3_t body_thrust; // current impulse in the inertial frame
    
-        //optimizedQuaternionRotateVectorInv(&body_thrust, &thrust_vector_up, &orientation);
         quaternionRotateVectorInv(&body_thrust, &thrust_vector_up, &orientation);
 
         imuTransformVectorBodyToEarth(&body_thrust);

--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -404,14 +404,14 @@ uint16_t packSensorStatus(void)
 {
     // Sensor bits
     uint16_t sensorStatus =
-            IS_ENABLED(sensors(SENSOR_ACC))     << 0 |
-            IS_ENABLED(sensors(SENSOR_BARO))    << 1 |
-            IS_ENABLED(sensors(SENSOR_MAG))     << 2 |
-            IS_ENABLED(sensors(SENSOR_GPS))     << 3 |
-            IS_ENABLED(sensors(SENSOR_RANGEFINDER))   << 4 |
-            IS_ENABLED(sensors(SENSOR_OPFLOW))  << 5 |
-            IS_ENABLED(sensors(SENSOR_PITOT))   << 6 |
-            IS_ENABLED(sensors(SENSOR_TEMP))   << 7;
+            IS_ENABLED(sensors(SENSOR_ACC))         << 0 |
+            IS_ENABLED(sensors(SENSOR_BARO))        << 1 |
+            IS_ENABLED(sensors(SENSOR_MAG))         << 2 |
+            IS_ENABLED(sensors(SENSOR_GPS))         << 3 |
+            IS_ENABLED(sensors(SENSOR_RANGEFINDER)) << 4 |
+            IS_ENABLED(sensors(SENSOR_OPFLOW))      << 5 |
+            IS_ENABLED(sensors(SENSOR_PITOT))       << 6 |
+            IS_ENABLED(sensors(SENSOR_TEMP))        << 7;
 
     // Hardware failure indication bit
     if (!isHardwareHealthy()) {

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3487,12 +3487,11 @@ groups:
         description: "Defines debug values exposed in debug variables (developer / debugging setting)"
         default_value: "NONE"
         table: debug_modes
-      - name: throttle_tilt_comp_str
-        description: "Can be used in ANGLE and HORIZON mode and will automatically boost throttle when banking. Setting is in percentage, 0=disabled."
-        default_value: 0
-        field: throttle_tilt_compensation_strength
-        min: 0
-        max: 100
+      - name: throttle_angle_boost
+        description: "Can be used in ANGLE and HORIZON mode and will automatically boost throttle when banking."
+        default_value: ON
+        field: throttle_angle_boost_enabled
+        type: bool
       - name: name
         description: "Craft name"
         default_value: ""


### PR DESCRIPTION
This PR makes:

- Rotates the body thrust by quaternion to obtain the current impulse in the inertial frame
- It calculates the angle boost to be based on the target lean angle. This reduces oscillation due to poor attitude control (bad tunes).
- It is no longer limited to 50 degrees.
- Inverted_factor is 1 for tilt angles below 60 degrees. Inverted_factor reduces from 1 to 0 for tilt angles between 60 and 90 degrees.
- It delays the reduction of throttle to 84 degrees providing support for aircraft capable of thrust to weight ratios of 10:1.
- It no longer has the parameter `throttle_tilt_comp_str` configurable from 0 to 100. Now there is only one parameter `throttle_angle_boost` of ON/OFF state to activate the Throttle Boost, by default it is activated.

Note:

This was a PR I was going to release next weekend, but I'm going to release it at once because it's stuck on my branch. I have a lot of ideas for improvements to iNav, Jetrell knows that, but this toxic community of people who call themselves "developers" is discouraging me, and I don't intend to put my ideas into practice here anymore, this will be the last. At EmuFlight I was welcomed better and I have the utmost respect from them for that, but unfortunately my ideas for improvements revolve around the autopilot system, and unfortunately that's not their focus, that's why I came to iNav.