### PR TITLE
Add BMI270 IMU configuration to IFLIGHT_H743_AIO_V2 target.

### DIFF
--- a/src/main/target/IFLIGHT_H743_AIO_V2/target.h
+++ b/src/main/target/IFLIGHT_H743_AIO_V2/target.h
@@ -42,6 +42,12 @@
 #define MPU6000_SPI_BUS         BUS_SPI1
 #define MPU6000_EXTI_PIN        PD0
 
+#define USE_IMU_BMI270
+#define IMU_BMI270_ALIGN        CW0_DEG
+#define BMI270_CS_PIN           SPI1_NSS_PIN
+#define BMI270_SPI_BUS          BUS_SPI1
+#define BMI270_EXTI_PIN
+
 #define USE_EXTI
 #define USE_MPU_DATA_READY_SIGNAL
 #define ENSURE_MPU_DATA_READY_IS_LOW


### PR DESCRIPTION
Their website has conflicting information about this board, but at least the version that I have here has a BMI270 on it.

This change works for me.