### PR TITLE
Adjust CMS and statistics page layout for HD OSD

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -167,9 +167,12 @@ displayPort_t *cmsDisplayPortGetCurrent(void)
 //   30 cols x 13 rows
 // HoTT Telemetry Screen
 //   21 cols x 8 rows
+// HD
+//   50 cols x 18 rows
 //
 
 #define NORMAL_SCREEN_MIN_COLS 18      // Less is a small screen
+#define NORMAL_SCREEN_MAX_COLS 30      // More is a big screen
 static bool smallScreen;
 static uint8_t leftMenuColumn;
 static uint8_t rightMenuColumn;
@@ -797,9 +800,14 @@ void cmsMenuOpen(void)
     } else {
         smallScreen = false;
         linesPerMenuItem = 1;
-        leftMenuColumn = 2;
-        rightMenuColumn = pCurrentDisplay->cols - 2;
         maxMenuItems = pCurrentDisplay->rows - 2;
+        if (pCurrentDisplay->cols > NORMAL_SCREEN_MAX_COLS) {
+            leftMenuColumn = 7;
+            rightMenuColumn = pCurrentDisplay->cols - 7;
+        } else {
+            leftMenuColumn = 2;
+            rightMenuColumn = pCurrentDisplay->cols - 2;
+        }
     }
 
     if (pCurrentDisplay->useFullscreen) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -32,7 +32,7 @@
 #include "platform.h"
 
 FILE_COMPILE_FOR_SPEED
-#define USE_OSD
+
 #ifdef USE_OSD
 
 #include "build/debug.h"


### PR DESCRIPTION
The CMS and statistics screens are cropped on the LHS when in HD 4:3 cut mode, making them unusable.
These changes adjust the columns of the elements to ensure the screens are fully visible when in HD mode.

(changes tested on both Analog and Digital HD systems)