### PR TITLE
send value throttle in telemetry exactly as shown on osd

### DIFF
--- a/src/main/telemetry/frsky_d.c
+++ b/src/main/telemetry/frsky_d.c
@@ -195,10 +195,7 @@ static void sendThrottleOrBatterySizeAsRpm(void)
 {
     sendDataHead(ID_RPM);
     if (ARMING_FLAG(ARMED)) {
-        uint16_t throttleForRPM = rcCommand[THROTTLE] / BLADE_NUMBER_DIVIDER;
-        if (throttleStickIsLow() && feature(FEATURE_MOTOR_STOP)) {
-            throttleForRPM = 0;
-        }
+        uint16_t throttleForRPM = getThrottlePercent() / BLADE_NUMBER_DIVIDER;
         serialize16(throttleForRPM);
     } else {
         serialize16((currentBatteryProfile->capacity.value / BLADE_NUMBER_DIVIDER));

--- a/src/main/telemetry/ibus.c
+++ b/src/main/telemetry/ibus.c
@@ -51,6 +51,7 @@
 
 #include "flight/imu.h"
 #include "flight/failsafe.h"
+#include "flight/mixer.h"
 
 #include "navigation/navigation.h"
 

--- a/src/main/telemetry/ibus_shared.c
+++ b/src/main/telemetry/ibus_shared.c
@@ -44,6 +44,7 @@
 
 #include "flight/imu.h"
 #include "flight/failsafe.h"
+#include "flight/mixer.h"
 
 #include "navigation/navigation.h"
 

--- a/src/main/telemetry/ibus_shared.c
+++ b/src/main/telemetry/ibus_shared.c
@@ -146,7 +146,7 @@ static uint8_t dispatchMeasurementRequest(ibusAddress_t address) {
         if (!temp_valid || (temperature < -400)) temperature = -400; // Minimum reported temperature is -40°C
         return sendIbusMeasurement2(address, (uint16_t)(temperature  + IBUS_TEMPERATURE_OFFSET));
     } else if (SENSOR_ADDRESS_TYPE_LOOKUP[address].value == IBUS_MEAS_VALUE_RPM) {
-        return sendIbusMeasurement2(address, (uint16_t) (rcCommand[THROTTLE]));
+        return sendIbusMeasurement2(address, (uint16_t)getThrottlePercent() );
     } else if (SENSOR_ADDRESS_TYPE_LOOKUP[address].value == IBUS_MEAS_VALUE_EXTERNAL_VOLTAGE) { //VBAT
         if (telemetryConfig()->report_cell_voltage) {
             return sendIbusMeasurement2(address, getBatteryAverageCellVoltage());

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -653,10 +653,7 @@ void mavlinkSendHUDAndHeartbeat(void)
     mavAltitude = getEstimatedActualPosition(Z) / 100.0f;
     mavClimbRate = getEstimatedActualVelocity(Z) / 100.0f;
 
-    int16_t thr = rxGetChannelValue(THROTTLE);
-    if (navigationIsControllingThrottle()) {
-        thr = rcCommand[THROTTLE];
-    }
+    int16_t thr = getThrottlePercent();
     mavlink_msg_vfr_hud_pack(mavSystemId, mavComponentId, &mavSendMsg,
         // airspeed Current airspeed in m/s
         mavAirSpeed,
@@ -665,7 +662,7 @@ void mavlinkSendHUDAndHeartbeat(void)
         // heading Current heading in degrees, in compass units (0..360, 0=north)
         DECIDEGREES_TO_DEGREES(attitude.values.yaw),
         // throttle Current throttle setting in integer percent, 0 to 100
-        scaleRange(constrain(thr, PWM_RANGE_MIN, PWM_RANGE_MAX), PWM_RANGE_MIN, PWM_RANGE_MAX, 0, 100),
+        thr, 
         // alt Current altitude (MSL), in meters, if we have surface or baro use them, otherwise use GPS (less accurate)
         mavAltitude,
         // climb Current climb rate in meters/second


### PR DESCRIPTION
Fixed: Throttle value in telemetry does not match value shown on OSD

Can be tested with mavlink and latest release of Telemetry viewer fork, which has Throttle sensor:
https://github.com/RomanLut/android-taranis-smartport-telemetry

