### PR TITLE
Add DPS310 and SPL06 to FLYWOOF745 target

### DIFF
--- a/src/main/target/FLYWOOF745/target.h
+++ b/src/main/target/FLYWOOF745/target.h
@@ -140,6 +140,10 @@
 
 #define USE_BARO
 #define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_BMP085
+#define USE_BARO_DPS310
+#define USE_BARO_SPL06
 #define BARO_I2C_BUS            BUS_I2C1
 
 #define USE_MAG


### PR DESCRIPTION
This was requested by flywoo support.

Also add other baros to match their internal target.