### PR TITLE
Fix build error in osd.c when USE_MSP_DISPLAYPORT is not defined.

### DIFF
--- a/src/main/io/displayport_msp_bf_compat.h
+++ b/src/main/io/displayport_msp_bf_compat.h
@@ -22,16 +22,11 @@
 
 #include "platform.h"
 
-#ifdef USE_MSP_DISPLAYPORT
-
-#ifndef DISABLE_MSP_BF_COMPAT
+#if defined(USE_MSP_DISPLAYPORT) && !defined(DISABLE_MSP_BF_COMPAT)
 #include "osd.h"
 uint8_t getBfCharacter(uint8_t ch, uint8_t page);
 #define isBfCompatibleVideoSystem(osdConfigPtr) (osdConfigPtr->video_system == VIDEO_SYSTEM_BFCOMPAT)
 #else
 #define getBfCharacter(x, page) (x)
 #define isBfCompatibleVideoSystem(osdConfigPtr) (false)
-
-#endif
-
 #endif


### PR DESCRIPTION
This will fix the build for the KROOZX target.

This changes the logic so we allways get definitions for the bf compatibility related functions (either the actual implementation, or the noop placeholders).

