### PR TITLE
Add MSP_BATTERY_STATE for DJI Googles battery display

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1123,6 +1123,25 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         serializeSDCardSummaryReply(dst);
         break;
 
+#if defined (USE_DJI_HD_OSD) || defined (USE_MSP_DISPLAYPORT)
+    case MSP_BATTERY_STATE:
+        // Battery characteristics
+        sbufWriteU8(dst, constrain(getBatteryCellCount(), 0, 255));
+        sbufWriteU16(dst, currentBatteryProfile->capacity.value);
+
+        // Battery state
+        sbufWriteU8(dst, constrain(getBatteryVoltage() / 10, 0, 255)); // in 0.1V steps
+        sbufWriteU16(dst, constrain(getMAhDrawn(), 0, 0xFFFF));
+        sbufWriteU16(dst, constrain(getAmperage(), -0x8000, 0x7FFF));
+
+        // Battery alerts - used values match Betaflight's/DJI's
+        sbufWriteU8(dst,  getBatteryState());
+
+        // Additional battery voltage field (in 0.01V steps)
+        sbufWriteU16(dst, getBatteryVoltage());
+        break;
+#endif
+
     case MSP_OSD_CONFIG:
 #ifdef USE_OSD
         sbufWriteU8(dst, OSD_DRIVER_MAX7456); // OSD supported

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -209,7 +209,7 @@
 #define MSP_SET_FILTER_CONFIG           93
 
 #define MSP_PID_ADVANCED                94
-#define MSP_SET_PID_ADVANCED         95
+#define MSP_SET_PID_ADVANCED            95
 
 #define MSP_SENSOR_CONFIG               96
 #define MSP_SET_SENSOR_CONFIG           97
@@ -257,6 +257,7 @@
 #define MSP_RC_DEADBAND          125    //out message         deadbands for yaw alt pitch roll
 #define MSP_SENSOR_ALIGNMENT     126    //out message         orientation of acc,gyro,mag
 #define MSP_LED_STRIP_MODECOLOR  127    //out message         Get LED strip mode_color settings
+#define MSP_BATTERY_STATE        130    // DJI googles fc battery info
 
 #define MSP_SET_RAW_RC           200    //in message          8 rc chan
 #define MSP_SET_RAW_GPS          201    //in message          fix, numsat, lat, lon, alt, speed


### PR DESCRIPTION
MSP_BATTERY_STATE is used by DJI googles to display flight pack volatge in the native OSD.

This should address #8840 and show flight pack voltage on the googles.

The code is a copy and paste from osd_dji_hd.c
![image](https://user-images.githubusercontent.com/23555060/222505197-abb4f7fb-edad-42c8-b562-d3f6a4607aba.png)
