### PR TITLE
fixed beeper -ON_USB for 1S setup, fixed beeper -SYSTEM_INIT

### DIFF
--- a/docs/Buzzer.md
+++ b/docs/Buzzer.md
@@ -62,12 +62,14 @@ beeper list
 giving:
 
 ```
-Available:  RUNTIME_CALIBRATION  HW_FAILURE  RX_LOST  RX_LOST_LANDING  DISARMING  ARMING  ARMING_GPS_FIX  BAT_CRIT_LOW  BAT_LOW  GPS_STATUS  RX_SET  ACTION_SUCCESS  ACTION_FAIL  READY_BEEP  MULTI_BEEPS  DISARM_REPEAT  ARMED  SYSTEM_INIT  ON_USB  LAUNCH_MODE  CAM_CONNECTION_OPEN  CAM_CONNECTION_CLOSED  ALL  PREFERED
+Available:  RUNTIME_CALIBRATION  HW_FAILURE  RX_LOST  RX_LOST_LANDING  DISARMING  ARMING  ARMING_GPS_FIX  BAT_CRIT_LOW
+BAT_LOW  GPS_STATUS  RX_SET  ACTION_SUCCESS  ACTION_FAIL  READY_BEEP  MULTI_BEEPS  DISARM_REPEAT  ARMED  SYSTEM_INIT
+ON_USB LAUNCH_MODE  CAM_CONNECTION_OPEN  CAM_CONNECTION_CLOSED  ALL  PREFERED
 ```
 
 The `beeper` command  syntax follows that of the `feature` command; a minus (`-`) in front of a name disables that function.
 
-So to disable the beeper / buzzer when connected to USB (may enhance domestic harmony)
+So to disable the beeper / buzzer when 	powered by USB (may enhance domestic harmony):
 
 ```
 beeper -ON_USB
@@ -78,8 +80,28 @@ Now the `beeper` command will show:
 ```
 # beeper
 Disabled:  ON_USB
+```
+
+*Note: SYSTEM_INIT sequence is not affected by ON_USB setting and will still be played on USB connection. Disable both ON_USB and SYSTEM_INIT to disable buzzer completely when FC is powered from USB.*
+
+*Note: ON_USB setting requires present and configured battery voltage metter.*
+
+To disable all features use:
 
 ```
+beeper -ALL
+```
+
+To store current set to preferences use (preferences also require ```save```):
+
+```
+beeper PREFERED
+```
+
+To restore set from preferences use:
+
+```
+beeper -PREFERED
 
 As with other CLI commands, the `save` command is needed to save the new settings.
 

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -174,7 +174,7 @@ void flashLedsAndBeep(void)
         LED1_TOGGLE;
         LED0_TOGGLE;
         delay(25);
-        if (!(getPreferredBeeperOffMask() & (1 << (BEEPER_SYSTEM_INIT - 1))))
+        if (!(getBeeperOffMask() & (1 << (BEEPER_SYSTEM_INIT - 1))))
             BEEP_ON;
         delay(25);
         BEEP_OFF;

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -218,7 +218,7 @@ static const beeperTableEntry_t *currentBeeperEntry = NULL;
  */
 void beeper(beeperMode_e mode)
 {
-    if (mode == BEEPER_SILENCE || ((getBeeperOffMask() & (1 << (BEEPER_USB-1))) && (feature(FEATURE_VBAT) && (getBatteryCellCount() < 2))) || IS_RC_MODE_ACTIVE(BOXBEEPERMUTE)) {
+    if (mode == BEEPER_SILENCE || ((getBeeperOffMask() & (1 << (BEEPER_USB-1))) && (feature(FEATURE_VBAT) && (getBatteryState() == BATTERY_NOT_PRESENT))) || IS_RC_MODE_ACTIVE(BOXBEEPERMUTE)) {
         beeperSilence();
         return;
     }

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -199,7 +199,7 @@ PG_RESET_TEMPLATE(batteryMetersConfig_t, batteryMetersConfig,
 void batteryInit(void)
 {
     batteryState = BATTERY_NOT_PRESENT;
-    batteryCellCount = 1;
+    batteryCellCount = 0;
     batteryFullVoltage = 0;
     batteryWarningVoltage = 0;
     batteryCriticalVoltage = 0;


### PR DESCRIPTION
This submit fixes two issues:

**- beeper -ON_USB silences beeper completely on 1S setup.**
IS: ```getBatteryCount()<2``` is used to  check if battery is disconnected
SHOULD: ```getBatteryState() == BATTERY_NOT_PRESENT``` should be used instead.

**- beeper -SYSTEM_INIT does not disable system init sound.**
IS: ```SYSTEM_INIT``` flag is read from ```beeper PREFERENCES``` for unknown reason.
SHOULD: ```getBeeperOffMask()``` should be used

Note: ```ON_USB``` was described as silencing when USB is connected. Actually it silences when battery is disconnected (so FC is powered from USB).

Note: System init sound is not influenced by ```ON_USB``` because system init sound is played before battery sensor is configured - Ok.

Note: I guess that on some FCs battery sensor may (incorrectly) sense USB voltage, and thus battery sensor can detect 1S battery. Well, on these targets ```ON_USB``` will not work. From the beeper part, code is correct. If workaround is reqired, it should be in battery sensor code, not in beeper code: ```getBatteryState() == BATTERY_NOT_PRESENT``` should work correctly.

Sidenote: personally I would remove ```beeper PREFERENCES``` as redundand feature.