### PR TITLE
Enable the virtual pitot by default

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4838,7 +4838,7 @@ Selection of pitot hardware.
 
 | Default | Min | Max |
 | --- | --- | --- |
-| NONE |  |  |
+| VIRTUAL |  |  |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -588,7 +588,7 @@ groups:
     members:
       - name: pitot_hardware
         description: "Selection of pitot hardware."
-        default_value: "NONE"
+        default_value: "VIRTUAL"
         table: pitot_hardware
       - name: pitot_lpf_milli_hz
         min: 0


### PR DESCRIPTION
This PR enables the virtual pitot by default. Since the huge improvement in accuracy in 6.0. The virtual pitot is now extremely useful. Currently for wind estimation. But, by enabling the virtual pitot by default, it paves the way for more changes based on airspeed. Such as using Airspeed PID Attenuation, instead of Throttle PID Attenuation. Throttle PID Attenuation can give completely inappropriate PIDs in some situations. For example, a low throttle dive, with a fast airspeed.

This change is obviously beneficial for fixed wing. The general consensus is that it would not have any negative effects on other platforms. [Discussion starts here](https://discord.com/channels/791437907478577172/797176904414658560/1143470488794959952). @mmosca did you get the chance to fly your quad with virtual pitot enabled?