### PR TITLE
[Multirotor only] Land: Improvment to check that the airframe is not accelerating

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2773,13 +2773,14 @@ void calculateNewCruiseTarget(fpVector3_t * origin, int32_t yaw, int32_t distanc
  *-----------------------------------------------------------*/
 void updateLandingStatus(void)
 {
-    const bool disarm_on_land_configured = navConfig()->general.flags.disarm_on_landing;
-
-    if (STATE(AIRPLANE) && !disarm_on_land_configured) {
+    if (STATE(AIRPLANE) && !navConfig()->general.flags.disarm_on_landing) {
         return;     // no point using this with a fixed wing if not set to disarm
     }
 
-    static bool landingDetectorIsActive = false;
+    static bool landingDetectorIsActive;
+
+    DEBUG_SET(DEBUG_LANDING, 0, landingDetectorIsActive);
+    DEBUG_SET(DEBUG_LANDING, 1, STATE(LANDING_DETECTED));
 
     if (!ARMING_FLAG(ARMED)) {
         resetLandingDetector();
@@ -2789,7 +2790,7 @@ void updateLandingStatus(void)
         }
         return;
     }
-    
+
     if (!landingDetectorIsActive) {
         if (isFlightDetected()) {
             landingDetectorIsActive = true;
@@ -2797,7 +2798,7 @@ void updateLandingStatus(void)
         }
     } else if (STATE(LANDING_DETECTED)) {
         pidResetErrorAccumulators();
-        if (disarm_on_land_configured) {
+        if (navConfig()->general.flags.disarm_on_landing) {
             ENABLE_ARMING_FLAG(ARMING_DISABLED_LANDING_DETECTED);
             disarm(DISARM_LANDING);
         } else if (!navigationIsFlyingAutonomousMode()) {

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2774,39 +2774,33 @@ void calculateNewCruiseTarget(fpVector3_t * origin, int32_t yaw, int32_t distanc
 void updateLandingStatus(void)
 {
     if (STATE(AIRPLANE) && !navConfig()->general.flags.disarm_on_landing) {
-        return;     // no point using this with a fixed wing if not set to disarm
+        return;     // No point using this with a fixed wing if not set to disarm
     }
-
-    static bool landingDetectorIsActive;
-
-    DEBUG_SET(DEBUG_LANDING, 0, landingDetectorIsActive);
-    DEBUG_SET(DEBUG_LANDING, 1, STATE(LANDING_DETECTED));
 
     if (!ARMING_FLAG(ARMED)) {
         resetLandingDetector();
-        landingDetectorIsActive = false;
         if (!IS_RC_MODE_ACTIVE(BOXARM)) {
             DISABLE_ARMING_FLAG(ARMING_DISABLED_LANDING_DETECTED);
         }
         return;
     }
 
-    if (!landingDetectorIsActive) {
-        if (isFlightDetected()) {
-            landingDetectorIsActive = true;
-            resetLandingDetector();
-        }
-    } else if (STATE(LANDING_DETECTED)) {
-        pidResetErrorAccumulators();
-        if (navConfig()->general.flags.disarm_on_landing) {
-            ENABLE_ARMING_FLAG(ARMING_DISABLED_LANDING_DETECTED);
-            disarm(DISARM_LANDING);
-        } else if (!navigationIsFlyingAutonomousMode()) {
-            // for multirotor only - reactivate landing detector without disarm when throttle raised toward hover throttle
-            landingDetectorIsActive = rxGetChannelValue(THROTTLE) < (0.5 * (currentBatteryProfile->nav.mc.hover_throttle + getThrottleIdleValue()));
-        }
+    if (isFlightDetected()) {
+        resetLandingDetector();
     } else if (isLandingDetected()) {
         ENABLE_STATE(LANDING_DETECTED);
+    } 
+    
+    // Trigger disarm-on-land if configured
+    bool disarm_on_land_configured = navConfig()->general.flags.disarm_on_landing;
+    const bool mode_disarms_on_land = FLIGHT_MODE(ANGLE_MODE) || !FLIGHT_MODE(HORIZON_MODE) || !FLIGHT_MODE(TURTLE_MODE);
+
+    if (STATE(LANDING_DETECTED)) {
+        pidResetErrorAccumulators();
+        if (ARMING_FLAG(ARMED) && disarm_on_land_configured && mode_disarms_on_land) {
+            ENABLE_ARMING_FLAG(ARMING_DISABLED_LANDING_DETECTED);
+            disarm(DISARM_LANDING);
+        }
     }
 }
 

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -595,6 +595,7 @@ bool isAdjustingHeading(void);
 
 float getEstimatedAglPosition(void);
 bool isEstimatedAglTrusted(void);
+float get_accel_ef_length(void);
 
 /* Returns the heading recorded when home position was acquired.
  * Note that the navigation system uses deg*100 as unit and angles

--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -635,13 +635,13 @@ bool isFixedWingLandingDetected(void)
     // Check horizontal and vertical volocities are low (cm/s)
     bool velCondition = fabsf(navGetCurrentActualPositionAndVelocity()->vel.z) < 50.0f && posControl.actualState.velXY < 100.0f;
 
-    // check that the airframe is not accelerating (not falling or braking after fast forward flight)
-    bool accel_stationary = get_accel_ef_length() <= LAND_DETECTOR_ACCEL_MAX;
+    // Check angular rates are low (degs/s)
+    bool gyroCondition = averageAbsGyroRates() < 2.0f;
 
     DEBUG_SET(DEBUG_LANDING, 2, velCondition);
-    DEBUG_SET(DEBUG_LANDING, 3, accel_stationary);
+    DEBUG_SET(DEBUG_LANDING, 3, gyroCondition);
 
-    if (velCondition && accel_stationary){
+    if (velCondition && gyroCondition){
         DEBUG_SET(DEBUG_LANDING, 4, 2);
         DEBUG_SET(DEBUG_LANDING, 5, fixAxisCheck);
         if (!fixAxisCheck) {        // capture roll and pitch angles to be used as datums to check for absolute change

--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -634,12 +634,14 @@ bool isFixedWingLandingDetected(void)
 
     // Check horizontal and vertical volocities are low (cm/s)
     bool velCondition = fabsf(navGetCurrentActualPositionAndVelocity()->vel.z) < 50.0f && posControl.actualState.velXY < 100.0f;
-    // Check angular rates are low (degs/s)
-    bool gyroCondition = averageAbsGyroRates() < 2.0f;
-    DEBUG_SET(DEBUG_LANDING, 2, velCondition);
-    DEBUG_SET(DEBUG_LANDING, 3, gyroCondition);
 
-    if (velCondition && gyroCondition){
+    // check that the airframe is not accelerating (not falling or braking after fast forward flight)
+    bool accel_stationary = get_accel_ef_length() <= LAND_DETECTOR_ACCEL_MAX;
+
+    DEBUG_SET(DEBUG_LANDING, 2, velCondition);
+    DEBUG_SET(DEBUG_LANDING, 3, accel_stationary);
+
+    if (velCondition && accel_stationary){
         DEBUG_SET(DEBUG_LANDING, 4, 2);
         DEBUG_SET(DEBUG_LANDING, 5, fixAxisCheck);
         if (!fixAxisCheck) {        // capture roll and pitch angles to be used as datums to check for absolute change

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -51,8 +51,6 @@
 #include "navigation/navigation_private.h"
 #include "navigation/sqrt_controller.h"
 
-#include "rx/rx.h"
-
 #include "sensors/battery.h"
 
 /*-----------------------------------------------------------

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -51,6 +51,8 @@
 #include "navigation/navigation_private.h"
 #include "navigation/sqrt_controller.h"
 
+#include "rx/rx.h"
+
 #include "sensors/battery.h"
 
 /*-----------------------------------------------------------

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -741,7 +741,7 @@ bool isMulticopterLandingDetected(void)
     bool velCondition = fabsf(navGetCurrentActualPositionAndVelocity()->vel.z) < MC_LAND_CHECK_VEL_Z_MOVING;
     
     // check that the airframe is not accelerating (not falling or braking after fast forward flight)
-    bool accel_stationary = get_accel_ef_length() <= LAND_DETECTOR_ACCEL_MAX;
+    bool accel_stationary = get_accel_ef_length() <= MC_LAND_DETECTOR_ACCEL_MAX;
 
     DEBUG_SET(DEBUG_LANDING, 2, velCondition);
     DEBUG_SET(DEBUG_LANDING, 3, accel_stationary);

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -460,8 +460,9 @@ static void updateIMUTopic(timeUs_t currentTimeUs)
             posEstimator.imu.accelNEU.y = 0.0f;
             posEstimator.imu.accelNEU.z = 0.0f;
         }
-
-        accel_ef_length = pt1FilterApply4(&accel_ef_lpf, calc_length_pythagorean_3D(posEstimator.imu.accelNEU.x, posEstimator.imu.accelNEU.y, posEstimator.imu.accelNEU.z), 1.0f, dt);
+        
+        const float acc_ef_length = calc_length_pythagorean_3D(posEstimator.imu.accelNEU.x, posEstimator.imu.accelNEU.y, posEstimator.imu.accelNEU.z);
+        accel_ef_length = pt1FilterApply4(&accel_ef_lpf, acc_ef_length, LAND_DETECTOR_ACCEL_LPF_CUTOFF, dt);
 
         /* Update blackbox values */
         navAccNEU[X] = posEstimator.imu.accelNEU.x;

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -99,7 +99,7 @@ PG_RESET_TEMPLATE(positionEstimationConfig_t, positionEstimationConfig,
 
 static pt1Filter_t accel_ef_lpf;
 
-static float accel_ef_length;
+static float accel_ef_length_filter;
 
 static bool updateTimer(navigationTimer_t * tim, timeUs_t interval, timeUs_t currentTimeUs)
 {
@@ -461,8 +461,8 @@ static void updateIMUTopic(timeUs_t currentTimeUs)
             posEstimator.imu.accelNEU.z = 0.0f;
         }
         
-        const float acc_ef_length = calc_length_pythagorean_3D(posEstimator.imu.accelNEU.x, posEstimator.imu.accelNEU.y, posEstimator.imu.accelNEU.z);
-        accel_ef_length = pt1FilterApply4(&accel_ef_lpf, acc_ef_length, LAND_DETECTOR_ACCEL_LPF_CUTOFF, dt);
+        const float accel_ef_length = calc_length_pythagorean_3D(posEstimator.imu.accelNEU.x, posEstimator.imu.accelNEU.y, posEstimator.imu.accelNEU.z);
+        accel_ef_length_filter = pt1FilterApply4(&accel_ef_lpf, accel_ef_length, LAND_DETECTOR_ACCEL_LPF_CUTOFF, dt);
 
         /* Update blackbox values */
         navAccNEU[X] = posEstimator.imu.accelNEU.x;
@@ -829,7 +829,7 @@ bool isEstimatedAglTrusted(void)
 
 float get_accel_ef_length(void)
 {
-    return accel_ef_length;
+    return accel_ef_length_filter;
 }
 
 /**

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -39,11 +39,14 @@
 
 #define MC_POS_CONTROL_JERK_LIMIT_CMSSS     1700.0f // jerk limit on horizontal acceleration (cm/s^3)
 
-#define MC_LAND_CHECK_VEL_XY_MOVING         100.0f  // cm/s
-#define MC_LAND_CHECK_VEL_Z_MOVING          25.0f   // cm/s
+#define MC_LAND_CHECK_VEL_Z_MOVING          100.0f  // cm/s
 #define MC_LAND_THR_STABILISE_DELAY         1       // seconds
 #define MC_LAND_DESCEND_THROTTLE            40      // uS
 #define MC_LAND_SAFE_SURFACE                5.0f    // cm
+
+#define MC_CHECK_ACCEL_MOVING               300.0f  // cm/s
+
+#define LAND_DETECTOR_ACCEL_MAX             100.0f  // cm/s
 
 #define NAV_RTH_TRACKBACK_POINTS            50      // max number RTH trackback points
 

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -46,6 +46,8 @@
 #define MC_LAND_THR_STABILISE_DELAY         1       // seconds
 #define MC_LAND_DESCEND_THROTTLE            40      // uS
 #define MC_LAND_SAFE_SURFACE                5.0f    // cm
+#define MC_LAND_DETECTOR_TRIGGER            1000    // ms
+#define MC_LAND_AIRMODE_DETECTOR_TRIGGER    3000    // ms
 
 #define NAV_RTH_TRACKBACK_POINTS            50      // max number RTH trackback points
 

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -27,26 +27,25 @@
 #include "fc/runtime_config.h"
 #include "navigation/navigation.h"
 
-#define MIN_POSITION_UPDATE_RATE_HZ         5       // Minimum position update rate at which XYZ controllers would be applied
+#define MIN_POSITION_UPDATE_RATE_HZ         5       // minimum position update rate at which XYZ controllers would be applied
 #define NAV_THROTTLE_CUTOFF_FREQENCY_HZ     4       // low-pass filter on throttle output
 #define NAV_FW_CONTROL_MONITORING_RATE      2
 #define NAV_DTERM_CUT_HZ                    10.0f
 #define NAV_VEL_Z_DERIVATIVE_CUT_HZ         5.0f
 #define NAV_VEL_Z_ERROR_CUT_HZ              5.0f
 #define NAV_ACCELERATION_XY_MAX             980.0f  // cm/s/s       // approx 45 deg lean angle
+#define LAND_DETECTOR_ACCEL_LPF_CUTOFF      1.0f    // frequency cutoff of land detector accelerometer filter
 
 #define INAV_SURFACE_MAX_DISTANCE           40
 
 #define MC_POS_CONTROL_JERK_LIMIT_CMSSS     1700.0f // jerk limit on horizontal acceleration (cm/s^3)
 
+#define MC_CHECK_ACCEL_MOVING               300.0f  // cm/s
+#define MC_LAND_DETECTOR_ACCEL_MAX          100.0f  // cm/s
 #define MC_LAND_CHECK_VEL_Z_MOVING          100.0f  // cm/s
 #define MC_LAND_THR_STABILISE_DELAY         1       // seconds
 #define MC_LAND_DESCEND_THROTTLE            40      // uS
 #define MC_LAND_SAFE_SURFACE                5.0f    // cm
-
-#define MC_CHECK_ACCEL_MOVING               300.0f  // cm/s
-
-#define LAND_DETECTOR_ACCEL_MAX             100.0f  // cm/s
 
 #define NAV_RTH_TRACKBACK_POINTS            50      // max number RTH trackback points
 

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -566,8 +566,3 @@ void gyroUpdateDynamicLpf(float cutoffFreq) {
         }
     }
 }
-
-float averageAbsGyroRates(void)
-{
-    return (fabsf(gyro.gyroADCf[ROLL]) + fabsf(gyro.gyroADCf[PITCH]) + fabsf(gyro.gyroADCf[YAW])) / 3.0f;
-}

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -566,3 +566,8 @@ void gyroUpdateDynamicLpf(float cutoffFreq) {
         }
     }
 }
+
+float averageAbsGyroRates(void)
+{
+    return (fabsf(gyro.gyroADCf[ROLL]) + fabsf(gyro.gyroADCf[PITCH]) + fabsf(gyro.gyroADCf[YAW])) / 3.0f;
+}

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -104,3 +104,4 @@ bool gyroReadTemperature(void);
 int16_t gyroGetTemperature(void);
 int16_t gyroRateDps(int axis);
 void gyroUpdateDynamicLpf(float cutoffFreq);
+float averageAbsGyroRates(void);

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -104,4 +104,3 @@ bool gyroReadTemperature(void);
 int16_t gyroGetTemperature(void);
 int16_t gyroRateDps(int axis);
 void gyroUpdateDynamicLpf(float cutoffFreq);
-float averageAbsGyroRates(void);


### PR DESCRIPTION
The current verification using an average between the 3 axes of the Gyro doesn't seem to be very functional for some users... And for me it never worked, my multirotor never disarms after Land. Now I present another method to make the substitution. In this new method that I am presenting, the Earth-Frame Acceleration calculated by the INS will be used to calculate the X, Y and Z normalization, and filter this normalization at 1Hz, simple. Now my multirotor always trips after a Land.