### PR TITLE
Show loiter instead of poshold in OSD for fixed wing

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2072,6 +2072,8 @@ static bool osdDrawSingleElement(uint8_t item)
                 p = "TURT";
             else if (FLIGHT_MODE(NAV_RTH_MODE))
                 p = isWaypointMissionRTHActive() ? "WRTH" : "RTH ";
+            else if (FLIGHT_MODE(NAV_POSHOLD_MODE) && STATE(AIRPLANE))
+                p = "LOTR";
             else if (FLIGHT_MODE(NAV_POSHOLD_MODE))
                 p = "HOLD";
             else if (FLIGHT_MODE(NAV_COURSE_HOLD_MODE) && FLIGHT_MODE(NAV_ALTHOLD_MODE))


### PR DESCRIPTION
Fixed #8873

Fixed wing will show `LOTR` instead of `HOLD` while loitering.