### PR TITLE
[SITL] suppress spurious linker warning with gcc12+

### DIFF
--- a/cmake/sitl.cmake
+++ b/cmake/sitl.cmake
@@ -59,7 +59,9 @@ if(NOT MACOSX)
         -Wno-error=maybe-uninitialized
         -fsingle-precision-constant
     )
-    set(SITL_LINK_OPTIONS ${SITL_LINK_OPTIONS} "-Wl,--no-warn-rwx-segments")
+    if (CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 12.0)
+        set(SITL_LINK_OPTIONS ${SITL_LINK_OPTIONS} "-Wl,--no-warn-rwx-segments")
+    endif()
 else()
     set(SITL_COMPILE_OPTIONS ${SITL_COMPILE_OPTIONS}
     )

--- a/cmake/sitl.cmake
+++ b/cmake/sitl.cmake
@@ -59,6 +59,7 @@ if(NOT MACOSX)
         -Wno-error=maybe-uninitialized
         -fsingle-precision-constant
     )
+    set(SITL_LINK_OPTIONS ${SITL_LINK_OPTIONS} "-Wl,--no-warn-rwx-segments")
 else()
     set(SITL_COMPILE_OPTIONS ${SITL_COMPILE_OPTIONS}
     )


### PR DESCRIPTION
gcc 12 and later generate a mainly useless linker warning:

```
warning: <TARGET>.elf has a LOAD segment with RWX permissions
```
For the SITL, ex-MacOS, suppress this.

Tested on:

* Arch Linux (gcc 13.1.1)
* FreeBSD (gcc 13.0.1)
* Cygwin (gcc 11.3)
* MacOS (clang)

Note: If it is ever possible to build reliable firmware with `cmake` and gcc 12 or later, the same directive may be applied to firmware builds.