### PR TITLE
Air drag compensation in mc vel controller

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3512,6 +3512,16 @@ timeout in ms for braking
 
 ---
 
+### nav_mc_drag_to_acceleration_factor
+
+Factor used for air drag to acceleration conversion in MC NAV horizontal velocity controller. set it as 0.5 * air_density[kg/m^3] * drag_coefficient * projection_area[m^2] / AllUpWeight[kg] * 10000 , assume around 100 on 3-7 inch quad
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 100 | 0 | 500 |
+
+---
+
 ### nav_mc_heading_p
 
 P gain of Heading Hold controller (Multirotor)
@@ -3588,7 +3598,7 @@ Maximum D-term attenution percentage for horizontal velocity PID controller (Mul
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 90 | 0 | 100 |
+| 50 | 0 | 100 |
 
 ---
 

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -91,6 +91,7 @@
         )
 #define MIN(a, b) _CHOOSE(<, a, b)
 #define MAX(a, b) _CHOOSE(>, a, b)
+#define SIGN(a) ((a >= 0) ? 1 : -1)
 
 #define _ABS_II(x, var)             \
     ( __extension__ ({              \

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2056,7 +2056,7 @@ groups:
         field: navVelXyDtermAttenuation
         min: 0
         max: 100
-        default_value: 90
+        default_value: 50
       - name: nav_mc_vel_xy_dterm_attenuation_start
         description: "A point (in percent of both target and current horizontal velocity) where nav_mc_vel_xy_dterm_attenuation begins"
         default_value: 10
@@ -2680,6 +2680,12 @@ groups:
         field: mc.max_bank_angle
         min: 15
         max: 45
+      - name: nav_mc_drag_to_acceleration_factor
+        description: "Factor used for air drag to acceleration conversion in MC NAV horizontal velocity controller. set it as 0.5 * air_density[kg/m^3] * drag_coefficient * projection_area[m^2] / AllUpWeight[kg] * 10000 , assume around 100 on 3-7 inch quad"
+        default_value: 100
+        field: mc.drag_to_acceleration_factor
+        min: 0
+        max: 500
       - name: nav_auto_disarm_delay
         description: "Delay before craft disarms when `nav_disarm_on_landing` is set (ms)"
         default_value: 1000

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -160,6 +160,7 @@ PG_RESET_TEMPLATE(navConfig_t, navConfig,
     // MC-specific
     .mc = {
         .max_bank_angle = SETTING_NAV_MC_BANK_ANGLE_DEFAULT,                          // degrees
+        .drag_to_acceleration_factor = SETTING_NAV_MC_DRAG_TO_ACCELERATION_FACTOR_DEFAULT,
 
 #ifdef USE_MR_BRAKING_MODE
         .braking_speed_threshold = SETTING_NAV_MC_BRAKING_SPEED_THRESHOLD_DEFAULT,               // Braking can become active above 1m/s

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -272,6 +272,7 @@ typedef struct navConfig_s {
 
     struct {
         uint8_t  max_bank_angle;                // multicopter max banking angle (deg)
+        uint16_t drag_to_acceleration_factor; //drag to acceleration factor 
 
 #ifdef USE_MR_BRAKING_MODE
         uint16_t braking_speed_threshold;       // above this speed braking routine might kick in

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -590,7 +590,7 @@ static void updatePositionAccelController_MC(timeDelta_t deltaMicros, float maxA
         accelLimitY = accelLimitX;
     }
 
-    // Apply additional jerk limiting of 1700 cm/s^3 (~100 deg/s), almost any copter should be able to achieve this rate
+    // Apply additional jerk limiting of 3400 cm/s^3 (~200 deg/s), almost any copter should be able to achieve this rate
     // This will assure that we wont't saturate out LEVEL and RATE PID controller
 
     float maxAccelChange = US2S(deltaMicros) * MC_POS_CONTROL_JERK_LIMIT_CMSSS;
@@ -688,6 +688,11 @@ static void updatePositionAccelController_MC(timeDelta_t deltaMicros, float maxA
     // Save last acceleration target
     lastAccelTargetX = newAccelX;
     lastAccelTargetY = newAccelY;
+
+    //correction as virtual acceleration to compensate air drag to maintain current speed
+    //drag_to_acceleration_factor = 0.5 * air_density(kg/m^3) * drag_coefficient * projection_area(m^2) / AllUpWeight(kg), assume around 0.01 on 3-7 inch quad
+    newAccelX = newAccelX + SIGN(measurementX) * measurementX/100.0f * measurementX/100.0f * (navConfig()->mc.drag_to_acceleration_factor / 10000.0f);
+    newAccelY = newAccelY + SIGN(measurementY) * measurementY/100.0f * measurementY/100.0f * (navConfig()->mc.drag_to_acceleration_factor / 10000.0f);
 
     // Rotate acceleration target into forward-right frame (aircraft)
     const float accelForward = newAccelX * posControl.actualState.cosYaw + newAccelY * posControl.actualState.sinYaw;

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -37,7 +37,7 @@
 
 #define INAV_SURFACE_MAX_DISTANCE           40
 
-#define MC_POS_CONTROL_JERK_LIMIT_CMSSS     1700.0f // jerk limit on horizontal acceleration (cm/s^3)
+#define MC_POS_CONTROL_JERK_LIMIT_CMSSS     3400.0f // jerk limit on horizontal acceleration (cm/s^3)
 
 #define MC_LAND_CHECK_VEL_XY_MOVING         100.0f  // cm/s
 #define MC_LAND_CHECK_VEL_Z_MOVING          100.0f  // cm/s


### PR DESCRIPTION
Add additional 'acceleration'/trust to overcome air drag in MC XY velocity controller.
Improve tracking performance at high speeds.

Simulation on realflight  shows pitch angle variance on 72km/h cruise has reduced by half

set nav_mc_drag_to_acceleration_factor=0/100 to try it on or off while testing