### PR TITLE
use MAX_SUPPORTED_RC_CHANNEL_COUNT instead of hardcoded 16

### DIFF
--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -778,7 +778,7 @@ int logicConditionGetOperandValue(logicOperandType_e type, int operand) {
 
         case LOGIC_CONDITION_OPERAND_TYPE_RC_CHANNEL:
             //Extract RC channel raw value
-            if (operand >= 1 && operand <= 16) {
+            if (operand >= 1 && operand <= MAX_SUPPORTED_RC_CHANNEL_COUNT) {
                 retVal = rxGetChannelValue(operand - 1);
             } 
             break;


### PR DESCRIPTION
Minor bugfix to use MAX_SUPPORTED_RC_CHANNEL_COUNT instead of hardcoded constant 16 in logic condition operand "RC Channel".
BTW MAX_SUPPORTED_RC_CHANNEL_COUNT is 18.