### PR TITLE
Fix: Inav 7.0.0 last build not working on SPEEDYBEEF405V3

### DIFF
--- a/src/main/drivers/sdcard/sdcard_spi.c
+++ b/src/main/drivers/sdcard/sdcard_spi.c
@@ -453,7 +453,6 @@ static bool sdcardSpi_poll(void)
     doMore:
     switch (sdcard.state) {
         case SDCARD_STATE_RESET:
-            busSetSpeed(sdcard.dev, BUS_SPEED_INITIALIZATION);
             sdcardSpi_select();
 
             initStatus = sdcardSpi_sendCommand(SDCARD_COMMAND_GO_IDLE_STATE, 0);
@@ -476,8 +475,6 @@ static bool sdcardSpi_poll(void)
         break;
 
         case SDCARD_STATE_CARD_INIT_IN_PROGRESS:
-            busSetSpeed(sdcard.dev, BUS_SPEED_INITIALIZATION);
-
             if (sdcardSpi_checkInitDone()) {
                 if (sdcard.version == 2) {
                     // Check for high capacity card
@@ -516,8 +513,6 @@ static bool sdcardSpi_poll(void)
             busSetSpeed(sdcard.dev, BUS_SPEED_STANDARD);
         break;
         case SDCARD_STATE_INITIALIZATION_RECEIVE_CID:
-            busSetSpeed(sdcard.dev, BUS_SPEED_INITIALIZATION);
-
             if (sdcardSpi_receiveCID()) {
                 sdcardSpi_deselect();
 
@@ -881,8 +876,6 @@ void sdcardSpi_init(void)
     sdcard.operationStartTime = millis();
     sdcard.state = SDCARD_STATE_RESET;
     sdcard.failureCount = 0;
-
-    busSetSpeed(sdcard.dev, BUS_SPEED_STANDARD);
 }
 
 sdcardVTable_t sdcardSpiVTable = {


### PR DESCRIPTION
Bug appears if you use analog OSD on SPEEDYBEEF405V3 and do not insert sd card.
SD card try to initialise many times and eche time slow down SPI bus speed, but analog OSD works on same SPI bus. When spi slow down, analog OSD slow and increase pid loop. It make unstabile gyro calibration. That fix restore standard bus speed after first attempt.
Fix #9153 