### PR TITLE
Add ICM42688 to Kakutef7miniv3 target.h

### DIFF
--- a/src/main/target/KAKUTEF7MINIV3/target.h
+++ b/src/main/target/KAKUTEF7MINIV3/target.h
@@ -88,6 +88,13 @@
 #define MPU6000_SPI_BUS         BUS_SPI1
 #define MPU6000_CS_PIN          PB2
 
+// ICM42688
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW270_DEG
+#define ICM42605_SPI_BUS        BUS_SPI1
+#define ICM42605_CS_PIN         PB2
+#define ICM42605_EXTI_PIN       PA4
+
 /*
  * Blackbox Onboard Flash
  */


### PR DESCRIPTION
Holybro will use ICM42688 to replace MPU6000 on this board.