### PR TITLE
mavlink home position

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -593,7 +593,8 @@ void mavlinkSendPosition(timeUs_t currentTimeUs)
 
     mavlinkSendMessage();
 
-    mavlink_msg_gps_global_origin_pack(mavSystemId, mavComponentId, &mavSendMsg,
+    // TODO: Don't think we need this message
+    /*mavlink_msg_gps_global_origin_pack(mavSystemId, mavComponentId, &mavSendMsg,
         // latitude Latitude (WGS84), expressed as * 1E7
         GPS_home.lat,
         // longitude Longitude (WGS84), expressed as * 1E7
@@ -604,7 +605,26 @@ void mavlinkSendPosition(timeUs_t currentTimeUs)
         // Use millis() * 1000 as micros() will overflow after 1.19 hours.
         ((uint64_t) millis()) * 1000);
 
-    mavlinkSendMessage();
+    mavlinkSendMessage();*/
+
+    // See https://mavlink.io/en/messages/common.html#HOME_POSITION
+    bool inav_has_home=true; // TODO when is the inav home position set ?
+    if(inav_has_home){
+        float dummy_q[4]; // World to surface normal and heading transformation, doubt this is of use
+        mavlink_msg_home_position_pack(mavSystemId, mavComponentId, &mavSendMsg,
+            // latitude Latitude (WGS84), expressed as * 1E7
+            GPS_home.lat,
+            // longitude Longitude (WGS84), expressed as * 1E7
+            GPS_home.lon,
+            // altitude Altitude(WGS84), expressed as * 1000
+            GPS_home.alt * 10, // FIXME
+            0,0,0, // xyz unsupported
+            dummy_q, // also unsupported
+            0,0,0, // approach_x,y,z unsupported
+            ((uint64_t) millis()) * 1000);
+
+        mavlinkSendMessage();
+    }
 }
 #endif
 


### PR DESCRIPTION
I am quite sure that the message to publish the home position via mavlink is 
msg_home_position
(See https://mavlink.io/en/messages/common.html#HOME_POSITION)
Right now msg_gps_global_origin is published, which serves little to no purpose here.
Would definitely increase compability with QOpenHD, from a quick glance at QGroundControl I also cannot
find proper use of msg_gps_global_origin there.

NOTE: I am not familiar with inav code, so I just wrote out the dummy code. Please let me know if there is a way
to check if inav has a home position (otherwise, i'd just ommit the message).

Also, for reference, I quite like the current pattern of just sending those messages in regular intervals, hoping at some point one might get through. Bandwidth is not really a concern in mavlink (and otherwise, one would have to implement a request home position message response).