### PR TITLE
Add EDGE, DELAY, DELTA, APPROX_EQUAL switches and TIMER to Logic Conditions

### DIFF
--- a/docs/Programming Framework.md
+++ b/docs/Programming Framework.md
@@ -81,6 +81,10 @@ IPF can be edited using INAV Configurator user interface, of via CLI
 | 45			| FLIGHT_AXIS_ANGLE_OVERRIDE	| Sets the target attitude angle for axis. In other words, when active, it enforces Angle mode (Heading Hold for Yaw) on this axis (Angle mode does not have to be active). `Operand A` defines the axis: `0` - Roll, `1` - Pitch, `2` - Yaw. `Operand B` defines the angle in degrees |
 | 46			| FLIGHT_AXIS_RATE_OVERRIDE	    | Sets the target rate (rotation speed) for axis. `Operand A` defines the axis: `0` - Roll, `1` - Pitch, `2` - Yaw. `Operand B` defines the rate in degrees per second |
 | 47            | EDGE                          | `Operand A` is activation operator [`boolean`], `Operand B` is the time for the edge to stay active [ms]. After activation, operator will return `true` until the time in Operand B is reached |
+| 48            | DELAY                         | This will return `true` when `Operand A` is true, and the delay time in `Operand B` [ms] has been exceeded. |
+| 49            | TIMER                         | `true` for the duration of `Operand A` [ms]. Then `false` for the duration of `Operand B` [ms]. |
+| 50            | DELTA                         | This returns `true` when the value of `Operand A` has changed by the value of `Operand B` or greater. |
+| 51            | APPROX_EQUAL                  | `true` if `Operand B` is within 1% of `Operand A`. |
 
 ### Operands
 

--- a/docs/Programming Framework.md
+++ b/docs/Programming Framework.md
@@ -80,6 +80,8 @@ IPF can be edited using INAV Configurator user interface, of via CLI
 | 44            | MAX                           | Finds the highest value of `Operand A` and `Operand B` |
 | 45			| FLIGHT_AXIS_ANGLE_OVERRIDE	| Sets the target attitude angle for axis. In other words, when active, it enforces Angle mode (Heading Hold for Yaw) on this axis (Angle mode does not have to be active). `Operand A` defines the axis: `0` - Roll, `1` - Pitch, `2` - Yaw. `Operand B` defines the angle in degrees |
 | 46			| FLIGHT_AXIS_RATE_OVERRIDE	    | Sets the target rate (rotation speed) for axis. `Operand A` defines the axis: `0` - Roll, `1` - Pitch, `2` - Yaw. `Operand B` defines the rate in degrees per second |
+| 47            | EDGE                          | `Operand A` is activation operator [`boolean`], `Operand B` is the time for the edge to stay active [ms]. After activation, operator will return `true` until the time in Operand B is reached |
+
 ### Operands
 
 | Operand Type  | Name                  | Notes |

--- a/docs/Programming Framework.md
+++ b/docs/Programming Framework.md
@@ -80,7 +80,7 @@ IPF can be edited using INAV Configurator user interface, of via CLI
 | 44            | MAX                           | Finds the highest value of `Operand A` and `Operand B` |
 | 45			| FLIGHT_AXIS_ANGLE_OVERRIDE	| Sets the target attitude angle for axis. In other words, when active, it enforces Angle mode (Heading Hold for Yaw) on this axis (Angle mode does not have to be active). `Operand A` defines the axis: `0` - Roll, `1` - Pitch, `2` - Yaw. `Operand B` defines the angle in degrees |
 | 46			| FLIGHT_AXIS_RATE_OVERRIDE	    | Sets the target rate (rotation speed) for axis. `Operand A` defines the axis: `0` - Roll, `1` - Pitch, `2` - Yaw. `Operand B` defines the rate in degrees per second |
-| 47            | EDGE                          | `Operand A` is activation operator [`boolean`], `Operand B` is the time for the edge to stay active [ms]. After activation, operator will return `true` until the time in Operand B is reached |
+| 47            | EDGE                          | `Operand A` is activation operator [`boolean`], `Operand B` _(Optional)_ is the time for the edge to stay active [ms]. After activation, operator will return `true` until the time in Operand B is reached. If a pure momentary edge is wanted. Just leave `Operand B` as the default `Value: 0` setting. |
 | 48            | DELAY                         | This will return `true` when `Operand A` is true, and the delay time in `Operand B` [ms] has been exceeded. |
 | 49            | TIMER                         | `true` for the duration of `Operand A` [ms]. Then `false` for the duration of `Operand B` [ms]. |
 | 50            | DELTA                         | This returns `true` when the value of `Operand A` has changed by the value of `Operand B` or greater. |

--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -89,7 +89,8 @@ static int logicConditionCompute(
     int32_t currentVaue,
     logicOperation_e operation,
     int32_t operandA,
-    int32_t operandB
+    int32_t operandB,
+    timeMs_t *timeout
 ) {
     int temporaryValue;
     vtxDeviceCapability_t vtxDeviceCapability;
@@ -160,6 +161,12 @@ static int logicConditionCompute(
 
             //When both operands are not met, keep current value 
             return currentVaue;
+            break;
+
+        case LOGIC_CONDITION_EDGE:
+            if (operandA && timeout == 0) {
+                
+            }
             break;
 
         case LOGIC_CONDITION_GVAR_SET:
@@ -425,7 +432,8 @@ void logicConditionProcess(uint8_t i) {
                 logicConditionStates[i].value, 
                 logicConditions(i)->operation, 
                 operandAValue, 
-                operandBValue
+                operandBValue,
+                &logicConditionStates[i].timeout,
             );
         
             logicConditionStates[i].value = newValue;
@@ -786,6 +794,7 @@ void logicConditionReset(void) {
     for (uint8_t i = 0; i < MAX_LOGIC_CONDITIONS; i++) {
         logicConditionStates[i].value = 0;
         logicConditionStates[i].flags = 0;
+        logicConditionStates[i].timeout = 0;
     }
 }
 

--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -167,7 +167,8 @@ typedef enum {
 } logicConditionsGlobalFlags_t;
 
 typedef enum {
-    LOGIC_CONDITION_FLAG_LATCH      = 1 << 0,
+    LOGIC_CONDITION_FLAG_LATCH          = 1 << 0,
+    LOGIC_CONDITION_FLAG_EDGE_SATISFIED = 1 << 1,
 } logicConditionFlags_e;
 
 typedef struct logicOperand_s {

--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -76,7 +76,8 @@ typedef enum {
     LOGIC_CONDITION_MAX                         = 44,
     LOGIC_CONDITION_FLIGHT_AXIS_ANGLE_OVERRIDE  = 45,
     LOGIC_CONDITION_FLIGHT_AXIS_RATE_OVERRIDE   = 46,
-    LOGIC_CONDITION_LAST                        = 47,
+    LOGIC_CONDITION_EDGE                        = 47,
+    LOGIC_CONDITION_LAST                        = 48,
 } logicOperation_e;
 
 typedef enum logicOperandType_s {
@@ -188,6 +189,7 @@ PG_DECLARE_ARRAY(logicCondition_t, MAX_LOGIC_CONDITIONS, logicConditions);
 typedef struct logicConditionState_s {
     int value;
     uint8_t flags;
+    timeMs_t timeout;
 } logicConditionState_t;
 
 typedef struct rcChannelOverride_s {

--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -193,6 +193,7 @@ PG_DECLARE_ARRAY(logicCondition_t, MAX_LOGIC_CONDITIONS, logicConditions);
 
 typedef struct logicConditionState_s {
     int value;
+    int32_t lastValue;
     uint8_t flags;
     timeMs_t timeout;
 } logicConditionState_t;

--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -77,7 +77,11 @@ typedef enum {
     LOGIC_CONDITION_FLIGHT_AXIS_ANGLE_OVERRIDE  = 45,
     LOGIC_CONDITION_FLIGHT_AXIS_RATE_OVERRIDE   = 46,
     LOGIC_CONDITION_EDGE                        = 47,
-    LOGIC_CONDITION_LAST                        = 48,
+    LOGIC_CONDITION_DELAY                       = 48,
+    LOGIC_CONDITION_TIMER                       = 49,
+    LOGIC_CONDITION_DELTA                       = 50,
+    LOGIC_CONDITION_APPROX_EQUAL                = 51,
+    LOGIC_CONDITION_LAST                        = 52,
 } logicOperation_e;
 
 typedef enum logicOperandType_s {
@@ -167,8 +171,8 @@ typedef enum {
 } logicConditionsGlobalFlags_t;
 
 typedef enum {
-    LOGIC_CONDITION_FLAG_LATCH          = 1 << 0,
-    LOGIC_CONDITION_FLAG_EDGE_SATISFIED = 1 << 1,
+    LOGIC_CONDITION_FLAG_LATCH              = 1 << 0,
+    LOGIC_CONDITION_FLAG_TIMEOUT_SATISFIED  = 1 << 1,
 } logicConditionFlags_e;
 
 typedef struct logicOperand_s {


### PR DESCRIPTION
This PR adds EDGE, DELAY, DELTA, APPROX EQUAL, and TIMER functionality to logic conditions

### EDGE
EDGE is a momentary logical switch, triggered by `Operand A`. An optional off delay has been added for flexibility. It takes 2 operands:
1. **Operand A**: EDGE Activator. This is a Boolean operand, such as a logical condition or flight mode on/off etc.
2. **Operand B**: _Optional_ On time for EDGE condition [_ms_]. Less than 100ms defaults to instant. If you don't want an off delay, leave `Operand B` as `Value: 0`.

[[Demo]](https://youtu.be/yUoATtfYV2c)

### DELAY
Delay adds a wait before it returns a true value. It takes 2 operands:
1. **Operand A**: DELAY Activator. This is a Boolean operand, such as a logical condition or flight mode on/off etc.
2. **Operand B**: Delay time, before the LC becomes active [_ms_]. The switch in `Operand A` must remain active for the delay to activate after the delay time.

### TIMER
Timer is a simple on/off timer. It works in the same way as OpenTX timers. It takes 2 operands:
1. **Operand A**: Time for the timer to be true [_ms_].
2. **Operand B**: Time for the timer to be false [_ms_].

### APPROX_EQUAL
Approximately equals sees if `Operand B` is within a 1% difference to `Operand A`. It takes 2 operands:
1. **Operand A**: The value that you want to compare.
2. **Operand B**: The value to compare to.

### DELTA
The delta comparator checks to see if `Operand A` has changed by the value in `Operand B` or greater. It takes 2 operands:
1. **Operand A**: The value that you want to compare.
2. **Operand B**: The minimum amount the value must change.

[[DEMO of all these conditions in action]](https://youtu.be/QUepHjfZWSU)

Requires configurator https://github.com/iNavFlight/inav-configurator/pull/1653