### PR TITLE
[FLYWOOF411]: enable TX pin for UART2

### DIFF
--- a/src/main/target/FLYWOOF411/target.h
+++ b/src/main/target/FLYWOOF411/target.h
@@ -102,11 +102,7 @@
 #endif
 
 #define USE_UART2
-#ifdef FLYWOOF411_V2
 #define UART2_TX_PIN            PA2
-#else
-#define UART2_TX_PIN            NONE    //PA2
-#endif
 #define UART2_RX_PIN            PA3
 
 #define USE_SOFTSERIAL1


### PR DESCRIPTION
This is needed when using a Crossfire RX and a GPS, for instance.

Is there any reason not to use the TX pin for UART2? Having softserial on that pin, too, is not a problem.