### PR TITLE
[AOCODARCF4V2]: Unset USE_TARGET_CONFIG

### DIFF
--- a/src/main/target/AOCODARCF4V2/target.h
+++ b/src/main/target/AOCODARCF4V2/target.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#define USE_TARGET_CONFIG
 
 #define TARGET_BOARD_IDENTIFIER         "AOF4V2"
 #define USBD_PRODUCT_STRING             "AocodaRCF4V2"


### PR DESCRIPTION
This seems to fix the missing accel. detection
as reported in #9217