### PR TITLE
Fix Sqrt Controller incorrect initialization

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3251,8 +3251,6 @@ void applyWaypointNavigationAndAltitudeHold(void)
     navTargetPosition[X] = lrintf(posControl.desiredState.pos.x);
     navTargetPosition[Y] = lrintf(posControl.desiredState.pos.y);
     navTargetPosition[Z] = lrintf(posControl.desiredState.pos.z);
-
-    DEBUG_SET(DEBUG_CRUISE, 0, posControl.desiredState.pos.z);
 }
 
 /*-----------------------------------------------------------

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3251,6 +3251,8 @@ void applyWaypointNavigationAndAltitudeHold(void)
     navTargetPosition[X] = lrintf(posControl.desiredState.pos.x);
     navTargetPosition[Y] = lrintf(posControl.desiredState.pos.y);
     navTargetPosition[Z] = lrintf(posControl.desiredState.pos.z);
+
+    DEBUG_SET(DEBUG_CRUISE, 0, posControl.desiredState.pos.z);
 }
 
 /*-----------------------------------------------------------

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -60,13 +60,13 @@ static int16_t rcCommandAdjustedThrottle;
 static int16_t altHoldThrottleRCZero = 1500;
 static pt1Filter_t altholdThrottleFilterState;
 static bool prepareForTakeoffOnReset = false;
-static sqrt_controller_t alt_hold_sqrt_controller;
+static sqrt_controller_t pos_z_sqrt_controller;
 
 // Position to velocity controller for Z axis
 static void updateAltitudeVelocityController_MC(timeDelta_t deltaMicros)
 {
     float targetVel = sqrtControllerApply(
-        &alt_hold_sqrt_controller,
+        &pos_z_sqrt_controller,
         posControl.desiredState.pos.z,
         navGetCurrentActualPositionAndVelocity()->pos.z,
         US2S(deltaMicros)
@@ -232,7 +232,7 @@ void resetMulticopterAltitudeController(void)
     }
 
     sqrtControllerInit(
-        &alt_hold_sqrt_controller,
+        &pos_z_sqrt_controller,
         posControl.pids.pos[Z].param.kP,
         -fabsf(nav_speed_down), 
         nav_speed_up, 

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -65,17 +65,13 @@ static sqrt_controller_t alt_hold_sqrt_controller;
 // Position to velocity controller for Z axis
 static void updateAltitudeVelocityController_MC(timeDelta_t deltaMicros)
 {
-    float pos_desired_z = posControl.desiredState.pos.z;
-
     float targetVel = sqrtControllerApply(
         &alt_hold_sqrt_controller,
-        &pos_desired_z,
+        posControl.desiredState.pos.z,
         navGetCurrentActualPositionAndVelocity()->pos.z,
         US2S(deltaMicros)
     );
 
-    posControl.desiredState.pos.z = pos_desired_z;
-    
     // hard limit desired target velocity to max_climb_rate
     float vel_max_z = 0.0f;
 

--- a/src/main/navigation/sqrt_controller.c
+++ b/src/main/navigation/sqrt_controller.c
@@ -127,7 +127,7 @@ void sqrtControllerInit(
         sqrt_controller_pointer->derivative_max = derivative_out_max;
     }
 
-    if ((output_min > 0.0f) && (sqrt_controller_pointer->kp > 0.0f)) {
+    if ((output_min < 0.0f) && (sqrt_controller_pointer->kp > 0.0f)) {
         sqrt_controller_pointer->error_min = sqrtControllerInverse(sqrt_controller_pointer->kp, sqrt_controller_pointer->derivative_max, output_min);
     }
 

--- a/src/main/navigation/sqrt_controller.c
+++ b/src/main/navigation/sqrt_controller.c
@@ -56,12 +56,6 @@ static float sqrtControllerInverse(float kp, float derivative_max, float output)
 // proportional controller with piecewise sqrt sections to constrainf second derivative
 float sqrtControllerApply(sqrt_controller_t *sqrt_controller_pointer, float *target, float measurement, float deltaTime)
 {
-
-    // In case kP is zero, we can't calculate the error, so we return 0.
-    if (sqrt_controller_pointer->kp == 0.0f) {
-        return 0.0f;
-    }
-
     float correction_rate;
 
     // calculate distance p_error

--- a/src/main/navigation/sqrt_controller.c
+++ b/src/main/navigation/sqrt_controller.c
@@ -58,7 +58,7 @@ static float sqrtControllerInverse(float kp, float derivative_max, float output)
     return (output > 0.0f) ? stopping_dist : -stopping_dist;
 }
 
-// Proportional controller with piecewise sqrt sections to constrainf derivative
+// Proportional controller with piecewise sqrt sections to constrain derivative
 float sqrtControllerApply(sqrt_controller_t *sqrt_controller_pointer, float target, float measurement, float deltaTime)
 {
     float correction_rate;

--- a/src/main/navigation/sqrt_controller.h
+++ b/src/main/navigation/sqrt_controller.h
@@ -25,7 +25,7 @@ typedef struct sqrt_controller_s {
     float derivative_max; // maximum derivative of output
 } sqrt_controller_t;
 
-float sqrtControllerApply(sqrt_controller_t *sqrt_controller_pointer, float *target, float measurement, float deltaTime);
+float sqrtControllerApply(sqrt_controller_t *sqrt_controller_pointer, float target, float measurement, float deltaTime);
 void sqrtControllerInit(
     sqrt_controller_t *sqrt_controller_pointer,
     const float kp,


### PR DESCRIPTION
I feel obliged to open a correction PR for this.

[on that line](https://github.com/iNavFlight/inav/blob/f3f0cf0d5bd125171e654859ff4f4b95fcc6acf9/src/main/navigation/sqrt_controller.c#L130) where it says  `if ((output_min > 0.0f) && (sqrt_controller_pointer->kp > 0.0f)) {` is incorrect

the correct one is `if ((output_min < 0.0f) && (sqrt_controller_pointer->kp > 0.0f)) {`

output_min will always be less than zero, not greater.

and yes, @Jetrell made me aware of the "problem" that occurred with @breadoven. I spent hours trying to reproduce the "problem" and talking to Jetrell about it, but I couldn't...

This PR also fixes the 10 meter addition issue reported by Breadoven >> https://github.com/iNavFlight/inav/pull/7845#issuecomment-1073696271