### PR TITLE
not even INAV should dereference NULL pointers

### DIFF
--- a/docs/VTx.md
+++ b/docs/VTx.md
@@ -10,6 +10,18 @@ To use the Matek 1G3SE with IRC Tramp. You will need to enter the CLI command `s
 
 Note: The frequencies required by the US version of the VTx are on `vtx_band` 2 (BAND B) only.
 
+Power levels are: 
+- `1` 25mW
+- `2` 200mW
+- `3` 800 mW
+
+##### Matek 1G3SE frequency chart
+
+| Band | 1    | 2    | 3    | 4    | 5    | 6    | 7    | 8    |
+|------|------|------|------|------|------|------|------|------|
+| A    | 1080 | 1120 | 1160 | 1200 | 1240 | 1280 | 1320 | 1360 |
+| B    | 1080 | 1120 | 1160 | 1200 | 1258 | 1280 | 1320 | 1360 |
+
 ### Team BlackSheep SmartAudio
 
 If you have problems getting SmartAudio working. There are a couple of CLI parameters you can try changing to see if they help.

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1690,7 +1690,7 @@ static void cliDelay(char* cmdLine) {
         cliPrintLine("CLI delay deactivated");
         return;
     }
-    
+
     ms = fastA2I(cmdLine);
     if (ms) {
         cliDelayMs = ms;
@@ -1699,7 +1699,7 @@ static void cliDelay(char* cmdLine) {
     } else {
         cliShowParseError();
     }
-    
+
 }
 
 static void printServo(uint8_t dumpMask, const servoParam_t *servoParam, const servoParam_t *defaultServoParam)
@@ -2288,7 +2288,7 @@ static void cliFlashInfo(char *cmdline)
     UNUSED(cmdline);
 
     const flashGeometry_t *layout = flashGetGeometry();
-    
+
     if (layout->totalSize == 0) {
         cliPrintLine("Flash not available");
         return;
@@ -2323,12 +2323,12 @@ static void cliFlashErase(char *cmdline)
     UNUSED(cmdline);
 
     const flashGeometry_t *layout = flashGetGeometry();
-    
+
     if (layout->totalSize == 0) {
         cliPrintLine("Flash not available");
         return;
     }
-    
+
     cliPrintLine("Erasing...");
     flashfsEraseCompletely();
 
@@ -3414,8 +3414,12 @@ static void cliStatus(char *cmdline)
     cliPrint("OSD: ");
 #if defined(USE_OSD)
     displayPort_t *osdDisplayPort = osdGetDisplayPort();
-    cliPrintf("%s [%u x %u]", osdDisplayPort->displayPortType, osdDisplayPort->cols, osdDisplayPort->rows);
-#else 
+    if (osdDisplayPort != NULL) {
+        cliPrintf("%s [%u x %u]", osdDisplayPort->displayPortType, osdDisplayPort->cols, osdDisplayPort->rows);
+    } else {
+        cliPrint("not enabled");
+    }
+#else
     cliPrint("not used");
 #endif
     cliPrintLinefeed();


### PR DESCRIPTION
If `feature -OSD` is set, then `osdDisplayPort` will be NULL ... not checking this is bad form.
