### PR TITLE
Improved wind estimator - OSD stale reading state

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -427,11 +427,12 @@ static void osdFormatWindSpeedStr(char *buff, int32_t ws, bool isValid)
             suffix = SYM_KMH;
             break;
     }
+
     osdFormatCentiNumber(buff, centivalue, 0, 2, 0, 3);
-    if (!isValid)
-    {
+    
+    if (!isValid && ((millis() / 1000) % 4 < 2))
         suffix = '*';
-    }
+
     buff[3] = suffix;
     buff[4] = '\0';
 }


### PR DESCRIPTION
Part fix for #8830. This makes the OSD part clearer. But the `isValid` check may need to be looked at for the other part.