### PR TITLE
serial: fix compile error when both GPS_UART and SMARTAUDIO_UART are defined

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -133,9 +133,9 @@ void pgResetFn_serialConfig(serialConfig_t *serialConfig)
 #endif
 
 #ifdef SMARTAUDIO_UART
-    serialPortConfig_t *gpsUartConfig = serialFindPortConfiguration(SMARTAUDIO_UART);
-    if (SMARTAUDIO_UART) {
-        gpsUartConfig->functionMask = FUNCTION_VTX_SMARTAUDIO;
+    serialPortConfig_t *smartAudioUartConfig = serialFindPortConfiguration(SMARTAUDIO_UART);
+    if (smartAudioUartConfig) {
+        smartAudioUartConfig->functionMask = FUNCTION_VTX_SMARTAUDIO;
     }
 #endif
 


### PR DESCRIPTION
Noticed that "by accident".
Looks like a copy'n'paste error to me.

Signed-off-by: Stefan Naewe <stefan.naewe@gmail.com>