### PR TITLE
BFCOMPAT mods to increase precision in value scalings

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1827,7 +1827,11 @@ static bool osdDrawSingleElement(uint8_t item)
             buff[0] = SYM_HDP_L;
             buff[1] = SYM_HDP_R;
             int32_t centiHDOP = 100 * gpsSol.hdop / HDOP_SCALE;
-            osdFormatCentiNumber(&buff[2], centiHDOP, 0, 1, 0, 2);
+            uint8_t digits = 2U;
+            if (isBfCompatibleVideoSystem(osdConfig())) {
+                digits = 3U;
+            }
+            osdFormatCentiNumber(&buff[2], centiHDOP, 0, 1, 0, digits);
             break;
         }
 
@@ -2810,7 +2814,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     }
                     if (!efficiencyValid) {
                         if(bf_compat){
-                            buff[0] = buff[1] = buff[2] = buf[3] = '-';    
+                            buff[0] = buff[1] = buff[2] = buff[3] = '-';    
                         } else {
                             buff[0] = buff[1] = buff[2] = '-';
                         }                        
@@ -2828,7 +2832,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     }
                     if (!efficiencyValid) {
                         if(bf_compat){
-                            buff[0] = buff[1] = buff[2] = buf[3] = '-';    
+                            buff[0] = buff[1] = buff[2] = buff[3] = '-';    
                         } else {
                             buff[0] = buff[1] = buff[2] = '-';
                         }
@@ -2848,7 +2852,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     }
                     if (!efficiencyValid) {
                         if(bf_compat){
-                            buff[0] = buff[1] = buff[2] = buf[3] = '-';    
+                            buff[0] = buff[1] = buff[2] = buff[3] = '-';    
                         } else {
                             buff[0] = buff[1] = buff[2] = '-';
                         }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2785,11 +2785,9 @@ static bool osdDrawSingleElement(uint8_t item)
             timeDelta_t efficiencyTimeDelta = cmpTimeUs(currentTimeUs, efficiencyUpdated);
             // Check for BFCOMPAT mode
             uint8_t digits = 3U;
-            bool bf_compat = false;
             if (isBfCompatibleVideoSystem(osdConfig())) {
                 // Increase number of digits so values above 99 don't get scaled by osdFormatCentiNumber
                 digits = 4U;
-                bf_compat = true;
             }
             if (STATE(GPS_FIX) && gpsSol.groundSpeed > 0) {
                 if (efficiencyTimeDelta >= EFFICIENCY_UPDATE_INTERVAL) {
@@ -2813,12 +2811,8 @@ static bool osdDrawSingleElement(uint8_t item)
                         tfp_sprintf(buff, "%s%c", buff, SYM_AH_MI);
                     }
                     if (!efficiencyValid) {
-                        if(bf_compat){
-                            buff[0] = buff[1] = buff[2] = buff[3] = '-';    
-                        } else {
-                            buff[0] = buff[1] = buff[2] = '-';
-                        }                        
-                        buff[digits] = SYM_MAH_MI_0;
+                        buff[0] = buff[1] = buff[2] = buff[3] = '-';    
+                        buff[digits] = SYM_MAH_MI_0;        // This will overwrite the "-" at buff[3] if not in BFCOMPAT mode
                         buff[digits + 1] = SYM_MAH_MI_1;
                         buff[digits + 2] = '\0';
                     }
@@ -2831,11 +2825,7 @@ static bool osdDrawSingleElement(uint8_t item)
                         tfp_sprintf(buff, "%s%c", buff, SYM_AH_NM);
                     }
                     if (!efficiencyValid) {
-                        if(bf_compat){
-                            buff[0] = buff[1] = buff[2] = buff[3] = '-';    
-                        } else {
-                            buff[0] = buff[1] = buff[2] = '-';
-                        }
+                        buff[0] = buff[1] = buff[2] = buff[3] = '-';    
                         buff[digits] = SYM_MAH_NM_0;
                         buff[digits + 1] = SYM_MAH_NM_1;
                         buff[digits + 2] = '\0';
@@ -2851,11 +2841,7 @@ static bool osdDrawSingleElement(uint8_t item)
                         tfp_sprintf(buff, "%s%c", buff, SYM_AH_KM);
                     }
                     if (!efficiencyValid) {
-                        if(bf_compat){
-                            buff[0] = buff[1] = buff[2] = buff[3] = '-';    
-                        } else {
-                            buff[0] = buff[1] = buff[2] = '-';
-                        }
+                        buff[0] = buff[1] = buff[2] = buff[3] = '-';    
                         buff[digits] = SYM_MAH_KM_0;
                         buff[digits + 1] = SYM_MAH_KM_1;
                         buff[digits + 2] = '\0';

--- a/src/main/io/osd_utils.c
+++ b/src/main/io/osd_utils.c
@@ -95,10 +95,15 @@ bool osdFormatCentiNumber(char *buff, int32_t centivalue, uint32_t scale, int ma
 
     // Keep number right aligned and correct length
     if(explicitDecimal && decimals == 0) {
-        if ((digits + 1) == length) {
+        uint8_t blank_spaces = ptr - buff;
+        int8_t rem_spaces = length - (digits + blank_spaces);
+        // Add any needed remaining leading spaces
+        while(rem_spaces > 0)
+        {
             *ptr = SYM_BLANK;
             ptr++;
             remaining--;
+            rem_spaces--;
         }
     }
 


### PR DESCRIPTION
When using BFCOMPAT OSD mode, with the decimal point taking one extra character, the decimal scaling feature of certain values does not work as expected. In the case of altitude or home distance, when it goes over 999meters, then the field would change to 1.00km. But what happens in BFCOMPAT mode is that it changes to 0.1km when over 99 meters, thus resulting in 100 meter steps (0.1, 0.2, 0.3 and so on), which is not ideal.

Upon investigating, it seems the "problem" is on the calls to osdFormatCentiNumber() with a fixed number of digits (3). Since the decimal point is considered a digit in itself, it leaves only 2 digits for the actual values. So this PR increases the number of digits in those calls when BFCOMPAT mode is active, so that the 3 value digits are maintained. Downside is extra space used on the screen to have one extra character/digit field.

So far, I have implemented these changes for:
- Home distance
- GPS HDOP
- mah/km efficiency fields

For the altitude field, the change in #8779 seems to "fix" this problem, so I haven't changed that.

With all that said, I have only tested this code on the bench for any obvious errors, I will not be able to flight test (to see if the values are displayed as expected) until the weekend, so if anyone is able to test it sooner and give feedback it will be greatly appreciated! Also any other suggestions/feedback is welcome.