### PR TITLE
Use timed timeouts for USB HAL functions, not simple counts, as per H7

### DIFF
--- a/lib/main/STM32F4/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c
+++ b/lib/main/STM32F4/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c
@@ -71,6 +71,27 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
+
+/** @defgroup USB_OTG_GRSTCTL_AHBIDL_TIMEOUT_MS AHB master idle timeout
+  * @{
+  */
+#define USB_OTG_GRSTCTL_AHBIDL_TIMEOUT_MS  ((uint32_t)50U)
+
+/** @defgroup USB_OTG_GRSTCTL_CSRST_TIMEOUT_MS Core soft reset timeout
+  * @{
+  */
+#define USB_OTG_GRSTCTL_CSRST_TIMEOUT_MS  ((uint32_t)10U)
+
+/** @defgroup USB_OTG_GRSTCTL_TXFFLSH_TIMEOUT_MS Tx FIFO flush timeout
+  * @{
+  */
+#define USB_OTG_GRSTCTL_TXFFLSH_TIMEOUT_MS  ((uint32_t)5U)
+
+/** @defgroup USB_OTG_GRSTCTL_RXFFLSH_TIMEOUT_MS Rx FIFO flush timeout
+  * @{
+  */
+#define USB_OTG_GRSTCTL_RXFFLSH_TIMEOUT_MS  ((uint32_t)5U)
+
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 /* Private functions ---------------------------------------------------------*/
@@ -350,19 +371,22 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   */
 HAL_StatusTypeDef USB_FlushTxFifo (USB_OTG_GlobalTypeDef *USBx, uint32_t num )
 {
-  uint32_t count = 0;
-  
-  USBx->GRSTCTL = ( USB_OTG_GRSTCTL_TXFFLSH |(uint32_t)( num << 6)); 
-  
-  do
+  uint32_t tickstart;
+
+  USBx->GRSTCTL = (USB_OTG_GRSTCTL_TXFFLSH | (num << 6));
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait for AHB master IDLE state. */
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_TXFFLSH) == USB_OTG_GRSTCTL_TXFFLSH)
   {
-    if (++count > 200000)
+    if ((HAL_GetTick() - tickstart) > USB_OTG_GRSTCTL_TXFFLSH_TIMEOUT_MS)
     {
       return HAL_TIMEOUT;
     }
   }
-  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_TXFFLSH) == USB_OTG_GRSTCTL_TXFFLSH);
-  
+
   return HAL_OK;
 }
 
@@ -374,19 +398,22 @@ HAL_StatusTypeDef USB_FlushTxFifo (USB_OTG_GlobalTypeDef *USBx, uint32_t num )
   */
 HAL_StatusTypeDef USB_FlushRxFifo(USB_OTG_GlobalTypeDef *USBx)
 {
-  uint32_t count = 0;
-  
+  uint32_t tickstart;
+
   USBx->GRSTCTL = USB_OTG_GRSTCTL_RXFFLSH;
-  
-  do
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait for AHB master IDLE state. */
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_RXFFLSH) == USB_OTG_GRSTCTL_RXFFLSH)
   {
-    if (++count > 200000)
+    if ((HAL_GetTick() - tickstart) > USB_OTG_GRSTCTL_RXFFLSH_TIMEOUT_MS)
     {
       return HAL_TIMEOUT;
     }
   }
-  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_RXFFLSH) == USB_OTG_GRSTCTL_RXFFLSH);
-  
+
   return HAL_OK;
 }
 
@@ -1195,31 +1222,34 @@ HAL_StatusTypeDef USB_EP0_OutStart(USB_OTG_GlobalTypeDef *USBx, uint8_t dma, uin
   */
 static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx)
 {
-  uint32_t count = 0U;
+  uint32_t tickstart;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   /* Wait for AHB master IDLE state. */
-  do
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_AHBIDL) == 0U)
   {
-    if (++count > 200000U)
+    if ((HAL_GetTick() - tickstart) > USB_OTG_GRSTCTL_AHBIDL_TIMEOUT_MS)
     {
       return HAL_TIMEOUT;
     }
   }
-  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_AHBIDL) == 0U);
-  
+
   /* Core Soft Reset */
-  count = 0U;
   USBx->GRSTCTL |= USB_OTG_GRSTCTL_CSRST;
 
-  do
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_CSRST) == USB_OTG_GRSTCTL_CSRST)
   {
-    if (++count > 200000U)
+    if ((HAL_GetTick() - tickstart) > USB_OTG_GRSTCTL_CSRST_TIMEOUT_MS)
     {
       return HAL_TIMEOUT;
     }
   }
-  while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_CSRST) == USB_OTG_GRSTCTL_CSRST);
-  
+
   return HAL_OK;
 }
 


### PR DESCRIPTION
The `STM32F4xx_HAL_Driver` and `STM32F7xx_HAL_Driver` folders are currently not used during compilation, but it may be useful in the future if one day LL is used.