### PR TITLE
Fix esc temperature sensor maxing out

### DIFF
--- a/src/main/sensors/esc_sensor.h
+++ b/src/main/sensors/esc_sensor.h
@@ -26,7 +26,7 @@
 
 typedef struct {
     uint8_t dataAge;
-    int8_t temperature;
+    int16_t temperature;
     int16_t voltage;
     int32_t current;
     uint32_t rpm;


### PR DESCRIPTION
Increase ESC temperature to int16_t, as int8_t maxes out at 127 degrees.

[Demo](https://youtu.be/ZC3tusoy2Vw)