### PR TITLE
Recognize MPU9255 as a valid IMU

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_mpu9250.c
@@ -115,6 +115,7 @@ static bool mpu9250DeviceDetect(busDevice_t * dev)
 
         switch (tmp) {
             case MPU9250_WHO_AM_I_CONST:
+            case MPU9255_WHO_AM_I_CONST:
                 // Compatible chip detected
                 return true;
 


### PR DESCRIPTION
Chips MPU9250 and MPU9255 are the same except for the `WHOAMI` register.