### PR TITLE
RTH Trackback - suspend track recording on fixed wing during Loiter

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2644,7 +2644,7 @@ static bool rthAltControlStickOverrideCheck(unsigned axis)
  static void updateRthTrackback(bool forceSaveTrackPoint)
 {
     static bool suspendTracking = false;
-    if (!(isNavHoldPositionActive() && STATE(AIRPLANE)) && suspendTracking) {
+    if (!FLIGHT_MODE(NAV_POSHOLD_MODE) && suspendTracking) {
         suspendTracking = false;
     }
 
@@ -2698,8 +2698,8 @@ static bool rthAltControlStickOverrideCheck(unsigned axis)
                 previousTBTripDist = posControl.totalTripDistance;
             }
 
-            // Suspend tracking during loiter on fixed wing saving trackpoint when loiter enabled
-            if (distanceIncrement && isNavHoldPositionActive() && STATE(AIRPLANE)) {
+            // Suspend tracking during loiter on fixed wing. Save trackpoint when loiter enabled.
+            if (distanceCounter && FLIGHT_MODE(NAV_POSHOLD_MODE) && STATE(AIRPLANE)) {
                 saveTrackpoint = suspendTracking = true;
             }
         }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2640,11 +2640,13 @@ static bool rthAltControlStickOverrideCheck(unsigned axis)
  * Reverts to normal RTH heading direct to home when end of track reached.
  * Trackpoints logged with precedence for course/altitude changes. Distance based changes
  * only logged if no course/altitude changes logged over an extended distance.
+ * Tracking suspended during fixed wing loiter (PosHold and WP Mode timed hold).
  * --------------------------------------------------------------------------------- */
  static void updateRthTrackback(bool forceSaveTrackPoint)
 {
     static bool suspendTracking = false;
-    if (!FLIGHT_MODE(NAV_POSHOLD_MODE) && suspendTracking) {
+    bool fwLoiterIsActive = STATE(AIRPLANE) && (NAV_Status.state == MW_NAV_STATE_HOLD_TIMED || FLIGHT_MODE(NAV_POSHOLD_MODE));
+    if (!fwLoiterIsActive && suspendTracking) {
         suspendTracking = false;
     }
 
@@ -2698,8 +2700,8 @@ static bool rthAltControlStickOverrideCheck(unsigned axis)
                 previousTBTripDist = posControl.totalTripDistance;
             }
 
-            // Suspend tracking during loiter on fixed wing. Save trackpoint when loiter enabled.
-            if (distanceCounter && FLIGHT_MODE(NAV_POSHOLD_MODE) && STATE(AIRPLANE)) {
+            // Suspend tracking during loiter on fixed wing. Save trackpoint at start of loiter.
+            if (distanceCounter && fwLoiterIsActive) {
                 saveTrackpoint = suspendTracking = true;
             }
         }


### PR DESCRIPTION
Suspends RTH Trackback track recording during loiter on a fixed wing (Position Hold and WP mode Timed Hold). Avoids wasting track points for a repetitive manoeuvre that isn't useful for tracking purposes.