### PR TITLE
[Multirotor Only] Automatic learning of hover throttle

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3462,6 +3462,16 @@ P gain of altitude PID controller (Multirotor)
 
 ---
 
+### nav_mc_thr_hover_learn
+
+Enable/Disable automatic learning of hover throttle.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| ON | OFF | ON |
+
+---
+
 ### nav_mc_vel_xy_d
 
 D gain of Position-Rate (Velocity to Acceleration) PID controller. It can damp P and I. Increasing D might help when drone overshoots target.

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -397,7 +397,7 @@ bool setConfigBatteryProfile(uint8_t profileIndex)
 {
     bool ret = true; // return true if current_battery_profile_index has changed
     if (systemConfig()->current_battery_profile_index == profileIndex) {
-        ret =  false;
+        ret = false;
     }
     if (profileIndex >= MAX_BATTERY_PROFILE_COUNT) {// sanity check
         profileIndex = 0;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1060,6 +1060,11 @@ groups:
         field: nav.mc.hover_throttle
         min: 1000
         max: 2000
+      - name: nav_mc_thr_hover_learn
+        description: "Enable/Disable automatic learning of hover throttle."
+        default_value: ON
+        field: nav.mc.thr_hover_learn_enabled
+        type: bool
       - name: nav_fw_cruise_thr
         description: "Cruise throttle in GPS assisted modes, this includes RTH. Should be set high enough to avoid stalling. This values gives INAV a base for throttle when flying straight, and it will increase or decrease throttle based on pitch of airplane and the parameters below. In addition it will increase throttle if GPS speed gets below 7m/s ( hardcoded )"
         default_value: 1400

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3514,6 +3514,8 @@ void applyWaypointNavigationAndAltitudeHold(void)
         posControl.activeRthTBPointIndex = -1;
         posControl.flags.rthTrackbackActive = false;
         posControl.rthTBWrapAroundCounter = -1;
+        
+        saveMultirotorThrottleHoverOnDisarm();
 
         return;
     }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3516,7 +3516,7 @@ void applyWaypointNavigationAndAltitudeHold(void)
         posControl.rthTBWrapAroundCounter = -1;
         
         saveMultirotorThrottleHoverOnDisarm();
-
+        
         return;
     }
 

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -901,9 +901,6 @@ static void updateThrottleHover(void)
             // We have chosen to constrain the hover throttle to be within the range reachable by the third order expo polynomial.
             currentBatteryProfileMutable->nav.mc.hover_throttle = constrainf(currentBatteryProfileMutable->nav.mc.hover_throttle + (0.01f / (0.01f + THROTTLE_HOVER_TC)) * (throttle - currentBatteryProfileMutable->nav.mc.hover_throttle), 1250.0f, 1680.0f);
         }
-        DEBUG_SET(DEBUG_CRUISE, 0, currentBatteryProfileMutable->nav.mc.hover_throttle);
-        DEBUG_SET(DEBUG_CRUISE, 1, attitude.values.roll);
-        DEBUG_SET(DEBUG_CRUISE, 2, attitude.values.pitch);
     }
 }
 

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -904,7 +904,7 @@ static void updateThrottleHover(void)
     }
 }
 
-void saveMultirotorThrottleHoverOnDisarm(void) 
+void saveMultirotorThrottleHoverOnDisarm(void)
 {
     // If not enabled then exit
     if (!currentBatteryProfile->nav.mc.thr_hover_learn_enabled) {
@@ -918,7 +918,7 @@ void saveMultirotorThrottleHoverOnDisarm(void)
 
     static uint16_t prevHoverThrottle;
     
-    // Firs initialization
+    // First initialization
     if (prevHoverThrottle == 0) {
         prevHoverThrottle = currentBatteryProfile->nav.mc.hover_throttle;
     }

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -911,22 +911,22 @@ void saveMultirotorThrottleHoverOnDisarm(void)
         return;
     }
     
+    static uint16_t prevHoverThrottle = 0;
+
     // If not Multirotor enabled then exit
     if (!STATE(MULTIROTOR)) {
         return;
     }
 
-    static uint16_t prevHoverThrottle;
-    
     // First initialization
     if (prevHoverThrottle == 0) {
         prevHoverThrottle = currentBatteryProfile->nav.mc.hover_throttle;
     }
 
-    // Save hover throttle
-    if (prevHoverThrottle != currentBatteryProfile->nav.mc.hover_throttle) {
-        prevHoverThrottle = currentBatteryProfile->nav.mc.hover_throttle;
-        setConfigBatteryProfileAndWriteEEPROM(getConfigBatteryProfile());
+    // Compare with the previous value and save a new value if necessary
+    if (prevHoverThrottle != currentBatteryProfileMutable->nav.mc.hover_throttle) {
+        saveConfigAndNotify();
+        prevHoverThrottle = 0;
     }
 }
 

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -27,12 +27,13 @@
 #include "fc/runtime_config.h"
 #include "navigation/navigation.h"
 
-#define MIN_POSITION_UPDATE_RATE_HZ         5       // Minimum position update rate at which XYZ controllers would be applied
+#define MIN_POSITION_UPDATE_RATE_HZ         5       // minimum position update rate at which XYZ controllers would be applied
 #define NAV_THROTTLE_CUTOFF_FREQENCY_HZ     4       // low-pass filter on throttle output
 #define NAV_FW_CONTROL_MONITORING_RATE      2
 #define NAV_DTERM_CUT_HZ                    10.0f
 #define NAV_VEL_Z_DERIVATIVE_CUT_HZ         5.0f
 #define NAV_VEL_Z_ERROR_CUT_HZ              5.0f
+#define THROTTLE_HOVER_TC                   10.0f   // time constant used to update estimated hover throttle
 #define NAV_ACCELERATION_XY_MAX             980.0f  // cm/s/s       // approx 45 deg lean angle
 
 #define INAV_SURFACE_MAX_DISTANCE           40

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -476,6 +476,7 @@ bool adjustMulticopterAltitudeFromRCInput(void);
 bool adjustMulticopterHeadingFromRCInput(void);
 bool adjustMulticopterPositionFromRCInput(int16_t rcPitchAdjustment, int16_t rcRollAdjustment);
 
+void saveMultirotorThrottleHoverOnDisarm(void);
 void applyMulticopterNavigationController(navigationFSMStateFlags_t navStateFlags, timeUs_t currentTimeUs);
 
 bool isMulticopterLandingDetected(void);

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -94,7 +94,7 @@ static int32_t mWhDrawn = 0;                    // energy (milliWatt hours) draw
 batteryState_e batteryState;
 const batteryProfile_t *currentBatteryProfile;
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(batteryProfile_t, MAX_BATTERY_PROFILE_COUNT, batteryProfiles, PG_BATTERY_PROFILES, 1);
+PG_REGISTER_ARRAY_WITH_RESET_FN(batteryProfile_t, MAX_BATTERY_PROFILE_COUNT, batteryProfiles, PG_BATTERY_PROFILES, 2);
 
 void pgResetFn_batteryProfiles(batteryProfile_t *instance)
 {
@@ -135,6 +135,7 @@ void pgResetFn_batteryProfiles(batteryProfile_t *instance)
             .nav = {
 
                 .mc = {
+                    .thr_hover_learn_enabled = SETTING_NAV_MC_THR_HOVER_LEARN,
                     .hover_throttle = SETTING_NAV_MC_HOVER_THR_DEFAULT,
                 },
 

--- a/src/main/sensors/battery_config_structs.h
+++ b/src/main/sensors/battery_config_structs.h
@@ -111,7 +111,8 @@ typedef struct batteryProfile_s {
     struct {
 
         struct {
-            uint16_t hover_throttle;        // multicopter hover throttle
+            bool thr_hover_learn_enabled;  // Enable/Disabled hover thrust learning 
+            uint16_t hover_throttle;       // multicopter hover throttle
         } mc;
 
         struct {


### PR DESCRIPTION
This PR adds an algorithm that has the ability to automatically learn the value of the Throttle Hover to be used in flight modes that depend on Alt-Hold (Pos-Hold, WP and RTH). The Throttle Hover value calculated by the algorithm will slowly move towards the average engine power whenever the vehicle is maintaining a constant hover (*Functional only when Alt-Hold is active (Alt-Hold alone, or Pos-Hold), does not work on Angle, Horizon or Acro*). By default this feature will always be active, and can be turned off by the user through the `nav_mc_thr_hover_learn` parameter.

## Two good things this PR promises:

This prevents users from creating multiple battery profiles, with a different Hover configuration to fly with batteries of different voltages.

The user does not need to fly and find the correct Throttle Hover value to be set in the `nav_mc_hover_thr` parameter, the algorithm will do it itself.

## How to make the feature calculate the Hover value for your Multirotor:

1 - Arm

2 - TakeOff

3 - Fly hovering in Alt-Hold or Pos-Hold.

4 - Avoid vertical speeds (Z) above 60 cm/s up and down (Above that the feature will be turned off).

5 - Avoid making the Roll and Pitch angles greater than 5 degrees of inclination.

6 - Wait for something between 10 to 15 seconds (The time here depends on how your multirotor is behaving, see previous steps 4 and 5).

7 - Disable Alt-Hold or Pos-Hold.

8 - Land

9 - Disarm. Done, you have an automatically calculated Throttle Hover value (See the new value stored in the `nav_mc_hover_thr` parameter)