### PR TITLE
Allow f722 to use mixer profile

### DIFF
--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -189,8 +189,8 @@
 #define USE_TELEMETRY_HOTT
 #define USE_HOTT_TEXTMODE
 #define USE_24CHANNELS
-#else
+#define MAX_MIXER_PROFILE_COUNT 2
+#elif !defined(STM32F7)
 #define MAX_MIXER_PROFILE_COUNT 1
 #endif
-
 #define USE_EZ_TUNE


### PR DESCRIPTION
Before

```
Linking C executable ../../../../bin/SPEEDYBEEF7V3.elf
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:        9680 B        16 KB     59.08%
      ITCM_FLASH:          0 GB        16 KB      0.00%
ITCM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     ITCM_FLASH1:          0 GB       480 KB      0.00%
           FLASH:         788 B        16 KB      4.81%
    FLASH_CONFIG:          0 GB        16 KB      0.00%
          FLASH1:      445085 B       480 KB     90.55%
             TCM:       18236 B        64 KB     27.83%
             RAM:       78448 B       192 KB     39.90%
       MEMORY_B1:          0 GB         0 GB
Built target SPEEDYBEEF7V3.elf
Built target SPEEDYBEEF7V3

```
After
```
Linking C executable ../../../../bin/SPEEDYBEEF7V3.elf
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:        9680 B        16 KB     59.08%
      ITCM_FLASH:          0 GB        16 KB      0.00%
ITCM_FLASH_CONFIG:          0 GB        16 KB      0.00%
     ITCM_FLASH1:          0 GB       480 KB      0.00%
           FLASH:         788 B        16 KB      4.81%
    FLASH_CONFIG:          0 GB        16 KB      0.00%
          FLASH1:      445805 B       480 KB     90.70%
             TCM:       18236 B        64 KB     27.83%
             RAM:       79240 B       192 KB     40.30%
       MEMORY_B1:          0 GB         0 GB
Built target SPEEDYBEEF7V3.elf
Built target SPEEDYBEEF7V3
```