### PR TITLE
Remove brew update step for SITL mac build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          brew update
           brew install cmake ninja ruby
 
       - name: Setup environment


### PR DESCRIPTION
It is currently failing and is not really required for SITL builds.