### PR TITLE
fixed wind estimator

### DIFF
--- a/src/main/flight/rth_estimator.c
+++ b/src/main/flight/rth_estimator.c
@@ -153,7 +153,7 @@ static float calculateRemainingEnergyBeforeRTH(bool takeWindIntoAccount) {
     uint16_t windHeading; // centidegrees
     const float horizontalWindSpeed = takeWindIntoAccount ? getEstimatedHorizontalWindSpeed(&windHeading) / 100 : 0; // m/s
     const float windHeadingDegrees = CENTIDEGREES_TO_DEGREES((float)windHeading);
-    const float verticalWindSpeed = getEstimatedWindSpeed(Z) / 100;
+    const float verticalWindSpeed = -getEstimatedWindSpeed(Z) / 100; //from NED to NEU
 
     const float RTH_distance = estimateRTHDistanceAndHeadingAfterAltitudeChange(RTH_initial_altitude_change, horizontalWindSpeed, windHeadingDegrees, verticalWindSpeed, &RTH_heading);
     const float RTH_speed = windCompensatedForwardSpeed((float)navConfig()->fw.cruise_speed / 100, RTH_heading, horizontalWindSpeed, windHeadingDegrees);

--- a/src/main/flight/wind_estimator.c
+++ b/src/main/flight/wind_estimator.c
@@ -102,8 +102,8 @@ void updateWindEstimator(timeUs_t currentTimeUs)
 
     // Fuselage direction in earth frame
     fuselageDirection[X] = rMat[0][0];
-    fuselageDirection[Y] = rMat[1][0];
-    fuselageDirection[Z] = rMat[2][0];
+    fuselageDirection[Y] = -rMat[1][0];
+    fuselageDirection[Z] = -rMat[2][0];
 
     timeDelta_t timeDelta = cmpTimeUs(currentTimeUs, lastUpdateUs);
     // scrap our data and start over if we're taking too long to get a direction change
@@ -131,7 +131,7 @@ void updateWindEstimator(timeUs_t currentTimeUs)
         // when turning, use the attitude response to estimate wind speed
         groundVelocityDiff[X] = groundVelocity[X] - lastGroundVelocity[X];
         groundVelocityDiff[Y] = groundVelocity[Y] - lastGroundVelocity[Y];
-        groundVelocityDiff[Z] = groundVelocity[X] - lastGroundVelocity[Z];
+        groundVelocityDiff[Z] = groundVelocity[Z] - lastGroundVelocity[Z];
 
         // estimate airspeed it using equation 6
         float V = (calc_length_pythagorean_3D(groundVelocityDiff[X], groundVelocityDiff[Y], groundVelocityDiff[Z])) / fast_fsqrtf(diffLengthSq);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2824,7 +2824,7 @@ static bool osdDrawSingleElement(uint8_t item)
             bool valid = isEstimatedWindSpeedValid();
             float verticalWindSpeed;
             if (valid) {
-                verticalWindSpeed = getEstimatedWindSpeed(Z);
+                verticalWindSpeed = -getEstimatedWindSpeed(Z);  //from NED to NEU
                 if (verticalWindSpeed < 0) {
                     buff[1] = SYM_AH_DECORATION_DOWN;
                     verticalWindSpeed = -verticalWindSpeed;


### PR DESCRIPTION
1) groundVelocity[**X**] - lastGroundVelocity[**Z**]; is typo obviously

2) we want **fuselageDirection** and **groundVelocity** vectors to point in the same direction.

groundVelocity[Z] = gpsSol.velNED[Z] is POSITIVE when velocity vector points DOWN
(as can be seen in navigation_pos_estimator.c line 257: ```posEstimator.gps.vel.z = -gpsSol.velNED[Z];```).
Thus  we have to invert Z component:  ```fuselageDirection[Z] = -rMat[2][0];```

groundVelocity[Y] = gpsSol.velNED[Y] is POSITIVE when velocity vector points EAST (yaw = 90)
(as can be seen in gps.c line 292: ```gpsSol.velNED[Y] = speed * sin_approx(DECIDEGREES_TO_RADIANS(FAKE_GPS_GROUND_COURSE_DECIDEGREES));```).

rMat[1][0] is NEGATIVE at yaw=90, which can be found out by debugging, or by looking at imu.c line 461:

```attitude.values.yaw = RADIANS_TO_DECIDEGREES(-atan2_approx(rMat[1][0], rMat[0][0]));```

which equals to:

```attitude.values.yaw = RADIANS_TO_DECIDEGREES(atan2_approx(-rMat[1][0], rMat[0][0]));```

thus we have to negate rMat[1][0].

3) estimated wind vector is in NED frame because it is derived from gpsSol.velNED.
gpsSol.velNED[Z] is POSITIVE when velocity vector points DOWN
thus getEstimatedWindSpeed(Z) value should be negated in osd.c and position estimator.


 In other words, groundVelocity is in NED frame ( North, East, Down). The signs of rMat[x][0] can be checked by debugging, by pointing airplane north, east and down.