### PR TITLE
New debug_mode POS_EST that is useful for autonomous flight

### DIFF
--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -71,5 +71,6 @@ typedef enum {
     DEBUG_AUTOTUNE,
     DEBUG_RATE_DYNAMICS,
     DEBUG_LANDING,
+    DEBUG_POS_EST,
     DEBUG_COUNT
 } debugType_e;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -91,7 +91,7 @@ tables:
     values: ["NONE", "AGL", "FLOW_RAW", "FLOW", "ALWAYS", "SAG_COMP_VOLTAGE",
       "VIBE", "CRUISE", "REM_FLIGHT_TIME", "SMARTAUDIO", "ACC",
       "NAV_YAW", "PCF8574", "DYN_GYRO_LPF", "AUTOLEVEL", "ALTITUDE",
-      "AUTOTRIM", "AUTOTUNE", "RATE_DYNAMICS", "LANDING"]
+      "AUTOTRIM", "AUTOTUNE", "RATE_DYNAMICS", "LANDING", "POS_EST"]
   - name: aux_operator
     values: ["OR", "AND"]
     enum: modeActivationOperator_e

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -36,6 +36,7 @@
 
 #include "fc/config.h"
 #include "fc/settings.h"
+#include "fc/rc_modes.h"
 
 #include "flight/imu.h"
 
@@ -800,6 +801,23 @@ static void publishEstimatedTopic(timeUs_t currentTimeUs)
         //Update Blackbox states
         navEPH = posEstimator.est.eph;
         navEPV = posEstimator.est.epv;
+
+        DEBUG_SET(DEBUG_POS_EST, 0, (int32_t) posEstimator.est.pos.x*1000.0F);                // Position estimate X
+        DEBUG_SET(DEBUG_POS_EST, 1, (int32_t) posEstimator.est.pos.y*1000.0F);                // Position estimate Y
+        if (IS_RC_MODE_ACTIVE(BOXSURFACE) && posEstimator.est.aglQual!=SURFACE_QUAL_LOW){
+            // SURFACE (following) MODE
+            DEBUG_SET(DEBUG_POS_EST, 2, (int32_t) posControl.actualState.agl.pos.z*1000.0F);  // Position estimate Z
+            DEBUG_SET(DEBUG_POS_EST, 5, (int32_t) posControl.actualState.agl.vel.z*1000.0F);  // Speed estimate VZ
+        } else {
+            DEBUG_SET(DEBUG_POS_EST, 2, (int32_t) posEstimator.est.pos.z*1000.0F);            // Position estimate Z
+            DEBUG_SET(DEBUG_POS_EST, 5, (int32_t) posEstimator.est.vel.z*1000.0F);            // Speed estimate VZ
+        }
+        DEBUG_SET(DEBUG_POS_EST, 3, (int32_t) posEstimator.est.vel.x*1000.0F);                // Speed estimate VX
+        DEBUG_SET(DEBUG_POS_EST, 4, (int32_t) posEstimator.est.vel.y*1000.0F);                // Speed estimate VY
+        DEBUG_SET(DEBUG_POS_EST, 6, (int32_t) attitude.values.yaw);                           // Yaw estimate (4 bytes still available here)
+        DEBUG_SET(DEBUG_POS_EST, 7, (int32_t) (posEstimator.flags & 0b1111111)<<20 |          // navPositionEstimationFlags fit into 8bits
+                                              (MIN(navEPH, 1000) & 0x3FF)<<10 | 
+                                              (MIN(navEPV, 1000) & 0x3FF));                   // Horizontal and vertical uncertainties (max value = 1000, fit into 20bits)
     }
 }
 


### PR DESCRIPTION
A new debug mode called POS_EST was added because it was needed to make life easier while debugging the position estimation. This debug mode also gives the states of the estimations (EST_Z_VALID, EST_XY_VALID) and the sensors (EST_GPS_XY_VALID, EST_GPS_Z_VALID, EST_BARO_VALID, EST_SURFACE_VALID, EST_FLOW_VALID), all very useful for anything using the NAV flight modes (maybe it should even become a new MSP2_ESTIMATORS message...). [Here](https://github.com/thecognifly/YAMSPy/blob/proxy/Examples/test_debug_pos_est.py) is an example of how to read the debug mode using python.