### PR TITLE
Rename functions to avoid confusion why it does not write eeprom

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -456,14 +456,14 @@ void setConfigBatteryProfileAndWriteEEPROM(uint8_t profileIndex)
     beeperConfirmationBeeps(profileIndex + 1);
 }
 
-void setGyroCalibrationAndWriteEEPROM(int16_t getGyroZero[XYZ_AXIS_COUNT])
+void setGyroCalibration(int16_t getGyroZero[XYZ_AXIS_COUNT])
 {
     gyroConfigMutable()->gyro_zero_cal[X] = getGyroZero[X];
     gyroConfigMutable()->gyro_zero_cal[Y] = getGyroZero[Y];
     gyroConfigMutable()->gyro_zero_cal[Z] = getGyroZero[Z];
 }
 
-void setGravityCalibrationAndWriteEEPROM(float getGravity)
+void setGravityCalibration(float getGravity)
 {
     gyroConfigMutable()->gravity_cmss_cal = getGravity;
 }

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -137,8 +137,8 @@ uint8_t getConfigBatteryProfile(void);
 bool setConfigBatteryProfile(uint8_t profileIndex);
 void setConfigBatteryProfileAndWriteEEPROM(uint8_t profileIndex);
 
-void setGyroCalibrationAndWriteEEPROM(int16_t getGyroZero[XYZ_AXIS_COUNT]);
-void setGravityCalibrationAndWriteEEPROM(float getGravity);
+void setGyroCalibration(int16_t getGyroZero[XYZ_AXIS_COUNT]);
+void setGravityCalibration(float getGravity);
 
 bool canSoftwareSerialBeUsed(void);
 void applyAndSaveBoardAlignmentDelta(int16_t roll, int16_t pitch);

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -434,7 +434,7 @@ static void updateIMUTopic(timeUs_t currentTimeUs)
 
                 if (gravityCalibrationComplete()) {
                     zeroCalibrationGetZeroS(&posEstimator.imu.gravityCalibration, &posEstimator.imu.calibratedGravityCMSS);
-                    setGravityCalibrationAndWriteEEPROM(posEstimator.imu.calibratedGravityCMSS);
+                    setGravityCalibration(posEstimator.imu.calibratedGravityCMSS);
                     LOG_DEBUG(POS_ESTIMATOR, "Gravity calibration complete (%d)", (int)lrintf(posEstimator.imu.calibratedGravityCMSS));
                 }
             }

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -362,7 +362,7 @@ STATIC_UNIT_TESTED void performGyroCalibration(gyroDev_t *dev, zeroCalibrationVe
         dev->gyroZero[Z] = v.v[Z];
 
 #ifndef USE_IMU_FAKE // fixes Test Unit compilation error
-        setGyroCalibrationAndWriteEEPROM(dev->gyroZero);
+        setGyroCalibration(dev->gyroZero);
 #endif
 
         LOG_DEBUG(GYRO, "Gyro calibration complete (%d, %d, %d)", dev->gyroZero[X], dev->gyroZero[Y], dev->gyroZero[Z]);


### PR DESCRIPTION
I came across this piece of code and i was trying to understand why it does not save Eeprom even though function name suggests it.
After reviewing history i saw that the write-read eeprom code was removed with 1c17a16b2b73be3252b98d65dab8f89fcfadf197.
So i assumed that the "AndWriteEEPROM" should be removed from the function name.