### PR TITLE
Fix LED Indicators mode for Fixed Wing and Rover

### DIFF
--- a/docs/LedStrip.md
+++ b/docs/LedStrip.md
@@ -237,6 +237,12 @@ The mapping between modes led placement and colors is currently fixed and cannot
 
 #### Indicator
 
+##### For fixed wing (INAV 6.1 onwards)
+
+This mode flashes LEDs that correspond to the roll stick position. Rolling left will flash any `indicator` LED on the left half of the grid. Rolling right will flash any `indicator` on the right side of the grid.
+
+##### For other platforms (all platforms pre INAV 6.1)
+
 This mode flashes LEDs that correspond to roll and pitch stick positions.  i.e.  they indicate the direction the craft is going to turn.
 
 | Mode | Direction | LED Color |

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -678,7 +678,7 @@ static void applyLedIndicatorLayer(bool updateNow, timeUs_t *timer)
     if (updateNow) {
         if (rxIsReceivingSignal()) {
             // calculate update frequency
-            int scale = (STATE(AIRPLANE)) ? ABS(rcCommand[ROLL]) : MAX(ABS(rcCommand[ROLL]), ABS(rcCommand[PITCH]));  // 0 - 500
+            int scale = (STATE(AIRPLANE) || STATE(ROVER)) ? ABS(rcCommand[ROLL]) : MAX(ABS(rcCommand[ROLL]), ABS(rcCommand[PITCH]));  // 0 - 500
             scale += (50 - INDICATOR_DEADBAND);  // start increasing frequency right after deadband
             *timer += LED_STRIP_HZ(5) * 50 / MAX(50, scale);   // 5 - 50Hz update, 2.5 - 25Hz blink
 
@@ -693,7 +693,7 @@ static void applyLedIndicatorLayer(bool updateNow, timeUs_t *timer)
 
     const hsvColor_t *flashColor = &HSV(ORANGE); // TODO - use user color?
 
-    if (STATE(AIRPLANE)) {
+    if (STATE(AIRPLANE) || STATE(ROVER)) {
         for (int ledIndex = 0; ledIndex < ledCounts.count; ledIndex++) {
             const ledConfig_t *ledConfig = &ledStripConfig()->ledConfigs[ledIndex];
             if (ledGetOverlayBit(ledConfig, LED_OVERLAY_INDICATOR)) {


### PR DESCRIPTION
Currently, the indicators mode is only really works for quads. It doesn't make any sense for fixed wing. This PR changes that. Roll movements to the left triggers indicators on the left half of the grid. Roll movements to the right triggers indicators on the right half of the grid.

This change may also be suitable for rovers too. If so, it's an easy modification. So feedback from rover people would be great.