### PR TITLE
Do not automatically persist the gyro calibration

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -426,16 +426,10 @@ void setGyroCalibrationAndWriteEEPROM(int16_t getGyroZero[XYZ_AXIS_COUNT]) {
     gyroConfigMutable()->gyro_zero_cal[X] = getGyroZero[X];
     gyroConfigMutable()->gyro_zero_cal[Y] = getGyroZero[Y];
     gyroConfigMutable()->gyro_zero_cal[Z] = getGyroZero[Z];
-    // save the calibration
-    writeEEPROM();
-    readEEPROM();
 }
 
 void setGravityCalibrationAndWriteEEPROM(float getGravity) {
     gyroConfigMutable()->gravity_cmss_cal = getGravity;
-    // save the calibration
-    writeEEPROM();
-    readEEPROM();
 }
 
 void beeperOffSet(uint32_t mask)


### PR DESCRIPTION
Connected to #7128
Gyro calibration would be persisted only on "save" command, not after each gyro calibration. Ultimate effect is the same as before but lower the number of config writes