### PR TITLE
Add a BF4.3 Compatible restricted OSD implementation.

### DIFF
--- a/docs/Betaflight 4.3 compatible OSD.md
+++ b/docs/Betaflight 4.3 compatible OSD.md
@@ -1,4 +1,4 @@
-# Betaflight 4.3 compatible MSP DisplayPort OSD (DJI O3 Canvas Mode)
+# Betaflight 4.3 compatible MSP DisplayPort OSD (DJI O3 "Canvas Mode")
 
 INAV 6.0 includes a special mode for MSP DisplayPort that supports incomplete implementations of MSP DisplayPort that only support BetaFlight, like the DJI O3 Air Unit.
 
@@ -40,3 +40,7 @@ Maybe. If a future version of BetaFlight includes more Glyphs that can be mapped
 ### Can you replace glyph `X` with text `x description`?
 
 While it might technically be possible to replace some glyphs with text in multiple cells, it will introduce a lot of complexity in the OSD rendering and configuration for something we hope is a temporary workaround.
+
+### Does DJI support Canvas Mode?
+
+Actually, no. What DJI calls Canvas Mode is actually MSP DisplayPort and is a character based OSD.

--- a/docs/Betaflight 4.3 compatible OSD.md
+++ b/docs/Betaflight 4.3 compatible OSD.md
@@ -1,0 +1,42 @@
+# Betaflight 4.3 compatible MSP DisplayPort OSD (DJI O3 Canvas Mode)
+
+INAV 6.0 includes a special mode for MSP DisplayPort that supports incomplete implementations of MSP DisplayPort that only support BetaFlight, like the DJI O3 Air Unit.
+
+Different flight controllers have different OSD symbols and elements and require different fonts. BetaFlight's font is a single page and supports a maximum of 256 glyphs, INAV's font is currently 2 pages and supports up to 512 different glyphs.
+
+While there is some overlap between the glyphs in BetaFlight and INAV, it is not possible to perform a 1 to 1 mapping for all the them. In cases where there is no suitable glyph in the BetaFlight font, a question mark `?` will be displayed.
+
+This mode can be enabled by selecting BF43COMPAT as video format in the OSD tab of the configurator or by typing the following command on the CLI:
+
+`set osd_video_system = BF43COMPAT`
+
+## Limitations
+
+* Canvas size is limited to PAL's canvas size.
+* Unsupported Glyphs show up as `?`
+
+## FAQ
+
+### I see a lot of `?` on my OSD.
+
+That is expected, when your INAV OSD widgets use glyphs that don't have a suitable mapping in BetaFlight's font.
+
+### Does it work with the G2 and Original Air Unit/Vista?
+
+Yes.
+
+### Is this a replacement for WTFOS?
+
+Not exactly. WTFOS is a full implementation of MSP-Displayport for rooted Air Unit/Vista/Googles V2 and actually works much better than BetaFlight compatibility mode, being able to display all INAV's glyphs.
+
+### Can INAV fix DJI's product?
+
+No. OSD renderinng happens on the googles/air unit side of things. Please ask DJI to fix their incomplete MSP DisplayPort implemenation. You can probably request it in [DJI's forum](https://forum.dji.com/forum.php?mod=forumdisplay&fid=129&filter=typeid&typeid=767).
+
+### BetaFlight X.Y now has more symbols, can you update INAV?
+
+Maybe. If a future version of BetaFlight includes more Glyphs that can be mapped into INAV it is fairly simple to add the mapping, but the problem with DJI's implemenation persists. Even if we update the mapping, if DJI does not update the fonts on their side the problem will persist.
+
+### Can you replace glyph `X` with text `x description`?
+
+While it might technically be possible to replace some glyphs with text in multiple cells, it will introduce a lot of complexity in the OSD rendering and configuration for something we hope is a temporary workaround.

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4704,7 +4704,7 @@ IMPERIAL, METRIC, UK
 
 ### osd_video_system
 
-Video system used. Possible values are `AUTO`, `PAL`, `NTSC`, `HDZERO` and 'DJIWTF'
+Video system used. Possible values are `AUTO`, `PAL`, `NTSC`, `HDZERO`, `DJIWTF` and `BF43COMPAT`
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -476,6 +476,8 @@ main_sources(COMMON_SRC
     io/displayport_max7456.h
     io/displayport_msp.c
     io/displayport_msp.h
+    io/displayport_msp_bf_compat.c
+    io/displayport_msp_bf_compat.h
     io/displayport_oled.c
     io/displayport_oled.h
     io/displayport_msp_osd.c

--- a/src/main/drivers/osd.h
+++ b/src/main/drivers/osd.h
@@ -47,7 +47,8 @@ typedef enum {
     VIDEO_SYSTEM_PAL,
     VIDEO_SYSTEM_NTSC,
     VIDEO_SYSTEM_HDZERO,
-    VIDEO_SYSTEM_DJIWTF
+    VIDEO_SYSTEM_DJIWTF,
+    VIDEO_SYSTEM_BFCOMPAT
 } videoSystem_e;
 
 typedef enum {

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -72,7 +72,7 @@ tables:
     values: ["BATTERY", "CELL"]
     enum: osd_stats_min_voltage_unit_e
   - name: osd_video_system
-    values: ["AUTO", "PAL", "NTSC", "HDZERO", "DJIWTF"]
+    values: ["AUTO", "PAL", "NTSC", "HDZERO", "DJIWTF", "BF43COMPAT"]
     enum: videoSystem_e
   - name: osd_telemetry
     values: ["OFF", "ON","TEST"]
@@ -3015,7 +3015,7 @@ groups:
         type: uint8_t
         default_value: "OFF"
       - name: osd_video_system
-        description: "Video system used. Possible values are `AUTO`, `PAL`, `NTSC`, `HDZERO` and 'DJIWTF'"
+        description: "Video system used. Possible values are `AUTO`, `PAL`, `NTSC`, `HDZERO`, `DJIWTF` and `BF43COMPAT`"
         default_value: "AUTO"
         table: osd_video_system
         field: video_system

--- a/src/main/io/bf_osd_symbols.h
+++ b/src/main/io/bf_osd_symbols.h
@@ -1,0 +1,163 @@
+/* @file max7456_symbols.h
+ * @brief max7456 symbols for the mwosd font set
+ *
+ * @author Nathan Tsoi nathan@vertile.com
+ *
+ * Copyright (C) 2016 Nathan Tsoi
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#pragma once
+
+//Misc
+#define BF_SYM_NONE                    0x00
+#define BF_SYM_END_OF_FONT             0xFF
+#define BF_SYM_BLANK                   0x20
+#define BF_SYM_HYPHEN                  0x2D
+#define BF_SYM_BBLOG                   0x10
+#define BF_SYM_HOMEFLAG                0x11
+//#define SYM_RPM                     0x12
+#define BF_SYM_ROLL                    0x14
+#define BF_SYM_PITCH                   0x15
+#define BF_SYM_TEMPERATURE             0x7A
+
+// GPS and navigation
+#define BF_SYM_LAT                     0x89
+#define BF_SYM_LON                     0x98
+#define BF_SYM_ALTITUDE                0x7F
+#define BF_SYM_TOTAL_DISTANCE          0x71
+#define BF_SYM_OVER_HOME               0x05
+
+// RSSI
+#define BF_SYM_RSSI                    0x01
+#define BF_SYM_LINK_QUALITY            0x7B
+
+// Throttle Position (%)
+#define BF_SYM_THR                     0x04
+
+// Unit Icons (Metric)
+#define BF_SYM_M                       0x0C
+#define BF_SYM_KM                      0x7D
+#define BF_SYM_C                       0x0E
+
+// Unit Icons (Imperial)
+#define BF_SYM_FT                      0x0F
+#define BF_SYM_MILES                   0x7E
+#define BF_SYM_F                       0x0D
+
+// Heading Graphics
+#define BF_SYM_HEADING_N               0x18
+#define BF_SYM_HEADING_S               0x19
+#define BF_SYM_HEADING_E               0x1A
+#define BF_SYM_HEADING_W               0x1B
+#define BF_SYM_HEADING_DIVIDED_LINE    0x1C
+#define BF_SYM_HEADING_LINE            0x1D
+
+// AH Center screen Graphics
+#define BF_SYM_AH_CENTER_LINE          0x72
+#define BF_SYM_AH_CENTER               0x73
+#define BF_SYM_AH_CENTER_LINE_RIGHT    0x74
+#define BF_SYM_AH_RIGHT                0x02
+#define BF_SYM_AH_LEFT                 0x03
+#define BF_SYM_AH_DECORATION           0x13
+
+// Satellite Graphics
+#define BF_SYM_SAT_L                   0x1E
+#define BF_SYM_SAT_R                   0x1F
+
+// Direction arrows
+#define BF_SYM_ARROW_SOUTH             0x60
+#define BF_SYM_ARROW_2                 0x61
+#define BF_SYM_ARROW_3                 0x62
+#define BF_SYM_ARROW_4                 0x63
+#define BF_SYM_ARROW_EAST              0x64
+#define BF_SYM_ARROW_6                 0x65
+#define BF_SYM_ARROW_7                 0x66
+#define BF_SYM_ARROW_8                 0x67
+#define BF_SYM_ARROW_NORTH             0x68
+#define BF_SYM_ARROW_10                0x69
+#define BF_SYM_ARROW_11                0x6A
+#define BF_SYM_ARROW_12                0x6B
+#define BF_SYM_ARROW_WEST              0x6C
+#define BF_SYM_ARROW_14                0x6D
+#define BF_SYM_ARROW_15                0x6E
+#define BF_SYM_ARROW_16                0x6F
+
+#define BF_SYM_ARROW_SMALL_UP          0x75
+#define BF_SYM_ARROW_SMALL_DOWN        0x76
+
+// AH Bars
+#define BF_SYM_AH_BAR9_0               0x80
+#define BF_SYM_AH_BAR9_1               0x81
+#define BF_SYM_AH_BAR9_2               0x82
+#define BF_SYM_AH_BAR9_3               0x83
+#define BF_SYM_AH_BAR9_4               0x84
+#define BF_SYM_AH_BAR9_5               0x85
+#define BF_SYM_AH_BAR9_6               0x86
+#define BF_SYM_AH_BAR9_7               0x87
+#define BF_SYM_AH_BAR9_8               0x88
+
+// Progress bar
+#define BF_SYM_PB_START                0x8A
+#define BF_SYM_PB_FULL                 0x8B
+#define BF_SYM_PB_HALF                 0x8C
+#define BF_SYM_PB_EMPTY                0x8D
+#define BF_SYM_PB_END                  0x8E
+#define BF_SYM_PB_CLOSE                0x8F
+
+// Batt evolution
+#define BF_SYM_BATT_FULL               0x90
+#define BF_SYM_BATT_5                  0x91
+#define BF_SYM_BATT_4                  0x92
+#define BF_SYM_BATT_3                  0x93
+#define BF_SYM_BATT_2                  0x94
+#define BF_SYM_BATT_1                  0x95
+#define BF_SYM_BATT_EMPTY              0x96
+
+// Batt Icons
+#define BF_SYM_MAIN_BATT               0x97
+
+// Voltage and amperage
+#define BF_SYM_VOLT                    0x06
+#define BF_SYM_AMP                     0x9A
+#define BF_SYM_MAH                     0x07
+#define BF_SYM_WATT                    0x57  // 0x57 is 'W'
+
+// Time
+#define BF_SYM_ON_M                    0x9B
+#define BF_SYM_FLY_M                   0x9C
+
+// Speed
+#define BF_SYM_SPEED                   0x70
+#define BF_SYM_KPH                     0x9E
+#define BF_SYM_MPH                     0x9D
+#define BF_SYM_MPS                     0x9F
+#define BF_SYM_FTPS                    0x99
+
+// Menu cursor
+#define BF_SYM_CURSOR                  BF_SYM_AH_LEFT
+
+// Stick overlays
+#define BF_SYM_STICK_OVERLAY_SPRITE_HIGH 0x08
+#define BF_SYM_STICK_OVERLAY_SPRITE_MID  0x09
+#define BF_SYM_STICK_OVERLAY_SPRITE_LOW  0x0A
+#define BF_SYM_STICK_OVERLAY_CENTER      0x0B
+#define BF_SYM_STICK_OVERLAY_VERTICAL    0x16
+#define BF_SYM_STICK_OVERLAY_HORIZONTAL  0x17
+
+// GPS degree/minute/second symbols
+#define BF_SYM_GPS_DEGREE              BF_SYM_STICK_OVERLAY_SPRITE_HIGH  // kind of looks like the degree symbol
+#define BF_SYM_GPS_MINUTE              0x27 // '
+#define BF_SYM_GPS_SECOND              0x22 // "

--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -27,16 +27,13 @@
 
 uint8_t get_bf_character(uint8_t ch, uint8_t page)
 {
-
     uint16_t ech = ch | (page << 8);
 
-    if(ech >= 0x20 && ech <= 0x5F) // ASCII range
-    {
+    if (ech >= 0x20 && ech <= 0x5F) { // ASCII range
         return ch;
     }
 
-    switch (ech)
-    {
+    switch (ech) {
     case SYM_RSSI:
         return BF_SYM_RSSI;
 

--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -25,7 +25,7 @@
 #include "io/bf_osd_symbols.h"
 #include "drivers/osd_symbols.h"
 
-uint8_t get_bf_character(uint8_t ch, uint8_t page)
+uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 {
     uint16_t ech = ch | (page << 8);
 

--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -1,0 +1,637 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#ifdef USE_MSP_DISPLAYPORT
+
+#ifndef DISABLE_MSP_BF_COMPAT
+
+#include "io/displayport_msp_bf_compat.h"
+#include "io/bf_osd_symbols.h"
+#include "drivers/osd_symbols.h"
+
+uint8_t get_bf_character(uint8_t ch, uint8_t page)
+{
+    if(ch >= 0x20 && ch <= 0x5F) // ASCII range
+    {
+        return ch;
+    }
+
+    uint16_t ech = ch | (page << 8);
+
+
+    switch (ech)
+    {
+    case SYM_RSSI:
+        return BF_SYM_RSSI;
+
+    case SYM_LQ:
+        return BF_SYM_LINK_QUALITY;
+
+    case SYM_LAT:
+        return BF_SYM_LAT;
+
+    case SYM_LON:
+        return BF_SYM_LON;
+
+    case SYM_SAT_L:
+        return BF_SYM_SAT_L;
+
+    case SYM_SAT_R:
+        return BF_SYM_SAT_R;
+
+    case SYM_HOME_NEAR:
+        return BF_SYM_HOMEFLAG;
+
+    case SYM_DEGREES:
+        return BF_SYM_GPS_DEGREE;
+
+/*
+    case SYM_HEADING:
+        return BF_SYM_HEADING;
+
+    case SYM_SCALE:
+        return BF_SYM_SCALE;
+
+    case SYM_HDP_L:
+        return BF_SYM_HDP_L;
+
+    case SYM_HDP_R:
+        return BF_SYM_HDP_R;
+*/
+    case SYM_HOME:
+        return BF_SYM_HOMEFLAG;
+
+    case SYM_2RSS:
+        return BF_SYM_RSSI;
+
+/*
+    case SYM_DB:
+        return BF_SYM_DB
+
+    case SYM_DBM:
+        return BF_SYM_DBM;
+
+    case SYM_SNR:
+        return BF_SYM_SNR;
+
+    case SYM_AH_DECORATION_UP:
+        return BF_SYM_AH_DECORATION_UP;
+
+    case SYM_AH_DECORATION_DOWN:
+        return BF_SYM_AH_DECORATION_DOWN;
+
+    case SYM_DIRECTION:
+        return BF_SYM_DIRECTION;
+*/
+    case SYM_VOLT:
+        return BF_SYM_VOLT;
+
+    case SYM_MAH:
+        return BF_SYM_MAH;
+
+    case SYM_AH_KM:
+        return BF_SYM_KM;
+
+    case SYM_AH_MI:
+        return BF_SYM_MILES;
+/*
+    case SYM_VTX_POWER:
+        return BF_SYM_VTX_POWER;
+
+    case SYM_AH_NM:
+        return BF_SYM_AH_NM;
+
+    case SYM_MAH_NM_0:
+        return BF_SYM_MAH_NM_0;
+
+    case SYM_MAH_NM_1:
+        return BF_SYM_MAH_NM_1;
+
+    case SYM_MAH_KM_0:
+        return BF_SYM_MAH_KM_0;
+
+    case SYM_MAH_KM_1:
+        return BF_SYM_MAH_KM_1;
+
+    case SYM_MILLIOHM:
+        return BF_SYM_MILLIOHM;
+*/
+    case SYM_BATT_FULL:
+        return BF_SYM_BATT_FULL;
+
+    case SYM_BATT_5:
+        return BF_SYM_BATT_5;
+
+    case SYM_BATT_4:
+        return BF_SYM_BATT_4;
+
+    case SYM_BATT_3:
+        return BF_SYM_BATT_3;
+
+    case SYM_BATT_2:
+        return BF_SYM_BATT_2;
+
+    case SYM_BATT_1:
+        return BF_SYM_BATT_1;
+
+    case SYM_BATT_EMPTY:
+        return BF_SYM_BATT_EMPTY;
+
+    case SYM_AMP:
+        return BF_SYM_AMP;
+/*
+    case SYM_WH:
+        return BF_SYM_WH;
+
+    case SYM_WH_KM:
+        return BF_SYM_WH_KM;
+
+    case SYM_WH_MI:
+        return BF_SYM_WH_MI;
+
+    case SYM_WH_NM:
+        return BF_SYM_WH_NM;
+*/
+    case SYM_WATT:
+        return BF_SYM_WATT;
+/*
+    case SYM_MW:
+        return BF_SYM_MW;
+
+    case SYM_KILOWATT:
+        return BF_SYM_KILOWATT;
+*/
+    case SYM_FT:
+        return BF_SYM_FT;
+/*
+    case SYM_TRIP_DIST:
+        return BF_SYM_TRIP_DIST;
+
+    case SYM_TOTAL:
+        return BF_SYM_TOTAL;
+
+    case SYM_ALT_M:
+        return BF_SYM_ALT_M;
+
+    case SYM_ALT_KM:
+        return BF_SYM_ALT_KM;
+
+    case SYM_ALT_FT:
+        return BF_SYM_ALT_FT;
+
+    case SYM_ALT_KFT:
+        return BF_SYM_ALT_KFT;
+
+    case SYM_DIST_M:
+        return BF_SYM_DIST_M;
+
+    case SYM_DIST_KM:
+        return BF_SYM_DIST_KM;
+
+    case SYM_DIST_FT:
+        return BF_SYM_DIST_FT;
+
+    case SYM_DIST_MI:
+        return BF_SYM_DIST_MI;
+
+    case SYM_DIST_NM:
+        return BF_SYM_DIST_NM;
+*/
+    case SYM_M:
+        return BF_SYM_M;
+
+    case SYM_KM:
+        return BF_SYM_KM;
+
+    case SYM_MI:
+        return BF_SYM_MILES;
+/*
+    case SYM_NM:
+        return BF_SYM_NM;
+
+    case SYM_WIND_HORIZONTAL:
+        return BF_SYM_WIND_HORIZONTAL;
+
+    case SYM_WIND_VERTICAL:
+        return BF_SYM_WIND_VERTICAL;
+
+    case SYM_3D_KMH:
+        return BF_SYM_3D_KMH;
+
+    case SYM_3D_MPH:
+        return BF_SYM_3D_MPH;
+
+    case SYM_3D_KT:
+        return BF_SYM_3D_KT;
+
+    case SYM_RPM:
+        return BF_SYM_RPM;
+
+    case SYM_AIR:
+        return BF_SYM_AIR;
+
+    case SYM_FTS:
+        return BF_SYM_FTS;
+
+    case SYM_100FTM:
+        return BF_SYM_100FTM;
+
+    case SYM_MS:
+        return BF_SYM_MS;
+
+    case SYM_KMH:
+        return BF_SYM_KMH;
+*/
+    case SYM_MPH:
+        return BF_SYM_MPH;
+/*
+    case SYM_KT:
+        return BF_SYM_KT;
+
+    case SYM_MAH_MI_0:
+        return BF_SYM_MAH_MI_0;
+
+    case SYM_MAH_MI_1:
+        return BF_SYM_MAH_MI_1;
+
+    case SYM_THR:
+        return BF_SYM_THR;
+
+    case SYM_TEMP_F:
+        return BF_SYM_TEMP_F;
+
+    case SYM_TEMP_C:
+        return BF_SYM_TEMP_C;
+*/
+    case SYM_BLANK:
+        return BF_SYM_BLANK;
+/*
+    case SYM_ON_H:
+        return BF_SYM_ON_H;
+
+    case SYM_FLY_H:
+        return BF_SYM_FLY_H;
+*/
+    case SYM_ON_M:
+        return BF_SYM_ON_M;
+
+    case SYM_FLY_M:
+        return BF_SYM_FLY_M;
+/*
+    case SYM_GLIDESLOPE:
+        return BF_SYM_GLIDESLOPE;
+
+    case SYM_WAYPOINT:
+        return BF_SYM_WAYPOINT;
+
+    case SYM_CLOCK:
+        return BF_SYM_CLOCK;
+
+    case SYM_ZERO_HALF_TRAILING_DOT:
+        return BF_SYM_ZERO_HALF_TRAILING_DOT;
+
+    case SYM_ZERO_HALF_LEADING_DOT:
+        return BF_SYM_ZERO_HALF_LEADING_DOT;
+
+    case SYM_AUTO_THR0:
+        return BF_SYM_AUTO_THR0;
+
+    case SYM_AUTO_THR1:
+        return BF_SYM_AUTO_THR1;
+
+    case SYM_ROLL_LEFT:
+        return BF_SYM_ROLL_LEFT;
+
+    case SYM_ROLL_LEVEL:
+        return BF_SYM_ROLL_LEVEL;
+
+    case SYM_ROLL_RIGHT:
+        return BF_SYM_ROLL_RIGHT;
+
+    case SYM_PITCH_UP:
+        return BF_SYM_PITCH_UP;
+
+    case SYM_PITCH_DOWN:
+        return BF_SYM_PITCH_DOWN;
+
+    case SYM_GFORCE:
+        return BF_SYM_GFORCE;
+
+    case SYM_GFORCE_X:
+        return BF_SYM_GFORCE_X;
+
+    case SYM_GFORCE_Y:
+        return BF_SYM_GFORCE_Y;
+
+    case SYM_GFORCE_Z:
+        return BF_SYM_GFORCE_Z;
+
+    case SYM_BARO_TEMP:
+        return BF_SYM_BARO_TEMP;
+
+    case SYM_IMU_TEMP:
+        return BF_SYM_IMU_TEMP;
+
+    case SYM_TEMP:
+        return BF_SYM_TEMP;
+
+    case SYM_TEMP_SENSOR_FIRST:
+        return BF_SYM_TEMP_SENSOR_FIRST;
+
+    case SYM_ESC_TEMP:
+        return BF_SYM_ESC_TEMP;
+
+    case SYM_TEMP_SENSOR_LAST:
+        return BF_SYM_TEMP_SENSOR_LAST;
+
+    case TEMP_SENSOR_SYM_COUNT:
+        return BF_TEMP_SENSOR_SYM_COUNT;
+*/
+    case SYM_HEADING_N:
+        return BF_SYM_HEADING_N;
+
+    case SYM_HEADING_S:
+        return BF_SYM_HEADING_S;
+
+    case SYM_HEADING_E:
+        return BF_SYM_HEADING_E;
+
+    case SYM_HEADING_W:
+        return BF_SYM_HEADING_W;
+
+    case SYM_HEADING_DIVIDED_LINE:
+        return BF_SYM_HEADING_DIVIDED_LINE;
+
+    case SYM_HEADING_LINE:
+        return BF_SYM_HEADING_LINE;
+/*
+    case SYM_MAX:
+        return BF_SYM_MAX;
+
+    case SYM_PROFILE:
+        return BF_SYM_PROFILE;
+
+    case SYM_SWITCH_INDICATOR_LOW:
+        return BF_SYM_SWITCH_INDICATOR_LOW;
+
+    case SYM_SWITCH_INDICATOR_MID:
+        return BF_SYM_SWITCH_INDICATOR_MID;
+
+    case SYM_SWITCH_INDICATOR_HIGH:
+        return BF_SYM_SWITCH_INDICATOR_HIGH;
+
+    case SYM_AH:
+        return BF_SYM_AH;
+
+    case SYM_GLIDE_DIST:
+        return BF_SYM_GLIDE_DIST;
+
+    case SYM_GLIDE_MINS:
+        return BF_SYM_GLIDE_MINS;
+
+    case SYM_AH_V_FT_0:
+        return BF_SYM_AH_V_FT_0;
+
+    case SYM_AH_V_FT_1:
+        return BF_SYM_AH_V_FT_1;
+
+    case SYM_AH_V_M_0:
+        return BF_SYM_AH_V_M_0;
+
+    case SYM_AH_V_M_1:
+        return BF_SYM_AH_V_M_1;
+
+    case SYM_FLIGHT_MINS_REMAINING:
+        return BF_SYM_FLIGHT_MINS_REMAINING;
+
+    case SYM_FLIGHT_HOURS_REMAINING:
+        return BF_SYM_FLIGHT_HOURS_REMAINING;
+
+    case SYM_GROUND_COURSE:
+        return BF_SYM_GROUND_COURSE;
+
+    case SYM_CROSS_TRACK_ERROR:
+        return BF_SYM_CROSS_TRACK_ERROR;
+
+    case SYM_LOGO_START:
+        return BF_SYM_LOGO_START;
+
+    case SYM_LOGO_WIDTH:
+        return BF_SYM_LOGO_WIDTH;
+
+    case SYM_LOGO_HEIGHT:
+        return BF_SYM_LOGO_HEIGHT;
+*/
+    case SYM_AH_LEFT:
+        return BF_SYM_AH_LEFT;
+
+    case SYM_AH_RIGHT:
+        return BF_SYM_AH_RIGHT;
+/*
+    case SYM_AH_DECORATION_MIN:
+        return BF_SYM_AH_DECORATION_MIN;
+*/
+    case SYM_AH_DECORATION:
+        return BF_SYM_AH_DECORATION;
+/*
+    case SYM_AH_DECORATION_MAX:
+        return BF_SYM_AH_DECORATION_MAX;
+
+    case SYM_AH_DECORATION_COUNT:
+        return BF_SYM_AH_DECORATION_COUNT;
+
+    case SYM_AH_CH_LEFT:
+        return BF_SYM_AH_CH_LEFT;
+
+    case SYM_AH_CH_RIGHT:
+        return BF_SYM_AH_CH_RIGHT;
+*/
+    case SYM_ARROW_UP:
+        return BF_SYM_ARROW_NORTH;
+
+    case SYM_ARROW_2:
+        return BF_SYM_ARROW_2;
+
+    case SYM_ARROW_3:
+        return BF_SYM_ARROW_3;
+
+    case SYM_ARROW_4:
+        return BF_SYM_ARROW_4;
+
+    case SYM_ARROW_RIGHT:
+        return BF_SYM_ARROW_EAST;
+
+    case SYM_ARROW_6:
+        return BF_SYM_ARROW_6;
+
+    case SYM_ARROW_7:
+        return BF_SYM_ARROW_7;
+
+    case SYM_ARROW_8:
+        return BF_SYM_ARROW_8;
+
+    case SYM_ARROW_DOWN:
+        return BF_SYM_ARROW_SOUTH;
+
+    case SYM_ARROW_10:
+        return BF_SYM_ARROW_10;
+
+    case SYM_ARROW_11:
+        return BF_SYM_ARROW_11;
+
+    case SYM_ARROW_12:
+        return BF_SYM_ARROW_12;
+
+    case SYM_ARROW_LEFT:
+        return BF_SYM_ARROW_WEST;
+
+    case SYM_ARROW_14:
+        return BF_SYM_ARROW_14;
+
+    case SYM_ARROW_15:
+        return BF_SYM_ARROW_15;
+
+    case SYM_ARROW_16:
+        return BF_SYM_ARROW_16;
+/*
+    case SYM_AH_H_START:
+        return BF_SYM_AH_H_START;
+
+    case SYM_AH_V_START:
+        return BF_SYM_AH_V_START;
+
+    case SYM_VARIO_UP_2A:
+        return BF_SYM_VARIO_UP_2A;
+
+    case SYM_VARIO_UP_1A:
+        return BF_SYM_VARIO_UP_1A;
+
+    case SYM_VARIO_DOWN_1A:
+        return BF_SYM_VARIO_DOWN_1A;
+
+    case SYM_VARIO_DOWN_2A:
+        return BF_SYM_VARIO_DOWN_2A;
+
+    case SYM_ALT:
+        return BF_SYM_ALT;
+
+    case SYM_HUD_SIGNAL_0:
+        return BF_SYM_HUD_SIGNAL_0;
+
+    case SYM_HUD_SIGNAL_1:
+        return BF_SYM_HUD_SIGNAL_1;
+
+    case SYM_HUD_SIGNAL_2:
+        return BF_SYM_HUD_SIGNAL_2;
+
+    case SYM_HUD_SIGNAL_3:
+        return BF_SYM_HUD_SIGNAL_3;
+
+    case SYM_HUD_SIGNAL_4:
+        return BF_SYM_HUD_SIGNAL_4;
+
+    case SYM_HOME_DIST:
+        return BF_SYM_HOME_DIST;
+
+    case SYM_AH_CH_CENTER:
+        return BF_SYM_AH_CH_CENTER;
+
+    case SYM_FLIGHT_DIST_REMAINING:
+        return BF_SYM_FLIGHT_DIST_REMAINING;
+
+    case SYM_AH_CH_TYPE3:
+        return BF_SYM_AH_CH_TYPE3;
+
+    case SYM_AH_CH_TYPE4:
+        return BF_SYM_AH_CH_TYPE4;
+
+    case SYM_AH_CH_TYPE5:
+        return BF_SYM_AH_CH_TYPE5;
+
+    case SYM_AH_CH_TYPE6:
+        return BF_SYM_AH_CH_TYPE6;
+
+    case SYM_AH_CH_TYPE7:
+        return BF_SYM_AH_CH_TYPE7;
+
+    case SYM_AH_CH_TYPE8:
+        return BF_SYM_AH_CH_TYPE8;
+
+    case SYM_AH_CH_AIRCRAFT0:
+        return BF_SYM_AH_CH_AIRCRAFT0;
+
+    case SYM_AH_CH_AIRCRAFT1:
+        return BF_SYM_AH_CH_AIRCRAFT1;
+
+    case SYM_AH_CH_AIRCRAFT2:
+        return BF_SYM_AH_CH_AIRCRAFT2;
+
+    case SYM_AH_CH_AIRCRAFT3:
+        return BF_SYM_AH_CH_AIRCRAFT3;
+
+    case SYM_AH_CH_AIRCRAFT4:
+        return BF_SYM_AH_CH_AIRCRAFT4;
+
+    case SYM_HUD_ARROWS_L1:
+        return BF_SYM_HUD_ARROWS_L1;
+
+    case SYM_HUD_ARROWS_L2:
+        return BF_SYM_HUD_ARROWS_L2;
+
+    case SYM_HUD_ARROWS_L3:
+        return BF_SYM_HUD_ARROWS_L3;
+
+    case SYM_HUD_ARROWS_R1:
+        return BF_SYM_HUD_ARROWS_R1;
+
+    case SYM_HUD_ARROWS_R2:
+        return BF_SYM_HUD_ARROWS_R2;
+
+    case SYM_HUD_ARROWS_R3:
+        return BF_SYM_HUD_ARROWS_R3;
+
+    case SYM_HUD_ARROWS_U1:
+        return BF_SYM_HUD_ARROWS_U1;
+
+    case SYM_HUD_ARROWS_U2:
+        return BF_SYM_HUD_ARROWS_U2;
+
+    case SYM_HUD_ARROWS_U3:
+        return BF_SYM_HUD_ARROWS_U3;
+
+    case SYM_HUD_ARROWS_D1:
+        return BF_SYM_HUD_ARROWS_D1;
+
+    case SYM_HUD_ARROWS_D2:
+        return BF_SYM_HUD_ARROWS_D2;
+
+    case SYM_HUD_ARROWS_D3:
+        return BF_SYM_HUD_ARROWS_D3;
+*/
+    default:
+        break;
+    }
+
+    return '?'; // Missing/not mapped character
+}
+
+
+#endif
+
+#endif

--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -27,13 +27,13 @@
 
 uint8_t get_bf_character(uint8_t ch, uint8_t page)
 {
-    if(ch >= 0x20 && ch <= 0x5F) // ASCII range
-    {
-        return ch;
-    }
 
     uint16_t ech = ch | (page << 8);
 
+    if(ech >= 0x20 && ech <= 0x5F) // ASCII range
+    {
+        return ch;
+    }
 
     switch (ech)
     {
@@ -509,10 +509,35 @@ uint8_t get_bf_character(uint8_t ch, uint8_t page)
 
     case SYM_ARROW_16:
         return BF_SYM_ARROW_16;
-/*
-    case SYM_AH_H_START:
-        return BF_SYM_AH_H_START;
 
+    case SYM_AH_H_START:
+        return BF_SYM_AH_BAR9_0;
+
+    case (SYM_AH_H_START+1):
+        return BF_SYM_AH_BAR9_1;
+
+    case (SYM_AH_H_START+2):
+        return BF_SYM_AH_BAR9_2;
+
+    case (SYM_AH_H_START+3):
+        return BF_SYM_AH_BAR9_3;
+
+    case (SYM_AH_H_START+4):
+        return BF_SYM_AH_BAR9_4;
+
+    case (SYM_AH_H_START+5):
+        return BF_SYM_AH_BAR9_5;
+
+    case (SYM_AH_H_START+6):
+        return BF_SYM_AH_BAR9_6;
+
+    case (SYM_AH_H_START+7):
+        return BF_SYM_AH_BAR9_7;
+
+    case (SYM_AH_H_START+8):
+        return BF_SYM_AH_BAR9_8;
+
+/*
     case SYM_AH_V_START:
         return BF_SYM_AH_V_START;
 

--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -457,10 +457,28 @@ uint8_t get_bf_character(uint8_t ch, uint8_t page)
         return BF_SYM_AH_DECORATION_COUNT;
 */
     case SYM_AH_CH_LEFT:
-        return BF_SYM_AH_LEFT;
+    case SYM_AH_CH_TYPE3:
+    case SYM_AH_CH_TYPE4:
+    case SYM_AH_CH_TYPE5:
+    case SYM_AH_CH_TYPE6:
+    case SYM_AH_CH_TYPE7:
+    case SYM_AH_CH_TYPE8:
+    case SYM_AH_CH_AIRCRAFT1:
+        return BF_SYM_AH_CENTER_LINE;
 
     case SYM_AH_CH_RIGHT:
-        return BF_SYM_AH_RIGHT;
+    case (SYM_AH_CH_TYPE3+2):
+    case (SYM_AH_CH_TYPE4+2):
+    case (SYM_AH_CH_TYPE5+2):
+    case (SYM_AH_CH_TYPE6+2):
+    case (SYM_AH_CH_TYPE7+2):
+    case (SYM_AH_CH_TYPE8+2):
+    case SYM_AH_CH_AIRCRAFT3:
+        return BF_SYM_AH_CENTER_LINE_RIGHT;
+    
+    case SYM_AH_CH_AIRCRAFT0:
+    case SYM_AH_CH_AIRCRAFT4:
+        return ' ';
 
     case SYM_ARROW_UP:
         return BF_SYM_ARROW_NORTH;
@@ -576,6 +594,13 @@ uint8_t get_bf_character(uint8_t ch, uint8_t page)
 */
 
     case SYM_AH_CH_CENTER:
+    case (SYM_AH_CH_TYPE3+1):
+    case (SYM_AH_CH_TYPE4+1):
+    case (SYM_AH_CH_TYPE5+1):
+    case (SYM_AH_CH_TYPE6+1):
+    case (SYM_AH_CH_TYPE7+1):
+    case (SYM_AH_CH_TYPE8+1):
+    case SYM_AH_CH_AIRCRAFT2:
         return BF_SYM_AH_CENTER;
 /*
     case SYM_FLIGHT_DIST_REMAINING:

--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -455,13 +455,13 @@ uint8_t get_bf_character(uint8_t ch, uint8_t page)
 
     case SYM_AH_DECORATION_COUNT:
         return BF_SYM_AH_DECORATION_COUNT;
-
+*/
     case SYM_AH_CH_LEFT:
-        return BF_SYM_AH_CH_LEFT;
+        return BF_SYM_AH_LEFT;
 
     case SYM_AH_CH_RIGHT:
-        return BF_SYM_AH_CH_RIGHT;
-*/
+        return BF_SYM_AH_RIGHT;
+
     case SYM_ARROW_UP:
         return BF_SYM_ARROW_NORTH;
 
@@ -573,10 +573,11 @@ uint8_t get_bf_character(uint8_t ch, uint8_t page)
 
     case SYM_HOME_DIST:
         return BF_SYM_HOME_DIST;
+*/
 
     case SYM_AH_CH_CENTER:
-        return BF_SYM_AH_CH_CENTER;
-
+        return BF_SYM_AH_CENTER;
+/*
     case SYM_FLIGHT_DIST_REMAINING:
         return BF_SYM_FLIGHT_DIST_REMAINING;
 

--- a/src/main/io/displayport_msp_bf_compat.h
+++ b/src/main/io/displayport_msp_bf_compat.h
@@ -25,9 +25,9 @@
 #ifdef USE_MSP_DISPLAYPORT
 
 #ifndef DISABLE_MSP_BF_COMPAT
-uint8_t get_bf_character(uint8_t ch, uint8_t page);
+uint8_t getBfCharacter(uint8_t ch, uint8_t page);
 #else
-#define get_bf_character(x, page) (x)
+#define getBfCharacter(x, page) (x)
 #endif
 
 #endif

--- a/src/main/io/displayport_msp_bf_compat.h
+++ b/src/main/io/displayport_msp_bf_compat.h
@@ -1,0 +1,33 @@
+
+/*
+ * This file is part of INAV Project.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#ifdef USE_MSP_DISPLAYPORT
+
+#ifndef DISABLE_MSP_BF_COMPAT
+uint8_t get_bf_character(uint8_t ch, uint8_t page);
+#else
+#define get_bf_character(x, page) (x)
+#endif
+
+#endif

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -284,7 +284,7 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
 
         subcmd[1] = row;
         subcmd[2] = col;
-        subcmd[3] = page;
+        subcmd[3] = (osdVideoSystem == VIDEO_SYSTEM_BFCOMPAT) ? 0 : page;
         output(displayPort, MSP_DISPLAYPORT, subcmd, len);
         updateCount++;
         next = BITARRAY_FIND_FIRST_SET(dirty, pos);
@@ -417,6 +417,7 @@ displayPort_t* mspOsdDisplayPortInit(const videoSystem_e videoSystem)
     if (mspOsdSerialInit()) {
         switch(videoSystem) {
         case VIDEO_SYSTEM_AUTO:
+        case VIDEO_SYSTEM_BFCOMPAT:
         case VIDEO_SYSTEM_PAL:
             currentOsdMode = SD_3016;
             screenRows = PAL_ROWS;

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -56,10 +56,12 @@ FILE_COMPILE_FOR_SPEED
 
 #define FONT_VERSION 3
 
+#define MSP_HEARTBEAT    0
+#define MSP_RELEASE      1
 #define MSP_CLEAR_SCREEN 2
 #define MSP_WRITE_STRING 3
-#define MSP_DRAW_SCREEN 4
-#define MSP_SET_OPTIONS 5
+#define MSP_DRAW_SCREEN  4
+#define MSP_SET_OPTIONS  5
 
 typedef enum {          // defines are from hdzero code
     SD_3016,
@@ -352,20 +354,19 @@ static bool isReady(displayPort_t *displayPort)
 
 static int grab(displayPort_t *displayPort)
 {
-    UNUSED(displayPort);
-    return 0;
+    return heartbeat(displayPort);
 }
 
 static int heartbeat(displayPort_t *displayPort)
 {
-    UNUSED(displayPort);
-    return 0;
+    uint8_t subcmd[] = { MSP_HEARTBEAT };
+    return output(displayPort, MSP_DISPLAYPORT, subcmd, sizeof(subcmd));
 }
 
 static int release(displayPort_t *displayPort)
 {
-    UNUSED(displayPort);
-    return 0;
+    uint8_t subcmd[] = { MSP_RELEASE };
+    return output(displayPort, MSP_DISPLAYPORT, subcmd, sizeof(subcmd));
 }
 
 static const displayPortVTable_t mspOsdVTable = {

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -352,15 +352,15 @@ static bool isReady(displayPort_t *displayPort)
     return vtxActive;
 }
 
-static int grab(displayPort_t *displayPort)
-{
-    return heartbeat(displayPort);
-}
-
 static int heartbeat(displayPort_t *displayPort)
 {
     uint8_t subcmd[] = { MSP_HEARTBEAT };
     return output(displayPort, MSP_DISPLAYPORT, subcmd, sizeof(subcmd));
+}
+
+static int grab(displayPort_t *displayPort)
+{
+    return heartbeat(displayPort);
 }
 
 static int release(displayPort_t *displayPort)

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -277,7 +277,7 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         uint8_t len = 4;
         do {
             bitArrayClr(dirty, pos);
-            subcmd[len++] = (osdVideoSystem == VIDEO_SYSTEM_BFCOMPAT) ? get_bf_character(screen[pos++], page): screen[pos++];
+            subcmd[len++] = (osdVideoSystem == VIDEO_SYSTEM_BFCOMPAT) ? getBfCharacter(screen[pos++], page): screen[pos++];
 
             if (bitArrayGet(dirty, pos)) {
                 next = pos;

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -52,6 +52,8 @@ FILE_COMPILE_FOR_SPEED
 
 #include "displayport_msp_osd.h"
 
+#include "displayport_msp_bf_compat.h"
+
 #define FONT_VERSION 3
 
 #define MSP_CLEAR_SCREEN 2
@@ -273,7 +275,7 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         uint8_t len = 4;
         do {
             bitArrayClr(dirty, pos);
-            subcmd[len++] = screen[pos++];
+            subcmd[len++] = (osdVideoSystem == VIDEO_SYSTEM_BFCOMPAT) ? get_bf_character(screen[pos++], page): screen[pos++];
 
             if (bitArrayGet(dirty, pos)) {
                 next = pos;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -257,8 +257,7 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
 
     int digits = digitCount(integerPart);
     int remaining = length - digits;
-    if (explicitDecimal)
-    {
+    if (explicitDecimal) {
         remaining--;
     }
 
@@ -300,8 +299,7 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
     ptr += digits;
 
     if (decimals > 0) {
-        if (explicitDecimal)
-        {
+        if (explicitDecimal) {
             *ptr = '.';
             ptr++;
         } else {
@@ -734,8 +732,7 @@ static void osdFormatCoordinate(char *buff, char sym, int32_t val)
     int32_t decimalPart = abs(val % GPS_DEGREES_DIVIDER);
     STATIC_ASSERT(GPS_DEGREES_DIVIDER == 1e7, adjust_max_decimal_digits);
     int decimalDigits;
-    if(osdConfig()->video_system != VIDEO_SYSTEM_BFCOMPAT)
-    {
+    if (osdConfig()->video_system != VIDEO_SYSTEM_BFCOMPAT) {
         decimalDigits = tfp_sprintf(buff + 1 + integerDigits, "%07d", (int)decimalPart);
         // Embbed the decimal separator
         buff[1 + integerDigits - 1] += SYM_ZERO_HALF_TRAILING_DOT - '0';
@@ -3004,7 +3001,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 if (h < 0) {
                     h += 360;
                 }
-                if(h >= 180)
+                if (h >= 180)
                     h = h - 180;
                 else
                     h = h + 180;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -298,15 +298,13 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
     // Now write the digits.
     ui2a(integerPart, 10, 0, ptr);
     ptr += digits;
-    if (explicitDecimal)
-    {
-        *ptr = '.';
-        ptr++;
-    }
 
     if (decimals > 0) {
-        if (!explicitDecimal)
+        if (explicitDecimal)
         {
+            *ptr = '.';
+            ptr++;
+        } else {
             *(ptr - 1) += SYM_ZERO_HALF_TRAILING_DOT - '0';
         }
         dec = ptr;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -270,8 +270,7 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
         millis = ((centivalue % (100 * scale)) * 10) / scale;
         digits = digitCount(integerPart);
         remaining = length - digits;
-        if (explicitDecimal)
-        {
+        if (explicitDecimal) {
             remaining--;
         }
     }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -241,6 +241,7 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
     int decimals = maxDecimals;
     bool negative = false;
     bool scaled = false;
+    bool explicitDecimal = osdConfig()->video_system == VIDEO_SYSTEM_BFCOMPAT;
 
     buff[length] = '\0';
 
@@ -256,6 +257,10 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
 
     int digits = digitCount(integerPart);
     int remaining = length - digits;
+    if (explicitDecimal)
+    {
+        remaining--;
+    }
 
     if (remaining < 0 && scale > 0) {
         // Reduce by scale
@@ -266,6 +271,10 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
         millis = ((centivalue % (100 * scale)) * 10) / scale;
         digits = digitCount(integerPart);
         remaining = length - digits;
+        if (explicitDecimal)
+        {
+            remaining--;
+        }
     }
 
     // 3 decimals at most
@@ -289,8 +298,17 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
     // Now write the digits.
     ui2a(integerPart, 10, 0, ptr);
     ptr += digits;
+    if (explicitDecimal)
+    {
+        *ptr = '.';
+        ptr++;
+    }
+
     if (decimals > 0) {
-        *(ptr-1) += SYM_ZERO_HALF_TRAILING_DOT - '0';
+        if (!explicitDecimal)
+        {
+            *(ptr - 1) += SYM_ZERO_HALF_TRAILING_DOT - '0';
+        }
         dec = ptr;
         int factor = 3; // we're getting the decimal part in millis first
         while (decimals < factor) {
@@ -304,7 +322,9 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
             ptr++;
         }
         ui2a(millis, 10, 0, ptr);
-        *dec += SYM_ZERO_HALF_LEADING_DOT - '0';
+        if (!explicitDecimal) {
+            *dec += SYM_ZERO_HALF_LEADING_DOT - '0';
+        }
     }
     return scaled;
 }
@@ -715,10 +735,16 @@ static void osdFormatCoordinate(char *buff, char sym, int32_t val)
     // We can show up to 7 digits in decimalPart.
     int32_t decimalPart = abs(val % GPS_DEGREES_DIVIDER);
     STATIC_ASSERT(GPS_DEGREES_DIVIDER == 1e7, adjust_max_decimal_digits);
-    int decimalDigits = tfp_sprintf(buff + 1 + integerDigits, "%07d", (int)decimalPart);
-    // Embbed the decimal separator
-    buff[1 + integerDigits - 1] += SYM_ZERO_HALF_TRAILING_DOT - '0';
-    buff[1 + integerDigits] += SYM_ZERO_HALF_LEADING_DOT - '0';
+    int decimalDigits;
+    if(osdConfig()->video_system != VIDEO_SYSTEM_BFCOMPAT)
+    {
+        decimalDigits = tfp_sprintf(buff + 1 + integerDigits, "%07d", (int)decimalPart);
+        // Embbed the decimal separator
+        buff[1 + integerDigits - 1] += SYM_ZERO_HALF_TRAILING_DOT - '0';
+        buff[1 + integerDigits] += SYM_ZERO_HALF_LEADING_DOT - '0';
+    } else {
+        decimalDigits = tfp_sprintf(buff + 1 + integerDigits, ".%06d", (int)decimalPart);
+    }
     // Fill up to coordinateLength with zeros
     int total = 1 + integerDigits + decimalDigits;
     while(total < coordinateLength) {


### PR DESCRIPTION
Add an OSD mode that would do a best effort to map INAV characters to BF characters.
If a character is not supported by BF4.3, it will be replaced by a question mark '?'.

This should provide a better user experience than random characters on screen when the VRX only supports BF (dji) while making it clear what is missing.

Impact on flash space was fairly small (0.04% difference on initial build)

This has been confirmed to work on different combinations of O3, G2, V2 and Vista/AU running O3 firmware.

Functionality can also be tested with rooted AU/Vista + Googles V2 by replacing the INAV font used by fpv.wtf with the BetaFlight font. 

Compatibility mode can be enabled on the CLI by:
set osd_video_system = BF43COMPAT

There is also a pull request (iNavFlight/inav-configurator#1671) for the configurator to allowing it to be setup as a normal MSP OSD device and selecting BF43COMPAT video format on the OSD tab. 
