### PR TITLE
Update target.h

### DIFF
--- a/src/main/target/BETAFPVF722/target.h
+++ b/src/main/target/BETAFPVF722/target.h
@@ -61,7 +61,7 @@
 #define I2C_DEVICE_2_SHARES_UART3
 
 #define USE_BARO
-#define BARO_I2C_BUS            BUS_I2C1
+#define BARO_I2C_BUS            BUS_I2C2
 #define USE_BARO_BMP280
 #define USE_BARO_MS5611
 #define USE_BARO_BMP085


### PR DESCRIPTION
Allows the use of an external barometer. BetFPV722 does not have a built-in barometer. Tested with BMP/BME280, DPS310, LSP25H