### PR TITLE
OSD battery status cleanup

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1045,8 +1045,11 @@ static void osdFormatBatteryChargeSymbol(char *buff)
 
 static void osdUpdateBatteryCapacityOrVoltageTextAttributes(textAttributes_t *attr)
 {
-    if ((getBatteryState() != BATTERY_NOT_PRESENT) && ((batteryUsesCapacityThresholds() && (getBatteryRemainingCapacity() <= currentBatteryProfile->capacity.warning - currentBatteryProfile->capacity.critical)) || ((!batteryUsesCapacityThresholds()) && (getBatteryVoltage() <= getBatteryWarningVoltage()))))
+    const batteryState_e batteryState = getBatteryState();
+
+    if (batteryState == BATTERY_WARNING || batteryState == BATTERY_CRITICAL) {
         TEXT_ATTRIBUTES_ADD_BLINK(*attr);
+    }
 }
 
 void osdCrosshairPosition(uint8_t *x, uint8_t *y)
@@ -1448,8 +1451,10 @@ static void osdDisplayBatteryVoltage(uint8_t elemPosX, uint8_t elemPosY, uint16_
     osdFormatCentiNumber(buff, voltage, 0, decimals, 0, digits);
     buff[digits] = SYM_VOLT;
     buff[digits+1] = '\0';
-    if ((getBatteryState() != BATTERY_NOT_PRESENT) && (getBatteryVoltage() <= getBatteryWarningVoltage()))
+    const batteryState_e batteryVoltageState = checkBatteryVoltageState();
+    if (batteryVoltageState == BATTERY_CRITICAL || batteryVoltageState == BATTERY_WARNING) {
         TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
+    }
     displayWriteWithAttr(osdDisplayPort, elemPosX + 1, elemPosY, buff, elemAttr);
 }
 
@@ -1679,8 +1684,9 @@ static bool osdDrawSingleElement(uint8_t item)
         buff[4] = currentBatteryProfile->capacity.unit == BAT_CAPACITY_UNIT_MAH ? SYM_MAH : SYM_WH;
         buff[5] = '\0';
 
-        if ((getBatteryState() != BATTERY_NOT_PRESENT) && batteryUsesCapacityThresholds() && (getBatteryRemainingCapacity() <= currentBatteryProfile->capacity.warning - currentBatteryProfile->capacity.critical))
-            TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
+        if (batteryUsesCapacityThresholds()) {
+            osdUpdateBatteryCapacityOrVoltageTextAttributes(&elemAttr);
+        }
 
         break;
 

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -478,11 +478,6 @@ float calculateThrottleCompensationFactor(void)
     return 1.0f + ((float)batteryFullVoltage / sagCompensatedVBat - 1.0f) * batteryMetersConfig()->throttle_compensation_weight;
 }
 
-uint16_t getBatteryWarningVoltage(void)
-{
-    return batteryWarningVoltage;
-}
-
 uint8_t getBatteryCellCount(void)
 {
     return batteryCellCount;

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -305,6 +305,44 @@ static void updateBatteryVoltage(timeUs_t timeDelta, bool justConnected)
     }
 }
 
+batteryState_e checkBatteryVoltageState(void)
+{
+    uint16_t stateVoltage = getBatteryVoltage();
+    switch (batteryState)
+    {
+        case BATTERY_OK:
+            if (stateVoltage <= (batteryWarningVoltage - VBATT_HYSTERESIS)) {
+                return BATTERY_WARNING;
+            }
+            break;
+        case BATTERY_WARNING:
+            if (stateVoltage <= (batteryCriticalVoltage - VBATT_HYSTERESIS)) {
+                return BATTERY_CRITICAL;
+            } else if (stateVoltage > (batteryWarningVoltage + VBATT_HYSTERESIS)){
+                return BATTERY_OK;
+            }
+            break;
+        case BATTERY_CRITICAL:
+            if (stateVoltage > (batteryCriticalVoltage + VBATT_HYSTERESIS)) {
+                return BATTERY_WARNING;
+            }
+            break;
+        default:
+            break;
+    }
+
+    return batteryState;
+}
+
+static void checkBatteryCapacityState(void)
+{
+    if (batteryRemainingCapacity == 0) {
+        batteryState = BATTERY_CRITICAL;
+    } else if (batteryRemainingCapacity <= currentBatteryProfile->capacity.warning - currentBatteryProfile->capacity.critical) {
+        batteryState = BATTERY_WARNING;
+    }
+}
+
 void batteryUpdate(timeUs_t timeDelta)
 {
     /* battery has just been connected*/
@@ -367,32 +405,9 @@ void batteryUpdate(timeUs_t timeDelta)
         }
 
         if (batteryUseCapacityThresholds) {
-            if (batteryRemainingCapacity == 0)
-                batteryState = BATTERY_CRITICAL;
-            else if (batteryRemainingCapacity <= currentBatteryProfile->capacity.warning - currentBatteryProfile->capacity.critical)
-                batteryState = BATTERY_WARNING;
+            checkBatteryCapacityState();
         } else {
-            uint16_t stateVoltage = getBatteryVoltage();
-            switch (batteryState)
-            {
-                case BATTERY_OK:
-                    if (stateVoltage <= (batteryWarningVoltage - VBATT_HYSTERESIS))
-                        batteryState = BATTERY_WARNING;
-                    break;
-                case BATTERY_WARNING:
-                    if (stateVoltage <= (batteryCriticalVoltage - VBATT_HYSTERESIS)) {
-                        batteryState = BATTERY_CRITICAL;
-                    } else if (stateVoltage > (batteryWarningVoltage + VBATT_HYSTERESIS)){
-                        batteryState = BATTERY_OK;
-                    }
-                    break;
-                case BATTERY_CRITICAL:
-                    if (stateVoltage > (batteryCriticalVoltage + VBATT_HYSTERESIS))
-                        batteryState = BATTERY_WARNING;
-                    break;
-                default:
-                    break;
-            }
+            batteryState = checkBatteryVoltageState();
         }
 
         // handle beeper

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -63,6 +63,7 @@ typedef enum {
 
 uint16_t batteryAdcToVoltage(uint16_t src);
 batteryState_e getBatteryState(void);
+batteryState_e checkBatteryVoltageState(void);
 bool batteryWasFullWhenPluggedIn(void);
 bool batteryUsesCapacityThresholds(void);
 void batteryInit(void);

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -76,7 +76,6 @@ bool isPowerSupplyImpedanceValid(void);
 uint16_t getBatteryVoltage(void);
 uint16_t getBatteryRawVoltage(void);
 uint16_t getBatterySagCompensatedVoltage(void);
-uint16_t getBatteryWarningVoltage(void);
 uint8_t getBatteryCellCount(void);
 uint16_t getBatteryRawAverageCellVoltage(void);
 uint16_t getBatteryAverageCellVoltage(void);


### PR DESCRIPTION
Replaces battery status checks in osd.c with those already available in battery.c. Also splits out battery voltage and capacity status checks in battery.c so they're available separately.