### PR TITLE
Enable Wind estimator in SITL

### DIFF
--- a/src/main/flight/wind_estimator.c
+++ b/src/main/flight/wind_estimator.c
@@ -40,6 +40,7 @@
 
 #include "io/gps.h"
 
+#include "navigation/navigation_pos_estimator_private.h"
 
 #define WINDESTIMATOR_TIMEOUT       60*15 // 15min with out altitude change
 #define WINDESTIMATOR_ALTITUDE_SCALE WINDESTIMATOR_TIMEOUT/500.0f //or 500m altitude change
@@ -103,11 +104,11 @@ void updateWindEstimator(timeUs_t currentTimeUs)
     float fuselageDirectionDiff[XYZ_AXIS_COUNT];
     float fuselageDirectionSum[XYZ_AXIS_COUNT];
 
-    // Get current 3D velocity from GPS in cm/s
+    // Get current 3D velocity from poisition estimator in cm/s
     // relative to earth frame
-    groundVelocity[X] = gpsSol.velNED[X];
-    groundVelocity[Y] = gpsSol.velNED[Y];
-    groundVelocity[Z] = gpsSol.velNED[Z];
+    groundVelocity[X] = posEstimator.gps.vel.x;
+    groundVelocity[Y] = posEstimator.gps.vel.y;
+    groundVelocity[Z] = posEstimator.gps.vel.z;
 
     // Fuselage direction in earth frame
     fuselageDirection[X] = HeadVecEFFiltered.x;


### PR DESCRIPTION
The SITL "GPS" does not set any velocity data, this is then calculated by the position estimator, but the wind estimator gets its data directly from the GPS. 
Changed so that the values calculated on demand are used.   