### PR TITLE
Update target AOCODARCF7DUAL and remove MPU6500

### DIFF
--- a/src/main/target/AOCODARCF7DUAL/target.c
+++ b/src/main/target/AOCODARCF7DUAL/target.c
@@ -27,24 +27,22 @@
 #include "drivers/sensor.h"
 
 BUSDEV_REGISTER_SPI_TAG(busdev_mpu6000,     DEVHW_MPU6000,      MPU6000_SPI_BUS,    MPU6000_CS_PIN,     NONE, 0,   DEVFLAGS_NONE,  IMU_MPU6000_ALIGN);
-BUSDEV_REGISTER_SPI_TAG(busdev_mpu6500,     DEVHW_MPU6500,      MPU6000_SPI_BUS,    MPU6500_CS_PIN,     NONE, 0,   DEVFLAGS_NONE,  IMU_MPU6500_ALIGN);
-BUSDEV_REGISTER_SPI_TAG(busdev_bmi270,      DEVHW_BMI270,       BMI270_SPI_BUS,     BMI270_CS_PIN,      NONE,  1,   DEVFLAGS_NONE,  IMU_BMI270_ALIGN);
-
+BUSDEV_REGISTER_SPI_TAG(busdev_bmi270,      DEVHW_BMI270,       BMI270_SPI_BUS,     BMI270_CS_PIN,      NONE,  0,   DEVFLAGS_NONE,  IMU_BMI270_ALIGN);
 
 timerHardware_t timerHardware[] = {
     DEF_TIM(TIM1, CH3, PA10, TIM_USE_PPM, 0, 0),    //PPM
 
-    DEF_TIM(TIM8, CH1, PC6, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 1),        // S1   D(2, 2, 7) 
-    DEF_TIM(TIM8, CH2, PC7, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 1),        // S2   D(2, 3, 7) 
-    DEF_TIM(TIM8, CH3, PC8, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 1),        // S3   D(2, 4, 7) 
-    DEF_TIM(TIM8, CH4, PC9, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),        // S4   D(2, 7, 7) 
-    
-    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MC_MOTOR  |TIM_USE_FW_SERVO, 0, 0),        // S5   D(1, 7, 5)
-    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MC_MOTOR  |TIM_USE_FW_SERVO, 0, 0),        // S6   D(1, 2, 5)  
-    DEF_TIM(TIM4, CH1, PB6, TIM_USE_MC_MOTOR  |TIM_USE_FW_SERVO, 0, 0),        // S7   D(1, 0, 2)  
+    DEF_TIM(TIM3, CH1, PC6, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),        // S1   D(2, 2, 7)
+    DEF_TIM(TIM3, CH2, PC7, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),        // S2   D(2, 3, 7)
+    DEF_TIM(TIM3, CH3, PC8, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),        // S3   D(2, 4, 7)
+    DEF_TIM(TIM3, CH4, PC9, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),        // S4   D(2, 7, 7)
+
+    DEF_TIM(TIM8, CH2N, PB0, TIM_USE_MC_MOTOR  |TIM_USE_FW_SERVO, 0, 0),        // S5   D(1, 7, 5)
+    DEF_TIM(TIM8, CH3N, PB1, TIM_USE_MC_MOTOR  |TIM_USE_FW_SERVO, 0, 0),        // S6   D(1, 2, 5)
+    DEF_TIM(TIM4, CH1, PB6, TIM_USE_MC_MOTOR  |TIM_USE_FW_SERVO, 0, 0),        // S7   D(1, 0, 2)
     DEF_TIM(TIM4, CH2, PB7, TIM_USE_MC_MOTOR  |TIM_USE_FW_SERVO, 0, 0),        // S8   D(1, 3, 2)
 
-    DEF_TIM(TIM2, CH1, PA0, TIM_USE_LED, 0, 0),    // LED_TRIP                   
+    DEF_TIM(TIM2, CH1, PA0, TIM_USE_LED, 0, 0),    // LED_TRIP
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/AOCODARCF7DUAL/target.h
+++ b/src/main/target/AOCODARCF7DUAL/target.h
@@ -27,7 +27,7 @@
 #define BEEPER                  PC13
 #define BEEPER_INVERTED
 
-// *************** SPI1 Gyro & ACC *******************
+// *************** SPI2 Gyro & ACC *******************
 #define USE_SPI
 #define USE_SPI_DEVICE_2
 #define SPI2_SCK_PIN            PB13
@@ -42,11 +42,6 @@
 #define IMU_MPU6000_ALIGN       CW270_DEG
 #define MPU6000_CS_PIN          PB12
 #define MPU6000_SPI_BUS         BUS_SPI2
-
-#define USE_IMU_MPU6500
-#define IMU_MPU6500_ALIGN       CW270_DEG
-#define MPU6500_CS_PIN          PB12
-#define MPU6500_SPI_BUS         BUS_SPI2
 
 #define USE_IMU_BMI270
 #define IMU_BMI270_ALIGN        CW180_DEG
@@ -87,7 +82,7 @@
 #define USE_RANGEFINDER
 #define RANGEFINDER_I2C_BUS     BUS_I2C2
 
-// *************** SPI2 OSD ***********************
+// *************** SPI1 OSD ***********************
 #define USE_SPI_DEVICE_1
 #define SPI1_SCK_PIN            PA5
 #define SPI1_MISO_PIN           PA6


### PR DESCRIPTION
This board currently does not support MPU6500 and BMI270 was not recognised.
In addition, some bad comments have been modified.

P.S.: Previous PRs didn't updated with branch changes that's why I made this new PR.