### PR TITLE
Crsf power states redo

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2015,7 +2015,7 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_CRSF_RSSI_DBM:
         {
             int16_t rssi = rxLinkStatistics.uplinkRSSI;
-            buff[0] = (rxLinkStatistics.activeAnt == 0) ? SYM_RSSI : SYM_2RSS; // Separate symbols for each antenna
+            buff[0] = (rxLinkStatistics.activeAntenna == 0) ? SYM_RSSI : SYM_2RSS; // Separate symbols for each antenna
             if (rssi <= -100) {
                 tfp_sprintf(buff + 1, "%4d%c", rssi, SYM_DBM);
             } else {

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -48,6 +48,7 @@ FILE_COMPILE_FOR_SPEED
 #define CRSF_DIGITAL_CHANNEL_MIN 172
 #define CRSF_DIGITAL_CHANNEL_MAX 1811
 #define CRSF_PAYLOAD_OFFSET offsetof(crsfFrameDef_t, type)
+#define CRSF_POWER_COUNT 9
 
 STATIC_UNIT_TESTED bool crsfFrameDone = false;
 STATIC_UNIT_TESTED crsfFrame_t crsfFrame;
@@ -59,8 +60,7 @@ static timeUs_t crsfFrameStartAt = 0;
 static uint8_t telemetryBuf[CRSF_FRAME_SIZE_MAX];
 static uint8_t telemetryBufLen = 0;
 
-// The power levels represented by uplinkTXPower above in mW (250mW added to full TX in v4.00 firmware, 50mW added for ExpressLRS)
-const uint16_t crsfPowerStates[] = {0, 10, 25, 100, 500, 1000, 2000, 250, 50};
+const uint16_t crsfTxPowerStatesmW[CRSF_POWER_COUNT] = {0, 10, 25, 100, 500, 1000, 2000, 250, 50};
 
 /*
  * CRSF protocol
@@ -122,7 +122,6 @@ typedef struct crsfPayloadLinkStatistics_s {
     uint8_t     downlinkRSSI;
     uint8_t     downlinkLQ;
     int8_t      downlinkSNR;
-    uint8_t     activeAnt;
 } __attribute__ ((__packed__)) crsfPayloadLinkStatistics_t;
 
 typedef struct crsfPayloadLinkStatistics_s crsfPayloadLinkStatistics_t;
@@ -234,13 +233,14 @@ STATIC_UNIT_TESTED uint8_t crsfFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)
             crsfFrame.frame.frameLength = CRSF_FRAME_LINK_STATISTICS_PAYLOAD_SIZE + CRSF_FRAME_LENGTH_TYPE_CRC;
 
             const crsfPayloadLinkStatistics_t* linkStats = (crsfPayloadLinkStatistics_t*)&crsfFrame.frame.payload;
+            const uint8_t crsftxpowerindex = (linkStats->uplinkTXPower < CRSF_POWER_COUNT) ? linkStats->uplinkTXPower : 0;
 
             rxLinkStatistics.uplinkRSSI = -1* (linkStats->activeAntenna ? linkStats->uplinkRSSIAnt2 : linkStats->uplinkRSSIAnt1);
             rxLinkStatistics.uplinkLQ = linkStats->uplinkLQ;
             rxLinkStatistics.uplinkSNR = linkStats->uplinkSNR;
             rxLinkStatistics.rfMode = linkStats->rfMode;
-            rxLinkStatistics.uplinkTXPower = crsfPowerStates[linkStats->uplinkTXPower];
-            rxLinkStatistics.activeAnt = linkStats->activeAntenna;
+            rxLinkStatistics.uplinkTXPower = crsfTxPowerStatesmW[crsftxpowerindex];
+            rxLinkStatistics.activeAntenna = linkStats->activeAntenna;
 
             if (rxLinkStatistics.uplinkLQ > 0) {
                 int16_t uplinkStrength;   // RSSI dBm converted to %

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -191,7 +191,7 @@ typedef struct rxLinkStatistics_s {
     int8_t      uplinkSNR;      // The SNR of the uplink in dB
     uint8_t     rfMode;         // A protocol specific measure of the transmission bandwidth [2 = 150Hz, 1 = 50Hz, 0 = 4Hz]
     uint16_t    uplinkTXPower;  // power in mW
-    uint8_t     activeAnt;
+    uint8_t     activeAntenna;
 } rxLinkStatistics_t;
 
 extern rxRuntimeConfig_t rxRuntimeConfig; //!!TODO remove this extern, only needed once for channelCount
@@ -227,5 +227,5 @@ uint16_t rxGetRefreshRate(void);
 
 // Processed RC channel value. These values might include
 // filtering and some extra processing like value holding
-// during failsafe. 
+// during failsafe.
 int16_t rxGetChannelValue(unsigned channelNumber);


### PR DESCRIPTION
Removed extra stat for TX power used for OSD that was not part of the protocol. OSD now uses the correct stat. Also changed the mW power array/stat for future CRSFv3 port.