### PR TITLE
changed WP mode priority in crsf telemetry

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -323,7 +323,7 @@ static void crsfFrameFlightMode(sbuf_t *dst)
         }
         if (FLIGHT_MODE(FAILSAFE_MODE)) {
             flightMode = "!FS!";
-        } else if (ARMING_FLAG(ARMED) && IS_RC_MODE_ACTIVE(BOXHOMERESET) && !FLIGHT_MODE(NAV_RTH_MODE) && !FLIGHT_MODE(NAV_WP_MODE)) {
+        } else if (IS_RC_MODE_ACTIVE(BOXHOMERESET) && !FLIGHT_MODE(NAV_RTH_MODE) && !FLIGHT_MODE(NAV_WP_MODE)) {
             flightMode = "HRST";
         } else if (FLIGHT_MODE(MANUAL_MODE)) {
             flightMode = "MANU";
@@ -335,10 +335,10 @@ static void crsfFrameFlightMode(sbuf_t *dst)
             flightMode = "CRUZ";
         } else if (FLIGHT_MODE(NAV_COURSE_HOLD_MODE)) {
             flightMode = "CRSH";
-        } else if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
-            flightMode = "AH";
         } else if (FLIGHT_MODE(NAV_WP_MODE)) {
             flightMode = "WP";
+        } else if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
+            flightMode = "AH";
         } else if (FLIGHT_MODE(ANGLE_MODE)) {
             flightMode = "ANGL";
         } else if (FLIGHT_MODE(HORIZON_MODE)) {


### PR DESCRIPTION
IS: WP mode is seen as AH in crsf telemetry
SHOULD: WP mode should have higher priority than AH in telemetry

Solution:
1) increased WP mode priority over AH
2) removed redundant ARMED flag check - flag is checked in parent "if" block already