### PR TITLE
Unable fo arm 3d esc rover

### DIFF
--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -119,8 +119,8 @@ throttleStatus_e FAST_CODE NOINLINE calculateThrottleStatus(throttleStatusType_e
         value = rcCommand[THROTTLE];
     }
 
-    const uint16_t mid_throttle_deadband = rcControlsConfig()->mid_throttle_deadband;
-    bool midThrottle = value > (PWM_RANGE_MIDDLE - mid_throttle_deadband) && value < (PWM_RANGE_MIDDLE + mid_throttle_deadband);
+    //const uint16_t mid_throttle_deadband = rcControlsConfig()->mid_throttle_deadband;
+    bool midThrottle = value > (rcControlsConfig->deadband_low) && value < (rcControlsConfig->deadband_high);
     if ((feature(FEATURE_REVERSIBLE_MOTORS) && midThrottle) || (!feature(FEATURE_REVERSIBLE_MOTORS) && (value < rxConfig()->mincheck))) {
         return THROTTLE_LOW;
     }

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -119,7 +119,7 @@ throttleStatus_e FAST_CODE NOINLINE calculateThrottleStatus(throttleStatusType_e
         value = rcCommand[THROTTLE];
     }
 
-    bool midThrottle = value > (rcControlsConfig->deadband_low) && value < (rcControlsConfig->deadband_high);
+    bool midThrottle = value > (reversibleMotorsConfig()->deadband_low) && value < (reversibleMotorsConfig()->deadband_high);
     if ((feature(FEATURE_REVERSIBLE_MOTORS) && midThrottle) || (!feature(FEATURE_REVERSIBLE_MOTORS) && (value < rxConfig()->mincheck))) {
         return THROTTLE_LOW;
     }

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -119,7 +119,6 @@ throttleStatus_e FAST_CODE NOINLINE calculateThrottleStatus(throttleStatusType_e
         value = rcCommand[THROTTLE];
     }
 
-    //const uint16_t mid_throttle_deadband = rcControlsConfig()->mid_throttle_deadband;
     bool midThrottle = value > (rcControlsConfig->deadband_low) && value < (rcControlsConfig->deadband_high);
     if ((feature(FEATURE_REVERSIBLE_MOTORS) && midThrottle) || (!feature(FEATURE_REVERSIBLE_MOTORS) && (value < rxConfig()->mincheck))) {
         return THROTTLE_LOW;


### PR DESCRIPTION
Fixes #9460

Logic check didn't match the configurator UI.

Old logic used 1500 +/- 3d_deadband_throttle instead of the values for deadband low and high in the configurator

3d_deadband_throttle is not on the configurator.

Alternative solution, is to replace setting in configurator with 3d_deadband_throttle



