### PR TITLE
Add MPU6000 accel/gyro for Foxeer F722 v4. Fixes #9059

### DIFF
--- a/src/main/target/FOXEERF722V4/target.h
+++ b/src/main/target/FOXEERF722V4/target.h
@@ -30,6 +30,12 @@
 
 #define USE_MPU_DATA_READY_SIGNAL
 
+// MPU6000
+#define USE_IMU_MPU6000
+#define IMU_MPU6000_ALIGN       CW270_DEG
+#define MPU6000_CS_PIN          PB2
+#define MPU6000_SPI_BUS         BUS_SPI1
+
 #define USE_IMU_ICM42605
 #define IMU_ICM42605_ALIGN      CW270_DEG
 #define ICM42605_SPI_BUS        BUS_SPI1


### PR DESCRIPTION
A newer variation of FOXEERF722V4 switched from ICM42605 to MPU6000 for accelerometer  No markings or other indications on the board show which is used other than the part number on the chip.  This PR adds MPU6000 support to the board's config.  Confirmed working on real hardware after change.