### PR TITLE
Re-order boxmodes to have as little disruption to 5.1 as possible

### DIFF
--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -87,14 +87,14 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { .boxId = BOXUSER1,            .boxName = "USER1",             .permanentId = BOX_PERMANENT_ID_USER1 },
     { .boxId = BOXUSER2,            .boxName = "USER2",             .permanentId = BOX_PERMANENT_ID_USER2 },
     { .boxId = BOXUSER3,            .boxName = "USER3",             .permanentId = BOX_PERMANENT_ID_USER3 },
-    { .boxId = BOXLOITERDIRCHN,     .boxName = "LOITER CHANGE",     .permanentId = 50 },
-    { .boxId = BOXMSPRCOVERRIDE,    .boxName = "MSP RC OVERRIDE",   .permanentId = 51 },
-    { .boxId = BOXPREARM,           .boxName = "PREARM",            .permanentId = 52 },
-    { .boxId = BOXTURTLE,           .boxName = "TURTLE",            .permanentId = 53 },
-    { .boxId = BOXNAVCRUISE,        .boxName = "NAV CRUISE",        .permanentId = 54 },
-    { .boxId = BOXAUTOLEVEL,        .boxName = "AUTO LEVEL",        .permanentId = 55 },
-    { .boxId = BOXPLANWPMISSION,    .boxName = "WP PLANNER",        .permanentId = 56 },
-    { .boxId = BOXSOARING,          .boxName = "SOARING",           .permanentId = 57 },
+    { .boxId = BOXMSPRCOVERRIDE,    .boxName = "MSP RC OVERRIDE",   .permanentId = 50 },
+    { .boxId = BOXPREARM,           .boxName = "PREARM",            .permanentId = 51 },
+    { .boxId = BOXTURTLE,           .boxName = "TURTLE",            .permanentId = 52 },
+    { .boxId = BOXNAVCRUISE,        .boxName = "NAV CRUISE",        .permanentId = 53 },
+    { .boxId = BOXAUTOLEVEL,        .boxName = "AUTO LEVEL",        .permanentId = 54 },
+    { .boxId = BOXPLANWPMISSION,    .boxName = "WP PLANNER",        .permanentId = 55 },
+    { .boxId = BOXSOARING,          .boxName = "SOARING",           .permanentId = 56 },
+    { .boxId = BOXLOITERDIRCHN,     .boxName = "LOITER CHANGE",     .permanentId = 57 },
     { .boxId = CHECKBOX_ITEM_COUNT, .boxName = NULL,                .permanentId = 0xFF }
 };
 


### PR DESCRIPTION
#8346 corrected an error in the boxmodes with a shared ID for USER3. However, in that change, 7 modes were unnecessarily reordered. This would cause issues when restoring diffs, as at least two of those modes are used frequently on fixed wing, and another two on multi-rotor. One mode will still need to be moved. Loiter direction change likely has the least usage, so would effect the least number of people.

**Note:** Boxmode numbering fixed in https://github.com/iNavFlight/inav/pull/8401. So no changes between 5.1 and 6.0 for existing boxmodes.