### PR TITLE
GEPRCF405 add IIC2 and change the barometer to IIC2

### DIFF
--- a/src/main/target/GEPRCF405/target.h
+++ b/src/main/target/GEPRCF405/target.h
@@ -61,9 +61,12 @@
 #define USE_I2C_DEVICE_1
 #define I2C1_SCL                PB8
 #define I2C1_SDA                PB9
+#define USE_I2C_DEVICE_2
+#define I2C2_SCL                PB10
+#define I2C2_SDA                PB11
 
 #define USE_BARO
-#define BARO_I2C_BUS            BUS_I2C1
+#define BARO_I2C_BUS            BUS_I2C2
 #define USE_BARO_BMP280
 #define USE_BARO_DPS310
 #define USE_BARO_MS5611


### PR DESCRIPTION
Based on feedback from some users, GEPRC decided to add the barometer in the subsequent FC production, so some changes were needed to the GEPRCF405 target to accommodate the barometer onboard.