### PR TITLE
[INS] Use Acc and Gyro calibration validation to calibrate the 1G of the acceleration

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -666,7 +666,7 @@ void imuUpdateAttitude(timeUs_t currentTimeUs)
 
 bool isImuReady(void)
 {
-    return sensors(SENSOR_ACC) && STATE(ACCELEROMETER_CALIBRATED);
+    return sensors(SENSOR_ACC) && STATE(ACCELEROMETER_CALIBRATED) && gyroIsCalibrationComplete();
 }
 
 bool isImuHeadingValid(void)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -666,7 +666,7 @@ void imuUpdateAttitude(timeUs_t currentTimeUs)
 
 bool isImuReady(void)
 {
-    return sensors(SENSOR_ACC) && gyroIsCalibrationComplete();
+    return sensors(SENSOR_ACC) && STATE(ACCELEROMETER_CALIBRATED);
 }
 
 bool isImuHeadingValid(void)


### PR DESCRIPTION
INS uses the `isImuReady()` function to calibrate the 1G of the acceleration. If the Acc is not calibrated, the INS should be inactive (which does not happen when checking the Gyro).