### PR TITLE
Fix read of DPS310 coef C11

### DIFF
--- a/src/main/drivers/barometer/barometer_2smpb_02b.c
+++ b/src/main/drivers/barometer/barometer_2smpb_02b.c
@@ -20,8 +20,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
- *
- * Copyright: INAVFLIGHT OU
  */
 
 #include <stdbool.h>

--- a/src/main/drivers/barometer/barometer_2smpb_02b.h
+++ b/src/main/drivers/barometer/barometer_2smpb_02b.h
@@ -20,8 +20,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
- *
- * Copyright: INAVFLIGHT OU
  */
 
 #pragma once

--- a/src/main/drivers/barometer/barometer_dps310.h
+++ b/src/main/drivers/barometer/barometer_dps310.h
@@ -20,8 +20,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
- *
- * Copyright: INAVFLIGHT OU
  */
 
 #pragma once


### PR DESCRIPTION
The reading of the compensation coefficients described in section 8.11, Calibration Coefficients (COEF), of the datasheet at https://www.infineon.com/dgdl/Infineon-DPS310-DataSheet-v01_02-EN.pdf?fileId=5546d462576f34750157750826c42242 was erroneously reading the C11 value from the C01 register.

This solves the problem described here >> https://github.com/iNavFlight/inav/discussions/6424