### PR TITLE
Update virtual pitot to use 3d speed

### DIFF
--- a/src/main/drivers/pitotmeter/pitotmeter_virtual.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_virtual.c
@@ -64,13 +64,18 @@ static void virtualPitotCalculate(pitotDev_t *pitot, float *pressure, float *tem
     UNUSED(pitot);
     float airSpeed = 0.0f;
     if (pitotIsCalibrationComplete()) {
-        if (isEstimatedWindSpeedValid()) {
+        if (isEstimatedWindSpeedValid() && STATE(GPS_FIX)) {
             uint16_t windHeading; //centidegrees
             float windSpeed = getEstimatedHorizontalWindSpeed(&windHeading); //cm/s
             float horizontalWindSpeed = windSpeed * cos_approx(CENTIDEGREES_TO_RADIANS(windHeading - posControl.actualState.yaw)); //yaw int32_t centidegrees
             airSpeed = posControl.actualState.velXY - horizontalWindSpeed; //float cm/s or gpsSol.groundSpeed int16_t cm/s
             airSpeed = calc_length_pythagorean_2D(airSpeed,getEstimatedActualVelocity(Z)+getEstimatedWindSpeed(Z));
-        } else {
+        } 
+        else if (STATE(GPS_FIX))
+        {
+            airSpeed = calc_length_pythagorean_3D(gpsSol.velNED[X],gpsSol.velNED[Y],gpsSol.velNED[Z]);
+        }
+        else {
             airSpeed = pidProfile()->fixedWingReferenceAirspeed; //float cm/s
         }
     }

--- a/src/main/drivers/pitotmeter/pitotmeter_virtual.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_virtual.c
@@ -69,6 +69,7 @@ static void virtualPitotCalculate(pitotDev_t *pitot, float *pressure, float *tem
             float windSpeed = getEstimatedHorizontalWindSpeed(&windHeading); //cm/s
             float horizontalWindSpeed = windSpeed * cos_approx(CENTIDEGREES_TO_RADIANS(windHeading - posControl.actualState.yaw)); //yaw int32_t centidegrees
             airSpeed = posControl.actualState.velXY - horizontalWindSpeed; //float cm/s or gpsSol.groundSpeed int16_t cm/s
+            airSpeed = calc_length_pythagorean_2D(airSpeed,getEstimatedActualVelocity(Z)+getEstimatedWindSpeed(Z));
         } else {
             airSpeed = pidProfile()->fixedWingReferenceAirspeed; //float cm/s
         }

--- a/src/main/flight/wind_estimator.c
+++ b/src/main/flight/wind_estimator.c
@@ -40,6 +40,8 @@
 
 #include "io/gps.h"
 
+
+#define WINDESTIMATOR_TIMEOUT       60 //60s
 // Based on WindEstimation.pdf paper
 
 static bool hasValidWindEstimate = false;
@@ -49,8 +51,6 @@ static float lastFuselageDirection[XYZ_AXIS_COUNT];
 
 bool isEstimatedWindSpeedValid(void)
 {
-    // TODO: Add a timeout. Estimated wind should expire if
-    // if we can't update it for an extended time.
     return hasValidWindEstimate;
 }
 
@@ -78,6 +78,12 @@ float getEstimatedHorizontalWindSpeed(uint16_t *angle)
 void updateWindEstimator(timeUs_t currentTimeUs)
 {
     static timeUs_t lastUpdateUs = 0;
+    static timeUs_t lastValidWindEstimate = 0;
+
+    if (US2MS(currentTimeUs - lastValidWindEstimate) > WINDESTIMATOR_TIMEOUT)
+    {
+        hasValidWindEstimate = false;
+    }
 
     if (!STATE(FIXED_WING_LEGACY) ||
         !isGPSHeadingValid() ||
@@ -167,6 +173,7 @@ void updateWindEstimator(timeUs_t currentTimeUs)
         }
 
         lastUpdateUs = currentTimeUs;
+        lastValidWindEstimate = currentTimeUs;
         hasValidWindEstimate = true;
     }
 }

--- a/src/main/flight/wind_estimator.c
+++ b/src/main/flight/wind_estimator.c
@@ -80,7 +80,7 @@ void updateWindEstimator(timeUs_t currentTimeUs)
     static timeUs_t lastUpdateUs = 0;
     static timeUs_t lastValidWindEstimate = 0;
 
-    if (US2MS(currentTimeUs - lastValidWindEstimate) > WINDESTIMATOR_TIMEOUT)
+    if (US2S(currentTimeUs - lastValidWindEstimate) > WINDESTIMATOR_TIMEOUT)
     {
         hasValidWindEstimate = false;
     }


### PR DESCRIPTION
Changes:
1. update the virtual pitot to 3D speed instead of 2D ground speed
2. when wind estimation is not valid use GPS 3d speed
3. added a 60s timeout in wind-estimator

Not tested it on real plane yet, anyone cloud help?