### PR TITLE
Remove barometer median filter

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -362,16 +362,6 @@ Selection of baro hardware. See Wiki Sensor auto detect and hardware failure det
 
 ---
 
-### baro_median_filter
-
-3-point median filtering for barometer readouts. No reason to change this setting
-
-| Default | Min | Max |
-| --- | --- | --- |
-| ON | OFF | ON |
-
----
-
 ### bat_cells
 
 Number of cells of the battery (0 = auto-detect), see battery documentation. 7S, 9S and 11S batteries cannot be auto-detected.

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -651,11 +651,6 @@ groups:
         description: "Selection of baro hardware. See Wiki Sensor auto detect and hardware failure detection for more info"
         default_value: "AUTO"
         table: baro_hardware
-      - name: baro_median_filter
-        description: "3-point median filtering for barometer readouts. No reason to change this setting"
-        default_value: ON
-        field: use_median_filtering
-        type: bool
       - name: baro_cal_tolerance
         description: "Baro calibration tolerance in cm. The default should allow the noisiest baro to complete calibration [cm]."
         default_value: 150

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -60,11 +60,10 @@ baro_t baro;                        // barometer access functions
 
 #ifdef USE_BARO
 
-PG_REGISTER_WITH_RESET_TEMPLATE(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 3);
+PG_REGISTER_WITH_RESET_TEMPLATE(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 4);
 
 PG_RESET_TEMPLATE(barometerConfig_t, barometerConfig,
     .baro_hardware = SETTING_BARO_HARDWARE_DEFAULT,
-    .use_median_filtering = SETTING_BARO_MEDIAN_FILTER_DEFAULT,
     .baro_calibration_tolerance = SETTING_BARO_CAL_TOLERANCE_DEFAULT
 );
 
@@ -248,51 +247,6 @@ bool baroInit(void)
     return true;
 }
 
-#define PRESSURE_SAMPLES_MEDIAN 3
-
-/*
-altitude pressure
-      0m   101325Pa
-    100m   100129Pa delta = 1196
-   1000m    89875Pa
-   1100m    88790Pa delta = 1085
-At sea level an altitude change of 100m results in a pressure change of 1196Pa, at 1000m pressure change is 1085Pa
-So set glitch threshold at 1000 - this represents an altitude change of approximately 100m.
-*/
-#define PRESSURE_DELTA_GLITCH_THRESHOLD 1000
-static int32_t applyBarometerMedianFilter(int32_t newPressureReading)
-{
-    static int32_t barometerFilterSamples[PRESSURE_SAMPLES_MEDIAN];
-    static int currentFilterSampleIndex = 0;
-    static bool medianFilterReady = false;
-
-    int nextSampleIndex = currentFilterSampleIndex + 1;
-    if (nextSampleIndex == PRESSURE_SAMPLES_MEDIAN) {
-        nextSampleIndex = 0;
-        medianFilterReady = true;
-    }
-    int previousSampleIndex = currentFilterSampleIndex - 1;
-    if (previousSampleIndex < 0) {
-        previousSampleIndex = PRESSURE_SAMPLES_MEDIAN - 1;
-    }
-    const int previousPressureReading = barometerFilterSamples[previousSampleIndex];
-
-    if (medianFilterReady) {
-        if (ABS(previousPressureReading - newPressureReading) < PRESSURE_DELTA_GLITCH_THRESHOLD) {
-            barometerFilterSamples[currentFilterSampleIndex] = newPressureReading;
-            currentFilterSampleIndex = nextSampleIndex;
-            return quickMedianFilter3(barometerFilterSamples);
-        } else {
-            // glitch threshold exceeded, so just return previous reading and don't add the glitched reading to the filter array
-            return barometerFilterSamples[previousSampleIndex];
-        }
-    } else {
-        barometerFilterSamples[currentFilterSampleIndex] = newPressureReading;
-        currentFilterSampleIndex = nextSampleIndex;
-        return newPressureReading;
-    }
-}
-
 typedef enum {
     BAROMETER_NEEDS_SAMPLES = 0,
     BAROMETER_NEEDS_CALCULATION
@@ -323,9 +277,6 @@ uint32_t baroUpdate(void)
                 baro.dev.start_ut(&baro.dev);
             }
             baro.dev.calculate(&baro.dev, &baro.baroPressure, &baro.baroTemperature);
-            if (barometerConfig()->use_median_filtering) {
-                baro.baroPressure = applyBarometerMedianFilter(baro.baroPressure);
-            }
             state = BAROMETER_NEEDS_SAMPLES;
             return baro.dev.ut_delay;
         break;

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -51,7 +51,6 @@ extern baro_t baro;
 
 typedef struct barometerConfig_s {
     uint8_t baro_hardware;                  // Barometer hardware to use
-    uint8_t use_median_filtering;           // Use 3-point median filtering
     uint16_t baro_calibration_tolerance;    // Baro calibration tolerance (cm at sea level)
 } barometerConfig_t;
 


### PR DESCRIPTION
This is no longer useful for multiple reasons:
- New baros are accurate enough and don't produce altitude glitches
- Filter creates unnecessary delay which affect the estimation performace (minimally, but nevertheless not negligible)
- Glitch prevention working together with median code is actually harmful (causes the barometer data to freeze when rapid altitude change is observed)