### PR TITLE
enable virtual pitot on F411 and F722

### DIFF
--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -185,12 +185,11 @@
 #define USE_WIND_ESTIMATOR
 
 #define USE_SIMULATOR
+#define USE_PITOT_VIRTUAL
 
 //Designed to free space of F722 and F411 MCUs
 #if (MCU_FLASH_SIZE > 512)
-
 #define USE_VTX_FFPV
-#define USE_PITOT_VIRTUAL
 #define USE_SERIALRX_SUMD
 #define USE_TELEMETRY_HOTT
 #define USE_HOTT_TEXTMODE


### PR DESCRIPTION
This feature is useful to prevent stalls on fixed-wing,
with only 0.07% increased usage of flash on f411 MCU
especially the wind estimator is working well on the current master 
