### PR TITLE
constrain fastA2I to [0-9] (vice [0-9A])

### DIFF
--- a/src/main/common/typeconversion.c
+++ b/src/main/common/typeconversion.c
@@ -322,7 +322,7 @@ int fastA2I(const char *s)
     }
 
     while ((digit = a2d(*s)) >= 0) {
-        if (digit > 10)
+        if (digit > 9)
             break;
         num = num * 10 + digit;
         s++;


### PR DESCRIPTION
`fastA2I()` has allowed the character set [0-9A] in conversions rather than [0-9], thus the string "A0" would have been converted to `100`. This is incorrect by any measure (base11, base16).

This trivial PR constrains `fastA2I()` to the expected decimal range `[0-9]'.
