### PR TITLE
[BMP280] Allow target-specific I2C address definition

### DIFF
--- a/src/main/drivers/barometer/barometer_bmp280.h
+++ b/src/main/drivers/barometer/barometer_bmp280.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#define BMP280_I2C_ADDR                      (0x76)
 #define BMP280_DEFAULT_CHIP_ID               (0x58)
 #define BME280_DEFAULT_CHIP_ID               (0x60)
 

--- a/src/main/drivers/barometer/barometer_bmp280.h
+++ b/src/main/drivers/barometer/barometer_bmp280.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#define BMP280_I2C_ADDR_DEFAULT              (0x76)
 #define BMP280_DEFAULT_CHIP_ID               (0x58)
 #define BME280_DEFAULT_CHIP_ID               (0x60)
 

--- a/src/main/drivers/barometer/barometer_bmp280.h
+++ b/src/main/drivers/barometer/barometer_bmp280.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define BMP280_I2C_ADDR                      (0x76)
+#define BMP280_I2C_ADDR_DEFAULT              (0x76)
 #define BMP280_DEFAULT_CHIP_ID               (0x58)
 #define BME280_DEFAULT_CHIP_ID               (0x60)
 

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -103,7 +103,10 @@
     #if !defined(BMP280_I2C_BUS)
         #define BMP280_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_bmp280,      DEVHW_BMP280,       BMP280_I2C_BUS,     0x76,               NONE,           DEVFLAGS_NONE,      0);
+    #if !defined(BMP280_I2C_ADDR)
+        #define BMP280_I2C_ADDR (0x76)
+    #endif
+    BUSDEV_REGISTER_I2C(busdev_bmp280,      DEVHW_BMP280,       BMP280_I2C_BUS,     BMP280_I2C_ADDR,	NONE,           DEVFLAGS_NONE,      0);
     #endif
 #endif
 

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -104,7 +104,7 @@
         #define BMP280_I2C_BUS BARO_I2C_BUS
     #endif
     #if !defined(BMP280_I2C_ADDR)
-        #define BMP280_I2C_ADDR BMP280_I2C_ADDR_DEFAULT
+        #define BMP280_I2C_ADDR (0x76)
     #endif
     BUSDEV_REGISTER_I2C(busdev_bmp280,      DEVHW_BMP280,       BMP280_I2C_BUS,     BMP280_I2C_ADDR,	NONE,           DEVFLAGS_NONE,      0);
     #endif

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -103,7 +103,10 @@
     #if !defined(BMP280_I2C_BUS)
         #define BMP280_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_bmp280,      DEVHW_BMP280,       BMP280_I2C_BUS,     0x76,               NONE,           DEVFLAGS_NONE,      0);
+    #if !defined(BMP280_I2C_ADDR)
+        #define BMP280_I2C_ADDR BMP280_I2C_ADDR_DEFAULT
+    #endif
+    BUSDEV_REGISTER_I2C(busdev_bmp280,      DEVHW_BMP280,       BMP280_I2C_BUS,     BMP280_I2C_ADDR,	NONE,           DEVFLAGS_NONE,      0);
     #endif
 #endif
 


### PR DESCRIPTION
Some targets can have BMP280 at address 0x77 instead of 0x76.

This PR allows to specify BMP280 address with BMP280_I2C_ADDR macro in target.h

Basically this PR was submitted by digitalentity https://github.com/iNavFlight/inav/pull/6005/commits/1a2ad14f59dbbd9dd0cb2391793e8f9eef36b572
but was lost in process.