### PR TITLE
Updated CMS GPSNAV PIDs

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -248,12 +248,14 @@ static const OSD_Entry cmsx_menuPidGpsnavEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- GPSNAV --", profileIndexString),
 
-    OTHER_PIDFF_ENTRY("POS  P", &cmsx_pidPosXY.P),
-    OTHER_PIDFF_ENTRY("POS  I", &cmsx_pidPosXY.I),
+    OTHER_PIDFF_ENTRY("POS P", &cmsx_pidPosXY.P),
+    OTHER_PIDFF_ENTRY("POS I", &cmsx_pidPosXY.I),
+    OTHER_PIDFF_ENTRY("POS D", &cmsx_pidPosXY.D),
 
-    OTHER_PIDFF_ENTRY("POSR P", &cmsx_pidVelXY.P),
-    OTHER_PIDFF_ENTRY("POSR I", &cmsx_pidVelXY.I),
-    OTHER_PIDFF_ENTRY("POSR D", &cmsx_pidVelXY.D),
+    OTHER_PIDFF_ENTRY("VEL P", &cmsx_pidVelXY.P),
+    OTHER_PIDFF_ENTRY("VEL I", &cmsx_pidVelXY.I),
+    OTHER_PIDFF_ENTRY("VEL D", &cmsx_pidVelXY.D),
+    OTHER_PIDFF_ENTRY("VEL FF", &cmsx_pidVelXY.FF),
 
     OSD_BACK_AND_END_ENTRY,
 };
@@ -436,7 +438,7 @@ static const OSD_Entry cmsx_menuMechanicsEntries[] =
     OSD_SETTING_ENTRY("ITERM RELAX", SETTING_MC_ITERM_RELAX),
     OSD_SETTING_ENTRY("ITERM CUTOFF", SETTING_MC_ITERM_RELAX_CUTOFF),
     OSD_SETTING_ENTRY("CD LPF", SETTING_MC_CD_LPF_HZ),
- 
+
     OSD_BACK_AND_END_ENTRY,
 };
 


### PR DESCRIPTION
Updated to be more meaningful given it appears POSR is long redundant.