### PR TITLE
IPF: Add yaw operand to go with pitch and roll

### DIFF
--- a/docs/Programming Framework.md
+++ b/docs/Programming Framework.md
@@ -152,6 +152,9 @@ IPF can be edited using INAV Configurator user interface, or via CLI. To use COn
 | 35            | AGL_STATUS                    | boolean `1` when AGL can be trusted, `0` when AGL estimate can not be trusted |
 | 36            | AGL                           | integer Above The Groud Altitude in `cm` |
 | 37            | RANGEFINDER_RAW               | integer raw distance provided by the rangefinder in `cm` |
+| 38            | ACTIVE_MIXER_PROFILE          | Which mixers are currently active (for vtol etc) |
+| 39            | MIXER_TRANSITION_ACTIVE       | Currently switching between mixers (quad to plane etc) |
+| 40            | ATTITUDE_YAW                  | current heading (yaw) in `degrees` |
 
 #### FLIGHT_MODE
 

--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -704,6 +704,10 @@ static int logicConditionGetFlightOperandValue(int operand) {
             return constrain(attitude.values.pitch / 10, -180, 180);
             break;
 
+        case LOGIC_CONDITION_OPERAND_FLIGHT_ATTITUDE_YAW: // deg
+            return constrain(attitude.values.yaw / 10, 0, 360);
+            break;
+
         case LOGIC_CONDITION_OPERAND_FLIGHT_IS_ARMED: // 0/1
             return ARMING_FLAG(ARMED) ? 1 : 0;
             break;

--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -135,8 +135,9 @@ typedef enum {
     LOGIC_CONDITION_OPERAND_FLIGHT_AGL_STATUS, //0,1,2                      // 35
     LOGIC_CONDITION_OPERAND_FLIGHT_AGL, //0,1,2                             // 36
     LOGIC_CONDITION_OPERAND_FLIGHT_RANGEFINDER_RAW, //int                   // 37
-    LOGIC_CONDITION_OPERAND_FLIGHT_ACTIVE_MIXER_PROFILE, //int              // 39
-    LOGIC_CONDITION_OPERAND_FLIGHT_MIXER_TRANSITION_ACTIVE, //0,1           // 40
+    LOGIC_CONDITION_OPERAND_FLIGHT_ACTIVE_MIXER_PROFILE, //int              // 38
+    LOGIC_CONDITION_OPERAND_FLIGHT_MIXER_TRANSITION_ACTIVE, //0,1           // 39
+    LOGIC_CONDITION_OPERAND_FLIGHT_ATTITUDE_YAW, // deg                     // 40
 } logicFlightOperands_e;
 
 typedef enum {


### PR DESCRIPTION
The programming framework has flight:pitch and flight:roll.
This PR adds yaw to round out the options.

A matching PR for Configurator will be submitted also.

Tested in HITL and will be tested today in flight.
