### PR TITLE
make mavlink rc channels override working as 2nd serial reciver

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2272,6 +2272,16 @@ Servo travel multiplier for the YAW axis in `MANUAL` flight mode [0-100]%
 
 ---
 
+### mavlink_chn_override_timeout_ms
+
+Time out for RC_CHANNELS_OVERRIDE, to stop updading the channels values
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | 0 | 65535 |
+
+---
+
 ### mavlink_ext_status_rate
 
 _// TODO_

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2992,6 +2992,13 @@ groups:
         min: 1
         max: 2
         default_value: 2
+      - name: mavlink_chn_override_timeout_ms
+        field: mavlink.chn_override_timeout_ms
+        description: "Time out for RC_CHANNELS_OVERRIDE, to stop updading the channels values"
+        type: uint16_t
+        min: 0
+        max: 65535
+        default_value: 0
 
   - name: PG_LED_STRIP_CONFIG
     type: ledStripConfig_t

--- a/src/main/rx/mavlink.c
+++ b/src/main/rx/mavlink.c
@@ -35,7 +35,7 @@ FILE_COMPILE_FOR_SPEED
 static uint16_t mavlinkChannelData[MAVLINK_CHANNEL_COUNT];
 static bool frameReceived;
 
-void mavlinkRxHandleMessage(const mavlink_rc_channels_override_t *msg) {
+uint16_t * mavlinkRxHandleMessage(const mavlink_rc_channels_override_t *msg) {
     if (msg->chan1_raw != 0 && msg->chan1_raw != UINT16_MAX) mavlinkChannelData[0] = msg->chan1_raw;
     if (msg->chan2_raw != 0 && msg->chan2_raw != UINT16_MAX) mavlinkChannelData[1] = msg->chan2_raw;
     if (msg->chan3_raw != 0 && msg->chan3_raw != UINT16_MAX) mavlinkChannelData[2] = msg->chan3_raw;
@@ -55,6 +55,7 @@ void mavlinkRxHandleMessage(const mavlink_rc_channels_override_t *msg) {
     if (msg->chan17_raw != 0 && msg->chan17_raw < UINT16_MAX - 1) mavlinkChannelData[16] = msg->chan17_raw;
     if (msg->chan18_raw != 0 && msg->chan18_raw < UINT16_MAX - 1) mavlinkChannelData[17] = msg->chan18_raw;
     frameReceived = true;
+    return mavlinkChannelData;
 }
 
 static uint8_t mavlinkFrameStatus(rxRuntimeConfig_t *rxRuntimeConfig)

--- a/src/main/rx/mavlink.h
+++ b/src/main/rx/mavlink.h
@@ -23,5 +23,5 @@
 #include "common/mavlink.h"
 #pragma GCC diagnostic pop
 
-void mavlinkRxHandleMessage(const mavlink_rc_channels_override_t *msg);
+uint16_t * mavlinkRxHandleMessage(const mavlink_rc_channels_override_t *msg);
 bool mavlinkRxInit(const struct rxConfig_s *initialRxConfig, struct rxRuntimeConfig_s *rxRuntimeConfig);

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -63,6 +63,9 @@
 #include "rx/sumd.h"
 #include "rx/ghst.h"
 #include "rx/mavlink.h"
+#include "telemetry/telemetry.h"
+#include "telemetry/mavlink.h"
+
 
 const char rcChannelLetters[] = "AERT";
 
@@ -508,6 +511,13 @@ bool calculateRxChannelsAndUpdateFailsafe(timeUs_t currentTimeUs)
 #if defined(USE_RX_MSP) && defined(USE_MSP_RC_OVERRIDE)
     if (IS_RC_MODE_ACTIVE(BOXMSPRCOVERRIDE) && !mspOverrideIsInFailsafe()) {
         mspOverrideChannels(rcChannels);
+    }
+#endif
+
+#if defined(USE_TELEMETRY) && defined(USE_TELEMETRY_MAVLINK)
+    // overwrite by mavlink only if mavlink_chn_override_timeout_ms is set
+    if ( telemetryConfig()->mavlink.chn_override_timeout_ms > 0) {
+         mavlinkOverrideChannels(rcChannels);    
     }
 #endif
 

--- a/src/main/telemetry/mavlink.h
+++ b/src/main/telemetry/mavlink.h
@@ -23,3 +23,4 @@ void checkMAVLinkTelemetryState(void);
 
 void freeMAVLinkTelemetryPort(void);
 void configureMAVLinkTelemetryPort(void);
+void mavlinkOverrideChannels(rcChannel_t *rcChannels);

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -91,7 +91,8 @@ PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
         .extra1_rate = SETTING_MAVLINK_EXTRA1_RATE_DEFAULT,
         .extra2_rate = SETTING_MAVLINK_EXTRA2_RATE_DEFAULT,
         .extra3_rate = SETTING_MAVLINK_EXTRA3_RATE_DEFAULT,
-        .version = SETTING_MAVLINK_VERSION_DEFAULT
+        .version = SETTING_MAVLINK_VERSION_DEFAULT,
+        .chn_override_timeout_ms = SETTING_MAVLINK_CHN_OVERRIDE_TIMEOUT_MS_DEFAULT
     }
 );
 

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -88,6 +88,7 @@ typedef struct telemetryConfig_s {
         uint8_t extra2_rate;
         uint8_t extra3_rate;
         uint8_t version;
+        uint16_t chn_override_timeout_ms;
     } mavlink;
 } telemetryConfig_t;
 


### PR DESCRIPTION
Hi,
It makes possible to control rc channels via mavlink even if standard serial rx (sbus or other) is in use. The rc channels values recived from mavlink are valid for a time defined by new mavlink_chn_override_timeout_ms parameters. So if you want to keep mavlink override rc channels you need to send a RC_CHANNELS_OVERRIDE more freqently that the mavlink_chn_override_timeout_ms. The timeout is calculated for every single channel.
