### PR TITLE
Change the count definition of the 4 main channels

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2768,11 +2768,11 @@ static void printMap(uint8_t dumpMask, const rxConfig_t *rxConfig, const rxConfi
     char bufDefault[16];
     uint32_t i;
 
-    for (i = 0; i < MAX_MAPPABLE_RX_INPUTS; i++) {
+    for (i = 0; i < STICK_CHANNEL_COUNT; i++) {
         buf[i] = bufDefault[i] = 0;
     }
 
-    for (i = 0; i < MAX_MAPPABLE_RX_INPUTS; i++) {
+    for (i = 0; i < STICK_CHANNEL_COUNT; i++) {
         buf[rxConfig->rcmap[i]] = rcChannelLetters[i];
         if (defaultRxConfig) {
             bufDefault[defaultRxConfig->rcmap[i]] = rcChannelLetters[i];
@@ -2789,16 +2789,16 @@ static void printMap(uint8_t dumpMask, const rxConfig_t *rxConfig, const rxConfi
 static void cliMap(char *cmdline)
 {
     uint32_t len;
-    char out[MAX_MAPPABLE_RX_INPUTS + 1];
+    char out[STICK_CHANNEL_COUNT + 1];
 
     len = strlen(cmdline);
 
-    if (len == MAX_MAPPABLE_RX_INPUTS) {
+    if (len == STICK_CHANNEL_COUNT) {
         // uppercase it
-        for (uint32_t i = 0; i < MAX_MAPPABLE_RX_INPUTS; i++) {
+        for (uint32_t i = 0; i < STICK_CHANNEL_COUNT; i++) {
             cmdline[i] = sl_toupper((unsigned char)cmdline[i]);
         }
-        for (uint32_t i = 0; i < MAX_MAPPABLE_RX_INPUTS; i++) {
+        for (uint32_t i = 0; i < STICK_CHANNEL_COUNT; i++) {
             if (strchr(rcChannelLetters, cmdline[i]) && !strchr(cmdline + i + 1, cmdline[i])) {
                 continue;
             }
@@ -2811,7 +2811,7 @@ static void cliMap(char *cmdline)
     }
     cliPrint("Map: ");
     uint32_t i;
-    for (i = 0; i < MAX_MAPPABLE_RX_INPUTS; i++){
+    for (i = 0; i < STICK_CHANNEL_COUNT; i++){
         out[rxConfig()->rcmap[i]] = rcChannelLetters[i];
     }
     out[i] = '\0';

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1032,7 +1032,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         break;
 
     case MSP_RX_MAP:
-        sbufWriteData(dst, rxConfig()->rcmap, MAX_MAPPABLE_RX_INPUTS);
+        sbufWriteData(dst, rxConfig()->rcmap, STICK_CHANNEL_COUNT);
         break;
 
     case MSP2_COMMON_SERIAL_CONFIG:
@@ -2624,8 +2624,8 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_RX_MAP:
-        if (dataSize == MAX_MAPPABLE_RX_INPUTS) {
-            for (int i = 0; i < MAX_MAPPABLE_RX_INPUTS; i++) {
+        if (dataSize == STICK_CHANNEL_COUNT) {
+            for (int i = 0; i < STICK_CHANNEL_COUNT; i++) {
                 rxConfigMutable()->rcmap[i] = sbufReadU8(src);
             }
         } else

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -529,7 +529,7 @@ void parseRcChannels(const char *input)
 {
     for (const char *c = input; *c; c++) {
         const char *s = strchr(rcChannelLetters, *c);
-        if (s && (s < rcChannelLetters + MAX_MAPPABLE_RX_INPUTS))
+        if (s && (s < rcChannelLetters + STICK_CHANNEL_COUNT))
             rxConfigMutable()->rcmap[s - rcChannelLetters] = c - input;
     }
 }

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -92,8 +92,6 @@ typedef enum {
 
 extern const char rcChannelLetters[];
 
-#define MAX_MAPPABLE_RX_INPUTS 4
-
 #define MAX_INVALID_RX_PULSE_TIME    300
 
 #define RSSI_VISIBLE_VALUE_MIN 0
@@ -108,7 +106,7 @@ PG_DECLARE_ARRAY(rxChannelRangeConfig_t, NON_AUX_CHANNEL_COUNT, rxChannelRangeCo
 
 typedef struct rxConfig_s {
     uint8_t receiverType;                   // RC receiver type (rxReceiverType_e enum)
-    uint8_t rcmap[MAX_MAPPABLE_RX_INPUTS];  // mapping of radio channels to internal RPYTA+ order
+    uint8_t rcmap[STICK_CHANNEL_COUNT];  // mapping of radio channels to internal RPYTA+ order
     uint8_t serialrx_provider;              // Type of UART-based receiver (rxSerialReceiverType_e enum). Only used if receiverType is RX_TYPE_SERIAL
     uint8_t serialrx_inverted;              // Flip the default inversion of the protocol - e.g. sbus (Futaba, FrSKY) is inverted if this is false, uninverted if it's true. Support for uninverted OpenLRS (and modified FrSKY) receivers.
     uint8_t halfDuplex;                     // allow rx to operate in half duplex mode. From tristate_e.


### PR DESCRIPTION
To me, using the definition `STICK_CHANNEL_COUNT` in place of `MAX_MAPPABLE_RX_INPUTS`, makes more sense. The `MAX_MAPPABLE_RX_INPUTS` definition of the impression that the maximum number of mappable channels of the RX is only 4, instead of 10, 12, 14 or 18.