### PR TITLE
Fix Docker build UID/GID mapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN apt-get update && apt-get install -y git cmake make ruby gcc python3 python3
 RUN pip install pyyaml
 
 # if either of these are already set the same as the user's machine, leave them be and ignore the error
-RUN addgroup --gid $GROUP_ID users; exit 0;
-RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user; exit 0;
+RUN addgroup --gid $GROUP_ID inav; exit 0;
+RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID inav; exit 0;
 
-USER user
+USER inav
 RUN git config --global --add safe.directory /src
 
 VOLUME /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 ARG USER_ID
 ARG GROUP_ID


### PR DESCRIPTION
The default GID for the "users" group is `100` in the official Ubuntu images, making it clash with the one requested through the buildscript arguments and causing failures or inconsistencies in the following build steps.
Choosing a different and almost certainly not already existing group name (`inav` is a safe bet) is a quick workaround with minimal side effects. The user itself has been renamed as well for consistency.

Since I was at it I checked that the latest Ubuntu 22.04 LTS release did not cause any problems and updated the base image as well.