### PR TITLE
OSD updated pitch level trim

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2091,9 +2091,6 @@ static bool osdDrawSingleElement(uint8_t item)
             else if (FLIGHT_MODE(HORIZON_MODE))
                 p = "HOR";
 		
-	    if (IS_RC_MODE_ACTIVE(BOXAUTOLEVEL) && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE) || FLIGHT_MODE(NAV_COURSE_HOLD_MODE))
-		p += "L";
-		
             displayWrite(osdDisplayPort, elemPosX, elemPosY, p);
             return true;
         }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2092,7 +2092,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 p = "HOR";
 	
 	    if (IS_RC_MODE_ACTIVE(BOXAUTOLEVEL) && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE) || FLIGHT_MODE(NAV_COURSE_HOLD_MODE))) {
-		char *new_p = malloc(strlen(p) + 2);
+		char *new_p = (char*)malloc(strlen(p) + 2);
 		strcpy(new_p, p);
 		strcat(new_p, "L");
 		p = new_p;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2089,7 +2089,7 @@ static bool osdDrawSingleElement(uint8_t item)
             else if (FLIGHT_MODE(ANGLE_MODE))
                 p = "ANGL";
             else if (FLIGHT_MODE(HORIZON_MODE))
-                p = "HOR";
+                p = " HOR";
 	
 	    if (IS_RC_MODE_ACTIVE(BOXAUTOLEVEL) && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE) || FLIGHT_MODE(NAV_COURSE_HOLD_MODE))) {
 		char *new_p = (char*)malloc(strlen(p) + 2);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2091,7 +2091,7 @@ static bool osdDrawSingleElement(uint8_t item)
             else if (FLIGHT_MODE(HORIZON_MODE))
                 p = "HOR";
 		
-	    if (IS_RC_MODE_ACTIVE(BOXAUTOLEVEL))
+	    if (IS_RC_MODE_ACTIVE(BOXAUTOLEVEL) && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE) || FLIGHT_MODE(NAV_COURSE_HOLD_MODE))
 		p += "L";
 		
             displayWrite(osdDisplayPort, elemPosX, elemPosY, p);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3191,7 +3191,7 @@ static bool osdDrawSingleElement(uint8_t item)
         }
     case OSD_FW_LEVEL_TRIM:
         {
-            osdDisplayAdjustableDecimalValue(elemPosX, elemPosY, "LEVEL", 0, pidProfileMutable()->fixedWingLevelTrim, 3, 1, ADJUSTMENT_FW_LEVEL_TRIM);
+            osdDisplayAdjustableDecimalValue(elemPosX, elemPosY, "LEVEL", 0, getFixedWingLevelTrim(), 3, 1, ADJUSTMENT_FW_LEVEL_TRIM);
             return true;
         }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2096,7 +2096,7 @@ static bool osdDrawSingleElement(uint8_t item)
 		strcpy(new_p, p);
 		strcat(new_p, "L");
 		p = new_p;
-		}
+	    }
 		
             displayWrite(osdDisplayPort, elemPosX, elemPosY, p);
             return true;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2090,6 +2090,13 @@ static bool osdDrawSingleElement(uint8_t item)
                 p = "ANGL";
             else if (FLIGHT_MODE(HORIZON_MODE))
                 p = "HOR";
+	
+	    if (IS_RC_MODE_ACTIVE(BOXAUTOLEVEL) && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE) || FLIGHT_MODE(NAV_COURSE_HOLD_MODE))) {
+		char *new_p = malloc(strlen(p) + 2);
+		strcpy(new_p, p);
+		strcat(new_p, "L");
+		p = new_p;
+		}
 		
             displayWrite(osdDisplayPort, elemPosX, elemPosY, p);
             return true;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2089,8 +2089,11 @@ static bool osdDrawSingleElement(uint8_t item)
             else if (FLIGHT_MODE(ANGLE_MODE))
                 p = "ANGL";
             else if (FLIGHT_MODE(HORIZON_MODE))
-                p = "HOR ";
-
+                p = "HOR";
+		
+	    if (IS_RC_MODE_ACTIVE(BOXAUTOLEVEL))
+		p += "L";
+		
             displayWrite(osdDisplayPort, elemPosX, elemPosY, p);
             return true;
         }


### PR DESCRIPTION
Fixes issue #8782
Squash : Added an "L" to flight modes with AutoLevel in OSD and not a message because some users use AutoLevel mode permanently.
The updated pitch level trim value is displayed in Level Field. Working but it does not reset