### PR TITLE
Apply custom gyro scale factor

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1512,6 +1512,36 @@ Defines the type of the main gyro LPF filter. Possible values: `PT1`, `BIQUAD`. 
 
 ---
 
+### gyro_scale_x
+
+Gyro scale to apply for axis X, 10000 is 100% no scaling
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 10000 | 7500 | 12500 |
+
+---
+
+### gyro_scale_y
+
+Gyro scale to apply for axis Y, 10000 is 100% no scaling
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 10000 | 7500 | 12500 |
+
+---
+
+### gyro_scale_z
+
+Gyro scale to apply for axis Z, 10000 is 100% no scaling
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 10000 | 7500 | 12500 |
+
+---
+
 ### gyro_to_use
 
 _// TODO_

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1514,7 +1514,7 @@ Defines the type of the main gyro LPF filter. Possible values: `PT1`, `BIQUAD`. 
 
 ### gyro_scale_x
 
-Gyro scale apply for axis X, 10000 is 100% no scaling
+Gyro scale apply for axis X, 0 is 100% no scaling, 1000 is 110% scaling
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -1524,7 +1524,7 @@ Gyro scale apply for axis X, 10000 is 100% no scaling
 
 ### gyro_scale_y
 
-Gyro scale apply for axis Y, 10000 is 100% no scaling
+Gyro scale apply for axis Y, 0 is 100% no scaling, 500 is 105% scaling
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -1534,7 +1534,7 @@ Gyro scale apply for axis Y, 10000 is 100% no scaling
 
 ### gyro_scale_z
 
-Gyro scale apply for axis Z, 10000 is 100% no scaling
+Gyro scale apply for axis Z, 0 is 100% no scaling, -1000 is 90% scaling
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1518,7 +1518,7 @@ Gyro scale apply for axis X, 10000 is 100% no scaling
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 10000 | 7500 | 12500 |
+| 0 | -2500 | 2500 |
 
 ---
 
@@ -1528,7 +1528,7 @@ Gyro scale apply for axis Y, 10000 is 100% no scaling
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 10000 | 7500 | 12500 |
+| 0 | -2500 | 2500 |
 
 ---
 
@@ -1538,7 +1538,7 @@ Gyro scale apply for axis Z, 10000 is 100% no scaling
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 10000 | 7500 | 12500 |
+| 0 | -2500 | 2500 |
 
 ---
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1514,7 +1514,7 @@ Defines the type of the main gyro LPF filter. Possible values: `PT1`, `BIQUAD`. 
 
 ### gyro_scale_x
 
-Gyro scale to apply for axis X, 10000 is 100% no scaling
+Gyro scale apply for axis X, 10000 is 100% no scaling
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -1524,7 +1524,7 @@ Gyro scale to apply for axis X, 10000 is 100% no scaling
 
 ### gyro_scale_y
 
-Gyro scale to apply for axis Y, 10000 is 100% no scaling
+Gyro scale apply for axis Y, 10000 is 100% no scaling
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -1534,7 +1534,7 @@ Gyro scale to apply for axis Y, 10000 is 100% no scaling
 
 ### gyro_scale_z
 
-Gyro scale to apply for axis Z, 10000 is 100% no scaling
+Gyro scale apply for axis Z, 10000 is 100% no scaling
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -349,23 +349,23 @@ groups:
         min: INT16_MIN
         max: INT16_MAX
       - name: gyro_scale_x
-        description: "Gyro scale apply for axis X, 10000 is 100% no scaling"
-        default_value: 10000
+        description: "Gyro scale apply for axis X, 0 is 100% no scaling, 1000 is 110% scaling"
+        default_value: 0
         field: gyro_scale_cal[X]
-        min: 7500
-        max: 12500
+        min: -2500
+        max: 2500
       - name: gyro_scale_y
-        description: "Gyro scale apply for axis Y, 10000 is 100% no scaling"
-        default_value: 10000
+        description: "Gyro scale apply for axis Y, 0 is 100% no scaling, 500 is 105% scaling"
+        default_value: 0
         field: gyro_scale_cal[Y]
-        min: 7500
-        max: 12500
+        min: -2500
+        max: 2500
       - name: gyro_scale_z
-        description: "Gyro scale apply for axis Z, 10000 is 100% no scaling"
-        default_value: 10000
+        description: "Gyro scale apply for axis Z, 0 is 100% no scaling, -1000 is 90% scaling"
+        default_value: 0
         field: gyro_scale_cal[Z]
-        min: 7500
-        max: 12500
+        min: -2500
+        max: 2500
       - name: ins_gravity_cmss
         description: "Calculated 1G of Acc axis Z to use in INS"
         default_value: 0.0

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -348,6 +348,24 @@ groups:
         field: gyro_zero_cal[Z]
         min: INT16_MIN
         max: INT16_MAX
+      - name: gyro_scale_x
+        description: "Gyro scale apply for axis X, 10000 is 100% no scaling"
+        default_value: 10000
+        field: gyro_scale_cal[X]
+        min: 7500
+        max: 12500
+      - name: gyro_scale_y
+        description: "Gyro scale apply for axis Y, 10000 is 100% no scaling"
+        default_value: 10000
+        field: gyro_scale_cal[Y]
+        min: 7500
+        max: 12500
+      - name: gyro_scale_z
+        description: "Gyro scale apply for axis Z, 10000 is 100% no scaling"
+        default_value: 10000
+        field: gyro_scale_cal[Z]
+        min: 7500
+        max: 12500
       - name: ins_gravity_cmss
         description: "Calculated 1G of Acc axis Z to use in INS"
         default_value: 0.0

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -87,7 +87,7 @@ STATIC_FASTRAM filter_t gyroLpfState[XYZ_AXIS_COUNT];
 
 STATIC_FASTRAM filterApplyFnPtr gyroLpf2ApplyFn;
 STATIC_FASTRAM filter_t gyroLpf2State[XYZ_AXIS_COUNT];
-FASTRAM float runtime_gyro_scale[XYZ_AXIS_COUNT];
+FASTRAM float runtime_gyro_scale[XYZ_AXIS_COUNT] = {1.0f, 1.0f, 1.0f};
 
 #ifdef USE_DYNAMIC_FILTERS
 
@@ -313,9 +313,9 @@ bool gyroInit(void)
     );
 #endif
     // calculate custom scale
-    runtime_gyro_scale[X]=gyroConfig()->gyro_scale_cal[X] / 10000.0f;
-    runtime_gyro_scale[Y]=gyroConfig()->gyro_scale_cal[Y] / 10000.0f;
-    runtime_gyro_scale[Z]=gyroConfig()->gyro_scale_cal[Z] / 10000.0f;
+    runtime_gyro_scale[X] = (gyroConfig()->gyro_scale_cal[X]) / 10000.0f + 1.0f;
+    runtime_gyro_scale[Y] = (gyroConfig()->gyro_scale_cal[Y]) / 10000.0f + 1.0f;
+    runtime_gyro_scale[Z] = (gyroConfig()->gyro_scale_cal[Z]) / 10000.0f + 1.0f;
     return true;
 }
 

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -89,6 +89,7 @@ typedef struct gyroConfig_s {
 #endif
     bool init_gyro_cal_enabled;
     int16_t gyro_zero_cal[XYZ_AXIS_COUNT];
+    int16_t gyro_scale_cal[XYZ_AXIS_COUNT];
     float gravity_cmss_cal;
 } gyroConfig_t;
 

--- a/src/test/unit/sensor_gyro_unittest.cc
+++ b/src/test/unit/sensor_gyro_unittest.cc
@@ -20,7 +20,6 @@
 
 #include <limits.h>
 #include <algorithm>
-#include <iostream>
 
 extern "C" {
     #include <platform.h>

--- a/src/test/unit/sensor_gyro_unittest.cc
+++ b/src/test/unit/sensor_gyro_unittest.cc
@@ -20,6 +20,7 @@
 
 #include <limits.h>
 #include <algorithm>
+#include <iostream>
 
 extern "C" {
     #include <platform.h>


### PR DESCRIPTION
### This pr allows applying gyro scale factor in inav firmware
#### what is gyro scale factor error
Rotation_speed=gyro_scale_factor *gyro_raw_reading
Similar to the accelerometer, gyro_scale_factor needs calibration due to manufacturing error


without calibration it will read angular speed incorrectly, which will result in AHI drift in rolls or flips, the internal state in ahrs always rotates more/less that actual rotation
You can `set imu_dcm_kp = 50` to have a look on pure gyro data to see if you have this problem, This is how it looks
https://www.youtube.com/watch?v=hnNc33QCbM8


Fortunately, some gyros already have factory scale factor calibration, such as mpu6000 or icm-20689
But BMI270 do not have a factory scale factor calibration , and it seems like it has some serious errors(as high as 7deg per 360deg) without calibration,This will cause fatal AHI error just after a few rolls or flips


#### MoreInfo
BMI270 gyro can perform motionless SENS error compensation (CRT) and store them into Non-volatile memory, The calibrated scale factor can be applied automatically on startup. But it is kind of risky and complicate process. And i found manual applying gyro scale with this pr will achieve better accuracy
