### PR TITLE
Add MSP_BATTERY_STATE

### DIFF
--- a/docs/VTx.md
+++ b/docs/VTx.md
@@ -10,6 +10,18 @@ To use the Matek 1G3SE with IRC Tramp. You will need to enter the CLI command `s
 
 Note: The frequencies required by the US version of the VTx are on `vtx_band` 2 (BAND B) only.
 
+Power levels are: 
+- `1` 25mW
+- `2` 200mW
+- `3` 800 mW
+
+##### Matek 1G3SE frequency chart
+
+| Band | 1    | 2    | 3    | 4    | 5    | 6    | 7    | 8    |
+|------|------|------|------|------|------|------|------|------|
+| A    | 1080 | 1120 | 1160 | 1200 | 1240 | 1280 | 1320 | 1360 |
+| B    | 1080 | 1120 | 1160 | 1200 | 1258 | 1280 | 1320 | 1360 |
+
 ### Team BlackSheep SmartAudio
 
 If you have problems getting SmartAudio working. There are a couple of CLI parameters you can try changing to see if they help.

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1123,6 +1123,25 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         serializeSDCardSummaryReply(dst);
         break;
 
+#if defined (USE_DJI_HD_OSD) || defined (USE_MSP_DISPLAYPORT)
+    case MSP_BATTERY_STATE:
+        // Battery characteristics
+        sbufWriteU8(dst, constrain(getBatteryCellCount(), 0, 255));
+        sbufWriteU16(dst, currentBatteryProfile->capacity.value);
+
+        // Battery state
+        sbufWriteU8(dst, constrain(getBatteryVoltage() / 10, 0, 255)); // in 0.1V steps
+        sbufWriteU16(dst, constrain(getMAhDrawn(), 0, 0xFFFF));
+        sbufWriteU16(dst, constrain(getAmperage(), -0x8000, 0x7FFF));
+
+        // Battery alerts - used values match Betaflight's/DJI's
+        sbufWriteU8(dst,  getBatteryState());
+
+        // Additional battery voltage field (in 0.01V steps)
+        sbufWriteU16(dst, getBatteryVoltage());
+        break;
+#endif
+
     case MSP_OSD_CONFIG:
 #ifdef USE_OSD
         sbufWriteU8(dst, OSD_DRIVER_MAX7456); // OSD supported

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -209,7 +209,7 @@
 #define MSP_SET_FILTER_CONFIG           93
 
 #define MSP_PID_ADVANCED                94
-#define MSP_SET_PID_ADVANCED         95
+#define MSP_SET_PID_ADVANCED            95
 
 #define MSP_SENSOR_CONFIG               96
 #define MSP_SET_SENSOR_CONFIG           97
@@ -257,6 +257,7 @@
 #define MSP_RC_DEADBAND          125    //out message         deadbands for yaw alt pitch roll
 #define MSP_SENSOR_ALIGNMENT     126    //out message         orientation of acc,gyro,mag
 #define MSP_LED_STRIP_MODECOLOR  127    //out message         Get LED strip mode_color settings
+#define MSP_BATTERY_STATE        130    // DJI googles fc battery info
 
 #define MSP_SET_RAW_RC           200    //in message          8 rc chan
 #define MSP_SET_RAW_GPS          201    //in message          fix, numsat, lat, lon, alt, speed


### PR DESCRIPTION
MSP_BATTERY_STATE is used by DJI googles to display flight pack volatge in the native OSD.

This should address #8840 and show flight pack voltage on the googles.

The code is a copy and paste from osd_dji_hd.c

![image](https://user-images.githubusercontent.com/23555060/222500134-9411341f-8811-4b04-b593-60201fdf3d8d.png)
