### PR TITLE
Increase the number of controlled LEDs ws2811 strip to 96

### DIFF
--- a/src/main/drivers/light_ws2811strip.h
+++ b/src/main/drivers/light_ws2811strip.h
@@ -18,7 +18,7 @@
 #pragma once
 #include "common/color.h"
 
-#define WS2811_LED_STRIP_LENGTH 32
+#define WS2811_LED_STRIP_LENGTH 96
 #define WS2811_BITS_PER_LED 24
 #define WS2811_DELAY_BUFFER_LENGTH 42 // for 50us delay
 

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -20,7 +20,7 @@
 #include "config/parameter_group.h"
 #include "common/color.h"
 
-#define LED_MAX_STRIP_LENGTH           32
+#define LED_MAX_STRIP_LENGTH           96
 #define LED_CONFIGURABLE_COLOR_COUNT   16
 #define LED_MODE_COUNT                  6
 #define LED_DIRECTION_COUNT             6


### PR DESCRIPTION
The iNAV firmware currently allows up to 32 ws2811 controllable LEDs. Since many people use this iNAV firmware on aircraft. To make a beautiful backlight, 32 LEDs are not enough. I suggest increasing the number to 96. I'm not good at programming, I may have missed important aspects. If this improvement is possible, I would be happy with these changes. Thanks!