### PR TITLE
Fix O3 overheat - clear arm flag before launch

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2842,6 +2842,16 @@ Launch abort stick deadband in [r/c points], applied after r/c deadband and expo
 
 ---
 
+### nav_fw_launch_vtx_lowpower
+
+Prevents VTX overheating by sending UNARMED to MSP until launch detected.
+
+| Default | Min | Max |
+|---------|-----|-----|
+| OFF     | OFF | ON  |
+
+---
+
 ### nav_fw_launch_accel
 
 Forward acceleration threshold for bungee launch of throw launch [cm/s/s], 1G = 981 cm/s/s

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2842,16 +2842,6 @@ Launch abort stick deadband in [r/c points], applied after r/c deadband and expo
 
 ---
 
-### nav_fw_launch_vtx_lowpower
-
-Prevents VTX overheating by sending UNARMED to MSP until launch detected.
-
-| Default | Min | Max |
-|---------|-----|-----|
-| OFF     | OFF | ON  |
-
----
-
 ### nav_fw_launch_accel
 
 Forward acceleration threshold for bungee launch of throw launch [cm/s/s], 1G = 981 cm/s/s
@@ -2999,6 +2989,16 @@ Forward velocity threshold for swing-launch detection [cm/s]
 | Default | Min | Max |
 | --- | --- | --- |
 | 300 | 100 | 10000 |
+
+---
+
+### nav_fw_launch_vtx_lowpower
+
+Prevents VTX overheating by sending UNARMED to MSP until launch detected
+
+| Default | Min | Max |
+| --- | --- | --- |
+| OFF | OFF | ON |
 
 ---
 

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -344,7 +344,7 @@ static void serializeDataflashReadReply(sbuf_t *dst, uint32_t address, uint16_t 
  */
 static bool needResetArmFlag(void)
 {
-    if (!STATE(FIXED_WING_LEGACY))
+    if (!STATE(AIRPLANE))
         return false;
     if (!isNavLaunchEnabled())
         return false;

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -445,7 +445,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
             packBoxModeFlags(&mspBoxModeFlags);
 
             if (needResetArmFlag()) {
-                bitArrayClr(mspBoxModeFlags.bits, 0);
+                bitArrayClr(mspBoxModeFlags.bits, BOXARM);
             }
 
             sbufWriteU16(dst, (uint16_t)cycleTime);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -350,6 +350,8 @@ static bool needResetArmFlag(void)
         return false;
     if (fixedWingLaunchStatus() >= FW_LAUNCH_DETECTED)
         return false;
+    if (!navConfig()->fw.launch_vtx_lowpower)
+        return false;
     return true;
 }
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2790,6 +2790,11 @@ groups:
         field: fw.launch_abort_deadband
         min: 2
         max: 250
+      - name: nav_fw_launch_vtx_lowpower
+        description: "Send UNARMED to MSP until launch detected"
+        default_value: OFF
+        field: fw.launch_vtx_lowpower
+        type: bool
       - name: nav_fw_cruise_yaw_rate
         description: "Max YAW rate when NAV CRUISE mode is enabled (0=disable control via yaw stick) [dps]"
         default_value: 20

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2791,7 +2791,7 @@ groups:
         min: 2
         max: 250
       - name: nav_fw_launch_vtx_lowpower
-        description: "Send UNARMED to MSP until launch detected"
+        description: "Prevents VTX overheating by sending UNARMED to MSP until launch detected"
         default_value: OFF
         field: fw.launch_vtx_lowpower
         type: bool

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -99,7 +99,7 @@ STATIC_ASSERT(NAV_MAX_WAYPOINTS < 254, NAV_MAX_WAYPOINTS_exceeded_allowable_rang
 PG_REGISTER_ARRAY(navWaypoint_t, NAV_MAX_WAYPOINTS, nonVolatileWaypointList, PG_WAYPOINT_MISSION_STORAGE, 2);
 #endif
 
-PG_REGISTER_WITH_RESET_TEMPLATE(navConfig_t, navConfig, PG_NAV_CONFIG, 3);
+PG_REGISTER_WITH_RESET_TEMPLATE(navConfig_t, navConfig, PG_NAV_CONFIG, 4);
 
 PG_RESET_TEMPLATE(navConfig_t, navConfig,
     .general = {

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -207,7 +207,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .launch_max_angle = SETTING_NAV_FW_LAUNCH_MAX_ANGLE_DEFAULT,            // 45 deg
         .launch_manual_throttle = SETTING_NAV_FW_LAUNCH_MANUAL_THROTTLE_DEFAULT,// OFF
         .launch_abort_deadband = SETTING_NAV_FW_LAUNCH_ABORT_DEADBAND_DEFAULT,  // 100 us
-        .launch_vtx_lowpower = SETTING_NAV_FW_LAUNCH_VTX_LOWPOWER,              // false
+        .launch_vtx_lowpower = SETTING_NAV_FW_LAUNCH_VTX_LOWPOWER_DEFAULT,      // false
 
         .cruise_yaw_rate  = SETTING_NAV_FW_CRUISE_YAW_RATE_DEFAULT,             // 20dps
         .allow_manual_thr_increase = SETTING_NAV_FW_ALLOW_MANUAL_THR_INCREASE_DEFAULT,

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -207,6 +207,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
         .launch_max_angle = SETTING_NAV_FW_LAUNCH_MAX_ANGLE_DEFAULT,            // 45 deg
         .launch_manual_throttle = SETTING_NAV_FW_LAUNCH_MANUAL_THROTTLE_DEFAULT,// OFF
         .launch_abort_deadband = SETTING_NAV_FW_LAUNCH_ABORT_DEADBAND_DEFAULT,  // 100 us
+        .launch_vtx_lowpower = SETTING_NAV_FW_LAUNCH_VTX_LOWPOWER,              // false
 
         .cruise_yaw_rate  = SETTING_NAV_FW_CRUISE_YAW_RATE_DEFAULT,             // 20dps
         .allow_manual_thr_increase = SETTING_NAV_FW_ALLOW_MANUAL_THR_INCREASE_DEFAULT,

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -312,6 +312,7 @@ typedef struct navConfig_s {
         uint8_t  launch_max_angle;           // Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg]
         bool     launch_manual_throttle;     // Allows launch with manual throttle control
         uint8_t  launch_abort_deadband;      // roll/pitch stick movement deadband for launch abort
+        bool     launch_vtx_lowpower;        // Send UNARMED to MSP until launch detected
         uint8_t  cruise_yaw_rate;            // Max yaw rate (dps) when CRUISE MODE is enabled
         bool     allow_manual_thr_increase;
         bool     useFwNavYawControl;


### PR DESCRIPTION
**The problem**
 - O3 air unit getting overheat when launching with auto-launch and bungee

**Details**
 - When using auto-launch with bungee you need to spend ±40 seconds after arm and before actual through an airplane. You arm airplane, then go to the beginning of bungee cord, attach airplane to a hook, stretch a hook with the airplane and finally release an airplane. It takes a while, and the O3 air unit getting overheat.

**Proposed solution**
- Don't send an ARM flag to the air unit until launch detected

