### PR TITLE
PINIO: Fix inverted pin handling

### DIFF
--- a/src/main/drivers/pinio.c
+++ b/src/main/drivers/pinio.c
@@ -100,16 +100,14 @@ void pinioInit(void)
     }
 }
 
-void pinioSet(int index, bool on)
+void pinioSet(int index, bool newState)
 {
-    const bool newState = on ^ pinioRuntime[index].inverted;
-
     if (!pinioRuntime[index].io) {
         return;
     }
 
     if (newState != pinioRuntime[index].state) {
-        IOWrite(pinioRuntime[index].io, newState);
+        IOWrite(pinioRuntime[index].io, newState ^ pinioRuntime[index].inverted);
         pinioRuntime[index].state = newState;
     }
 }

--- a/src/main/drivers/pinio.h
+++ b/src/main/drivers/pinio.h
@@ -38,4 +38,4 @@ extern const pinioHardware_t pinioHardware[];
 extern const int pinioHardwareCount;
 
 void pinioInit(void);
-void pinioSet(int index, bool on);
+void pinioSet(int index, bool newState);


### PR DESCRIPTION
PINIO pins that are inverted are initially set to High and the internal state is false, which is correct. But in `pinioSet` the newState was XOR-ed with the inverted flag before comparing with the stored state. So when calling `pinioSet` with `on = True`, the pin was not set to Low as it should. To put the pin in the correct state, one therefore had to call `pinioSet` with `on = False` first.

Due to this bug, it was e.g. necessary to toggle the RC transmitter switch assigned to the VTX pit switch after boot to turn off the VTX, as the VTX was on even though the RC transmitter switch was in the "VTX off position" (pit switch active). 

This PR fixes this bug by XOR-ing the new state with the inverted flag when calling `IOWrite`, such that the output of the pin is inverted. 