### PR TITLE
[SITL] disable nagle for UART TCP

### DIFF
--- a/src/main/drivers/serial_tcp.c
+++ b/src/main/drivers/serial_tcp.c
@@ -37,6 +37,7 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <errno.h>
+#include <netinet/tcp.h>
 
 #include "common/utils.h"
 
@@ -147,6 +148,7 @@ static tcpPort_t *tcpReConfigure(tcpPort_t *port, uint32_t id)
 #endif
 
     int one = 1;
+    err = setsockopt(port->socketFd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     err = setsockopt(port->socketFd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
     err = fcntl(port->socketFd, F_SETFL, fcntl(port->socketFd, F_GETFL, 0) | O_NONBLOCK);
 


### PR DESCRIPTION
The SITL UART workload (small packets, essential half-duplex for MSP) performs badly on systems where Nagle is enabled by default.

This PR sets `TCP_NODELAY` on TCP (UART) sockets, resulting in an order of magnitude increase in `MSP` throughput. This is likely to be similar for other workloads, as they all use small packet sizes.

MSP test:
* Prior to this PR, typically c. 25 messages / second (c.f. 70 messages/second on real hardware/VCP). 
* After this PR, c. 1990 messages / second. 