### PR TITLE
Fix SoftSerial StopBit Length

### DIFF
--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -381,7 +381,9 @@ void processTxState(softSerial_t *softSerial)
             serialOutputPortActivate(softSerial);
         }
 
-        return;
+        if ((softSerial->port.options & SERIAL_BIDIR) == 0) {
+            return;
+        }
     }
 
     if (softSerial->bitsLeftToTransmit) {
@@ -390,7 +392,10 @@ void processTxState(softSerial_t *softSerial)
 
         setTxSignal(softSerial, mask);
         softSerial->bitsLeftToTransmit--;
-        return;
+
+        if (softSerial->bitsLeftToTransmit) {
+            return;
+        }
     }
 
     softSerial->isTransmittingData = false;


### PR DESCRIPTION
Solves https://github.com/iNavFlight/inav/issues/7937

Currently Bidirectional SoftSerial have 3x timer interval long stopbit.

Due to excessive "return's" after each byte sent and ready to send next byte, Timer counts 1 additional time to set `softSerial->isTransmittingData = false` and one additional time after new byte is taken from `txBuffer` to `internalTxBuffer`.

SoftSerial in BiDir mode fixed to have 1 timer interval wide stopbit.

Tested on F4 MCU with TrampHV, SmartAudio 2.1 VTX by me and Panda 5804M VTX by @flyingzzy