### PR TITLE
prevent opposite i-term accumulation in nav pid

### DIFF
--- a/src/main/common/fp_pid.c
+++ b/src/main/common/fp_pid.c
@@ -90,7 +90,7 @@ float navPidApply3(
     newFeedForward = setpoint * pid->param.kFF * gainScaler;
 
     /* Pre-calculate output and limit it if actuator is saturating */
-    const float outVal = newProportional + (pid->integrator * gainScaler) + newDerivative + newFeedForward;
+    const float outVal = constrainf(newProportional + newDerivative + newFeedForward, outMin, outMax) + (pid->integrator * gainScaler);
     const float outValConstrained = constrainf(outVal, outMin, outMax);
 
     pid->proportional = newProportional;

--- a/src/main/common/fp_pid.c
+++ b/src/main/common/fp_pid.c
@@ -89,7 +89,8 @@ float navPidApply3(
      */
     newFeedForward = setpoint * pid->param.kFF * gainScaler;
 
-    /* Pre-calculate output and limit it if actuator is saturating */
+    /* Pre-calculate output and limit it if actuator is saturating,
+    constrainf the PDFF output to prevent opposite integrator accumulation by ((outValConstrained - outVal) * pid->param.kT * dt)*/ 
     const float outVal = constrainf(newProportional + newDerivative + newFeedForward, 2.0f * outMin, 2.0f * outMax) + (pid->integrator * gainScaler);
     const float outValConstrained = constrainf(outVal, outMin, outMax);
 

--- a/src/main/common/fp_pid.c
+++ b/src/main/common/fp_pid.c
@@ -90,7 +90,7 @@ float navPidApply3(
     newFeedForward = setpoint * pid->param.kFF * gainScaler;
 
     /* Pre-calculate output and limit it if actuator is saturating */
-    const float outVal = constrainf(newProportional + newDerivative + newFeedForward, outMin, outMax) + (pid->integrator * gainScaler);
+    const float outVal = constrainf(newProportional + newDerivative + newFeedForward, 2.0f * outMin, 2.0f * outMax) + (pid->integrator * gainScaler);
     const float outValConstrained = constrainf(outVal, outMin, outMax);
 
     pid->proportional = newProportional;


### PR DESCRIPTION
Closes #9026
replace #9159

New method here #9224 
Prevent opposite iterm accumulation in nav pid controller when nav pid controller is saturated a lot. but this will deteriorate anti-windup performance. Still looking for a smarter may

From here we can see the real problem is opposite i-term accumulation, It should be positive all the time. But it is negative in this video
https://github.com/iNavFlight/inav/issues/9026#issuecomment-1532865999
![image](https://github.com/iNavFlight/inav/assets/38871576/590cd2a4-ec22-4b1e-9818-98f8ddcf56ea)

TEST in SITL, waypoint altitude setting is 1000m
https://youtu.be/mPif0hbwtpg