### PR TITLE
Increase Logic Conditions to 64

### DIFF
--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -26,7 +26,7 @@
 #include "config/parameter_group.h"
 #include "common/time.h"
 
-#define MAX_LOGIC_CONDITIONS 32
+#define MAX_LOGIC_CONDITIONS 64
 
 typedef enum {
     LOGIC_CONDITION_TRUE                        = 0,


### PR DESCRIPTION
Allow up to 64 logic conditions.

Configurator PR https://github.com/iNavFlight/inav-configurator/pull/1514