### PR TITLE
VTX SoftSerial StopBit Time

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -5842,6 +5842,16 @@ Enable workaround for early AKK SAudio-enabled VTX bug.
 
 ---
 
+### vtx_softserial_shortstop
+
+Enable the 3x shorter stopbit on softserial. Need for some IRC Tramp VTXes.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| OFF | OFF | ON |
+
+---
+
 ### yaw_deadband
 
 These are values (in us) by how much RC input can be different before it's considered valid. For transmitters with jitter on outputs, this value can be increased. Defaults are zero, but can be increased up to 10 or so if rc inputs twitch while idle.

--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -38,6 +38,8 @@ typedef enum portOptions_t {
     SERIAL_PARITY_EVEN   = 1 << 2,
     SERIAL_UNIDIR        = 0 << 3,
     SERIAL_BIDIR         = 1 << 3,
+    SERIAL_LONGSTOP      = 0 << 4,
+    SERIAL_SHORTSTOP     = 1 << 4,
 
     /*
      * Note on SERIAL_BIDIR_PP

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -381,7 +381,9 @@ void processTxState(softSerial_t *softSerial)
             serialOutputPortActivate(softSerial);
         }
 
-        return;
+        if ((softSerial->port.options & SERIAL_BIDIR) == 0) {
+            return;
+        }
     }
 
     if (softSerial->bitsLeftToTransmit) {
@@ -390,7 +392,10 @@ void processTxState(softSerial_t *softSerial)
 
         setTxSignal(softSerial, mask);
         softSerial->bitsLeftToTransmit--;
-        return;
+
+        if (softSerial->bitsLeftToTransmit) {
+            return;
+        }
     }
 
     softSerial->isTransmittingData = false;

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -381,7 +381,7 @@ void processTxState(softSerial_t *softSerial)
             serialOutputPortActivate(softSerial);
         }
 
-        if ((softSerial->port.options & SERIAL_BIDIR) == 0) {
+        if ((softSerial->port.options & SERIAL_SHORTSTOP) == 0) {
             return;
         }
     }
@@ -393,7 +393,7 @@ void processTxState(softSerial_t *softSerial)
         setTxSignal(softSerial, mask);
         softSerial->bitsLeftToTransmit--;
 
-        if (softSerial->bitsLeftToTransmit) {
+        if (((softSerial->port.options & SERIAL_SHORTSTOP) == 0) || softSerial->bitsLeftToTransmit) {
             return;
         }
     }

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3651,6 +3651,11 @@ groups:
         default_value: ON
         field: smartAudioAltSoftSerialMethod
         type: bool
+      - name: vtx_softserial_shortstop
+        description: "Enable the 3x shorter stopbit on softserial. Need for some IRC Tramp VTXes."
+        default_value: OFF
+        field: softSerialShortStop
+        type: bool
 
   - name: PG_VTX_SETTINGS_CONFIG
     type: vtxSettingsConfig_t

--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -46,6 +46,7 @@ PG_RESET_TEMPLATE(vtxConfig_t, vtxConfig,
       .halfDuplex = SETTING_VTX_HALFDUPLEX_DEFAULT,
       .smartAudioEarlyAkkWorkaroundEnable = SETTING_VTX_SMARTAUDIO_EARLY_AKK_WORKAROUND_DEFAULT,
       .smartAudioAltSoftSerialMethod = SETTING_VTX_SMARTAUDIO_ALTERNATE_SOFTSERIAL_METHOD_DEFAULT,
+      .softSerialShortStop = SETTING_VTX_SOFTSERIAL_SHORTSTOP_DEFAULT,
 );
 
 static uint8_t locked = 0;

--- a/src/main/io/vtx_control.h
+++ b/src/main/io/vtx_control.h
@@ -33,6 +33,7 @@ typedef struct vtxConfig_s {
     uint8_t halfDuplex;
     uint8_t smartAudioEarlyAkkWorkaroundEnable;
     bool    smartAudioAltSoftSerialMethod;
+    bool    softSerialShortStop;
 } vtxConfig_t;
 
 PG_DECLARE(vtxConfig_t, vtxConfig);

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -609,6 +609,7 @@ bool vtxTrampInit(void)
     if (portConfig) {
         portOptions_t portOptions = 0;
         portOptions = portOptions | (vtxConfig()->halfDuplex ? SERIAL_BIDIR : SERIAL_UNIDIR);
+        portOptions = portOptions | (vtxConfig()->softSerialShortStop ? SERIAL_SHORTSTOP : SERIAL_LONGSTOP);
         vtxState.port = openSerialPort(portConfig->identifier, FUNCTION_VTX_TRAMP, NULL, NULL, 9600, MODE_RXTX, portOptions);
     }
 


### PR DESCRIPTION
Solves https://github.com/iNavFlight/inav/issues/7937

On some Tramp protocol VTX'es stop bit should be not longer as 1 bit wide.
Currently SoftSerial provides it 3 bit long, because of returns from function which is called every timer overflow, which time is  bit long.

Configurable CLI setting `vtx_softserial_shortstop` added (default is `OFF`)