### PR TITLE
[SITL] parameterise and reduce TASK_SERIAL rate

### DIFF
--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -123,7 +123,7 @@ void systemInit(void) {
           break;
     }
 
-    rescheduleTask(TASK_SERIAL, 1);
+    rescheduleTask(TASK_SERIAL, SITL_SERIAL_TASK_US);
 }
 
 bool parseMapping(char* mapStr)

--- a/src/main/target/SITL/target.h
+++ b/src/main/target/SITL/target.h
@@ -53,6 +53,7 @@
 #define USE_UART8
 
 #define SERIAL_PORT_COUNT 8
+#define SITL_SERIAL_TASK_US (500)
 
 #define DEFAULT_RX_FEATURE      FEATURE_RX_MSP
 #define DEFAULT_FEATURES        (FEATURE_GPS |  FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT)
@@ -181,7 +182,7 @@ typedef struct
 #define UART7 ((USART_TypeDef *)0x0007)
 #define UART8 ((USART_TypeDef *)0x0008)
 
-typedef enum 
+typedef enum
 {
     SITL_SIM_NONE,
     SITL_SIM_REALFLIGHT,


### PR DESCRIPTION
Currently, the SITL cannot be armed on old  / slow hardware or VMs due to OVERLOAD from:
```
    rescheduleTask(TASK_SERIAL, 1);
```
even if after the scheduler throttles the specified 1us to 100us. This causes overload due to the excessive activity of the serial task.

This patch reschedules at 500us, but I'm not sure that any reschedule is really necessary. Still, this seems safe; tested on a 2009 "Intel® AtomTM processor N270 (1.6GHz single core with HT)" (ia32) as working correctly with `fl2sitl` as the X-Plane protocol "simulator".