### PR TITLE
Add flash support to SpeedyBeeF7V3

### DIFF
--- a/src/main/target/SPEEDYBEEF7V3/CMakeLists.txt
+++ b/src/main/target/SPEEDYBEEF7V3/CMakeLists.txt
@@ -1,1 +1,2 @@
 target_stm32f722xe(SPEEDYBEEF7V3)
+target_stm32f722xe(SPEEDYBEEF7V3_NOSD)

--- a/src/main/target/SPEEDYBEEF7V3/target.h
+++ b/src/main/target/SPEEDYBEEF7V3/target.h
@@ -21,7 +21,11 @@
 #pragma once
 
 #define TARGET_BOARD_IDENTIFIER "SB73"
+#ifdef SPEEDYBEEF7V3_NOSD
+#define USBD_PRODUCT_STRING  "SpeedyBeeF7V3_NOSD"
+#else
 #define USBD_PRODUCT_STRING  "SpeedyBeeF7V3"
+#endif
 
 #define LED0                PA14
 #define LED1                PA13
@@ -107,19 +111,33 @@
 #define USE_MAG_MAG3110
 #define USE_MAG_LIS3MDL
 
-// *************** Internal SD card **************************
-
+// *************** SPI3/Blackbox **************************
 #define USE_SPI_DEVICE_3
 #define SPI3_SCK_PIN            PC10
-#define SPI3_MISO_PIN   	    PC11
-#define SPI3_MOSI_PIN   	    PC12
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PC12
 
+#ifdef SPEEDYBEEF7V3
+// *************** Internal SD card **************************
 #define USE_SDCARD
 #define USE_SDCARD_SPI
 #define SDCARD_SPI_BUS          BUS_SPI3
 #define SDCARD_CS_PIN           PD2
-
 #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+#else
+// *************** Onboard blackbox **************************
+#define USE_FLASHFS
+
+#define USE_FLASH_M25P16
+#define M25P16_SPI_BUS		BUS_SPI3
+#define M25P16_CS_PIN		PD2
+
+#define USE_FLASH_W25N01G
+#define W25N01G_SPI_BUS		BUS_SPI3
+#define W25N01G_CS_PIN		PD2
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#endif
 
 // *************** OSD *****************************
 #define USE_OSD


### PR DESCRIPTION
Attempt at fixing #8998 

CS pin is the same as SD card, as well as SPI BUS.

Add new target SPEEDYBEEF7V3_NOSD.

This target replaces the SD card with onboard flash.

Needs to be verified by someone with access to the hardware. The version on the website does not include a sdcard slot.
