### PR TITLE
TMOTORF7V2 has an optional baro, so add more drivers

### DIFF
--- a/src/main/target/TMOTORF7/target.h
+++ b/src/main/target/TMOTORF7/target.h
@@ -52,9 +52,7 @@
 
 #define USE_BARO
 #define BARO_I2C_BUS            BUS_I2C2
-#define USE_BARO_BMP280
-#define USE_BARO_MS5611
-#define USE_BARO_DPS310
+#define USE_BARO_ALL
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2

--- a/src/main/target/TMOTORF7V2/target.h
+++ b/src/main/target/TMOTORF7V2/target.h
@@ -95,7 +95,7 @@
 // BMP280 BARO --- I2C1
 #define USE_I2C
 #define USE_BARO
-#define USE_BARO_BMP280
+#define USE_BARO_ALL
 #define BARO_I2C_BUS            BUS_I2C1
 
 #define USE_I2C_DEVICE_1


### PR DESCRIPTION
Since the baro is not always populated, it needs more drivers.

Reported by Pi-Wi74 over on discord.