### PR TITLE
allow HITL to run with HW baro failure

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -3478,7 +3478,9 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
 				DISABLE_ARMING_FLAG(SIMULATOR_MODE_HITL);
 
 #ifdef USE_BARO
+            if ( requestedSensors[SENSOR_INDEX_BARO] != BARO_NONE ) {
 				baroStartCalibration();
+            }
 #endif
 #ifdef USE_MAG
 				DISABLE_STATE(COMPASS_CALIBRATED);
@@ -3489,10 +3491,15 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
 
 				disarm(DISARM_SWITCH);  // Disarm to prevent motor output!!!
 			}   
-		} else if (!areSensorsCalibrating()) {
+        } else {
 			if (!ARMING_FLAG(SIMULATOR_MODE_HITL)) { // Just once
 #ifdef USE_BARO
-				baroStartCalibration();
+                if ( requestedSensors[SENSOR_INDEX_BARO] != BARO_NONE ) {
+                    sensorsSet(SENSOR_BARO);
+                    setTaskEnabled(TASK_BARO, true);
+                    DISABLE_ARMING_FLAG(ARMING_DISABLED_HARDWARE_FAILURE);
+				    baroStartCalibration();
+                }
 #endif			
 
 #ifdef USE_MAG

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -254,6 +254,12 @@ uint32_t baroUpdate(void)
 {
     static barometerState_e state = BAROMETER_NEEDS_SAMPLES;
 
+#ifdef USE_SIMULATOR
+    if (ARMING_FLAG(SIMULATOR_MODE_HITL)) {
+        return 0;
+    }
+#endif
+
     switch (state) {
         default:
         case BAROMETER_NEEDS_SAMPLES:
@@ -269,19 +275,13 @@ uint32_t baroUpdate(void)
 
         case BAROMETER_NEEDS_CALCULATION:
             if (baro.dev.get_up) {
-                baro.dev.get_up(&baro.dev);
+                 baro.dev.get_up(&baro.dev);
             }
             if (baro.dev.start_ut) {
                 baro.dev.start_ut(&baro.dev);
             }
-#ifdef USE_SIMULATOR
-            if (!ARMING_FLAG(SIMULATOR_MODE_HITL)) {
-                //output: baro.baroPressure, baro.baroTemperature
-                baro.dev.calculate(&baro.dev, &baro.baroPressure, &baro.baroTemperature);
-            }
-#else
+            //output: baro.baroPressure, baro.baroTemperature
             baro.dev.calculate(&baro.dev, &baro.baroPressure, &baro.baroTemperature);
-#endif
             state = BAROMETER_NEEDS_SAMPLES;
             return baro.dev.ut_delay;
         break;

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -275,7 +275,7 @@ uint32_t baroUpdate(void)
 
         case BAROMETER_NEEDS_CALCULATION:
             if (baro.dev.get_up) {
-                 baro.dev.get_up(&baro.dev);
+                baro.dev.get_up(&baro.dev);
             }
             if (baro.dev.start_ut) {
                 baro.dev.start_ut(&baro.dev);

--- a/src/main/sensors/diagnostics.c
+++ b/src/main/sensors/diagnostics.c
@@ -94,6 +94,17 @@ hardwareSensorStatus_e getHwCompassStatus(void)
 hardwareSensorStatus_e getHwBarometerStatus(void)
 {
 #if defined(USE_BARO)
+#ifdef USE_SIMULATOR
+	if (ARMING_FLAG(SIMULATOR_MODE_HITL) || ARMING_FLAG(SIMULATOR_MODE_SITL)) {
+        if (requestedSensors[SENSOR_INDEX_BARO] == BARO_NONE) {
+            return HW_SENSOR_NONE;
+        } else if (baroIsHealthy()) {
+            return HW_SENSOR_OK;
+        } else {
+            return HW_SENSOR_UNHEALTHY;
+        }
+	}
+#endif
     if (detectedSensors[SENSOR_INDEX_BARO] != BARO_NONE) {
         if (baroIsHealthy()) {
             return HW_SENSOR_OK;


### PR DESCRIPTION
This PR allows HITL to run on setups where baro sensor is selected in configuration, but:
- baro sensor is not present physically
- battery not connected, baro sensor is not powered from USB power
- battery not connected, baro sensor is locked by other hardware on I2C bus ( f.e. compass) which is not powered from USB power
