### PR TITLE
Fix PC2/PC3 ADC not working on MAMBAH743

### DIFF
--- a/src/main/target/MAMBAH743/target.h
+++ b/src/main/target/MAMBAH743/target.h
@@ -148,7 +148,7 @@
 
 // *************** ADC *****************************
 #define USE_ADC
-#define ADC_INSTANCE                ADC1
+#define ADC_INSTANCE                ADC3
 
 #define ADC_CHANNEL_1_PIN           PC1
 #define ADC_CHANNEL_2_PIN           PC3


### PR DESCRIPTION
This is the fix for #8146. It was checked that no other H743 target was affected by the issue as they either not use PC2 or PC3 or already are using ADC3.
Working was verified on a MAMBAH743 board, measurements for voltage still work as well as before and current is now working, too.