### PR TITLE
Compatiable for DJI O3

### DIFF
--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -62,10 +62,10 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
     case SYM_DEGREES:
         return BF_SYM_GPS_DEGREE;
 
-/*
     case SYM_HEADING:
-        return BF_SYM_HEADING;
+        return BF_SYM_ARROW_NORTH;
 
+/*
     case SYM_SCALE:
         return BF_SYM_SCALE;
 
@@ -186,17 +186,17 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 
     case SYM_ALT_M:
         return BF_SYM_M;
+    
+    case SYM_TOTAL:
+        return BF_SYM_TOTAL_DISTANCE;
 
 /*
     case SYM_TRIP_DIST:
         return BF_SYM_TRIP_DIST;
-
-    case SYM_TOTAL:
-        return BF_SYM_TOTAL;
-
+*/
     case SYM_ALT_KM:
-        return BF_SYM_ALT_KM;
-
+        return BF_SYM_KM;
+/*
     case SYM_ALT_KFT:
         return BF_SYM_ALT_KFT;
 
@@ -319,25 +319,21 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 
     case SYM_AUTO_THR1:
         return BF_SYM_AUTO_THR1;
+        */
 
     case SYM_ROLL_LEFT:
-        return BF_SYM_ROLL_LEFT;
-
     case SYM_ROLL_LEVEL:
-        return BF_SYM_ROLL_LEVEL;
-
     case SYM_ROLL_RIGHT:
-        return BF_SYM_ROLL_RIGHT;
+        return BF_SYM_ROLL;
 
     case SYM_PITCH_UP:
-        return BF_SYM_PITCH_UP;
-
     case SYM_PITCH_DOWN:
-        return BF_SYM_PITCH_DOWN;
+        return BF_SYM_PITCH;
 
     case SYM_GFORCE:
-        return BF_SYM_GFORCE;
+        return 'G';
 
+    /*
     case SYM_GFORCE_X:
         return BF_SYM_GFORCE_X;
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2385,7 +2385,12 @@ static bool osdDrawSingleElement(uint8_t item)
             if (!failsafeIsReceivingRxData())
                 tfp_sprintf(buff, "%s%c", "    ", SYM_BLANK);
             else
-                tfp_sprintf(buff, "%4d%c", rxLinkStatistics.uplinkTXPower, SYM_MW);
+                if (isBfCompatibleVideoSystem(osdConfig())) {
+                    tfp_sprintf(buff, "%4dMW", rxLinkStatistics.uplinkTXPower);
+                }
+                else {
+                    tfp_sprintf(buff, "%4d%c", rxLinkStatistics.uplinkTXPower, SYM_MW);
+                }
             break;
         }
 #endif


### PR DESCRIPTION
Better compatibility for DJI O3, including:

1. G force: for 3d g forces, use single 'G'
2. Transmitter power, use 'MW'
3. Roll and pitch, use PIT or ROL
4. Fly distance
5. Heading

Some is not perfect, but I believe they are better than '?'

Before
![image](https://github.com/iNavFlight/inav/assets/5087930/f8dee3cd-fa97-4bb3-bd43-041cae76547b)

After 
![image](https://github.com/iNavFlight/inav/assets/5087930/f82b471f-6ce0-476b-8831-36bf8daaad5d)

Performed fly test on DJI-O3 system with SpeedyBee F405Wing on BF 6.1.1, cherry pick to 7.0 and verified on ground.
