### PR TITLE
move current_meter_scale and current_meter_offset to battery profile

### DIFF
--- a/docs/Battery.md
+++ b/docs/Battery.md
@@ -216,6 +216,8 @@ Up to 3 battery profiles are supported. You can select the battery profile from 
 - `nav_fw_launch_idle_thr`
 - `failsafe_throttle`
 - `nav_mc_hover_thr`
+- `current_meter_scale`
+- `current_meter_offset`
 
 To enable the automatic battery profile switching based on battery voltage enable the `BAT_PROF_AUTOSWITCH` feature. For a profile to be automatically selected the number of cells of the battery needs to be specified (>0).
 

--- a/docs/Battery.md
+++ b/docs/Battery.md
@@ -206,9 +206,11 @@ Up to 3 battery profiles are supported. You can select the battery profile from 
 - `battery_capacity_warning`
 - `battery_capacity_critical`
 - `throttle_idle`
-- `fw_min_throttle_down_pitch`
+- `throttle_scale`
+- `turtle_mode_power_factor`
 - `nav_fw_cruise_thr`
 - `nav_fw_min_thr`
+- `nav_fw_max_thr`
 - `nav_fw_pitch2thr`
 - `nav_fw_launch_thr`
 - `nav_fw_launch_idle_thr`

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1834,8 +1834,8 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE_CUSTOM(
             //Note: Log even if this is a virtual current meter, since the virtual meter uses these parameters too:
             if (feature(FEATURE_CURRENT_METER)) {
-                blackboxPrintfHeaderLine("currentMeter", "%d,%d",           batteryMetersConfig()->current.offset,
-                                                                            batteryMetersConfig()->current.scale);
+                blackboxPrintfHeaderLine("currentMeter", "%d,%d",           currentBatteryProfile->batteryMeters.current.offset,
+                                                                            currentBatteryProfile->batteryMeters.current.scale);
             }
             );
 

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -857,8 +857,8 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         sbufWriteU16(dst, 0);
 #endif
 
-        sbufWriteU16(dst, batteryMetersConfig()->current.offset);
-        sbufWriteU16(dst, batteryMetersConfig()->current.scale);
+        sbufWriteU16(dst, currentBatteryProfile->batteryMeters.current.offset);
+        sbufWriteU16(dst, currentBatteryProfile->batteryMeters.current.scale);
 
         sbufWriteU32(dst, currentBatteryProfile->capacity.value);
         sbufWriteU32(dst, currentBatteryProfile->capacity.warning);
@@ -968,8 +968,8 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         break;
 
     case MSP_CURRENT_METER_CONFIG:
-        sbufWriteU16(dst, batteryMetersConfig()->current.scale);
-        sbufWriteU16(dst, batteryMetersConfig()->current.offset);
+        sbufWriteU16(dst, currentBatteryProfile->batteryMeters.current.scale);
+        sbufWriteU16(dst, currentBatteryProfile->batteryMeters.current.offset);
         sbufWriteU8(dst, batteryMetersConfig()->current.type);
         sbufWriteU16(dst, constrain(currentBatteryProfile->capacity.value, 0, 0xFFFF));
         break;
@@ -1931,8 +1931,8 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             sbufReadU16(src);
 #endif
 
-            batteryMetersConfigMutable()->current.offset = sbufReadU16(src);
-            batteryMetersConfigMutable()->current.scale = sbufReadU16(src);
+            currentBatteryProfileMutable->batteryMeters.current.offset = sbufReadU16(src);
+            currentBatteryProfileMutable->batteryMeters.current.scale = sbufReadU16(src);
 
             currentBatteryProfileMutable->capacity.value = sbufReadU32(src);
             currentBatteryProfileMutable->capacity.warning = sbufReadU32(src);
@@ -2580,8 +2580,8 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP_SET_CURRENT_METER_CONFIG:
         if (dataSize == 7) {
-            batteryMetersConfigMutable()->current.scale = sbufReadU16(src);
-            batteryMetersConfigMutable()->current.offset = sbufReadU16(src);
+            currentBatteryProfileMutable->batteryMeters.current.scale = sbufReadU16(src);
+            currentBatteryProfileMutable->batteryMeters.current.offset = sbufReadU16(src);
             batteryMetersConfigMutable()->current.type = sbufReadU8(src);
             currentBatteryProfileMutable->capacity.value = sbufReadU16(src);
         } else

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -905,18 +905,6 @@ groups:
         condition: USE_ADC
         min: 0
         max: 65535
-      - name: current_meter_scale
-        description: "This sets the output voltage to current scaling for the current sensor in 0.1 mV/A steps. 400 is 40mV/A such as the ACS756 sensor outputs. 183 is the setting for the uberdistro with a 0.25mOhm shunt."
-        default_value: :target
-        field: current.scale
-        min: -10000
-        max: 10000
-      - name: current_meter_offset
-        description: "This sets the output offset voltage of the current sensor in millivolts."
-        default_value: :target
-        field: current.offset
-        min: -32768
-        max: 32767
       - name: current_meter_type
         description: "ADC , VIRTUAL, NONE. The virtual current sensor, once calibrated, estimates the current value from throttle position."
         default_value: "ADC"
@@ -1138,6 +1126,19 @@ groups:
         default_value: 0
         field: powerLimits.burstPowerFalldownTime
         max: 3000
+
+      - name: current_meter_scale
+        description: "This sets the output voltage to current scaling for the current sensor in 0.1 mV/A steps. 400 is 40mV/A such as the ACS756 sensor outputs. 183 is the setting for the uberdistro with a 0.25mOhm shunt."
+        default_value: :target
+        field: batteryMeters.current.scale
+        min: -10000
+        max: 10000
+      - name: current_meter_offset
+        description: "This sets the output offset voltage of the current sensor in millivolts."
+        default_value: :target
+        field: batteryMeters.current.offset
+        min: -32768
+        max: 32767
 
   - name: PG_MIXER_CONFIG
     type: mixerConfig_t

--- a/src/main/sensors/battery_config_structs.h
+++ b/src/main/sensors/battery_config_structs.h
@@ -59,9 +59,8 @@ typedef struct batteryMetersConfig_s {
 #endif
 
     struct {
-        int16_t scale;          // scale the current sensor output voltage to milliamps. Value in 1/10th mV/A
-        int16_t offset;         // offset of the current sensor in millivolt steps
         currentSensor_e type;   // type of current meter used, either ADC or virtual
+        //scale and offset are moved to battery config
     } current;
 
     batVoltageSource_e voltageSource;
@@ -139,4 +138,10 @@ typedef struct batteryProfile_s {
     } powerLimits;
 #endif // USE_POWER_LIMITS
 
+    struct {
+        struct {
+            int16_t scale;          // scale the current sensor output voltage to milliamps. Value in 1/10th mV/A
+            int16_t offset;         // offset of the current sensor in millivolt steps
+        } current;
+    } batteryMeters;
 } batteryProfile_t;

--- a/src/main/target/ALIENFLIGHTF4/config.c
+++ b/src/main/target/ALIENFLIGHTF4/config.c
@@ -60,8 +60,8 @@ void targetConfiguration(void)
     compassConfigMutable()->mag_align = CW90_DEG;
 
     serialConfigMutable()->portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
-    batteryMetersConfigMutable()->current.offset = CURRENTOFFSET;
-    batteryMetersConfigMutable()->current.scale = CURRENTSCALE;
+    currentBatteryProfileMutable->batteryMeters.current.offset = CURRENTOFFSET;
+    currentBatteryProfileMutable->batteryMeters.current.scale = CURRENTSCALE;
 
     if (hardwareMotorType == MOTOR_BRUSHED) {
         motorConfigMutable()->motorPwmProtocol = PWM_TYPE_BRUSHED;

--- a/src/main/target/ALIENFLIGHTF4/config.c
+++ b/src/main/target/ALIENFLIGHTF4/config.c
@@ -60,8 +60,11 @@ void targetConfiguration(void)
     compassConfigMutable()->mag_align = CW90_DEG;
 
     serialConfigMutable()->portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
-    currentBatteryProfileMutable->batteryMeters.current.offset = CURRENTOFFSET;
-    currentBatteryProfileMutable->batteryMeters.current.scale = CURRENTSCALE;
+
+    for ( int i = 0; i < MAX_BATTERY_PROFILE_COUNT; i++ ) {
+        batteryProfilesMutable(i)->batteryMeters.current.offset = CURRENTOFFSET;
+        batteryProfilesMutable(i)->batteryMeters.current.scale = CURRENTSCALE;
+    }
 
     if (hardwareMotorType == MOTOR_BRUSHED) {
         motorConfigMutable()->motorPwmProtocol = PWM_TYPE_BRUSHED;

--- a/src/main/target/ALIENFLIGHTNGF7/config.c
+++ b/src/main/target/ALIENFLIGHTNGF7/config.c
@@ -62,8 +62,8 @@ void targetConfiguration(void)
     compassConfigMutable()->mag_align = CW90_DEG;
 
     serialConfigMutable()->portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
-    batteryMetersConfigMutable()->current.offset = CURRENTOFFSET;
-    batteryMetersConfigMutable()->current.scale = CURRENTSCALE;
+    currentBatteryProfileMutable->batteryMeters.current.offset = CURRENTOFFSET;
+    currentBatteryProfileMutable->batteryMeters.current.scale = CURRENTSCALE;
 
     if (hardwareMotorType == MOTOR_BRUSHED) {
         motorConfigMutable()->motorPwmRate = BRUSHED_MOTORS_PWM_RATE;

--- a/src/main/target/ALIENFLIGHTNGF7/config.c
+++ b/src/main/target/ALIENFLIGHTNGF7/config.c
@@ -62,8 +62,11 @@ void targetConfiguration(void)
     compassConfigMutable()->mag_align = CW90_DEG;
 
     serialConfigMutable()->portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
-    currentBatteryProfileMutable->batteryMeters.current.offset = CURRENTOFFSET;
-    currentBatteryProfileMutable->batteryMeters.current.scale = CURRENTSCALE;
+
+    for ( int i = 0; i < MAX_BATTERY_PROFILE_COUNT; i++ ) {
+        batteryProfilesMutable(i)->batteryMeters.current.offset = CURRENTOFFSET;
+        batteryProfilesMutable(i)->batteryMeters.current.scale = CURRENTSCALE;
+    }
 
     if (hardwareMotorType == MOTOR_BRUSHED) {
         motorConfigMutable()->motorPwmRate = BRUSHED_MOTORS_PWM_RATE;

--- a/src/main/target/FF_PIKOF4/config.c
+++ b/src/main/target/FF_PIKOF4/config.c
@@ -28,5 +28,7 @@
 void targetConfiguration(void)
 {
     rxConfigMutable()->halfDuplex = TRISTATE_OFF;
-    currentBatteryProfileMutable->batteryMeters.current.scale = CURRENTSCALE;
+    for ( int i = 0; i < MAX_BATTERY_PROFILE_COUNT; i++ ) {
+        batteryProfilesMutable(i)->batteryMeters.current.scale = CURRENTSCALE;
+    }
 }

--- a/src/main/target/FF_PIKOF4/config.c
+++ b/src/main/target/FF_PIKOF4/config.c
@@ -28,5 +28,5 @@
 void targetConfiguration(void)
 {
     rxConfigMutable()->halfDuplex = TRISTATE_OFF;
-    batteryMetersConfigMutable()->current.scale = CURRENTSCALE;
+    currentBatteryProfileMutable->batteryMeters.current.scale = CURRENTSCALE;
 }


### PR DESCRIPTION
Virtual current metter settings depend on battery voltage and on throttle_scale (which is already is battery profile). So theese parameters should be in battery profile too.
