### PR TITLE
Add support to BMI270 for IFLIGHT BLITZ F722

### DIFF
--- a/src/main/target/IFLIGHT_BLITZ_F722/target.h
+++ b/src/main/target/IFLIGHT_BLITZ_F722/target.h
@@ -36,6 +36,11 @@
 #define USE_MPU_DATA_READY_SIGNAL
 #define GYRO_INT_EXTI           PC4
 
+#define USE_IMU_BMI270
+#define IMU_BMI270_ALIGN       CW0_DEG
+#define BMI270_CS_PIN          PA4
+#define BMI270_SPI_BUS         BUS_SPI1
+
 #define USE_IMU_MPU6000
 #define IMU_MPU6000_ALIGN       CW0_DEG
 #define MPU6000_CS_PIN          PA4


### PR DESCRIPTION
As right now IFlightRC is selling the FC IFLIGHT BLITZ F722 with BMI270  I have added the define for BMI270 , it's using the same BUS and alignment of MPU6000.