### PR TITLE
SITL: OSD CMS menu does not work

### DIFF
--- a/src/main/drivers/serial_tcp.c
+++ b/src/main/drivers/serial_tcp.c
@@ -265,13 +265,8 @@ uint32_t tcpTotalRxBytesWaiting(const serialPort_t *instance)
 
 uint32_t tcpTotalTxBytesFree(const serialPort_t *instance)
 {
-    tcpPort_t *port = (tcpPort_t*)instance;
-
-    if (port->isClientConnected) {
-        return TCP_MAX_PACKET_SIZE;
-    } else {
-        return 0;
-    }
+    UNUSED(instance);
+    return TCP_MAX_PACKET_SIZE;
 }
 
 bool isTcpTransmitBufferEmpty(const serialPort_t *instance)


### PR DESCRIPTION
uint32_t tcpTotalTxBytesFree(const serialPort_t *instance)

should always return  TCP_MAX_PACKET_SIZE regardles connection estabilished or not. 

Returning 0 may block execution in various places as there is never free space in tx buffer to proceed (as with CMS updating ).

