### PR TITLE
Use USER $USER_ID, in case a user already exists with the specified UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install pyyaml
 RUN addgroup --gid $GROUP_ID inav; exit 0;
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID inav; exit 0;
 
-USER inav
+USER $USER_ID
 RUN git config --global --add safe.directory /src
 
 VOLUME /src


### PR DESCRIPTION
Docker build triggered by build.sh may fail if a user already exists with the same UID as the current user as it tries to switch to the inav user which was not created.

This will specify the UID instead of the username in docker.

