### PR TITLE
Fix mixer config initialization sequence

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -305,6 +305,7 @@ static void activateConfig(void)
 {
     activateControlRateConfig();
     activateBatteryProfile();
+    activateMixerConfig();
 
     resetAdjustmentStates();
 
@@ -486,7 +487,6 @@ bool setConfigMixerProfile(uint8_t profileIndex)
         profileIndex = 0;
     }
     systemConfigMutable()->current_mixer_profile_index = profileIndex;
-    // setMixerProfile(profileIndex);
     return ret;
 }
 

--- a/src/main/flight/mixer_profile.c
+++ b/src/main/flight/mixer_profile.c
@@ -77,11 +77,15 @@ void pgResetFn_mixerProfiles(mixerProfile_t *instance)
     }
 }
 
-void mixerConfigInit(void)
-{
+void activateMixerConfig(){
     currentMixerProfileIndex = getConfigMixerProfile();
     currentMixerConfig = *mixerConfig();
     nextProfileIndex = (currentMixerProfileIndex + 1) % MAX_MIXER_PROFILE_COUNT;
+}
+
+void mixerConfigInit(void)
+{
+    activateMixerConfig();
     servosInit();
     mixerUpdateStateFlags();
     mixerInit();

--- a/src/main/flight/mixer_profile.h
+++ b/src/main/flight/mixer_profile.h
@@ -73,5 +73,6 @@ static inline const mixerProfile_t* mixerProfiles_CopyArray_by_index(int _index)
 
 bool outputProfileHotSwitch(int profile_index);
 bool checkMixerProfileHotSwitchAvalibility(void);
+void activateMixerConfig(void);
 void mixerConfigInit(void);
 void outputProfileUpdateTask(timeUs_t currentTimeUs);


### PR DESCRIPTION
**Fixes a critical bug**, which will cause the firmware to load the wrong PID controller.

platform type was not loaded before the PID controller initialization, This PR fixes this issue