### PR TITLE
Make sure first motorCount outputs get assigned to motor on MR

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -230,6 +230,9 @@ void pwmBuildTimerOutputList(timMotorServoHardware_t * timOutputs, bool isMixerU
     timOutputs->maxTimMotorCount = 0;
     timOutputs->maxTimServoCount = 0;
 
+    uint8_t motorCount = getMotorCount();
+    uint8_t motorIdx = 0;
+
     for (int idx = 0; idx < timerHardwareCount; idx++) {
 
         timerHardware_t *timHw = &timerHardware[idx];
@@ -247,6 +250,13 @@ void pwmBuildTimerOutputList(timMotorServoHardware_t * timOutputs, bool isMixerU
         // Determine if timer belongs to motor/servo
         if (mixerConfig()->platformType == PLATFORM_MULTIROTOR || mixerConfig()->platformType == PLATFORM_TRICOPTER) {
             // Multicopter
+
+            // Make sure first motorCount outputs get assigned to motor
+            if ((timHw->usageFlags & TIM_USE_MC_MOTOR) && (motorIdx < motorCount)) {
+                timHw->usageFlags = timHw->usageFlags & ~TIM_USE_MC_SERVO;
+                motorIdx += 1;
+            }
+
             // We enable mapping to servos if mixer is actually using them
             if (isMixerUsingServos && timHw->usageFlags & TIM_USE_MC_SERVO) {
                 type = MAP_TO_SERVO_OUTPUT;


### PR DESCRIPTION
Updated version of #7350. This makes sure that the first N outputs get assigned to a motor on multirotor. Unlike the previous PR, it modifies the timer hardware table (like `timerHardwareOverride` does), so the output mapping is also correctly displayed in the configurator. 

To illustrate what this does, assume we have the timer hardware list below. Without this change, it was not possible to configure and X8 with 2 additional servos, as S7 and S8 would get assigned to servos first and S9 and S10 don't support motor output. With this change, S1 to S8 will be motors and S9 and S10 servos. Similarly, on a hex with 2 servos, S1 to S6 will be motors and S7 and S8 servos.

    DEF_TIM(TIM2,  CH1, PA0,   TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0,  0), // S1
    DEF_TIM(TIM3,  CH2, PB5,   TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0,  1), // S2
    DEF_TIM(TIM4,  CH1, PD12,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0,  2), // S3
    DEF_TIM(TIM4,  CH2, PD13,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0,  3), // S4

    DEF_TIM(TIM8,  CH4, PC9,   TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0,  4), // S5
    DEF_TIM(TIM8,  CH3, PC8,   TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0,  5), // S6
    DEF_TIM(TIM1,  CH3, PE13,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO | TIM_USE_MC_SERVO, 0,  6), // S7
    DEF_TIM(TIM1,  CH2, PE11,  TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO | TIM_USE_MC_SERVO, 0,  7), // S8

    DEF_TIM(TIM15, CH1, PA2,   TIM_USE_FW_SERVO | TIM_USE_MC_SERVO, 0,  0), // S9
    DEF_TIM(TIM15, CH2, PA3,   TIM_USE_FW_SERVO | TIM_USE_MC_SERVO, 0,  0), // S10