### PR TITLE
docs: fix documentation of gvar set

### DIFF
--- a/docs/Programming Framework.md
+++ b/docs/Programming Framework.md
@@ -51,7 +51,8 @@ IPF can be edited using INAV Configurator user interface, or via CLI
 | 15            | SUB                           | Substract `Operand B` from `Operand A` and returns the result |
 | 16            | MUL                           | Multiply `Operand A` by `Operand B` and returns the result |
 | 17            | DIV                           | Divide `Operand A` by `Operand B` and returns the result |
-| 18            | GVAR SET                      | Store value from `Operand B` into the Global Variable addressed by `Operand B`. Bear in mind, that operand `Global Variable` means: Value stored in Global Variable of an index! To store in GVAR 1 use `Value 1` not `Global Variable 1` |
+| 18            | GVAR SET                      | Store value from `Operand B` into the Global Variable addressed by
+`Operand A`. Bear in mind, that operand `Global Variable` means: Value stored in Global Variable of an index! To store in GVAR 1 use `Value 1` not `Global Variable 1` |
 | 19            | GVAR INC                      | Increase the GVAR indexed by `Operand A` (use `Value 1` for Global Variable 1) with value from `Operand B`  |
 | 20            | GVAR DEC                      | Decrease the GVAR indexed by `Operand A` (use `Value 1` for Global Variable 1) with value from `Operand B`  |
 | 21            | IO PORT SET                   | Set I2C IO Expander pin `Operand A` to value of `Operand B`. `Operand A` accepts values `0-7` and `Operand B` accepts `0` and `1` |


### PR DESCRIPTION
gvar set sets the variable referenced by A, not the variable referenced by B.