### PR TITLE
Change logo size for future enhancements

### DIFF
--- a/src/main/drivers/osd_symbols.h
+++ b/src/main/drivers/osd_symbols.h
@@ -172,8 +172,8 @@
 #define SYM_AH_V_M_0                0xD8  // 216 mAh/v-m left
 #define SYM_AH_V_M_1                0xD9  // 217 mAh/v-m right
 
-#define SYM_LOGO_START              0x101 // 257 to 280, INAV logo
-#define SYM_LOGO_WIDTH              6
+#define SYM_LOGO_START              0x101 // 257 to 297, INAV logo
+#define SYM_LOGO_WIDTH              10
 #define SYM_LOGO_HEIGHT             4
 
 #define SYM_AH_LEFT                 0x12C // 300 Arrow left


### PR DESCRIPTION
This PR is in preparation for some future updates I have planned. I figured that as 6.0 is such a milestone release. It would be good to at least get this part in, so that the future updates don't need the font change to work. I think pretty much everyone will run 6.0. It's like INAV Reboot.

This change increased the logo from a square aspect ratio, to a rectangle. This would be more usable for customising the logo. There were free characters near the logo, so I used them.  This adds 2 columns either side of the existing logo to get the desired shape.

The current logo will still look the same on screen.
![classic-logo](https://user-images.githubusercontent.com/17590174/204105096-d739e9aa-2213-4ad0-96c8-050db3edd504.png)
But it allows for stuff like this
![winged-logo](https://user-images.githubusercontent.com/17590174/204105114-ee37a8fc-52b4-4110-b0b7-7a5409149640.png)
...and even greater flexibility and way better images with the HD fonts.

Requires configurator https://github.com/iNavFlight/inav-configurator/pull/1657