### PR TITLE
Modified OSD stats functions to accomodate single page stats for HD

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -234,6 +234,9 @@ bool osdVideoSystemIsSinglePageStatsCompatible(void)
     switch ((videoSystem_e)osdConfig()->video_system) {
         case VIDEO_SYSTEM_HDZERO:
             FALLTHROUGH;
+        // Placeholder for Avatar system support once Darren completes that.
+        // case VIDEO_SYSTEM_AVATAR:
+        //      FALLTHROUGH;
         case VIDEO_SYSTEM_DJIWTF:
             result = true;
             break;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3920,7 +3920,7 @@ static void osdShowStats(bool isSinglePageStatsCompatible, int page)
     if (isSinglePageStatsCompatible || page == 1) {
         if (feature(FEATURE_GPS)) {            
             if (isSinglePageStatsCompatible) {
-                displayWrite(osdDisplayPort, statNameX, top, "SPEED MAX/AVG    :");
+                displayWrite(osdDisplayPort, statNameX, top, "MAX/AVG SPEED    :");
                 osdFormatVelocityStr(buff, stats.max_3D_speed, true, false);
                 osdLeftAlignString(buff);
                 strcat(osdFormatTrimWhiteSpace(buff),"/");

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3865,28 +3865,22 @@ static void osdShowStats(bool isHD, int page)
     statsPagesCheck = 1;
 
     if (page < 1 || page > 2)
-    {
-        page = 1;
-    }
+    page = 1;
 
     displayBeginTransaction(osdDisplayPort, DISPLAY_TRANSACTION_OPT_RESET_DRAWING);
     displayClearScreen(osdDisplayPort);
 
-    if (isHD)
-    {
+    if (isHD) {
         displayWrite(osdDisplayPort, statNameX, top++, "--- STATS ---");
     }
-    else if (page == 1)
-    {
+    else if (page == 1) {
         displayWrite(osdDisplayPort, statNameX, top++, "--- STATS ---      1/2 ->");
     }
-    else if (page == 2)
-    {
+    else if (page == 2) {
         displayWrite(osdDisplayPort, statNameX, top++, "--- STATS ---   <- 2/2");
     }
 
-    if (isHD || page == 1)
-    {
+    if (isHD || page == 1) {
         if (feature(FEATURE_GPS)) {
             displayWrite(osdDisplayPort, statNameX, top, "MAX SPEED        :");
             osdFormatVelocityStr(buff, stats.max_3D_speed, true, false);
@@ -3948,8 +3942,7 @@ static void osdShowStats(bool isHD, int page)
         displayWrite(osdDisplayPort, statValuesX, top++, disarmReasonStr[getDisarmReason()]);
     }
     
-    if (isHD || page == 2)
-    {
+    if (isHD || page == 2) {
         if (osdConfig()->stats_min_voltage_unit == OSD_STATS_MIN_VOLTAGE_UNIT_BATTERY) {
             displayWrite(osdDisplayPort, statNameX, top, "MIN BATTERY VOLT :");
             osdFormatCentiNumber(buff, stats.min_voltage, 0, osdConfig()->main_voltage_decimals, 0, osdConfig()->main_voltage_decimals + 2);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -244,7 +244,7 @@ bool osdDisplayIsHD(void)
 }
 
 bool osdVideoSystemIsSinglePageStatsCompatible(void)
-{    
+{   
     bool result = false;
 
     switch ((videoSystem_e)osdConfig()->video_system) {
@@ -4374,14 +4374,14 @@ static void osdRefresh(timeUs_t currentTimeUs)
     }
 
     if (resumeRefreshAt) {
-
+                            
+        /* This is a workaround to introduce a delay for the paging stick commands so that
+        *  holding the roll stick doesn't cause a race condition with the osdShowStats() method
+        */
         bool pageUp = false;  
-        bool pageDown = false;              
+        bool pageDown = false;  
         if (!osdVideoSystemIsSinglePageStatsCompatible())
         {
-            /* This is a workaround to introduce a delay for the paging stick commands so that
-            *  holding the roll stick doesn't cause a race condition with the osdShowStats() method
-            */
             if (osdIsPageUpKeyHeld()) {               
                 pageUp = true;
                 statsPageAutoSwapCntl = 2;
@@ -4389,30 +4389,72 @@ static void osdRefresh(timeUs_t currentTimeUs)
                 pageDown = true;                
                 statsPageAutoSwapCntl = 2;
             }
-            if (statsPageAutoSwapCntl == 2) {
-                if (pageDown) {
-                    if (statsPagesCheck == 1) {
-                        osdShowStats(false, 1);                       
-                    }
-                } else if (pageUp) {
-                    if (statsPagesCheck == 1) {
-                        osdShowStats(false, 2);
-                    }
+        }
+
+        if (statsPageAutoSwapCntl == 2) {
+            if (pageDown) {
+                if (statsPagesCheck == 1) {
+                    osdShowStats(osdVideoSystemIsSinglePageStatsCompatible(), 1);                       
+                }
+            } else if (pageUp) {
+                if (statsPagesCheck == 1) {
+                    osdShowStats(osdVideoSystemIsSinglePageStatsCompatible(), 2);
+                }
+            }
+        } else {
+            if (OSD_ALTERNATING_CHOICES((osdConfig()->stats_page_auto_swap_time * 1000), 2)) {
+                if (statsPageAutoSwapCntl == 0) {
+                    osdShowStats(osdVideoSystemIsSinglePageStatsCompatible(), 1);
+                    statsPageAutoSwapCntl = 1;
                 }
             } else {
-                if (OSD_ALTERNATING_CHOICES((osdConfig()->stats_page_auto_swap_time * 1000), 2)) {
-                    if (statsPageAutoSwapCntl == 0) {
-                        osdShowStats(false, 1);
-                        statsPageAutoSwapCntl = 1;
-                    }
-                } else {
-                    if (statsPageAutoSwapCntl == 1) {
-                        osdShowStats(false, 2);
-                        statsPageAutoSwapCntl = 0;
-                    }
+                if (statsPageAutoSwapCntl == 1) {
+                    osdShowStats(osdVideoSystemIsSinglePageStatsCompatible(), 2);
+                    statsPageAutoSwapCntl = 0;
                 }
             }
         }
+
+        // bool pageUp = false;  
+        // bool pageDown = false;                              
+        // if (!osdVideoSystemIsSinglePageStatsCompatible())
+        // {
+        //     /* This is a workaround to introduce a delay for the paging stick commands so that
+        //     *  holding the roll stick doesn't cause a race condition with the osdShowStats() method
+        //     */
+        //     if (osdIsPageUpKeyHeld()) {               
+        //         pageUp = true;
+        //         statsPageAutoSwapCntl = 2;
+        //     } else if (osdIsPageDownKeyHeld()) {
+        //         pageDown = true;                
+        //         statsPageAutoSwapCntl = 2;
+        //     }
+
+
+        //     if (statsPageAutoSwapCntl == 2) {
+        //         if (pageDown) {
+        //             if (statsPagesCheck == 1) {
+        //                 osdShowStats(false, 1);                       
+        //             }
+        //         } else if (pageUp) {
+        //             if (statsPagesCheck == 1) {
+        //                 osdShowStats(false, 2);
+        //             }
+        //         }
+        //     } else {
+        //         if (OSD_ALTERNATING_CHOICES((osdConfig()->stats_page_auto_swap_time * 1000), 2)) {
+        //             if (statsPageAutoSwapCntl == 0) {
+        //                 osdShowStats(false, 1);
+        //                 statsPageAutoSwapCntl = 1;
+        //             }
+        //         } else {
+        //             if (statsPageAutoSwapCntl == 1) {
+        //                 osdShowStats(false, 2);
+        //                 statsPageAutoSwapCntl = 0;
+        //             }
+        //         }
+        //     }
+        // }
 
         if ((currentTimeUs > resumeRefreshAt) || CANCEL_STATS_COMMAND) {
             displayClearScreen(osdDisplayPort);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -4023,8 +4023,7 @@ static void osdShowStats(bool isSinglePageStatsCompatible, int page)
         displayWrite(osdDisplayPort, statValuesX, top++, disarmReasonStr[getDisarmReason()]);
 
         /* We only want to show this message once, so it will be shown after the second
-        *  section for single page stats.
-        */
+        *  section for single page stats. */
         if (!isSinglePageStatsCompatible) {
             if (savingSettings == true) {
                 displayWrite(osdDisplayPort, statNameX, top++, OSD_MESSAGE_STR(OSD_MSG_SAVING_SETTNGS));
@@ -4376,8 +4375,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
     if (resumeRefreshAt) {
                             
         /* This is a workaround to introduce a delay for the paging stick commands so that
-        *  holding the roll stick doesn't cause a race condition with the osdShowStats() method
-        */
+        *  holding the roll stick doesn't cause a race condition with the osdShowStats() method. */
         bool pageUp = false;  
         bool pageDown = false;  
         if (!osdVideoSystemIsSinglePageStatsCompatible())
@@ -4414,47 +4412,6 @@ static void osdRefresh(timeUs_t currentTimeUs)
                 }
             }
         }
-
-        // bool pageUp = false;  
-        // bool pageDown = false;                              
-        // if (!osdVideoSystemIsSinglePageStatsCompatible())
-        // {
-        //     /* This is a workaround to introduce a delay for the paging stick commands so that
-        //     *  holding the roll stick doesn't cause a race condition with the osdShowStats() method
-        //     */
-        //     if (osdIsPageUpKeyHeld()) {               
-        //         pageUp = true;
-        //         statsPageAutoSwapCntl = 2;
-        //     } else if (osdIsPageDownKeyHeld()) {
-        //         pageDown = true;                
-        //         statsPageAutoSwapCntl = 2;
-        //     }
-
-
-        //     if (statsPageAutoSwapCntl == 2) {
-        //         if (pageDown) {
-        //             if (statsPagesCheck == 1) {
-        //                 osdShowStats(false, 1);                       
-        //             }
-        //         } else if (pageUp) {
-        //             if (statsPagesCheck == 1) {
-        //                 osdShowStats(false, 2);
-        //             }
-        //         }
-        //     } else {
-        //         if (OSD_ALTERNATING_CHOICES((osdConfig()->stats_page_auto_swap_time * 1000), 2)) {
-        //             if (statsPageAutoSwapCntl == 0) {
-        //                 osdShowStats(false, 1);
-        //                 statsPageAutoSwapCntl = 1;
-        //             }
-        //         } else {
-        //             if (statsPageAutoSwapCntl == 1) {
-        //                 osdShowStats(false, 2);
-        //                 statsPageAutoSwapCntl = 0;
-        //             }
-        //         }
-        //     }
-        // }
 
         if ((currentTimeUs > resumeRefreshAt) || CANCEL_STATS_COMMAND) {
             displayClearScreen(osdDisplayPort);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3920,7 +3920,7 @@ static void osdShowStats(bool isSinglePageStatsCompatible, int page)
     if (isSinglePageStatsCompatible || page == 1) {
         if (feature(FEATURE_GPS)) {            
             if (isSinglePageStatsCompatible) {
-                displayWrite(osdDisplayPort, statNameX, top, "MAX/AVG SPEED    :");
+                displayWrite(osdDisplayPort, statNameX, top, "SPEED MAX/AVG    :");
                 osdFormatVelocityStr(buff, stats.max_3D_speed, true, false);
                 osdLeftAlignString(buff);
                 strcat(osdFormatTrimWhiteSpace(buff),"/");


### PR DESCRIPTION
![SnapShot](https://user-images.githubusercontent.com/100724300/209537324-ed52903f-7820-41c3-9b4c-d7ffe08f75b3.jpg)

Implements a single function "osdShowStats()" for showing stats with parameters for whether the display is HD and which page to show if it is SD. So, existing paging functionality will be maintained for SD displays and a single stats page will be shown on HD displays.