### PR TITLE
Update Building in Windows 10 or 11 with Linux Subsystem.md

### DIFF
--- a/docs/development/Building in Windows 10 or 11 with Linux Subsystem.md
+++ b/docs/development/Building in Windows 10 or 11 with Linux Subsystem.md
@@ -26,7 +26,7 @@ Install Git, Make, gcc and Ruby
 -  `sudo apt-get install git make cmake ruby`
 
 Install python and python-yaml to allow updates to settings.md
--  `sudo apt-get install python3 python-yaml`
+-  `sudo apt-get install python3`
 
 ### CMAKE and Ubuntu 18_04
 


### PR DESCRIPTION
Removed "python-yaml" as it is now python3-yaml in WSL Ubuntu 22.01, which is apparently included with python3. Keeping "python-yaml" results in an error message, "Package python-yaml is not available, but is referred to by another package. This may mean that the package is missing, has been obsoleted, or is only available from another source"