### PR TITLE
Add PINIO support to Matek F405 SE

### DIFF
--- a/docs/boards/MatekF405 Wing.md
+++ b/docs/boards/MatekF405 Wing.md
@@ -18,6 +18,11 @@
 * SBUS pin is connected to UART2
 * SmartPort telemetry can be setup with `SoftwareSerial` feature turned on, SmartPort configured in SoftwareSerial1 and receiver connected to UART2 TX pad
 
+### Alternate targets
+
+#### MATEKF045SE_PINIO
+`MATEKF045SE_PINIO` replaces UART 6 (TX) with a pad that can be used for PINIO
+
 ## Where to buy:
 
 * [Banggood](https://inavflight.com/shop/p/MATEKF405WING)

--- a/src/main/target/MATEKF405SE/CMakeLists.txt
+++ b/src/main/target/MATEKF405SE/CMakeLists.txt
@@ -1,1 +1,2 @@
 target_stm32f405xg(MATEKF405SE)
+target_stm32f405xg(MATEKF405SE_PINIO)

--- a/src/main/target/MATEKF405SE/README.md
+++ b/src/main/target/MATEKF405SE/README.md
@@ -14,3 +14,6 @@
 * 2x I2C
 * 2x Motors & 7x Servos
 * 4x BEC + current sensor
+
+### MATEKF405SE_PINIO
+Replaces UART 6 Tx with USER 1 for PINIO

--- a/src/main/target/MATEKF405SE/config.c
+++ b/src/main/target/MATEKF405SE/config.c
@@ -17,16 +17,25 @@
 
 #include <stdint.h>
 #include <platform.h>
+
 #include "config/config_master.h"
 #include "config/feature.h"
+
 #include "flight/mixer.h"
+
 #include "io/serial.h"
+
 #include "telemetry/telemetry.h"
+#include "fc/fc_msp_box.h"
+#include "io/piniobox.h"
 
 // alternative defaults settings for MATEKF405SE targets
 void targetConfiguration(void)
-{
-    
+{  
+#ifdef MATEKF405SE_PINIO
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+#endif
+
     serialConfigMutable()->portConfigs[1].functionMask = FUNCTION_MSP;
     serialConfigMutable()->portConfigs[1].msp_baudrateIndex = BAUD_57600;
 

--- a/src/main/target/MATEKF405SE/target.h
+++ b/src/main/target/MATEKF405SE/target.h
@@ -20,8 +20,11 @@
 #define TARGET_BOARD_IDENTIFIER "MF4S"
 #define USBD_PRODUCT_STRING  "Matek_F405SE"
 
+// ******** Board LEDs  **********************
 #define LED0                    PA14  //Blue
 #define LED1                    PA13  //Green
+
+// ******* Beeper ***********
 #define BEEPER                  PC15
 #define BEEPER_INVERTED
 
@@ -33,6 +36,7 @@
 #define SPI1_MISO_PIN   	    PA6
 #define SPI1_MOSI_PIN   	    PA7
 
+// MPU6000
 #define USE_IMU_MPU6000
 #define IMU_MPU6000_ALIGN       CW270_DEG
 #define MPU6000_CS_PIN          PA4
@@ -43,7 +47,7 @@
 #define USE_MPU_DATA_READY_SIGNAL
 
 
-// *************** I2C /Baro/Mag *********************
+// *************** I2C/Baro/Mag *********************
 #define USE_I2C
 #define USE_I2C_DEVICE_1
 #define I2C1_SCL                PB8
@@ -127,9 +131,11 @@
 #define UART5_TX_PIN            PC12
 #define UART5_RX_PIN            PD2
 
+#ifndef MATEKF405SE_PINIO
 #define USE_UART6
 #define UART6_TX_PIN            PC6
 #define UART6_RX_PIN            PC7
+#endif
 
 #define USE_SOFTSERIAL1               //Frsky SmartPort on TX2 pad
 #define SOFTSERIAL_1_TX_PIN      PA2
@@ -159,6 +165,13 @@
 #define WS2811_DMA_STREAM               DMA1_Stream5
 #define WS2811_DMA_CHANNEL              DMA_Channel_3
 
+// *************** PINIO ***************************
+#ifdef MATEKF405SE_PINIO
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                  PC6 // USER 1
+#endif
+
 // ***************  OTHERS *************************
 #define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_SOFTSERIAL)
 #define CURRENT_METER_SCALE   317
@@ -168,7 +181,6 @@
 
 #define USE_DSHOT
 #define USE_ESC_SENSOR
-
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define TARGET_IO_PORTA         0xffff


### PR DESCRIPTION
Adds a MATEKF405SE_PINIO target variant. PINIO replaces UART6 (TX)

Tested with Caddx Peanut. [[DEMO]](https://youtu.be/nmbhSygxs2w)