### PR TITLE
Revert "Enable the virtual pitot by default"

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -5058,7 +5058,7 @@ Selection of pitot hardware.
 
 | Default | Min | Max |
 | --- | --- | --- |
-| VIRTUAL |  |  |
+| NONE |  |  |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -588,7 +588,7 @@ groups:
     members:
       - name: pitot_hardware
         description: "Selection of pitot hardware."
-        default_value: "VIRTUAL"
+        default_value: "NONE"
         table: pitot_hardware
       - name: pitot_lpf_milli_hz
         min: 0


### PR DESCRIPTION
This reverts commit 83844e996fbd229a16dc83e76e553fcf297ed5c8.

This reverts done in #9299 . when flashed on FC without a GPS connected, this causes alert that confuses pilots