### PR TITLE
HITL/SITL: allow hitl/sitl to arm with uncalibrated accelerometer

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -3586,6 +3586,7 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
 				}
 #endif
 				ENABLE_ARMING_FLAG(SIMULATOR_MODE_HITL);
+                ENABLE_STATE(ACCELEROMETER_CALIBRATED);
 				LOG_DEBUG(SYSTEM, "Simulator enabled");
 			}
 


### PR DESCRIPTION
Allow HITL/SITL arming without calibration.
It is not possible to calibrate accelerometer in SITL.

The main purpose is to allow using SITL with INAV-XPLANE-HITL plugin:
https://github.com/RomanLut/INAV-X-Plane-HITL/issues/14#issuecomment-1749787915

