### PR TITLE
VTX MSP fix for hdzero

### DIFF
--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -108,12 +108,10 @@ void taskHandleSerial(timeUs_t currentTimeUs)
     djiOsdSerialProcess();
 #endif
 
+
 #ifdef USE_MSP_OSD
 	// Capture MSP Displayport messages to determine if VTX is connected
     mspOsdSerialProcess(mspFcProcessCommand);
-#ifdef USE_VTX_MSP
-    mspVtxSerialProcess(mspFcProcessCommand);
-#endif
 #endif
 
 }

--- a/src/main/io/vtx_msp.h
+++ b/src/main/io/vtx_msp.h
@@ -49,5 +49,3 @@ typedef struct mspPowerTable_s {
 bool vtxMspInit(void);
 void setMspVtxDeviceStatusReady(const int descriptor);
 void prepareMspFrame(uint8_t *mspFrame);
-
-void mspVtxSerialProcess(mspProcessCommandFnPtr mspProcessCommandFn);

--- a/src/main/msp/msp.h
+++ b/src/main/msp/msp.h
@@ -42,6 +42,7 @@ typedef struct mspPacket_s {
     int16_t cmd;
     uint8_t flags;
     int16_t result;
+    uint8_t portIdentifier;
 } mspPacket_t;
 
 typedef enum {

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -406,6 +406,7 @@ static mspPostProcessFnPtr mspSerialProcessReceivedCommand(mspPort_t *msp, mspPr
         .cmd = msp->cmdMSP,
         .flags = msp->cmdFlags,
         .result = 0,
+        .portIdentifier = msp->port->identifier,
     };
 
     mspPostProcessFnPtr mspPostProcessFn = NULL;

--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -295,6 +295,12 @@ static int logicConditionCompute(
                 vtxCommonGetDeviceCapability(vtxCommonDevice(), &vtxDeviceCapability)
             ) {
                 logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_POWER_LEVEL] = constrain(operandA, VTX_SETTINGS_MIN_POWER, vtxDeviceCapability.powerCount);
+
+                vtxDevice_t *vtxDevice = vtxCommonDevice();
+                if (vtxDevice) {
+                    vtxCommonSetPowerByIndex(vtxDevice, logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_POWER_LEVEL]);
+                }
+
                 vtxSettingsConfigMutable()->power = logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_POWER_LEVEL];
                 return logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_POWER_LEVEL];
             } else {
@@ -311,6 +317,12 @@ static int logicConditionCompute(
                 vtxCommonGetDeviceCapability(vtxCommonDevice(), &vtxDeviceCapability)
             ) {
                 logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_BAND] = constrain(operandA, VTX_SETTINGS_MIN_BAND, VTX_SETTINGS_MAX_BAND);
+
+                vtxDevice_t *vtxDevice = vtxCommonDevice();
+                if (vtxDevice) {
+                    vtxCommonSetBandAndChannel(vtxDevice, logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_BAND], vtxSettingsConfig()->channel);
+                }
+
                 vtxSettingsConfigMutable()->band = logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_BAND];
                 return logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_BAND];
             } else {
@@ -323,6 +335,12 @@ static int logicConditionCompute(
                 vtxCommonGetDeviceCapability(vtxCommonDevice(), &vtxDeviceCapability)
             ) {
                 logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_CHANNEL] = constrain(operandA, VTX_SETTINGS_MIN_CHANNEL, VTX_SETTINGS_MAX_CHANNEL);
+
+                vtxDevice_t *vtxDevice = vtxCommonDevice();
+                if (vtxDevice) {
+                    vtxCommonSetBandAndChannel(vtxDevice, vtxSettingsConfig()->band, logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_CHANNEL]);
+                }
+
                 vtxSettingsConfigMutable()->channel = logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_CHANNEL];
                 return logicConditionValuesByType[LOGIC_CONDITION_SET_VTX_CHANNEL];
             } else {


### PR DESCRIPTION
Hi,

it's continue of https://github.com/iNavFlight/inav/issues/9512  in the **vtx_msp.c** is lot of dead code and durring fixing I'm not sure that I dont make it worse. 

How I think how it should work: 
For configurator and for other VTX devices shoud be use same MSP code 88 and 89, parsing these codes should be in **fc_msp.c**, but function **mspFcProcessOutCommand** must contains more parameters there must be port identifier. If arrived MSP frame with code MSP_VTX_CONFIG 89 (request for VTX settings), then we have to know from which port message came. 

If message came from configurator then do nothing,  if message came from VTX then we have to set flag VTX ready to true, and now we know that VTX is properly connected.  It works but durring boot FC sends configuration to VTX twice. it's in image, second image is debug from hdzero VTX.
![image](https://github.com/iNavFlight/inav/assets/1698092/6e932a4b-f278-42be-b0bb-15c31c7c0355)
![image](https://github.com/iNavFlight/inav/assets/1698092/cf78b3ba-a4bc-4bca-83a5-425e52084cb1)

Second issue was if FC settings for VTX was updated from VTX. https://github.com/iNavFlight/inav/blob/master/src/main/io/vtx_msp.c#L212  variables like prevLowPowerDisarmedState  are updated from vTable, thse function are never called if Vtx send new settings to FC by MSP_SET_VTX_CONFIG message. It causes periodically sending settings to VTX. 

![image](https://github.com/iNavFlight/inav/assets/1698092/cf63300a-96be-402f-bc51-4b831e31e37d)

After all fixes in this PR it looks much better. 
![image](https://github.com/iNavFlight/inav/assets/1698092/0180ac90-0f86-4992-a7b9-d8dc612f2ee4)

**This PR works for HDZERO VTX but I'm not sure whether I understand code right way. Can you plase look at code and maybe it's for discusing how to fix it properly.** 



