### PR TITLE
Use GPS lag to have a better relationship between GPS and IMU

### DIFF
--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -74,3 +74,5 @@ void imuTransformVectorBodyToEarth(fpVector3_t * v);
 void imuTransformVectorEarthToBody(fpVector3_t * v);
 
 void imuInit(void);
+
+void imuCorrectGPSLag(int32_t *lat, int32_t *lon);

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -555,6 +555,7 @@ bool geoConvertGeodeticToLocalOrigin(fpVector3_t * pos, const gpsLocation_t *llh
 // geodetic coordinates using the provided GPS origin. It returns wether
 // the provided origin is valid and the conversion could be performed.
 bool geoConvertLocalToGeodetic(gpsLocation_t *llh, const gpsOrigin_t *origin, const fpVector3_t *pos);
+void geoOffsetLatLng(int32_t *lat, int32_t *lng, float ofs_north, float ofs_east);
 float geoCalculateMagDeclination(const gpsLocation_t * llh); // degrees units
 // Select absolute or relative altitude based on WP mission flag setting
 geoAltitudeConversionMode_e waypointMissionAltConvMode(geoAltitudeDatumFlag_e datumFlag);

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -201,6 +201,8 @@ void onNewGPSData(void)
     newLLH.lon = gpsSol.llh.lon;
     newLLH.alt = gpsSol.llh.alt;
 
+    imuCorrectGPSLag(&newLLH.lat, &newLLH.lon);
+
     if (sensors(SENSOR_GPS)) {
         if (!STATE(GPS_FIX)) {
             isFirstGPSUpdate = true;

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#define DISTANCE_BETWEEN_TWO_LONGITUDE_POINTS_AT_EQUATOR    1.113195f  // MagicEarthNumber from APM
+#define DISTANCE_BETWEEN_TWO_LONGITUDE_POINTS_AT_EQUATOR 1.113195f  // MagicEarthNumber from APM
+#define LOCATION_SCALING_FACTOR_INV                      89.83204651f
 
 #include "common/axis.h"
 #include "common/maths.h"


### PR DESCRIPTION
I don't have much to say, but basically this algorithm uses GPS lag to help correlate the GPS information with the IMU information.

I'll leave it as Draft for now, because each GPS model has a different lag in milliseconds, and it will be necessary to create a function to identify the type of chip used (6, 7, M8, M9 and F9) and correctly set the Lag value. As long as the algorithm has the Ublox 7 and M8 Lag defined (because that's what I'm using in my Multirotor)