### PR TITLE
remove obsolete static_assert

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -330,13 +330,6 @@ static const OSD_Entry menuOsdElemsEntries[] =
     OSD_BACK_AND_END_ENTRY,
 };
 
-#if defined(USE_GPS) && defined(USE_BARO) && defined(USE_PITOT) && defined(USE_TEMPERATURE_SENSOR) && defined(USE_RX_MSP) && defined(USE_MSP_RC_OVERRIDE)
-// All CMS OSD elements should be enabled in this case. The menu has 2 extra
-// elements (label, back+end), but there's an OSD element that we intentionally
-// don't show here (OSD_DEBUG).
-_Static_assert(ARRAYLEN(menuOsdElemsEntries) - 2 + 1 == OSD_ITEM_COUNT, "missing OSD elements in CMS");
-#endif
-
 const CMS_Menu menuOsdElements = {
 #ifdef CMS_MENU_DEBUG
     .GUARD_text = "MENUOSDE",


### PR DESCRIPTION
Due to a myriad of OSD changes since the static_assert was introduced, the assert is now obsolete and it's only current  purpose is to prevent users easily compiling firmware with ` USE_MSP_RC_OVERRIDE` defined. 

Currently the difference between `ARRAYLEN(menuOsdElemsEntries)` and `OSD_ITEM_COUNT` is c. 40 and even if it could be revived, remains a maintenance burden.