### PR TITLE
Failsafe RC adjustment bug fix

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3142,6 +3142,7 @@ static void processNavigationRCAdjustments(void)
             if (!STATE(FIXED_WING_LEGACY)) {
                 resetMulticopterBrakingMode();
             }
+            posControl.flags.isAdjustingPosition = false;
         }
     }
     else {

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3135,14 +3135,9 @@ static void processNavigationRCAdjustments(void)
     }
 
     if (navStateFlags & NAV_RC_POS) {
-        if (!FLIGHT_MODE(FAILSAFE_MODE)) {
-            posControl.flags.isAdjustingPosition = adjustPositionFromRCInput();
-        }
-        else {
-            if (!STATE(FIXED_WING_LEGACY)) {
-                resetMulticopterBrakingMode();
-            }
-            posControl.flags.isAdjustingPosition = false;
+        posControl.flags.isAdjustingPosition = adjustPositionFromRCInput() && !FLIGHT_MODE(FAILSAFE_MODE);
+        if (STATE(MULTIROTOR) && FLIGHT_MODE(FAILSAFE_MODE)) {
+            resetMulticopterBrakingMode();
         }
     }
     else {


### PR DESCRIPTION
Closes https://github.com/iNavFlight/inav/discussions/7826.

Ensures RC input adjustment is always disabled (`posControl.flags.isAdjustingPosition` set `false`) when failsafe active.