### PR TITLE
Add support for FBUS

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -25,7 +25,7 @@ tables:
     values: ["NONE", "SERIAL", "MSP"]
     enum: rxReceiverType_e
   - name: serial_rx
-    values: ["SPEK1024", "SPEK2048", "SBUS", "SUMD", "IBUS", "JETIEXBUS", "CRSF", "FPORT", "SBUS_FAST", "FPORT2", "SRXL2", "GHST", "MAVLINK"]
+    values: ["SPEK1024", "SPEK2048", "SBUS", "SUMD", "IBUS", "JETIEXBUS", "CRSF", "FPORT", "SBUS_FAST", "FPORT2", "SRXL2", "GHST", "MAVLINK", "FBUS"]
   - name: blackbox_device
     values: ["SERIAL", "SPIFLASH", "SDCARD"]
   - name: motor_pwm_protocol

--- a/src/main/rx/fport2.c
+++ b/src/main/rx/fport2.c
@@ -61,6 +61,7 @@
 #define FPORT2_FC_COMMON_ID 0x1B
 #define FPORT2_FC_MSP_ID 0x0D
 #define FPORT2_BAUDRATE 115200
+#define FBUS_BAUDRATE 460800
 #define FPORT2_PORT_OPTIONS (SERIAL_STOPBITS_1 | SERIAL_PARITY_NO)
 #define FPORT2_RX_TIMEOUT 120 // µs
 #define FPORT2_CONTROL_FRAME_LENGTH 24
@@ -629,7 +630,7 @@ static bool processFrame(const rxRuntimeConfig_t *rxRuntimeConfig)
 }
 
 
-bool fport2RxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
+bool fport2RxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, bool isFBUS)
 {
     static uint16_t sbusChannelData[SBUS_MAX_CHANNEL];
     rxRuntimeConfig->channelData = sbusChannelData;
@@ -644,11 +645,13 @@ bool fport2RxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig
         return false;
     }
 
+    uint32_t baudRate = (isFBUS) ? FBUS_BAUDRATE : FPORT2_BAUDRATE;
+
     fportPort = openSerialPort(portConfig->identifier,
         FUNCTION_RX_SERIAL,
         fportDataReceive,
         NULL,
-        FPORT2_BAUDRATE,
+        baudRate,
         MODE_RXTX,
         FPORT2_PORT_OPTIONS | (rxConfig->serialrx_inverted ? 0 : SERIAL_INVERTED) | (tristateWithDefaultOnIsActive(rxConfig->halfDuplex) ? SERIAL_BIDIR : 0)
     );

--- a/src/main/rx/fport2.h
+++ b/src/main/rx/fport2.h
@@ -22,6 +22,6 @@
 
 #ifdef USE_SERIALRX_FPORT2
 
-bool fport2RxInit(const rxConfig_t *initialRxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
+bool fport2RxInit(const rxConfig_t *initialRxConfig, rxRuntimeConfig_t *rxRuntimeConfig, bool isFBUS);
 
 #endif

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -233,7 +233,10 @@ bool serialRxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig
 #endif
 #ifdef USE_SERIALRX_FPORT2
     case SERIALRX_FPORT2:
-        enabled = fport2RxInit(rxConfig, rxRuntimeConfig);
+        enabled = fport2RxInit(rxConfig, rxRuntimeConfig, false);
+        break;
+    case SERIALRX_FBUS:
+        enabled = fport2RxInit(rxConfig, rxRuntimeConfig, true);
         break;
 #endif
 #ifdef USE_SERIALRX_GHST

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -79,6 +79,7 @@ typedef enum {
     SERIALRX_SRXL2,
     SERIALRX_GHST,
     SERIALRX_MAVLINK,
+    SERIALRX_FBUS,
 } rxSerialReceiverType_e;
 
 #define MAX_SUPPORTED_RC_CHANNEL_COUNT              18


### PR DESCRIPTION
Speaking with FrSky, the main difference currently between FPORT2 and FBUS is the baud rate. This PR just adds an option for FBUS, which uses the current FPORT2 implementation, but running at the correct baud of 460800.