### PR TITLE
mavlink telemetry half/full duplex  support

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -1105,7 +1105,13 @@ void handleMAVLinkTelemetry(timeUs_t currentTimeUs)
 
     if ((currentTimeUs - lastMavlinkMessage) >= TELEMETRY_MAVLINK_DELAY) {
         // Only process scheduled data if we didn't serve any incoming request this cycle
-        if (!incomingRequestServed) {
+        if (!incomingRequestServed || 
+            (
+                 (rxConfig()->receiverType == RX_TYPE_SERIAL) && 
+                 (rxConfig()->serialrx_provider == SERIALRX_MAVLINK) &&
+                 !tristateWithDefaultOnIsActive(rxConfig()->halfDuplex)
+            )
+        ) {
             processMAVLinkTelemetry(currentTimeUs);
         }
         lastMavlinkMessage = currentTimeUs;


### PR DESCRIPTION
Fixes https://github.com/iNavFlight/inav/issues/8132

With default settings (AUTO) existing behavior does not change ( mavlink is half-duplex).