### PR TITLE
Update Flight Mode operand in programming framework

### DIFF
--- a/docs/Programming Framework.md
+++ b/docs/Programming Framework.md
@@ -143,19 +143,24 @@ IPF can be edited using INAV Configurator user interface, of via CLI
 
 #### FLIGHT_MODE
 
-| Operand Value | Name      | Notes |
-|---------------|-----------|-------|
-| 0             | FAILSAFE  |  |
-| 1             | MANUAL    |  |
-| 2             | RTH       |  |
-| 3             | POSHOLD   |  |
-| 4             | CRUISE    |  |
-| 5             | ALTHOLD   |  |
-| 6             | ANGLE     |  |
-| 7             | HORIZON   |  |
-| 8             | AIR       |  |
-| 9             | USER1     |  |
-| 10            | USER2     |  |
+| Operand Value | Name              | Notes |
+|---------------|-------------------|-------|
+| 0             | FAILSAFE          |  |
+| 1             | MANUAL            |  |
+| 2             | RTH               |  |
+| 3             | POSHOLD           |  |
+| 4             | CRUISE            |  |
+| 5             | ALTHOLD           |  |
+| 6             | ANGLE             |  |
+| 7             | HORIZON           |  |
+| 8             | AIR               |  |
+| 9             | USER1             |  |
+| 10            | USER2             |  |
+| 11            | COURSE_HOLD       |  |
+| 12            | USER3             |  |
+| 13            | USER4             |  |
+| 14            | ACRO              |  |
+| 15            | WAYPOINT_MISSION  |  | 
 
 #### WAYPOINTS
 
@@ -195,7 +200,8 @@ All flags are reseted on ARM and DISARM event.
 
 | bit   | Decimal   | Function  |
 |-------|-----------|-----------|
-| 0     | 1         | Latch - after activation LC will stay active until LATCH flag is reseted |
+| 0     | 1         | Latch - after activation LC will stay active until LATCH flag is reset |
+| 1     | 2         | Timeout satisfied - Used in timed operands to determine if the timeout has been met |
 
 ## Global variables
 

--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -808,12 +808,16 @@ static int logicConditionGetFlightModeOperandValue(int operand) {
             return (bool) FLIGHT_MODE(NAV_POSHOLD_MODE);
             break;
 
+        case LOGIC_CONDITION_OPERAND_FLIGHT_MODE_WAYPOINT_MISSION:
+            return (bool) FLIGHT_MODE(NAV_WP_MODE);
+            break;
+
         case LOGIC_CONDITION_OPERAND_FLIGHT_MODE_COURSE_HOLD:
-            return (bool) FLIGHT_MODE(NAV_COURSE_HOLD_MODE);
+            return ((bool) FLIGHT_MODE(NAV_COURSE_HOLD_MODE) && !(bool)FLIGHT_MODE(NAV_ALTHOLD_MODE));
             break;
 
         case LOGIC_CONDITION_OPERAND_FLIGHT_MODE_CRUISE:
-            return (bool)(FLIGHT_MODE(NAV_COURSE_HOLD_MODE) && FLIGHT_MODE(NAV_ALTHOLD_MODE));
+            return (bool) (FLIGHT_MODE(NAV_COURSE_HOLD_MODE) && FLIGHT_MODE(NAV_ALTHOLD_MODE));
             break;
 
         case LOGIC_CONDITION_OPERAND_FLIGHT_MODE_ALTHOLD:
@@ -830,6 +834,11 @@ static int logicConditionGetFlightModeOperandValue(int operand) {
 
         case LOGIC_CONDITION_OPERAND_FLIGHT_MODE_AIR:
             return (bool) FLIGHT_MODE(AIRMODE_ACTIVE);
+            break;
+
+        case LOGIC_CONDITION_OPERAND_FLIGHT_MODE_ACRO:
+            return (((bool) FLIGHT_MODE(ANGLE_MODE) || (bool) FLIGHT_MODE(HORIZON_MODE) || (bool) FLIGHT_MODE(MANUAL_MODE) || (bool) FLIGHT_MODE(NAV_RTH_MODE) || 
+                    (bool) FLIGHT_MODE(NAV_POSHOLD_MODE) || (bool) FLIGHT_MODE(NAV_COURSE_HOLD_MODE) || (bool) FLIGHT_MODE(NAV_WP_MODE)) == false);
             break;
 
         case LOGIC_CONDITION_OPERAND_FLIGHT_MODE_USER1:

--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -152,6 +152,8 @@ typedef enum {
     LOGIC_CONDITION_OPERAND_FLIGHT_MODE_COURSE_HOLD,                        // 11
     LOGIC_CONDITION_OPERAND_FLIGHT_MODE_USER3,                              // 12
     LOGIC_CONDITION_OPERAND_FLIGHT_MODE_USER4,                              // 13
+    LOGIC_CONDITION_OPERAND_FLIGHT_MODE_ACRO,                               // 14
+    LOGIC_CONDITION_OPERAND_FLIGHT_MODE_WAYPOINT_MISSION,                   // 15
 } logicFlightModeOperands_e;
 
 typedef enum {


### PR DESCRIPTION
- Add `ACRO` to `FLIGHT_MODE` operand
- Add `WAYPOINT_MISSION` to `FLIGHT_MODE` operand
- Update functionality of `COURSE_HOLD` as currently it will still be active if `CRUISE` is active
- Update Programming Framework.md document

Fixes #8675 

Requires Configurator https://github.com/iNavFlight/inav-configurator/pull/1705