### PR TITLE
ESP32 Radar: Added support for missing OSD unit types

### DIFF
--- a/src/main/io/osd_hud.c
+++ b/src/main/io/osd_hud.c
@@ -202,17 +202,46 @@ void osdHudDrawPoi(uint32_t poiDistance, int16_t poiDirection, int32_t poiAltitu
 
     // Distance
 
-    if (((millis() / 1000) % 6 == 0) && poiType > 0) { // For Radar and WPs, display the difference in altitude
-        altc = ((osd_unit_e)osdConfig()->units == OSD_UNIT_IMPERIAL) ? constrain(CENTIMETERS_TO_FEET(poiAltitude * 100), -99, 99) : constrain(poiAltitude, -99 , 99);
+    if (((millis() / 1000) % 7 == 0 || (millis() / 1000) % 7 == 1) && poiType > 0) { // For Radar and WPs, display the difference in altitude for 2 seconds, then distance for 5 seconds
+        altc = constrain(poiAltitude, -99 , 99);
+
+        switch ((osd_unit_e)osdConfig()->units) {
+            case OSD_UNIT_UK:
+                FALLTHROUGH;
+            case OSD_UNIT_GA:
+                FALLTHROUGH;
+            case OSD_UNIT_IMPERIAL:
+                // Convert to feet
+                altc = constrain(CENTIMETERS_TO_FEET(poiAltitude * 100), -99, 99);
+                break;
+            default:
+                FALLTHROUGH;
+            case OSD_UNIT_METRIC_MPH:
+                FALLTHROUGH;
+            case OSD_UNIT_METRIC:
+                // Already in metres
+                break;
+        }
+
         tfp_sprintf(buff, "%3d", altc);
         buff[0] = (poiAltitude >= 0) ? SYM_DIRECTION : SYM_DIRECTION+4;
-    }
-    else { // Display the distance by default 
-        if ((osd_unit_e)osdConfig()->units == OSD_UNIT_IMPERIAL) {
-            osdFormatCentiNumber(buff, CENTIMETERS_TO_CENTIFEET(poiDistance * 100), FEET_PER_MILE, 0, 3, 3);
-        }
-        else {
-            osdFormatCentiNumber(buff, poiDistance * 100, METERS_PER_KILOMETER, 0, 3, 3);
+    } else { // Display the distance by default 
+        switch ((osd_unit_e)osdConfig()->units) {
+            case OSD_UNIT_UK:
+                FALLTHROUGH;
+            case OSD_UNIT_IMPERIAL:
+                osdFormatCentiNumber(buff, CENTIMETERS_TO_CENTIFEET(poiDistance * 100), FEET_PER_MILE, 0, 3, 3);
+                break;
+            case OSD_UNIT_GA:
+                osdFormatCentiNumber(buff, CENTIMETERS_TO_CENTIFEET(poiDistance * 100), FEET_PER_NAUTICALMILE, 0, 3, 3);
+                break;
+            default:
+                FALLTHROUGH;
+            case OSD_UNIT_METRIC_MPH:
+                FALLTHROUGH;
+            case OSD_UNIT_METRIC:
+                osdFormatCentiNumber(buff, poiDistance * 100, METERS_PER_KILOMETER, 0, 3, 3);
+                break;
         }
     }
 


### PR DESCRIPTION
- Added support for missing OSD unit types (UK, GA)
- Increased altitude display time from 1 to 2 seconds. 1 second was a case of blink and miss it.