### PR TITLE
Make CLI string input uppercase

### DIFF
--- a/src/main/common/string_light.c
+++ b/src/main/common/string_light.c
@@ -17,6 +17,7 @@
 
 #include <limits.h>
 
+#include "string.h"
 #include "string_light.h"
 #include "typeconversion.h"
 
@@ -48,6 +49,15 @@ int sl_tolower(int c)
 int sl_toupper(int c)
 {
     return sl_islower(c) ? (c) - 'a' + 'A' : c;
+}
+
+void sl_toupperptr(char * c)
+{
+    for (unsigned int i = 0; i < strlen(c); i++) {
+        if (c[i] >= 'a' && c[i] <= 'z') {
+           c[i] = c[i] - 'a' + 'A'; 
+        }
+    }
 }
 
 int sl_strcasecmp(const char * s1, const char * s2)

--- a/src/main/common/string_light.h
+++ b/src/main/common/string_light.h
@@ -23,6 +23,7 @@ int sl_isupper(int c);
 int sl_islower(int c);
 int sl_tolower(int c);
 int sl_toupper(int c);
+void sl_toupperptr(char * c);
 
 int sl_strcasecmp(const char * s1, const char * s2);
 int sl_strncasecmp(const char * s1, const char * s2, int n);

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -3194,8 +3194,10 @@ static void cliSet(char *cmdline)
             if (settingNameIsExactMatch(val, name, cmdline, variableNameLength)) {
                 const setting_type_e type = SETTING_TYPE(val);
                 if (type == VAR_STRING) {
+                    // Convert strings to uppercase. Lower case is not supported by the OSD.
+                    sl_toupperptr(eqptr);
                     // if setting the craftname, remove any quotes around the name.  This allows leading spaces in the name
-                    if (strcmp(name, "name") == 0 && eqptr[0] == '"' && eqptr[strlen(eqptr)-1] == '"') {
+                    if ((strcmp(name, "name") == 0 || strcmp(name, "pilot_name") == 0) && (eqptr[0] == '"' && eqptr[strlen(eqptr)-1] == '"')) {
                         settingSetString(val, eqptr + 1, strlen(eqptr)-2);
                     } else {
                         settingSetString(val, eqptr, strlen(eqptr));

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3589,11 +3589,13 @@ groups:
       - name: name
         description: "Craft name"
         default_value: ""
+        type: string
         field: craftName
         max: MAX_NAME_LENGTH
       - name: pilot_name
         description: "Pilot name"
         default_value: ""
+        type: string
         field: pilotName
         max: MAX_NAME_LENGTH
 


### PR DESCRIPTION
Convert strings input from the CLI to uppercase . Fixes issue with craft name and other settings where lower case entry was allowed via CLI.