### PR TITLE
reenable LTO for MacOS firmware builds

### DIFF
--- a/cmake/main.cmake
+++ b/cmake/main.cmake
@@ -83,7 +83,7 @@ function(setup_executable exe name)
     set_target_properties(${exe} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
     )
-    if(IS_RELEASE_BUILD AND NOT CMAKE_HOST_APPLE)
+    if(IS_RELEASE_BUILD AND NOT (CMAKE_HOST_APPLE AND SITL))
         set_target_properties(${exe} PROPERTIES
             INTERPROCEDURAL_OPTIMIZATION ON
         )


### PR DESCRIPTION
Fixes the firmware build regression from #9082, retaining no-lto for MacOS SITL builds. Fixes #9134