### PR TITLE
Added possibility to shift GPS lat/lon to a custom value. Useful for …

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4222,6 +4222,26 @@ Value under which the OSD axis g force indicators will blink (g)
 
 ---
 
+### osd_gps_shift_lat
+
+Value to shift GPS latitude (lat + osd_gps_shift_lat/100)
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | 9999 | -9999 |
+
+---
+
+### osd_gps_shift_lon
+
+Value to shift GPS longitude (lon + osd_gps_shift_lon/100)
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | 9999 | -9999 |
+
+---
+
 ### osd_home_position_arm_screen
 
 Should home position coordinates be displayed on the arming screen.

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3138,6 +3138,18 @@ groups:
         field: gforce_axis_alarm_max
         min: -20
         max: 20
+      - name: osd_gps_shift_lat
+        description: "Value to shift GPS latitude (lat + osd_gps_shift_lat/100)"
+        default_value: 0
+        field: gps_shift_lat
+        min: -9999
+        max: 9999
+      - name: osd_gps_shift_lon
+        description: "Value to shift GPS longitude (lon + osd_gps_shift_lon/100)"
+        default_value: 0
+        field: gps_shift_lon
+        min: -9999
+        max: 9999
       - name: osd_imu_temp_alarm_min
         description: "Temperature under which the IMU temperature OSD element will start blinking (decidegrees centigrade)"
         default_value: -200

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1653,7 +1653,7 @@ static bool osdDrawSingleElement(uint8_t item)
         break;
 
     case OSD_GPS_LON:
-		osdFormatCoordinate(buff, SYM_LON, gpsSol.llh.lon);
+        osdFormatCoordinate(buff, SYM_LON, gpsSol.llh.lon);
         break;
 
     case OSD_HOME_DIR:

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -697,6 +697,18 @@ static void osdFormatCoordinate(char *buff, char sym, int32_t val)
     // up to 4 for number + 1 for the symbol + null terminator + fill the rest with decimals
     const int coordinateLength = osdConfig()->coordinate_digits + 1;
 
+	if (val != 0) {
+		switch (sym) {
+			case SYM_LAT:
+				val = val + osdConfig()->gps_shift_lat * 100000;
+				break;
+			case SYM_LON:
+				val = val + osdConfig()->gps_shift_lon * 100000;
+				break;
+			default:
+				break;
+		}
+	}
     buff[0] = sym;
     int32_t integerPart = val / GPS_DEGREES_DIVIDER;
     // Latitude maximum integer width is 3 (-90) while
@@ -1641,7 +1653,7 @@ static bool osdDrawSingleElement(uint8_t item)
         break;
 
     case OSD_GPS_LON:
-        osdFormatCoordinate(buff, SYM_LON, gpsSol.llh.lon);
+		osdFormatCoordinate(buff, SYM_LON, gpsSol.llh.lon);
         break;
 
     case OSD_HOME_DIR:

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -393,6 +393,8 @@ typedef struct osdConfig_s {
     uint8_t ahi_width;                  // In pixels, only used by the AHI widget
     uint8_t ahi_height;                 // In pixels, only used by the AHI widget
     int8_t  ahi_vertical_offset;        // Offset from center in pixels. Positive moves the AHI down. Widget only.
+    int16_t gps_shift_lat;
+    int16_t gps_shift_lon;
     int8_t sidebar_horizontal_offset;   // Horizontal offset from default position. Units are grid slots for grid OSDs, pixels for pixel based OSDs. Positive values move sidebars closer to the edges.
     uint8_t left_sidebar_scroll_step;   // How many units each sidebar step represents. 0 means the default value for the scroll type.
     uint8_t right_sidebar_scroll_step;  // Same as left_sidebar_scroll_step, but for the right sidebar.


### PR DESCRIPTION
Sometimes we need to hide our GPS location from other people but be able to see recorded video and decrypt our position
My suggestion is to add few parameters: `osd_gps_shift_lat` / `osd_gps_shift_lon` for shifting our real coordinates for this value.
As we know both values we will be able to restore original coordinates any time