### PR TITLE
Navigation altitude and position controller reset improvements

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -1506,7 +1506,6 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_WAYPOINT_INITIALIZE(nav
     // Prepare controllers
     resetPositionController();
     resetAltitudeController(false);     // Make sure surface tracking is not enabled - WP uses global altitude, not AGL
-    setupAltitudeController();
 
     if (posControl.activeWaypointIndex == posControl.startWpIndex || posControl.wpMissionRestart) {
         /* Use p3 as the volatile jump counter, allowing embedded, rearmed jumps


### PR DESCRIPTION
Closes https://github.com/iNavFlight/inav/issues/8882.

Should improve control behaviour when switching directly from one Nav mode to another, although change mainly affects AltHold and PosHold modes.

Tested on HITL fixed wing sim OK. Still needs testing on a multirotor.