### PR TITLE
Remove non-existent extension from CMakesList

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -314,7 +314,6 @@ main_sources(COMMON_SRC
     flight/mixer.h
     flight/pid.c
     flight/pid.h
-    flight/pid_autotune.c
     flight/power_limits.c
     flight/power_limits.h
     flight/rth_estimator.c


### PR DESCRIPTION
The compiler should complain that this extension doesn't exist... but, the compiler simply compiles as if this extension exists