### PR TITLE
BFCOMPAT - fix power field scalings and improve auto throttle labels

### DIFF
--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -65,10 +65,10 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 /*
     case SYM_HEADING:
         return BF_SYM_HEADING;
-
+*/
     case SYM_SCALE:
-        return BF_SYM_SCALE;
-
+        return 'S';     // S for scaled
+/*
     case SYM_HDP_L:
         return BF_SYM_HDP_L;
 
@@ -313,13 +313,13 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 
     case SYM_ZERO_HALF_LEADING_DOT:
         return BF_SYM_ZERO_HALF_LEADING_DOT;
-
+*/
     case SYM_AUTO_THR0:
-        return BF_SYM_AUTO_THR0;
+        return 'A';     // A for Auto
 
     case SYM_AUTO_THR1:
-        return BF_SYM_AUTO_THR1;
-
+        return 'T';     // T for Throttle
+/*
     case SYM_ROLL_LEFT:
         return BF_SYM_ROLL_LEFT;
 

--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -174,10 +174,10 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 /*
     case SYM_MW:
         return BF_SYM_MW;
-
-    case SYM_KILOWATT:
-        return BF_SYM_KILOWATT;
 */
+    case SYM_KILOWATT:
+        return 'K';     // K for KiloWatt
+
     case SYM_FT:
         return BF_SYM_FT;
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2875,9 +2875,15 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_POWER:
         {
-            bool kiloWatt = osdFormatCentiNumber(buff, getPower(), 1000, 2, 2, 3, false);
-            buff[3] = kiloWatt ? SYM_KILOWATT : SYM_WATT;
-            buff[4] = '\0';
+            uint8_t digits = 3U;                
+            #ifndef DISABLE_MSP_BF_COMPAT // IF BFCOMPAT is not supported, there's no need to check for it and change the values
+                if (isBfCompatibleVideoSystem(osdConfig())) {
+                    digits = 4U;
+                }            
+            #endif
+            bool kiloWatt = osdFormatCentiNumber(buff, getPower(), 1000, 2, 2, digits, false);
+            buff[digits] = kiloWatt ? SYM_KILOWATT : SYM_WATT;
+            buff[digits + 1U] = '\0';
 
             uint8_t current_alarm = osdConfig()->current_alarm;
             if ((current_alarm > 0) && ((getAmperage() / 100.0f) > current_alarm)) {
@@ -3512,9 +3518,15 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_PLIMIT_ACTIVE_POWER_LIMIT:
         {
             if (currentBatteryProfile->powerLimits.continuousPower) {
-                bool kiloWatt = osdFormatCentiNumber(buff, powerLimiterGetActivePowerLimit(), 1000, 2, 2, 3, false);
-                buff[3] = kiloWatt ? SYM_KILOWATT : SYM_WATT;
-                buff[4] = '\0';
+                uint8_t digits = 3U;                
+                #ifndef DISABLE_MSP_BF_COMPAT // IF BFCOMPAT is not supported, there's no need to check for it and change the values
+                    if (isBfCompatibleVideoSystem(osdConfig())) {
+                        digits = 4U;
+                    }            
+                #endif
+                bool kiloWatt = osdFormatCentiNumber(buff, powerLimiterGetActivePowerLimit(), 1000, 2, 2, digits, false);
+                buff[digits] = kiloWatt ? SYM_KILOWATT : SYM_WATT;
+                buff[digits + 1U] = '\0';
 
                 if (powerLimiterIsLimitingPower()) {
                     TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
@@ -4372,9 +4384,16 @@ static void osdShowStats(bool isSinglePageStatsCompatible, uint8_t page)
             displayWrite(osdDisplayPort, statValuesX, top++, buff);
 
             displayWrite(osdDisplayPort, statNameX, top, "MAX POWER        :");
-            bool kiloWatt = osdFormatCentiNumber(buff, stats.max_power, 1000, 2, 2, 3, false);
-            buff[3] = kiloWatt ? SYM_KILOWATT : SYM_WATT;
-            buff[4] = '\0';
+            uint8_t digits = 3U;
+            bool kiloWatt = false;
+            #ifndef DISABLE_MSP_BF_COMPAT // IF BFCOMPAT is not supported, there's no need to check for it and change the values
+                if (isBfCompatibleVideoSystem(osdConfig())) {
+                    digits = 4U;
+                }            
+            #endif      
+            kiloWatt = osdFormatCentiNumber(buff, stats.max_power, 1000, 2, 2, digits, false);
+            buff[digits] = kiloWatt ? SYM_KILOWATT : SYM_WATT;
+            buff[digits + 1U] = '\0';
             displayWrite(osdDisplayPort, statValuesX, top++, buff);
 
             displayWrite(osdDisplayPort, statNameX, top, "USED CAPACITY    :");


### PR DESCRIPTION
- Add 'AT' as label for when auto-throttle is active and 'S' when scaled throttle is enabled (thus giving a visual sign to the pilot)
- Fix OSD live and post-disarm stats page power/max power fields scaling (similar to #8866 and #9109)
- Add 'K' as the label for kilowatt values