### PR TITLE
Change tz_offset min and max

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -5778,7 +5778,7 @@ Time zone offset from UTC, in minutes. This is applied to the GPS time for loggi
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0 | -1440 | 1440 |
+| 0 | -720 | 840 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3687,8 +3687,8 @@ groups:
       - name: tz_offset
         description: "Time zone offset from UTC, in minutes. This is applied to the GPS time for logging and time-stamping of Blackbox logs"
         default_value: 0
-        min: -1440
-        max: 1440
+        min: -720
+        max: 840
       - name: tz_automatic_dst
         description: "Automatically add Daylight Saving Time to the GPS time when needed or simply ignore it. Includes presets for EU and the USA - if you live outside these areas it is suggested to manage DST manually via `tz_offset`."
         default_value: "OFF"


### PR DESCRIPTION
The current min and max for `tz_offset` is 1440, or 24 hours. The actual min and max for UTC is -12 hours (-720) and +14 hours (840). This PR uses the UTC values as the actual min and max offsets.

Mentioned in https://github.com/iNavFlight/inav-configurator/pull/1640