### PR TITLE
fix conflicting types

### DIFF
--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -218,7 +218,7 @@ static void flashConfigurePartitions(void)
 #endif
 }
 
-flashPartition_t *flashPartitionFindByType(uint8_t type)
+flashPartition_t *flashPartitionFindByType(flashPartitionType_e type)
 {
     for (int index = 0; index < FLASH_MAX_PARTITIONS; index++) {
         flashPartition_t *candidate = &flashPartitionTable.partitions[index];


### PR DESCRIPTION
gcc 13.1.1 reports a (mainly harmless) conflicting type:
```
/src/main/drivers/flash.c:221:19: warning: conflicting types for 'flashPartitionFindByType' due to enum/integer mismatch; have 'flashPartition_t *(uint8_t)' {aka 'struct flashPartition_s *(unsigned char)'} [-Wenum-int-mismatch]
  221 | flashPartition_t *flashPartitionFindByType(uint8_t type)
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./src/main/drivers/flash.c:31:
./src/main/drivers/flash.h:101:19: note: previous declaration of 'flashPartitionFindByType' with type 'flashPartition_t *(flashPartitionType_e)' {aka 'struct flashPartition_s *(flashPartitionType_e)'}
  101 | flashPartition_t *flashPartitionFindByType(flashPartitionType_e type);
      |  
```

So let's fix it ... 