### PR TITLE
Update RUSH_BLADE_F7 and add RUSH_BLADE_F7_HD targets

### DIFF
--- a/src/main/target/RUSH_BLADE_F7/CMakeLists.txt
+++ b/src/main/target/RUSH_BLADE_F7/CMakeLists.txt
@@ -1,1 +1,2 @@
-target_stm32f722xe(RUSH_BLADE_F7 SKIP_RELEASES)
+target_stm32f722xe(RUSH_BLADE_F7)
+target_stm32f722xe(RUSH_BLADE_F7_HD)

--- a/src/main/target/RUSH_BLADE_F7/target.c
+++ b/src/main/target/RUSH_BLADE_F7/target.c
@@ -23,15 +23,19 @@
 #include "drivers/timer.h"
 
 timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM8, CH3, PC8, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0), // S1
+    DEF_TIM(TIM8, CH4, PC9, TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0), // S2
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0, 0), // S3
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0, 0), // S4
+    DEF_TIM(TIM8, CH2, PC7, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO | TIM_USE_MC_SERVO, 0, 0), // S5
+    DEF_TIM(TIM8, CH1, PC6, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO | TIM_USE_MC_SERVO, 0, 0), // S6
+    DEF_TIM(TIM4, CH1, PB6, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO | TIM_USE_MC_SERVO, 0, 0), // S7
+    DEF_TIM(TIM4, CH2, PB7, TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO | TIM_USE_MC_SERVO, 0, 0), // S8
 
-    DEF_TIM(TIM8, CH3, PC8,     TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0, 0),   // S1   UP2-1   D(2, 4, 7)
-    DEF_TIM(TIM8, CH4, PC9,     TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0, 0),   // S2   UP2-1   D(2, 7, 7)
-    DEF_TIM(TIM3, CH4, PB1,     TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),   // S6   UP1-2   D(1, 2, 5)
-    DEF_TIM(TIM3, CH3, PB0,     TIM_USE_MC_MOTOR | TIM_USE_FW_MOTOR, 0, 0),   // S5   UP1-2   D(1, 7, 5)
-    DEF_TIM(TIM8, CH2, PC7,     TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0, 0),   // S5 D(2, 3, 7)
-    DEF_TIM(TIM8, CH1, PC6,     TIM_USE_MC_MOTOR | TIM_USE_FW_SERVO, 0, 0),   // S6 D(1, 4, 5)
-
-    DEF_TIM(TIM2, CH1, PA15,    TIM_USE_LED, 0, 0),                            // LED 
+    DEF_TIM(TIM2, CH1, PA15, TIM_USE_LED, 0, 0), // LED STRIP
+    #ifdef RUSH_BLADE_F7
+    DEF_TIM(TIM1, CH1, PA8, TIM_USE_ANY, 0, 0), // CAM CONTROL
+    #endif
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/RUSH_BLADE_F7/target.h
+++ b/src/main/target/RUSH_BLADE_F7/target.h
@@ -15,32 +15,59 @@
  * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
+#ifdef RUSH_BLADE_F7
 #define TARGET_BOARD_IDENTIFIER "RBF7"
 #define USBD_PRODUCT_STRING  "RUSH_BLADE_F7"
+#endif
 
-#define LED0                    PB10  //Blue   SWCLK
-// #define LED1                    PA13  //Green  SWDIO
+#ifdef RUSH_BLADE_F7_HD
+#define TARGET_BOARD_IDENTIFIER "RBF7HD"
+#define USBD_PRODUCT_STRING     "RUSH_BLADE_F7_HD"
+#endif
 
+#define LED0                    PB10
 #define BEEPER                  PB2
 #define BEEPER_INVERTED
 
-// *************** SPI1 Gyro & ACC *******************
+// *************** SPI **********************
 #define USE_SPI
+
 #define USE_SPI_DEVICE_1
+#define SPI1_NSS_PIN            PC4
 #define SPI1_SCK_PIN            PA5
 #define SPI1_MISO_PIN           PA6
 #define SPI1_MOSI_PIN           PA7
 
+#define USE_SPI_DEVICE_2
+#define SPI2_NSS_FLASH_PIN      PB12
+#define SPI2_NSS_OSD_PIN        PB11
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+
+// *************** Gyro & ACC **********************
+#define USE_EXTI
+#define USE_MPU_DATA_READY_SIGNAL
+#define GYRO_INT_EXTI           PA4
+
 #define USE_IMU_MPU6000
 #define IMU_MPU6000_ALIGN       CW270_DEG
-#define MPU6000_CS_PIN          PC4
 #define MPU6000_SPI_BUS         BUS_SPI1
+#define MPU6000_CS_PIN          SPI1_NSS_PIN
+#define MPU6000_EXTI_PIN        GYRO_INT_EXTI
 
-// *************** I2C /Baro/Mag *********************
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW270_DEG
+#define ICM42605_SPI_BUS        BUS_SPI1
+#define ICM42605_CS_PIN         SPI1_NSS_PIN
+#define ICM42605_EXTI_PIN       GYRO_INT_EXTI
+
+// *************** I2C/Baro/Mag *********************
 #define USE_I2C
+
 #define USE_I2C_DEVICE_1
 #define I2C1_SCL                PB8
 #define I2C1_SDA                PB9
@@ -48,7 +75,7 @@
 #define USE_BARO
 #define BARO_I2C_BUS            BUS_I2C1
 #define USE_BARO_BMP280
-#define USE_BARO_MS5611
+#define USE_BARO_SPL06
 #define USE_BARO_DPS310
 
 #define USE_MAG
@@ -61,28 +88,24 @@
 #define USE_MAG_MAG3110
 #define USE_MAG_LIS3MDL
 
-#define TEMPERATURE_I2C_BUS     BUS_I2C1
-#define PITOT_I2C_BUS           BUS_I2C1
 
-#define USE_RANGEFINDER
-#define RANGEFINDER_I2C_BUS     BUS_I2C1
-
-// *************** SPI2 Flash ***********************
-#define USE_SPI_DEVICE_2
-#define SPI2_SCK_PIN            PB13
-#define SPI2_MISO_PIN           PB14
-#define SPI2_MOSI_PIN           PB15
-
+// *************** Flash ****************************
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
 #define M25P16_SPI_BUS          BUS_SPI2
-#define M25P16_CS_PIN           PB12
+#define M25P16_CS_PIN           SPI2_NSS_FLASH_PIN
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+
+// *************** Analog OSD ************************
+#ifdef RUSH_BLADE_F7
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          SPI2_NSS_OSD_PIN
+#endif
 
 // *************** UART *****************************
 #define USE_VCP
-#define USB_DETECT_PIN          PC14
-#define USE_USB_DETECT
 
 #define USE_UART1
 #define UART1_TX_PIN            PA9
@@ -108,12 +131,11 @@
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_SBUS
-#define SERIALRX_UART           SERIAL_PORT_USART2
 
 // *************** ADC *****************************
 #define USE_ADC
 #define ADC_INSTANCE                ADC1
-#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC1_DMA_STREAM             DMA2_Stream4
 
 #define ADC_CHANNEL_1_PIN           PC0
 #define ADC_CHANNEL_2_PIN           PC1
@@ -121,20 +143,28 @@
 #define VBAT_ADC_CHANNEL            ADC_CHN_1
 #define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
 
-// *************** LEDSTRIP ************************
-#define USE_LED_STRIP
-#define WS2811_PIN                  PA8
+#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_CURRENT_METER | FEATURE_TELEMETRY | FEATURE_VBAT | FEATURE_OSD | FEATURE_LED_STRIP)
 
-#define DEFAULT_FEATURES   (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TX_PROF_SEL)
 #define CURRENT_METER_SCALE     179
+
+
+// ********** Optiical Flow and Lidar **************
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_MSP
+#define USE_OPFLOW
+#define USE_OPFLOW_MSP
+
+// *************** LED *****************************
+#define USE_LED_STRIP
+#define WS2811_PIN              PA15
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
-#define TARGET_IO_PORTA 0xffff
-#define TARGET_IO_PORTB 0xffff
-#define TARGET_IO_PORTC 0xffff
-#define TARGET_IO_PORTD 0xffff
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
 
-#define MAX_PWM_OUTPUT_PORTS        10
+#define MAX_PWM_OUTPUT_PORTS    8
 #define USE_DSHOT
 #define USE_ESC_SENSOR

--- a/src/main/target/RUSH_BLADE_F7/target.h
+++ b/src/main/target/RUSH_BLADE_F7/target.h
@@ -49,10 +49,6 @@
 
 
 // *************** Gyro & ACC **********************
-#define USE_EXTI
-#define USE_MPU_DATA_READY_SIGNAL
-#define GYRO_INT_EXTI           PA4
-
 #define USE_IMU_MPU6000
 #define IMU_MPU6000_ALIGN       CW270_DEG
 #define MPU6000_SPI_BUS         BUS_SPI1
@@ -75,6 +71,7 @@
 #define USE_BARO
 #define BARO_I2C_BUS            BUS_I2C1
 #define USE_BARO_BMP280
+#define USE_BARO_MS5611
 #define USE_BARO_SPL06
 #define USE_BARO_DPS310
 


### PR DESCRIPTION
RUSH made a minor hardware revision to their Blade F7 board and also added a digital (`_HD`) variant.
The manufacturer confirmed that these targets are retrocompatible with the older revisions with different baro/IMU combos.

The targets have been added back to the release process (`SKIP_RELEASES` attribute was removed).