### PR TITLE
rework rc channel remapping

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2790,15 +2790,15 @@ static void printMap(uint8_t dumpMask, const rxConfig_t *rxConfig, const rxConfi
 static void cliMap(char *cmdline)
 {
     uint32_t len;
-    char out[5];
+    char out[MAX_MAPPABLE_RX_INPUTS + 1];
 
     len = strlen(cmdline);
 
-    if (len == 4) {
+    if (len == MAX_MAPPABLE_RX_INPUTS) {
         // uppercase it
-        for (uint32_t i = 0; i < 4; i++)
+        for (uint32_t i = 0; i < len; i++)
             cmdline[i] = sl_toupper((unsigned char)cmdline[i]);
-        for (uint32_t i = 0; i < 4; i++) {
+        for (uint32_t i = 0; i < len; i++) {
             if (strchr(rcChannelLetters, cmdline[i]) && !strchr(cmdline + i + 1, cmdline[i]))
                 continue;
             cliShowParseError();
@@ -2809,7 +2809,7 @@ static void cliMap(char *cmdline)
         cliShowParseError();
     cliPrint("Map: ");
     uint32_t i;
-    for (i = 0; i < 4; i++)
+    for (i = 0; i < MAX_MAPPABLE_RX_INPUTS; i++)
         out[rxConfig()->rcmap[i]] = rcChannelLetters[i];
     out[i] = '\0';
     cliPrintLinef("%s", out);

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -71,7 +71,7 @@
 
 //#define DEBUG_RX_SIGNAL_LOSS
 
-const char rcChannelLetters[] = "AERT";
+const char rcChannelLetters[] = "AERT1234";
 
 static uint16_t rssi = 0;                  // range: [0;1023]
 static timeUs_t lastMspRssiUpdateUs = 0;
@@ -124,7 +124,7 @@ PG_REGISTER_WITH_RESET_TEMPLATE(rxConfig_t, rxConfig, PG_RX_CONFIG, 10);
 #define RX_MIN_USEX 885
 PG_RESET_TEMPLATE(rxConfig_t, rxConfig,
     .receiverType = DEFAULT_RX_TYPE,
-    .rcmap = {0, 1, 3, 2},      // Default to AETR map
+    .rcmap = {0, 1, 3, 2, 4, 5, 6, 7},      // Default to AETR1234 map
     .halfDuplex = SETTING_SERIALRX_HALFDUPLEX_DEFAULT,
     .serialrx_provider = SERIALRX_PROVIDER,
 #ifdef USE_RX_SPI

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -70,8 +70,11 @@
 #include "rx/mavlink.h"
 
 //#define DEBUG_RX_SIGNAL_LOSS
-
+#if (MAX_MAPPABLE_RX_INPUTS == 4)
+const char rcChannelLetters[] = "AERT";
+#else
 const char rcChannelLetters[] = "AERT1234";
+#endif
 
 static uint16_t rssi = 0;                  // range: [0;1023]
 static timeUs_t lastMspRssiUpdateUs = 0;
@@ -124,7 +127,11 @@ PG_REGISTER_WITH_RESET_TEMPLATE(rxConfig_t, rxConfig, PG_RX_CONFIG, 10);
 #define RX_MIN_USEX 885
 PG_RESET_TEMPLATE(rxConfig_t, rxConfig,
     .receiverType = DEFAULT_RX_TYPE,
+#if (MAX_MAPPABLE_RX_INPUTS == 4)
+    .rcmap = {0, 1, 3, 2},      // Default to AETR map
+#else
     .rcmap = {0, 1, 3, 2, 4, 5, 6, 7},      // Default to AETR1234 map
+#endif
     .halfDuplex = SETTING_SERIALRX_HALFDUPLEX_DEFAULT,
     .serialrx_provider = SERIALRX_PROVIDER,
 #ifdef USE_RX_SPI

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -95,7 +95,7 @@ typedef enum {
 
 extern const char rcChannelLetters[];
 
-#define MAX_MAPPABLE_RX_INPUTS 4
+#define MAX_MAPPABLE_RX_INPUTS 8
 
 #define MAX_INVALID_RX_PULSE_TIME    300
 

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -95,7 +95,7 @@ typedef enum {
 
 extern const char rcChannelLetters[];
 
-#define MAX_MAPPABLE_RX_INPUTS 8
+#define MAX_MAPPABLE_RX_INPUTS 4  //either 4 or 8
 
 #define MAX_INVALID_RX_PULSE_TIME    300
 


### PR DESCRIPTION
Allow remapping of rc channels 1-8 for example TAER1234, AERT2134 or 3AER12T4.
[https://github.com/iNavFlight/inav-configurator/pull/1560](https://github.com/iNavFlight/inav-configurator/pull/1560)