### PR TITLE
Fix for #9225, some OSD elements are skipped incorrectly, when GPS is not present.

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3552,10 +3552,10 @@ uint8_t osdIncElementIndex(uint8_t elementIndex)
             elementIndex = OSD_AIR_MAX_SPEED;
         }
         if (elementIndex == OSD_GLIDE_RANGE) {
-            elementIndex = feature(FEATURE_CURRENT_METER) ? OSD_CLIMB_EFFICIENCY : OSD_ITEM_COUNT;
+            elementIndex = feature(FEATURE_CURRENT_METER) ? OSD_CLIMB_EFFICIENCY : OSD_PILOT_NAME;
         }
         if (elementIndex == OSD_NAV_WP_MULTI_MISSION_INDEX) {
-            elementIndex = OSD_ITEM_COUNT;
+            elementIndex = OSD_PILOT_NAME;
         }
     }
 


### PR DESCRIPTION
Fixes #9225
Replaces #9228

Skipping to OSD_ITEM_COUNT ignores new OSD elements

Any OSD elements after OSD_NAV_WP_MULTI_MISSION_INDEX are skipped, if GPS feature is disabled.

This fix this and allows newer elements to be rendered, even with GPS feature disabled.