### PR TITLE
additional fixes for mixer profile

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -727,6 +727,8 @@ void processRx(timeUs_t currentTimeUs)
         } else {
             DISABLE_FLIGHT_MODE(MANUAL_MODE);
         }
+    }else{
+        DISABLE_FLIGHT_MODE(MANUAL_MODE);
     }
 
     /* In airmode Iterm should be prevented to grow when Low thottle and Roll + Pitch Centered.

--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -202,7 +202,7 @@ void initActiveBoxIds(void)
     //Camstab mode is enabled always
     ADD_ACTIVE_BOX(BOXCAMSTAB);
 
-    if (STATE(MULTIROTOR)) {
+    if (STATE(MULTIROTOR) || platformTypeConfigured(PLATFORM_MULTIROTOR) || platformTypeConfigured(PLATFORM_TRICOPTER)) {
         if ((sensors(SENSOR_ACC) || sensors(SENSOR_MAG))) {
             ADD_ACTIVE_BOX(BOXHEADFREE);
             ADD_ACTIVE_BOX(BOXHEADADJ);
@@ -244,13 +244,13 @@ void initActiveBoxIds(void)
 #endif
         }
 
-        if (STATE(AIRPLANE)) {
+        if (STATE(AIRPLANE) || platformTypeConfigured(PLATFORM_AIRPLANE)) {
             ADD_ACTIVE_BOX(BOXSOARING);
         }
     }
 
 #ifdef USE_MR_BRAKING_MODE
-    if (mixerConfig()->platformType == PLATFORM_MULTIROTOR) {
+    if (mixerConfig()->platformType == PLATFORM_MULTIROTOR || platformTypeConfigured(PLATFORM_MULTIROTOR)) {
         ADD_ACTIVE_BOX(BOXBRAKING);
     }
 #endif
@@ -259,11 +259,12 @@ void initActiveBoxIds(void)
         ADD_ACTIVE_BOX(BOXNAVALTHOLD);
     }
 
-    if (STATE(AIRPLANE) || STATE(ROVER) || STATE(BOAT)) {
+    if (STATE(AIRPLANE) || STATE(ROVER) || STATE(BOAT) || 
+        platformTypeConfigured(PLATFORM_AIRPLANE) || platformTypeConfigured(PLATFORM_ROVER) || platformTypeConfigured(PLATFORM_BOAT)) {
         ADD_ACTIVE_BOX(BOXMANUAL);
     }
 
-    if (STATE(AIRPLANE)) {
+    if (STATE(AIRPLANE) || platformTypeConfigured(PLATFORM_AIRPLANE)) {
         if (!feature(FEATURE_FW_LAUNCH)) {
            ADD_ACTIVE_BOX(BOXNAVLAUNCH);
         }

--- a/src/main/flight/mixer_profile.c
+++ b/src/main/flight/mixer_profile.c
@@ -108,6 +108,14 @@ void setMixerProfileAT(void)
     mixerProfileAT.transitionTransEndTime = mixerProfileAT.transitionStartTime + (timeMs_t)currentMixerConfig.switchTransitionTimer * 100;
 }
 
+bool platformTypeConfigured(flyingPlatformType_e platformType)
+{   
+    if (!isModeActivationConditionPresent(BOXMIXERPROFILE)){
+        return false;
+    }
+    return mixerConfigByIndex(nextProfileIndex)->platformType == platformType;
+}
+
 bool checkMixerATRequired(mixerProfileATRequest_e required_action)
 {
     //return false if mixerAT condition is not required or setting is not valid

--- a/src/main/flight/mixer_profile.c
+++ b/src/main/flight/mixer_profile.c
@@ -23,6 +23,7 @@
 #include "fc/runtime_config.h"
 #include "fc/settings.h"
 #include "fc/rc_modes.h"
+#include "fc/cli.h"
 
 #include "programming/logic_condition.h"
 #include "navigation/navigation.h"
@@ -187,8 +188,9 @@ bool checkMixerProfileHotSwitchAvalibility(void)
 }
 
 void outputProfileUpdateTask(timeUs_t currentTimeUs)
-{
+{   
     UNUSED(currentTimeUs);
+    if(cliMode) return;
     bool mixerAT_inuse = mixerProfileAT.phase != MIXERAT_PHASE_IDLE;
     // transition mode input for servo mix and motor mix
     if (!FLIGHT_MODE(FAILSAFE_MODE) && (!mixerAT_inuse))

--- a/src/main/flight/mixer_profile.h
+++ b/src/main/flight/mixer_profile.h
@@ -71,6 +71,7 @@ static inline const mixerProfile_t* mixerProfiles_CopyArray_by_index(int _index)
 #define mixerMotorMixersByIndex(index) (mixerProfiles(index)->MotorMixers)
 #define mixerServoMixersByIndex(index) (mixerProfiles(index)->ServoMixers)
 
+bool platformTypeConfigured(flyingPlatformType_e platformType);
 bool outputProfileHotSwitch(int profile_index);
 bool checkMixerProfileHotSwitchAvalibility(void);
 void activateMixerConfig(void);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1130,7 +1130,7 @@ void FAST_CODE pidController(float dT)
         canUseFpvCameraMix = false;     // FPVANGLEMIX is incompatible with TURN_ASSISTANT
     }
 
-    if (canUseFpvCameraMix && IS_RC_MODE_ACTIVE(BOXFPVANGLEMIX) && currentControlRateProfile->misc.fpvCamAngleDegrees) {
+    if (canUseFpvCameraMix && IS_RC_MODE_ACTIVE(BOXFPVANGLEMIX) && currentControlRateProfile->misc.fpvCamAngleDegrees && STATE(MULTIROTOR)) {
         pidApplyFpvCameraAngleMix(pidState, currentControlRateProfile->misc.fpvCamAngleDegrees);
     }
 


### PR DESCRIPTION
Simplify the servo mixing(revert some codes/features to 6.1)
Fixes mode settings on mixed platformtype models
Block improper RC modes based on current platform type
Block mixer_profile related RC modes get activated in cli

tested in sim