### PR TITLE
Fix mspSerialTxBytesFree() in msp_serial.c 

### DIFF
--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -139,7 +139,8 @@ static void resync(displayPort_t *displayPort)
 static uint32_t txBytesFree(const displayPort_t *displayPort)
 {
     UNUSED(displayPort);
-    return mspSerialTxBytesFree();
+    // Should be fixed if we ever get this thing to work
+    return UINT32_MAX;
 }
 
 static const displayPortVTable_t mspDisplayPortVTable = {

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -342,7 +342,7 @@ static int screenSize(const displayPort_t *displayPort)
 static uint32_t txBytesFree(const displayPort_t *displayPort)
 {
     UNUSED(displayPort);
-    return mspSerialTxBytesFree();
+    return mspSerialTxBytesFree(mspPort.port);
 }
 
 static bool getFontMetadata(displayFontMetadata_t *metadata, const displayPort_t *displayPort)

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -550,28 +550,9 @@ int mspSerialPush(uint8_t cmd, const uint8_t *data, int datalen)
     return ret; // return the number of bytes written
 }
 
-uint32_t mspSerialTxBytesFree(void)
+uint32_t mspSerialTxBytesFree(serialPort_t *port)
 {
-    uint32_t ret = UINT32_MAX;
-
-    for (int portIndex = 0; portIndex < MAX_MSP_PORT_COUNT; portIndex++) {
-        mspPort_t * const mspPort = &mspPorts[portIndex];
-        if (!mspPort->port) {
-            continue;
-        }
-
-        // XXX Kludge!!! Avoid zombie VCP port (avoid VCP entirely for now)
-        if (mspPort->port->identifier == SERIAL_PORT_USB_VCP) {
-            continue;
-        }
-
-        const uint32_t bytesFree = serialTxBytesFree(mspPort->port);
-        if (bytesFree < ret) {
-            ret = bytesFree;
-        }
-    }
-
-    return ret;
+   return serialTxBytesFree(port);
 }
 
 mspPort_t * mspSerialPortFind(const serialPort_t *serialPort)

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -107,5 +107,5 @@ void mspSerialAllocatePorts(void);
 void mspSerialReleasePortIfAllocated(struct serialPort_s *serialPort);
 int mspSerialPushPort(uint16_t cmd, const uint8_t *data, int datalen, mspPort_t *mspPort, mspVersion_e version);
 int mspSerialPush(uint8_t cmd, const uint8_t *data, int datalen);
-uint32_t mspSerialTxBytesFree(void);
+uint32_t mspSerialTxBytesFree(serialPort_t *port);
 mspPort_t * mspSerialPortFind(const struct serialPort_s *serialPort);


### PR DESCRIPTION
Currently only affects the CMS menu in SITL, wich did not work.
But mspSerialTxBytesFree() in msp_serial.c has so far returned the smallest free number of bytes of a port of ALL "normal" MSP ports (NOT OSD ports), which makes no sense (Has this ever made sense?). Has only worked because a normal MSP port was always registered and active. 