### PR TITLE
[SITL] add missing BSD header from IP consolidation

### DIFF
--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -38,6 +38,7 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <netinet/in.h>
 
 #include <platform.h>
 #include "target.h"


### PR DESCRIPTION
Required on FreeBSD, alas