### PR TITLE
Increased AUX entries number

### DIFF
--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -80,7 +80,7 @@ typedef enum {
 // type to hold enough bits for CHECKBOX_ITEM_COUNT. Struct used for value-like behavior
 typedef struct boxBitmask_s { BITARRAY_DECLARE(bits, CHECKBOX_ITEM_COUNT); } boxBitmask_t;
 
-#define MAX_MODE_ACTIVATION_CONDITION_COUNT 40
+#define MAX_MODE_ACTIVATION_CONDITION_COUNT 60
 
 #define CHANNEL_RANGE_MIN 900
 #define CHANNEL_RANGE_MAX 2100


### PR DESCRIPTION
Increasing Max aux entries number to implement different schemes for small number of channels. (Receivers can have only 4 aux channels. It's too small for navigation and camera features)
Example:
aux 0 0 0 1425 1475
aux 1 0 0 1525 1575
aux 2 0 0 1625 1675
aux 3 0 0 1725 1775
aux 4 0 0 1825 1875
aux 5 0 0 1925 1975
aux 6 1 0 1425 1475
aux 7 1 0 1475 1525
aux 8 1 0 1625 1675
aux 9 1 0 1675 1725
aux 10 1 0 1825 1875
aux 11 1 0 1875 1925
aux 12 3 0 1625 1675
aux 13 3 0 1675 1725
aux 14 3 0 1725 1775
aux 15 3 0 1775 1825
aux 16 33 0 1625 1675
aux 17 33 0 1675 1725
aux 18 33 0 1725 1775
aux 19 33 0 1775 1825
aux 20 11 0 1425 1475
aux 21 11 0 1475 1525
aux 22 11 0 1525 1575
aux 23 11 0 1575 1625
aux 24 10 1 1275 1325
aux 25 10 1 1475 1525
aux 26 10 1 1675 1725
aux 27 10 1 1875 1925
aux 28 28 1 1325 1375
aux 29 28 1 1525 1575
aux 30 28 1 1725 1775
aux 31 28 1 1925 1975
aux 32 40 1 1275 1325
aux 33 40 1 1325 1375
aux 34 40 1 1375 1425
aux 35 40 1 1475 1525
aux 36 40 1 1525 1575
aux 37 40 1 1575 1625
aux 38 41 1 1275 1325
aux 39 41 1 1325 1375
aux 40 41 1 1375 1425
aux 41 41 1 1675 1725
aux 42 41 1 1725 1775
aux 43 41 1 1775 1825
