### PR TITLE
RTH sanity checking safehome fix

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2323,6 +2323,11 @@ void setHomePosition(const fpVector3_t * pos, int32_t yaw, navSetWaypointFlags_t
     // Update target RTH altitude as a waypoint above home
     updateDesiredRTHAltitude();
 
+    // Reset RTH sanity checker for new home position if RTH active
+    if (FLIGHT_MODE(NAV_RTH_MODE)) {
+        initializeRTHSanityChecker();
+    }
+
     updateHomePositionCompatibility();
     ENABLE_STATE(GPS_FIX_HOME);
 }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2323,7 +2323,7 @@ void setHomePosition(const fpVector3_t * pos, int32_t yaw, navSetWaypointFlags_t
     // Update target RTH altitude as a waypoint above home
     updateDesiredRTHAltitude();
 
-    // Reset RTH sanity checker for new home position if RTH active
+    //  Reset RTH sanity checker for new home position if RTH active
     if (FLIGHT_MODE(NAV_RTH_MODE)) {
         initializeRTHSanityChecker();
     }


### PR DESCRIPTION
Fixes an issue where RTH sanity checking fails due to home distance suddenly increasing when a safehome becomes active during failsafe RTH. More an issue if `nav_rth_abort_threshold ` is set low and the safehome is some distance from the arming home point in the "wrong" direction relative to the craft.