### PR TITLE
Add ICM42688 and BMI270 to Betafpv F722 #8841

### DIFF
--- a/src/main/target/BETAFPVF722/target.h
+++ b/src/main/target/BETAFPVF722/target.h
@@ -40,6 +40,11 @@
 #define USE_IMU_MPU6000
 #define IMU_MPU6000_ALIGN       CW180_DEG
 
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW180_DEG
+#define ICM42605_SPI_BUS        BUS_SPI1
+#define ICM42605_CS_PIN         PA4
+
 // *************** I2C/Baro/Mag *********************
 #define USE_I2C
 

--- a/src/main/target/BETAFPVF722/target.h
+++ b/src/main/target/BETAFPVF722/target.h
@@ -45,6 +45,11 @@
 #define ICM42605_SPI_BUS        BUS_SPI1
 #define ICM42605_CS_PIN         PA4
 
+#define USE_IMU_BMI270
+#define IMU_BMI270_ALIGN        CW180_DEG
+#define BMI270_SPI_BUS          BUS_SPI1
+#define BMI270_CS_PIN           PA4
+
 // *************** I2C/Baro/Mag *********************
 #define USE_I2C
 


### PR DESCRIPTION
Betaflight unified target has a total of 3 gyros for this FC (mpu6000, bmi270 and ICM42688), but it also lists 2 CS pins (gyro1 and gyro2).

Gyro2 cs is PC3. Both are connected to SPI1. There is no way to tell from the target which gyros may be connected to which CS pins.

Hard to tell if this is a mistake on the target or a case of multiple board revisions/layouts sharing the same target in BF.