### PR TITLE
Remove nav_extra_arming_safety = OFF option

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -146,7 +146,7 @@ tables:
   - name: airmodeHandlingType
     values: ["STICK_CENTER", "THROTTLE_THRESHOLD", "STICK_CENTER_ONCE"]
   - name: nav_extra_arming_safety
-    values: ["OFF", "ON", "ALLOW_BYPASS"]
+    values: ["ON", "ALLOW_BYPASS"]
     enum: navExtraArmingSafety_e
   - name: rssi_source
     values: ["NONE", "AUTO", "ADC", "CHANNEL", "PROTOCOL", "MSP"]

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3557,10 +3557,6 @@ navArmingBlocker_e navigationIsBlockingArming(bool *usedBypass)
         *usedBypass = false;
     }
 
-    if (navConfig()->general.flags.extra_arming_safety == NAV_EXTRA_ARMING_SAFETY_OFF) {
-        return NAV_ARMING_BLOCKER_NONE;
-    }
-
     // Apply extra arming safety only if pilot has any of GPS modes configured
     if ((isUsingNavigationModes() || failsafeMayRequireNavigationMode()) && !navigationPositionEstimateIsHealthy()) {
         if (navConfig()->general.flags.extra_arming_safety == NAV_EXTRA_ARMING_SAFETY_ALLOW_BYPASS &&

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -120,7 +120,7 @@ typedef enum {
 
 typedef enum {
     NAV_EXTRA_ARMING_SAFETY_ON = 0,
-    NAV_EXTRA_ARMING_SAFETY_ALLOW_BYPASS = 1, // Allow disabling by holding THR+YAW low
+    NAV_EXTRA_ARMING_SAFETY_ALLOW_BYPASS = 1, // Allow disabling by holding THR + YAW high
 } navExtraArmingSafety_e;
 
 typedef enum {

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -119,9 +119,8 @@ typedef enum {
 } navRTHAllowLanding_e;
 
 typedef enum {
-    NAV_EXTRA_ARMING_SAFETY_OFF = 0,
-    NAV_EXTRA_ARMING_SAFETY_ON = 1,
-    NAV_EXTRA_ARMING_SAFETY_ALLOW_BYPASS = 2, // Allow disabling by holding THR+YAW low
+    NAV_EXTRA_ARMING_SAFETY_ON = 0,
+    NAV_EXTRA_ARMING_SAFETY_ALLOW_BYPASS = 1, // Allow disabling by holding THR+YAW low
 } navExtraArmingSafety_e;
 
 typedef enum {


### PR DESCRIPTION
With the addition of the `ALLOW_BYPASS` option, there is no real sensible reason to keep the `OFF` option. If a GPS is installed, making sure that these checks are successful are imperative to prevent fly-aways; because a model has been armed and flown before a 3D fix has been acquired, so no home point is set. For occasional ignoring the checks or bench testing, `ALLOW_BYPASS` is the much safer option. As next power cycle, the checks will be enforced again.

[`ALLOW_BYPASS` and the 10x switch toggle are still working. (demo)](https://youtu.be/xyGu8lIsOzA)

### Release Notes
The `off` option has been removed from `nav_extra_arming_safety`. Instead, the `allow_bypass` can be used for with the same effect. To allow the bypass, yaw right and arm. The extra arming safety features will be disabled until the next power cycle of the battery. Please update your diff if you use this parameter; either manually, or using [this tool](https://www.mrd-rc.com/iNav/INAV-6.0-CLI-Update.php#newCLIResults).