### PR TITLE
Rename AUTO LEVEL

### DIFF
--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -93,7 +93,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { .boxId = BOXPREARM,           .boxName = "PREARM",            .permanentId = 51 },
     { .boxId = BOXTURTLE,           .boxName = "TURTLE",            .permanentId = 52 },
     { .boxId = BOXNAVCRUISE,        .boxName = "NAV CRUISE",        .permanentId = 53 },
-    { .boxId = BOXAUTOLEVEL,        .boxName = "AUTO LEVEL",        .permanentId = 54 },
+    { .boxId = BOXAUTOLEVEL,        .boxName = "AUTO LEVEL TRIM",   .permanentId = 54 },
     { .boxId = BOXPLANWPMISSION,    .boxName = "WP PLANNER",        .permanentId = 55 },
     { .boxId = BOXSOARING,          .boxName = "SOARING",           .permanentId = 56 },
     { .boxId = BOXCHANGEMISSION,    .boxName = "MISSION CHANGE",    .permanentId = 59 },

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -112,7 +112,7 @@
 #define OSD_MSG_AUTOTRIM            "(AUTOTRIM)"
 #define OSD_MSG_AUTOTUNE            "(AUTOTUNE)"
 #define OSD_MSG_AUTOTUNE_ACRO       "SWITCH TO ACRO"
-#define OSD_MSG_AUTOLEVEL           "(AUTOLEVEL)"
+#define OSD_MSG_AUTOLEVEL           "(AUTO LEVEL TRIM)"
 #define OSD_MSG_HEADFREE            "(HEADFREE)"
 #define OSD_MSG_NAV_SOARING         "(SOARING)"
 #define OSD_MSG_UNABLE_ARM          "UNABLE TO ARM"

--- a/src/main/io/osd_dji_hd.c
+++ b/src/main/io/osd_dji_hd.c
@@ -1048,7 +1048,7 @@ static bool djiFormatMessages(char *buff)
                 }
 
                 if (IS_RC_MODE_ACTIVE(BOXAUTOLEVEL)) {
-                    messages[messageCount++] = "(AUTOLEVEL)";
+                    messages[messageCount++] = "(AUTO LEVEL TRIM)";
                 }
 
                 if (FLIGHT_MODE(HEADFREE_MODE)) {


### PR DESCRIPTION
People are still confused with AUTOLEVEL. Some think that it self levels the airplane. This little modification adds TRIM to the name to disassociate with self-levelling and also be more consistent with the PID Tuning tab, where it's called Fixed Wing level trim.

![image](https://user-images.githubusercontent.com/17590174/231247141-66482615-b101-451a-884d-568dcd8e7614.png)

Requires Configurator https://github.com/iNavFlight/inav-configurator/pull/1755

## Release Notes
`AUTO LEVEL` has been renamed to `AUTO LEVEL TRIM`. The tuning mode functions in the same way as before. This is just a name change to try and avoid confusion with self levelling.