### PR TITLE
SAFETY issue -- servos.c: Correct servo throttle *off* when disarmed (not full throttle at disarm)

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -376,8 +376,9 @@ void servoMixer(float dT)
             const uint8_t target = currentServoMixer[i].targetChannel;
             const uint8_t from = currentServoMixer[i].inputSource;
 
+            // Translate minimum throttle values to -500 ... +500 servo range for use below.
             if (from == INPUT_STABILIZED_THROTTLE || from == INPUT_RC_THROTTLE) {
-                servo[target] = motorConfig()->mincommand;
+                servo[target] = motorConfig()->mincommand - servoParams(target)->middle;
             }
         }
     }


### PR DESCRIPTION
When disarmed, the existing code is intended to set "servo" outputs that use throttle to minimum:

`servo[target] = motorConfig()->mincommand;`

Which was expected to set the value to 1000.

However, the range at that point is intended to be -500 to +500.
servoParams(target)->middle is added a few lines later. 
Therefore this ended up setting them to minimum + middle = 2500.  Ie _full throttle when disarmed_.

PR subtracts servoParams(target)->middle, to offset the fact it's added a few lines later.

Tested by me and by INAV Discord user "driftingS13".

