### PR TITLE
BFCOMPAT - improve wind and airspeed fields and labels

### DIFF
--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -96,10 +96,31 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 
     case SYM_AH_DECORATION_DOWN:
         return BF_SYM_AH_DECORATION_DOWN;
-
-    case SYM_DIRECTION:
-        return BF_SYM_DIRECTION;
 */
+    case SYM_DIRECTION:
+        return return BF_SYM_ARROW_NORTH;
+    
+    case SYM_DIRECTION + 1: // NE pointing arrow
+        return BF_SYM_ARROW_7;
+
+    case SYM_DIRECTION + 2: // E pointing arrow
+        return BF_SYM_ARROW_EAST;
+
+    case SYM_DIRECTION + 3: // SE pointing arrow
+        return BF_SYM_ARROW_3;
+
+    case SYM_DIRECTION + 4: // S pointing arrow
+        return BF_SYM_ARROW_SOUTH;
+
+    case SYM_DIRECTION + 5: // SW pointing arrow
+        return BF_SYM_ARROW_15;
+
+    case SYM_DIRECTION + 6: // W pointing arrow
+        return BF_SYM_ARROW_WEST;
+
+    case SYM_DIRECTION + 7: // NW pointing arrow
+        return BF_SYM_ARROW_11;
+
     case SYM_VOLT:
         return BF_SYM_VOLT;
 
@@ -226,20 +247,19 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 /*
     case SYM_NM:
         return BF_SYM_NM;
-
+*/
     case SYM_WIND_HORIZONTAL:
-        return BF_SYM_WIND_HORIZONTAL;
+        return 'W';     // W for wind
 
+/*
     case SYM_WIND_VERTICAL:
         return BF_SYM_WIND_VERTICAL;
 
     case SYM_3D_KT:
         return BF_SYM_3D_KT;
-
-
-    case SYM_AIR:
-        return BF_SYM_AIR;
 */
+    case SYM_AIR:
+        return 'A';     // A for airspeed
 
     case SYM_3D_KMH:
         return BF_SYM_KPH;

--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -98,7 +98,7 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
         return BF_SYM_AH_DECORATION_DOWN;
 */
     case SYM_DIRECTION:
-        return return BF_SYM_ARROW_NORTH;
+        return BF_SYM_ARROW_NORTH;
     
     case SYM_DIRECTION + 1: // NE pointing arrow
         return BF_SYM_ARROW_7;


### PR DESCRIPTION
- Add labels, A for airspeed and W for horizontal wind speed. 
- Fix the horizontal wind direction arrows, to use the default (and existing) BF direction arrows instead of the customized ones.

This makes the wind speed and direction calculation usable in the O3 OSD modes.
