### PR TITLE
Increase number of voltage digits in BF compatibility mode OSD

### DIFF
--- a/src/main/io/displayport_msp_bf_compat.h
+++ b/src/main/io/displayport_msp_bf_compat.h
@@ -25,9 +25,13 @@
 #ifdef USE_MSP_DISPLAYPORT
 
 #ifndef DISABLE_MSP_BF_COMPAT
+#include "osd.h"
 uint8_t getBfCharacter(uint8_t ch, uint8_t page);
+
+#define isBfCompatible(osdConfigPtr) (osdConfigPtr->video_system == VIDEO_SYSTEM_BFCOMPAT)
 #else
 #define getBfCharacter(x, page) (x)
+#define isBfCompatible(osdConfigPtr) (false)
 #endif
 
 #endif

--- a/src/main/io/displayport_msp_bf_compat.h
+++ b/src/main/io/displayport_msp_bf_compat.h
@@ -27,7 +27,6 @@
 #ifndef DISABLE_MSP_BF_COMPAT
 #include "osd.h"
 uint8_t getBfCharacter(uint8_t ch, uint8_t page);
-
 #define isBfCompatible(osdConfigPtr) (osdConfigPtr->video_system == VIDEO_SYSTEM_BFCOMPAT)
 #else
 #define getBfCharacter(x, page) (x)

--- a/src/main/io/displayport_msp_bf_compat.h
+++ b/src/main/io/displayport_msp_bf_compat.h
@@ -27,10 +27,10 @@
 #ifndef DISABLE_MSP_BF_COMPAT
 #include "osd.h"
 uint8_t getBfCharacter(uint8_t ch, uint8_t page);
-#define isBfCompatible(osdConfigPtr) (osdConfigPtr->video_system == VIDEO_SYSTEM_BFCOMPAT)
+#define isBfCompatibleVideoSystem(osdConfigPtr) (osdConfigPtr->video_system == VIDEO_SYSTEM_BFCOMPAT)
 #else
 #define getBfCharacter(x, page) (x)
-#define isBfCompatible(osdConfigPtr) (false)
+#define isBfCompatibleVideoSystem(osdConfigPtr) (false)
 #endif
 
 #endif

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -242,7 +242,7 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
     int decimals = maxDecimals;
     bool negative = false;
     bool scaled = false;
-    bool explicitDecimal = isBfCompatible(osdConfig());
+    bool explicitDecimal = isBfCompatibleVideoSystem(osdConfig());
 
     buff[length] = '\0';
 
@@ -732,7 +732,7 @@ static void osdFormatCoordinate(char *buff, char sym, int32_t val)
     int32_t decimalPart = abs(val % GPS_DEGREES_DIVIDER);
     STATIC_ASSERT(GPS_DEGREES_DIVIDER == 1e7, adjust_max_decimal_digits);
     int decimalDigits;
-    if (!isBfCompatible(osdConfig())) {
+    if (!isBfCompatibleVideoSystem(osdConfig())) {
         decimalDigits = tfp_sprintf(buff + 1 + integerDigits, "%07d", (int)decimalPart);
         // Embbed the decimal separator
         buff[1 + integerDigits - 1] += SYM_ZERO_HALF_TRAILING_DOT - '0';
@@ -1595,11 +1595,11 @@ static bool osdDrawSingleElement(uint8_t item)
         }
 
     case OSD_MAIN_BATT_VOLTAGE:
-        osdDisplayBatteryVoltage(elemPosX, elemPosY, getBatteryRawVoltage(), (isBfCompatible(osdConfig()) ? 3 : 2) + osdConfig()->main_voltage_decimals, osdConfig()->main_voltage_decimals);
+        osdDisplayBatteryVoltage(elemPosX, elemPosY, getBatteryRawVoltage(), (isBfCompatibleVideoSystem(osdConfig()) ? 3 : 2) + osdConfig()->main_voltage_decimals, osdConfig()->main_voltage_decimals);
         return true;
 
     case OSD_SAG_COMPENSATED_MAIN_BATT_VOLTAGE:
-        osdDisplayBatteryVoltage(elemPosX, elemPosY, getBatterySagCompensatedVoltage(), (isBfCompatible(osdConfig()) ? 3 : 2) + osdConfig()->main_voltage_decimals, osdConfig()->main_voltage_decimals);
+        osdDisplayBatteryVoltage(elemPosX, elemPosY, getBatterySagCompensatedVoltage(), (isBfCompatibleVideoSystem(osdConfig()) ? 3 : 2) + osdConfig()->main_voltage_decimals, osdConfig()->main_voltage_decimals);
         return true;
 
     case OSD_CURRENT_DRAW:
@@ -2706,13 +2706,13 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_MAIN_BATT_CELL_VOLTAGE:
         {
-            osdDisplayBatteryVoltage(elemPosX, elemPosY, getBatteryRawAverageCellVoltage(), (isBfCompatible(osdConfig()) ? 4 : 3), 2);
+            osdDisplayBatteryVoltage(elemPosX, elemPosY, getBatteryRawAverageCellVoltage(), (isBfCompatibleVideoSystem(osdConfig()) ? 4 : 3), 2);
             return true;
         }
 
     case OSD_MAIN_BATT_SAG_COMPENSATED_CELL_VOLTAGE:
         {
-            osdDisplayBatteryVoltage(elemPosX, elemPosY, getBatterySagCompensatedAverageCellVoltage(), (isBfCompatible(osdConfig()) ? 4 : 3), 2);
+            osdDisplayBatteryVoltage(elemPosX, elemPosY, getBatterySagCompensatedAverageCellVoltage(), (isBfCompatibleVideoSystem(osdConfig()) ? 4 : 3), 2);
             return true;
         }
 


### PR DESCRIPTION
The voltage display in BF compatibility mode loses 1 digit of precision.

Main battery voltage becomes an integer by default and cell voltage is reduced to a single digit.

This change would increase the number of characters by 1 in BF compatibility mode so it can display the expected number of decimal places.

Other video systems are not affected.

Main pack voltage seems like an important enough metric for this change.
