### PR TITLE
fixed wind direction icon on osd

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2802,8 +2802,8 @@ static bool osdDrawSingleElement(uint8_t item)
             if (valid) {
                 uint16_t angle;
                 horizontalWindSpeed = getEstimatedHorizontalWindSpeed(&angle);
-                int16_t windDirection = osdGetHeadingAngle((int)angle - DECIDEGREES_TO_DEGREES(attitude.values.yaw));
-                buff[1] = SYM_DIRECTION + (windDirection * 2 / 90);
+                int16_t windDirection = osdGetHeadingAngle( DECIDEGREES_TO_DEGREES(attitude.values.yaw) - CENTIDEGREES_TO_DEGREES((int)angle) + 22);
+                buff[1] = SYM_DIRECTION + (windDirection*2 / 90);
             } else {
                 horizontalWindSpeed = 0;
                 buff[1] = SYM_BLANK;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2802,7 +2802,7 @@ static bool osdDrawSingleElement(uint8_t item)
             if (valid) {
                 uint16_t angle;
                 horizontalWindSpeed = getEstimatedHorizontalWindSpeed(&angle);
-                int16_t windDirection = osdGetHeadingAngle( DECIDEGREES_TO_DEGREES(attitude.values.yaw) - CENTIDEGREES_TO_DEGREES((int)angle) + 22);
+                int16_t windDirection = osdGetHeadingAngle( CENTIDEGREES_TO_DEGREES((int)angle) - DECIDEGREES_TO_DEGREES(attitude.values.yaw) + 22);
                 buff[1] = SYM_DIRECTION + (windDirection*2 / 90);
             } else {
                 horizontalWindSpeed = 0;


### PR DESCRIPTION
1) As can be seen in wind_estimator.c:
```
float getEstimatedHorizontalWindSpeed(uint16_t *angle)
{
    float xWindSpeed = getEstimatedWindSpeed(X);
    float yWindSpeed = getEstimatedWindSpeed(Y);
    if (angle) {
        float horizontalWindAngle = atan2_approx(yWindSpeed, xWindSpeed);
        // atan2 returns [-M_PI, M_PI], with 0 indicating the vector points in the X direction
        // We want [0, 360) in degrees
        if (horizontalWindAngle < 0) {
            horizontalWindAngle += 2 * M_PIf;
        }
        *angle = RADIANS_TO_CENTIDEGREES(horizontalWindAngle);
    }
    return calc_length_pythagorean_2D(xWindSpeed, yWindSpeed);
}
```
angle is returned from **getEstimatedHorizontalWindSpeed()** in CENTIDEGREES. Have to be converted to DEGREES.

2) Current implementation maps symbol 0 (airplane arrow up ) to the range 0...45, symbol 1 to the range 45...90 and so on. Instead, we want symbol 0 to map to the range -22.5...22.5. This way airplane arrow will point up if we are flying approximatelly with the wind direction. So we add constant 22.

(Updated): Note: Airplane icon shows "wind direction relative to plane":
- Airplane icon up - flywing with wind
- Airplane icon down - flying against the wind
- Airplane icon left - wind blows from the right side etc.
