### PR TITLE
Make HUD offset more intuitive

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1001,7 +1001,7 @@ void osdCrosshairPosition(uint8_t *x, uint8_t *y)
 {
     *x = osdDisplayPort->cols / 2;
     *y = osdDisplayPort->rows / 2;
-    *y += osdConfig()->horizon_offset;
+    *y -= osdConfig()->horizon_offset; // positive horizon_offset moves the HUD up, negative moves down
 }
 
 /**


### PR DESCRIPTION
Updated HUD offset to be more intuitive. Positive values for `osd_horizon_offset` moves the HUD up. Negative values move the HUD down.

Works with https://github.com/iNavFlight/inav-configurator/pull/1540

### Release Notes
The operation of `osd_horizon_offset` has been reversed, to make it more intuitve. If you have a non-zero value for `osd_horizon_offset` it will need to be inverted. For example `osd_horizon_offset = 1` would become `osd_horizon_offset = -1`. Positive values move the HUD up, and negative values move it down. Please update your diff if you use this parameter; either manually, or using [this tool](https://www.mrd-rc.com/iNav/INAV-6.0-CLI-Update.php#newCLIResults).