### PR TITLE
Lower default hover throttle to 30%

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3438,7 +3438,7 @@ Multicopter hover throttle hint for altitude controller. Should be set to approx
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 1500 | 1000 | 2000 |
+| 1300 | 1000 | 2000 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1045,7 +1045,7 @@ groups:
         max: PWM_RANGE_MAX
       - name: nav_mc_hover_thr
         description: "Multicopter hover throttle hint for altitude controller. Should be set to approximate throttle value when drone is hovering."
-        default_value: 1500
+        default_value: 1300
         field: nav.mc.hover_throttle
         min: 1000
         max: 2000


### PR DESCRIPTION
Current value of 1500 (50%) is often too high and quad tends to shoot up.

throttle around 30% seems closer to reality for most small quads and probably wont result in quad loosing too much altitude or dropping.