### PR TITLE
Set 10Hz update rate for M9 and M10 gps devices by default and allow higher refresh rates

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1422,6 +1422,16 @@ Which SBAS mode to be used
 
 ---
 
+### gps_ublox7_nav_hz
+
+Navigation update rate for UBLOX7 receivers. Some receivers may limit the maximum number of satellites tracked when the value is too high.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 10 | 5 | 200 |
+
+---
+
 ### gps_ublox_use_galileo
 
 Enable use of Galileo satellites. This is at the expense of other regional constellations, so benefit may also be regional. Requires M8N and Ublox firmware 3.x (or later) [OFF/ON].

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1422,7 +1422,7 @@ Which SBAS mode to be used
 
 ---
 
-### gps_ublox7_nav_hz
+### gps_ublox_nav_hz
 
 Navigation update rate for UBLOX7 receivers. Some receivers may limit the maximum number of satellites tracked when the value is too high.
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1424,7 +1424,7 @@ Which SBAS mode to be used
 
 ### gps_ublox_nav_hz
 
-Navigation update rate for UBLOX7 receivers. Some receivers may limit the maximum number of satellites tracked when the value is too high.
+Navigation update rate for UBLOX7 receivers. Some receivers may limit the maximum number of satellites tracked when set to a higher rate or even stop sending navigation updates if the value is too high. Some M10 devices can do up to 25Hz. 10 is a safe value for M8 and newer.
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1544,7 +1544,7 @@ groups:
         min: 5
         max: 10
       - name: gps_ublox_nav_hz
-        description: "Navigation update rate for UBLOX7 receivers. Some receivers may limit the maximum number of satellites tracked when the value is too high."
+        description: "Navigation update rate for UBLOX7 receivers. Some receivers may limit the maximum number of satellites tracked when set to a higher rate or even stop sending navigation updates if the value is too high. Some M10 devices can do up to 25Hz. 10 is a safe value for M8 and newer."
         default_value: 10
         field: ubloxNavHz
         type: uint8_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1543,7 +1543,7 @@ groups:
         field: gpsMinSats
         min: 5
         max: 10
-      - name: gps_ublox7_nav_hz
+      - name: gps_ublox_nav_hz
         description: "Navigation update rate for UBLOX7 receivers. Some receivers may limit the maximum number of satellites tracked when the value is too high."
         default_value: 10
         field: ubloxNavHz

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1543,6 +1543,14 @@ groups:
         field: gpsMinSats
         min: 5
         max: 10
+      - name: gps_ublox7_nav_hz
+        description: "Navigation update rate for UBLOX7 receivers. Some receivers may limit the maximum number of satellites tracked when the value is too high."
+        default_value: 10
+        field: ubloxNavHz
+        type: uint8_t
+        min: 5
+        max: 200
+
 
   - name: PG_RC_CONTROLS_CONFIG
     type: rcControlsConfig_t

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -122,7 +122,7 @@ PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .dynModel = SETTING_GPS_DYN_MODEL_DEFAULT,
     .gpsMinSats = SETTING_GPS_MIN_SATS_DEFAULT,
     .ubloxUseGalileo = SETTING_GPS_UBLOX_USE_GALILEO_DEFAULT,
-    .ubloxNavHz = SETTING_GPS_UBLOX7_NAV_HZ_DEFAULT
+    .ubloxNavHz = SETTING_GPS_UBLOX_NAV_HZ_DEFAULT
 );
 
 void gpsSetState(gpsState_e state)

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -121,7 +121,8 @@ PG_RESET_TEMPLATE(gpsConfig_t, gpsConfig,
     .autoBaud = SETTING_GPS_AUTO_BAUD_DEFAULT,
     .dynModel = SETTING_GPS_DYN_MODEL_DEFAULT,
     .gpsMinSats = SETTING_GPS_MIN_SATS_DEFAULT,
-    .ubloxUseGalileo = SETTING_GPS_UBLOX_USE_GALILEO_DEFAULT
+    .ubloxUseGalileo = SETTING_GPS_UBLOX_USE_GALILEO_DEFAULT,
+    .ubloxNavHz = SETTING_GPS_UBLOX7_NAV_HZ_DEFAULT
 );
 
 void gpsSetState(gpsState_e state)

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -94,6 +94,7 @@ typedef struct gpsConfig_s {
     gpsDynModel_e dynModel;
     bool ubloxUseGalileo;
     uint8_t gpsMinSats;
+    uint8_t ubloxNavHz;
 } gpsConfig_t;
 
 PG_DECLARE(gpsConfig_t, gpsConfig);

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -816,7 +816,7 @@ static bool gpsNewFrameUBLOX(uint8_t data)
     return parsed;
 }
 
-uint16_t hz2rate(uint8_t hz)
+static uint16_t hz2rate(uint8_t hz)
 {
     return 1000 / hz;
 }

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -816,6 +816,11 @@ static bool gpsNewFrameUBLOX(uint8_t data)
     return parsed;
 }
 
+uint16_t hz2rate(uint8_t hz)
+{
+    return 1000 / hz;
+}
+
 STATIC_PROTOTHREAD(gpsConfigure)
 {
     ptBegin(gpsConfigure);
@@ -886,7 +891,7 @@ STATIC_PROTOTHREAD(gpsConfigure)
         ptWait(_ack_state == UBX_ACK_GOT_ACK);
 
         if ((gpsState.gpsConfig->provider == GPS_UBLOX7PLUS) && (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX7)) {
-            configureRATE(100); // 10Hz
+            configureRATE(hd2rate(gpsState.gpsConfig->ubloxNavHz)); // defautl 10Hz
         } else {
             configureRATE(200); // 5Hz
         }
@@ -918,7 +923,7 @@ STATIC_PROTOTHREAD(gpsConfigure)
             ptWait(_ack_state == UBX_ACK_GOT_ACK);
 
             if ((gpsState.gpsConfig->provider == GPS_UBLOX7PLUS) && (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX7)) {
-                configureRATE(100); // 10Hz
+                configureRATE(hd2rate(gpsState.gpsConfig->ubloxNavHz)); // defautl 10Hz
             }
             else {
                 configureRATE(200); // 5Hz

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -891,7 +891,7 @@ STATIC_PROTOTHREAD(gpsConfigure)
         ptWait(_ack_state == UBX_ACK_GOT_ACK);
 
         if ((gpsState.gpsConfig->provider == GPS_UBLOX7PLUS) && (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX7)) {
-            configureRATE(hz2rate(gpsState.gpsConfig->ubloxNavHz)); // defautl 10Hz
+            configureRATE(hz2rate(gpsState.gpsConfig->ubloxNavHz)); // default 10Hz
         } else {
             configureRATE(200); // 5Hz
         }
@@ -923,7 +923,7 @@ STATIC_PROTOTHREAD(gpsConfigure)
             ptWait(_ack_state == UBX_ACK_GOT_ACK);
 
             if ((gpsState.gpsConfig->provider == GPS_UBLOX7PLUS) && (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX7)) {
-                configureRATE(hz2rate(gpsState.gpsConfig->ubloxNavHz)); // defautl 10Hz
+                configureRATE(hz2rate(gpsState.gpsConfig->ubloxNavHz)); // default 10Hz
             }
             else {
                 configureRATE(200); // 5Hz

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -891,7 +891,7 @@ STATIC_PROTOTHREAD(gpsConfigure)
         ptWait(_ack_state == UBX_ACK_GOT_ACK);
 
         if ((gpsState.gpsConfig->provider == GPS_UBLOX7PLUS) && (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX7)) {
-            configureRATE(hd2rate(gpsState.gpsConfig->ubloxNavHz)); // defautl 10Hz
+            configureRATE(hz2rate(gpsState.gpsConfig->ubloxNavHz)); // defautl 10Hz
         } else {
             configureRATE(200); // 5Hz
         }
@@ -923,7 +923,7 @@ STATIC_PROTOTHREAD(gpsConfigure)
             ptWait(_ack_state == UBX_ACK_GOT_ACK);
 
             if ((gpsState.gpsConfig->provider == GPS_UBLOX7PLUS) && (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX7)) {
-                configureRATE(hd2rate(gpsState.gpsConfig->ubloxNavHz)); // defautl 10Hz
+                configureRATE(hz2rate(gpsState.gpsConfig->ubloxNavHz)); // defautl 10Hz
             }
             else {
                 configureRATE(200); // 5Hz

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -885,9 +885,11 @@ STATIC_PROTOTHREAD(gpsConfigure)
         configureMSG(MSG_CLASS_UBX, MSG_NAV_SIG, 0);
         ptWait(_ack_state == UBX_ACK_GOT_ACK);
 
-        // u-Blox 9 receivers such as M9N can do 10Hz as well, but the number of used satellites will be restricted to 16.
-        // Not mentioned in the datasheet
-        configureRATE(200);
+        if ((gpsState.gpsConfig->provider == GPS_UBLOX7PLUS) && (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX7)) {
+            configureRATE(100); // 10Hz
+        } else {
+            configureRATE(200); // 5Hz
+        }
         ptWait(_ack_state == UBX_ACK_GOT_ACK);
     }
     else {

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -895,7 +895,12 @@ STATIC_PROTOTHREAD(gpsConfigure)
         } else {
             configureRATE(200); // 5Hz
         }
-        ptWait(_ack_state == UBX_ACK_GOT_ACK);
+        ptWait(_ack_state == UBX_ACK_GOT_ACK || _ack_state == UBX_ACK_GOT_NAK);
+
+        if(_ack_state == UBX_ACK_GOT_NAK) { // Fallback to safe 5Hz in case of error
+            configureRATE(200); // 5Hz
+            ptWait(_ack_state == UBX_ACK_GOT_ACK);
+        }
     }
     else {
         // u-Blox 5/6/7/8 or unknown
@@ -928,7 +933,12 @@ STATIC_PROTOTHREAD(gpsConfigure)
             else {
                 configureRATE(200); // 5Hz
             }
-            ptWait(_ack_state == UBX_ACK_GOT_ACK);
+            ptWait(_ack_state == UBX_ACK_GOT_ACK || _ack_state == UBX_ACK_GOT_NAK);
+
+            if(_ack_state == UBX_ACK_GOT_NAK) { // Fallback to safe 5Hz in case of error
+                configureRATE(200); // 5Hz
+                ptWait(_ack_state == UBX_ACK_GOT_ACK);
+            }
         }
         // u-Blox 5/6 doesn't support PVT, use legacy config
         // UNKNOWN also falls here, use as a last resort


### PR DESCRIPTION
Update rate of M9 was limited to 5Hz to enable tracking of more than 16 satellites but m10 does not appear to have such limitation.

Position hold also seems to work better with an update rate of 10Hz.

This will change the behavior of M9 and newer devices to match M5-8, enabling 10Hz when using UBLOX7 and limiting it to 5Hz when using regular UBLOX.

Is it also possible to set a custom navigation update rate in UBLOX7 to support even higher update rates, like 25Hz on M10 devices, or 5Hz for M9 devices.

```
set gps_ublox_nav_hz = 25
```

In case the user specified a refresh rate that is rejected by the GPS module it will fall back to 5Hz.