### PR TITLE
Added target JHEHMCU_GHF405AIO_ICM

### DIFF
--- a/src/main/target/JHEHMCU_GHF405AIO_ICM/CMakeLists.txt
+++ b/src/main/target/JHEHMCU_GHF405AIO_ICM/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f405xg(JHEHMCU_GHF405AIO_ICM)

--- a/src/main/target/JHEHMCU_GHF405AIO_ICM/target.c
+++ b/src/main/target/JHEHMCU_GHF405AIO_ICM/target.c
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM4, CH3, PB8, TIM_USE_PPM, 0, 0), // PPM
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MC_MOTOR, 0, 0),  // S1
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MC_MOTOR, 0, 0),  // S2
+    DEF_TIM(TIM2, CH4, PA3, TIM_USE_MC_MOTOR, 0, 1),  // S3
+    DEF_TIM(TIM2, CH3, PA2, TIM_USE_MC_MOTOR, 0, 0),  // S4
+    DEF_TIM(TIM1, CH2, PA9, TIM_USE_LED,  0, 1 ),     //LED
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/JHEHMCU_GHF405AIO_ICM/target.h
+++ b/src/main/target/JHEHMCU_GHF405AIO_ICM/target.h
@@ -1,0 +1,167 @@
+/*
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "JHEF405PRO"
+#define USBD_PRODUCT_STRING  "JHEF405PRO"
+
+#define LED0                PC14
+
+#define BEEPER              PC13
+#define BEEPER_INVERTED
+
+// *************** Gyro & ACC **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN   	    PA6
+#define SPI1_MOSI_PIN           PA7
+
+
+/*
+#define USE_IMU_BMI270
+#define IMU_BMI270_ALIGN        CW180_DEG
+#define BMI270_SPI_BUS          BUS_SPI1
+#define BMI270_CS_PIN           PB12
+*/
+
+// ICM42688-P
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW180_DEG
+#define ICM42605_SPI_BUS        BUS_SPI1
+#define ICM42605_CS_PIN         PB12
+
+
+//FLASH
+//#define USE_SPI_DEVICE_2
+//#define SPI2_SCK_PIN            PC10
+//#define SPI2_MISO_PIN           PC11
+//#define SPI2_MOSI_PIN           PC12
+
+//#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+//#define USE_FLASHFS
+//#define USE_FLASH_M25P16
+//#define M25P16_CS_PIN           PB3
+//#define M25P16_SPI_BUS          BUS_SPI3
+
+//OSD
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PC12
+
+//#define USE_MAX7456
+//#define MAX7456_SPI_BUS         BUS_SPI3
+//#define MAX7456_CS_PIN          PB14
+
+//Flash
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN           PB3
+#define M25P16_SPI_BUS          BUS_SPI3
+
+//I2C
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+#define DEFAULT_I2C_BUS         BUS_I2C1
+
+#define USE_BARO
+#define BARO_I2C_BUS            DEFAULT_I2C_BUS
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_BMP085
+
+// new baro since 22.9
+#define USE_BARO_SPL06
+
+#define USE_MAG
+#define MAG_I2C_BUS             DEFAULT_I2C_BUS
+#define USE_MAG_AK8963
+#define USE_MAG_AK8975
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define USE_MAG_IST8310
+#define USE_MAG_MAG3110
+#define USE_MAG_LIS3MDL
+
+#define TEMPERATURE_I2C_BUS     BUS_I2C1
+#define BNO055_I2C_BUS          BUS_I2C1
+
+#define USE_RANGEFINDER
+#define RANGEFINDER_I2C_BUS     DEFAULT_I2C_BUS
+
+#define PITOT_I2C_BUS           DEFAULT_I2C_BUS
+
+//USART
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PB6
+
+#define USE_UART2
+#define UART2_RX_PIN            PD6
+#define UART2_TX_PIN            PD5
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define SERIAL_PORT_COUNT       6
+
+//LED_STRIP
+#define USE_LED_STRIP
+#define WS2811_PIN                      PA9
+
+//ADC
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM         DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC3
+#define ADC_CHANNEL_2_PIN           PC2
+#define ADC_CHANNEL_3_PIN           PC0
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_3
+
+#define DEFAULT_FEATURES        (FEATURE_VBAT | FEATURE_OSD)
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         0xffff
+
+//TIMER
+#define MAX_PWM_OUTPUT_PORTS       4
+
+#define USE_DSHOT


### PR DESCRIPTION
In [#8726](https://github.com/iNavFlight/inav/pull/8726), [ltwin8](https://github.com/ltwin8) gives a target of GHF405AIO, but it does not work correctly on my board after testing.

After asking the manufacturer, I learned that after September 2022, they had changed the IMU and barometer of the flight controller of this model, so I made this target to let it work with the latest board.