### PR TITLE
NAV PID loop I term wind up fix

### DIFF
--- a/src/main/common/fp_pid.c
+++ b/src/main/common/fp_pid.c
@@ -40,9 +40,9 @@ float navPidApply3(
     const float dt,
     const float outMin,
     const float outMax,
+    pidControllerFlags_e pidFlags,
     const float gainScaler,
-    const float dTermScaler,
-    pidControllerFlags_e pidFlags
+    const float dTermScaler
 ) {
     float newProportional, newDerivative, newFeedForward;
     float error = 0.0f;

--- a/src/main/common/fp_pid.h
+++ b/src/main/common/fp_pid.h
@@ -70,7 +70,7 @@ float navPidApply3(
     const float dt,
     const float outMin,
     const float outMax,
-    const pidControllerFlags_e pidFlags,
+    pidControllerFlags_e pidFlags,
     const float gainScaler,
     const float dTermScaler
 );


### PR DESCRIPTION
Closes https://github.com/iNavFlight/inav/issues/9026.

Resets I term in Nav PID controller when P term saturated which avoids I term wind up upsetting Nav PID loop when Nav target conditions change.

Tested on HITL sim OK for fixed wing. Needs testing for multirotor.