### PR TITLE
[flash_m25p16.c] Add W25Q128 variant

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -56,6 +56,8 @@
 #define JEDEC_ID_SPANSION_S25FL116     0x014015
 #define JEDEC_ID_EON_W25Q64            0x1C3017
 #define JEDEC_ID_CYPRESS_S25FL128L     0x016018
+#define JEDEC_ID_WINBOND_W25Q128_2     0xEF7018
+
 
 // The timeout we expect between being able to issue page program instructions
 #define DEFAULT_TIMEOUT_MILLIS       6
@@ -190,7 +192,8 @@ static bool m25p16_readIdentification(void)
 
         case JEDEC_ID_MICRON_N25Q128:
         case JEDEC_ID_WINBOND_W25Q128:
-	case JEDEC_ID_CYPRESS_S25FL128L:
+	    case JEDEC_ID_CYPRESS_S25FL128L:
+        case JEDEC_ID_WINBOND_W25Q128_2:
             geometry.sectors = 256;
             geometry.pagesPerSector = 256;
             break;


### PR DESCRIPTION
Has a slightly different ID. No FC yet contains this variant chip, but we'll leave that already done, it might be useful in the future if any manufacturer decides to use this chip.