### PR TITLE
Stop allowing navigation modes to be active while arming.

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3846,8 +3846,7 @@ bool navigationPositionEstimateIsHealthy(void)
 navArmingBlocker_e navigationIsBlockingArming(bool *usedBypass)
 {
     const bool navBoxModesEnabled = IS_RC_MODE_ACTIVE(BOXNAVRTH) || IS_RC_MODE_ACTIVE(BOXNAVWP) || IS_RC_MODE_ACTIVE(BOXNAVPOSHOLD) || (STATE(FIXED_WING_LEGACY) && IS_RC_MODE_ACTIVE(BOXNAVALTHOLD)) || (STATE(FIXED_WING_LEGACY) && (IS_RC_MODE_ACTIVE(BOXNAVCOURSEHOLD) || IS_RC_MODE_ACTIVE(BOXNAVCRUISE)));
-    const bool navLaunchComboModesEnabled = isNavLaunchEnabled() && (IS_RC_MODE_ACTIVE(BOXNAVRTH) || IS_RC_MODE_ACTIVE(BOXNAVWP) || IS_RC_MODE_ACTIVE(BOXNAVALTHOLD) || IS_RC_MODE_ACTIVE(BOXNAVCOURSEHOLD) || IS_RC_MODE_ACTIVE(BOXNAVCRUISE));
-
+    
     if (usedBypass) {
         *usedBypass = false;
     }
@@ -3865,7 +3864,7 @@ navArmingBlocker_e navigationIsBlockingArming(bool *usedBypass)
     }
 
     // Don't allow arming if any of NAV modes is active
-    if (!ARMING_FLAG(ARMED) && navBoxModesEnabled && !navLaunchComboModesEnabled) {
+    if (!ARMING_FLAG(ARMED) && navBoxModesEnabled) {
         return NAV_ARMING_BLOCKER_NAV_IS_ALREADY_ACTIVE;
     }
 


### PR DESCRIPTION
Remove special case for allowing nav modes while arming, if autolaunch is permanently enabled. This is a dangerous practice. It is far to easy to not know and have the motor start. Using the correct sequence, this will not stop people from using a navigation mode on launch exit.

### Release Notes
The ability to arm the craft while in a navigation mode has been removed. The only people who this will effect are those who use permanently enabled autolaunch. Pre-6.0 you could arm while in a navigation mode. However this is dangerous, as it is easy to not realise, arm, disable the launch, then have the motor go to the cruise throttle. You will still be able to use a navigation mode as the exit mode from a launch. You just need to use the correct procedure for initiating the launch:
1. Be in a non-navigation mode
2. Arm
3. Select the flight mode that you want to use on launch exit
4. Raise the throttle to the level you want on launch exit
5. The motor will enter idle if idle throttle is used, or await being thrown
6. Throw the plane in to the air, and autolaunch will trigger