### PR TITLE
Update Navigation.md

### DIFF
--- a/docs/Navigation.md
+++ b/docs/Navigation.md
@@ -4,11 +4,14 @@ The navigation system in INAV is responsible for assisting the pilot allowing al
 
 ## NAV ALTHOLD mode - altitude hold
 
-Altitude hold requires a valid source of altitude - barometer, GPS or rangefinder. The best source is chosen automatically. GPS is available as an altitude source for airplanes only.
+Altitude hold requires a valid source of altitude - barometer, GPS or rangefinder. The best source is chosen automatically. 
 In this mode THROTTLE stick controls climb rate (vertical velocity). When pilot moves stick up - quad goes up, pilot moves stick down - quad descends, you keep stick at neutral position - quad hovers.
+
+By default, GPS is available as an altitude source for airplanes only. Multirotor requires barometer, unless *inav_use_gps_no_baro* is enabled.
 
 ### CLI parameters affecting ALTHOLD mode:
 * *nav_use_midthr_for_althold* - when set to "0", firmware will remember where your throttle stick was when ALTHOLD was activated - this will be considered neutral position. When set to "1" - 50% throttle will be considered neutral position.
+* *inav_use_gps_no_baro* - Multirotor only: enable althold based on GPS only, without baromemer installed. Default is OFF. 
 
 ### Related PIDs
 PIDs affecting altitude hold: ALT & VEL
@@ -22,12 +25,13 @@ Throttle tilt compensation attempts to maintain constant vertical thrust when co
 
 ## NAV POSHOLD mode - position hold
 
-Position hold requires GPS, accelerometer and compass sensors. Flight modes that require a compass (POSHOLD, RTH) are locked until compass is properly calibrated.
+Position hold requires GPS, accelerometer and compass sensors. Multirotor requires barometer, unless *inav_use_gps_no_baro* is enabled. Flight modes that require a compass (POSHOLD, RTH) are locked until compass is properly calibrated.
 When activated, this mode will attempt to keep copter where it is (based on GPS coordinates). From INAV 2.0, POSHOLD is a full 3D position hold. Heading hold in this mode is assumed and activated automatically.
 
 ### CLI parameters affecting POSHOLD mode:
 * *nav_user_control_mode* - can be set to "0" (GPS_ATTI) or "1" (GPS_CRUISE), controls how firmware will respond to roll/pitch stick movement. When in GPS_ATTI mode, right stick controls attitude, when it is released, new position is recorded and held. When in GPS_CRUISE mode right stick controls velocity and firmware calculates required attitude on its own.
-
+* *inav_use_gps_no_baro* - Multirotor only: enable althold based on GPS only, without baromemer installed. Default is OFF. 
+ 
 ### Related PIDs
 PIDs affecting position hold: POS, POSR
 PID meaning:
@@ -38,9 +42,9 @@ PID meaning:
 
 Home for RTH is the position where vehicle was first armed. This position may be offset by the CLI settings `nav_rth_home_offset_distance` and `nav_rth_home_offset_direction`. This position may also be overridden with Safehomes. RTH requires accelerometer, compass and GPS sensors.
 
-If barometer is NOT present, RTH will fly directly to home, altitude control here is up to pilot.
+RTH requires barometer for multirotor, unless unless *inav_use_gps_no_baro* is enabled.
 
-If barometer is present, RTH will maintain altitude during the return. When home is reached, a copter will attempt automated landing. An airplane will either loiter around the home position, or attempt an automated landing, depending on your settings.
+RTH will maintain altitude during the return. When home is reached, a copter will attempt automated landing. An airplane will either loiter around the home position, or attempt an automated landing, depending on your settings.
 When deciding what altitude to maintain, RTH has 6 different modes of operation (controlled by *nav_rth_alt_mode* and *nav_rth_altitude* cli variables):
 * 0 (NAV_RTH_NO_ALT) - keep current altitude during whole RTH sequence (*nav_rth_altitude* is ignored)
 * 1 (NAV_RTH_EXTRA_ALT) - climb to current altitude plus extra margin prior to heading home (*nav_rth_altitude* defines the extra altitude (cm))


### PR DESCRIPTION
State that POSHOLD and ALTHOLD require baromenter on multirotor, unless *inav_use_gps_no_baro* is enabled.