### PR TITLE
Change speedybeeF7V3 default timer allocation

### DIFF
--- a/src/main/target/SPEEDYBEEF7V3/config.c
+++ b/src/main/target/SPEEDYBEEF7V3/config.c
@@ -31,4 +31,7 @@ void targetConfiguration(void)
 {
     serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].functionMask = FUNCTION_ESCSERIAL;
     pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+    timerOverridesMutable(timer2id(TIM2))->outputMode = OUTPUT_MODE_MOTORS;
+    timerOverridesMutable(timer2id(TIM3))->outputMode = OUTPUT_MODE_MOTORS;
+    timerOverridesMutable(timer2id(TIM4))->outputMode = OUTPUT_MODE_MOTORS;
 }

--- a/src/main/target/SPEEDYBEEF7V3/config.c
+++ b/src/main/target/SPEEDYBEEF7V3/config.c
@@ -26,6 +26,7 @@
 
 #include "fc/fc_msp_box.h"
 #include "io/serial.h"
+#include "drivers/pwm_mapping.h"
 
 void targetConfiguration(void)
 {


### PR DESCRIPTION
This target timer allocation causes the default motor allocation to end up in S1, S2, S3 and S5.

Force default timer output mode to MOTOR in all timers.