### PR TITLE
Update target.h

### DIFF
--- a/src/main/target/BETAFPVF722/target.h
+++ b/src/main/target/BETAFPVF722/target.h
@@ -61,7 +61,7 @@
 #define I2C_DEVICE_2_SHARES_UART3
 
 #define USE_BARO
-#define BARO_I2C_BUS            BUS_I2C1
+#define BARO_I2C_BUS            BUS_I2C2
 #define USE_BARO_BMP280
 #define USE_BARO_MS5611
 #define USE_BARO_BMP085


### PR DESCRIPTION
Enable external I2C2 barometer on shared UART3 Pins PB11, PB10. On BetaFPV722 FC. Tested with BMP280, BME280, DPS310, PLS25H.

BetaFlight BetaFPV722 no built-in barometer

https://www.facebook.com/photo/?fbid=6778379242190956&set=gm.1657873597988618&idorvanity=467150727060917