### PR TITLE
Ignore tasks.json and use tabs in C files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ README.pdf
 # local changes only
 make/local.mk
 launch.json
+.vscode/tasks.json
+.vscode/c_cpp_properties.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
         "ranges": "c"
     },
     "editor.tabSize": 4,
-    "editor.insertSpaces": false,
+    "editor.insertSpaces": true,
     "editor.detectIndentation": false,
     "editor.expandTabs": true,
     "C_Cpp.clang_format_fallbackStyle": "{ BasedOnStyle: Google, IndentWidth: 4,  BreakBeforeBraces: Mozilla }"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
         "ranges": "c"
     },
     "editor.tabSize": 4,
-    "editor.insertSpaces": true,
+    "editor.insertSpaces": false,
     "editor.detectIndentation": false,
     "editor.expandTabs": true,
     "C_Cpp.clang_format_fallbackStyle": "{ BasedOnStyle: Google, IndentWidth: 4,  BreakBeforeBraces: Mozilla }"


### PR DESCRIPTION
Added ignore flags for
- .vscode\tasks.json
- .vscode\c_cpp_properties.json

Changed settings.json to use tabs, not spaces for C file types.