### PR TITLE
Fix git security issue with docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 FROM ubuntu:focal
 
+ARG USER_ID
+ARG GROUP_ID
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y git cmake make ruby gcc python3 python3-pip
+RUN apt-get update && apt-get install -y git cmake make ruby gcc python3 python3-pip gcc-arm-none-eabi
 
 RUN pip install pyyaml
 
-RUN useradd inav
+# if either of these are already set the same as the user's machine, leave them be and ignore the error
+RUN addgroup --gid $GROUP_ID users; exit 0;
+RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user; exit 0;
 
-USER inav
+USER user
+RUN git config --global --add safe.directory /src
 
 VOLUME /src
 

--- a/build.sh
+++ b/build.sh
@@ -21,19 +21,29 @@ fi
 
 if [ -z "$(docker images -q inav-build)" ]; then
   echo -e "*** Building image\n"
-  docker build -t inav-build .
+  docker build -t inav-build --build-arg USER_ID="$(id -u)" --build-arg GROUP_ID="$(id -g)" .
   echo -ne "\n"
 fi
 
 if [ ! -d ./build ]; then
   echo -e "*** Creating build directory\n"
-  mkdir ./build
+  mkdir ./build && chmod 777 ./build
+fi
+
+if [ ! -d ./downloads ]; then
+  echo -e "*** Creating downloads directory\n"
+  mkdir ./downloads && chmod 777 ./downloads
+fi
+
+if [ ! -d ./tools ]; then
+  echo -e "*** Creating tools directory\n"
+  mkdir ./tools && chmod 777 ./tools
 fi
 
 echo -e "*** Building targets [$@]\n"
 docker run --rm -it -v "$(pwd)":/src inav-build $@
 
-if ls ./build/*.hex &> /dev/null; then
+if [ -z "$(ls ./build/*.hex &> /dev/null)" ]; then
   echo -e "\n*** Built targets in ./build:"
   stat -c "%n (%.19y)" ./build/*.hex
 fi


### PR DESCRIPTION
Fixes #8235. I don't use this project and likely never will, but happened across this issue looking for a solution to my own problem and figured I could fix it. Feel free to close if you don't want it fixed :smile:.

Make the docker user id and group id match the running user's, so that files built by the container are seen as owned by the current user. Also set the current directory as "safe" in git so it's able to inspect the git history.

_note_: this will successfully run in a rootless docker install, but the created files will have random uid/guids. You'll have to sudo to delete them or chown them. For normal docker installs there should be no issues. See [this issue](https://github.com/moby/moby/issues/41497) to track the rootless problem on the docker side.