### PR TITLE
TBS Sixty9 SA2.1 UART Configuration

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -5952,6 +5952,16 @@ Enable workaround for early AKK SAudio-enabled VTX bug.
 
 ---
 
+### vtx_smartaudio_stopbits
+
+Set stopbit count for serial (TBS Sixty9 SmartAudio 2.1 require value of 1 bit)
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 2 | 1 | 2 |
+
+---
+
 ### vtx_softserial_shortstop
 
 Enable the 3x shorter stopbit on softserial. Need for some IRC Tramp VTXes.

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3719,6 +3719,12 @@ groups:
         default_value: OFF
         field: softSerialShortStop
         type: bool
+      - name: vtx_smartaudio_stopbits
+        description: "Set stopbit count for serial (TBS Sixty9 SmartAudio 2.1 require value of 1 bit)"
+        default_value: 2
+        field: smartAudioStopBits
+        min: 1
+        max: 2
 
   - name: PG_VTX_SETTINGS_CONFIG
     type: vtxSettingsConfig_t

--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -47,6 +47,7 @@ PG_RESET_TEMPLATE(vtxConfig_t, vtxConfig,
       .smartAudioEarlyAkkWorkaroundEnable = SETTING_VTX_SMARTAUDIO_EARLY_AKK_WORKAROUND_DEFAULT,
       .smartAudioAltSoftSerialMethod = SETTING_VTX_SMARTAUDIO_ALTERNATE_SOFTSERIAL_METHOD_DEFAULT,
       .softSerialShortStop = SETTING_VTX_SOFTSERIAL_SHORTSTOP_DEFAULT,
+      .smartAudioStopBits = SETTING_VTX_SMARTAUDIO_STOPBITS_DEFAULT,
 );
 
 static uint8_t locked = 0;

--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -40,7 +40,7 @@
 
 #if defined(USE_VTX_CONTROL)
 
-PG_REGISTER_WITH_RESET_TEMPLATE(vtxConfig_t, vtxConfig, PG_VTX_CONFIG, 3);
+PG_REGISTER_WITH_RESET_TEMPLATE(vtxConfig_t, vtxConfig, PG_VTX_CONFIG, 4);
 
 PG_RESET_TEMPLATE(vtxConfig_t, vtxConfig,
       .halfDuplex = SETTING_VTX_HALFDUPLEX_DEFAULT,

--- a/src/main/io/vtx_control.h
+++ b/src/main/io/vtx_control.h
@@ -34,6 +34,7 @@ typedef struct vtxConfig_s {
     uint8_t smartAudioEarlyAkkWorkaroundEnable;
     bool    smartAudioAltSoftSerialMethod;
     bool    softSerialShortStop;
+    uint8_t smartAudioStopBits;
 } vtxConfig_t;
 
 PG_DECLARE(vtxConfig_t, vtxConfig);

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -689,7 +689,7 @@ bool vtxSmartAudioInit(void)
 {
     serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_VTX_SMARTAUDIO);
     if (portConfig) {
-        portOptions_t portOptions = SERIAL_STOPBITS_2 | SERIAL_BIDIR_NOPULL;
+        portOptions_t portOptions = (vtxConfig()->smartAudioStopBits == 2 ? SERIAL_STOPBITS_2 : SERIAL_STOPBITS_1) | SERIAL_BIDIR_NOPULL;
         portOptions = portOptions | (vtxConfig()->halfDuplex ? SERIAL_BIDIR | SERIAL_BIDIR_PP : SERIAL_UNIDIR);
         smartAudioSerialPort = openSerialPort(portConfig->identifier, FUNCTION_VTX_SMARTAUDIO, NULL, NULL, 4800, MODE_RXTX, portOptions);
     }


### PR DESCRIPTION
Solves https://github.com/iNavFlight/inav/issues/7938

TBS Sixty9 VTX SmartAudio 2.1 not working with 8N2 UART configuration (tested on two Sixty9's I have, v6.13 and 6.17).
New CLI parameter `vtx_smartaudio_sixtynine`, default is `OFF` added.
After enabling 8N1 choosen for SA.