### PR TITLE
Fix #9562 bmi166 acc readout

### DIFF
--- a/src/main/drivers/accgyro/accgyro_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_bmi160.c
@@ -195,9 +195,9 @@ bool bmi160AccReadScratchpad(accDev_t *acc)
     bmi160ContextData_t * ctx = busDeviceGetScratchpadMemory(acc->busDev);
 
     if (ctx->lastReadStatus) {
-        acc->ADCRaw[X] = (float) int16_val_little_endian(ctx->gyroRaw, 0);
-        acc->ADCRaw[Y] = (float) int16_val_little_endian(ctx->gyroRaw, 1);
-        acc->ADCRaw[Z] = (float) int16_val_little_endian(ctx->gyroRaw, 2);
+        acc->ADCRaw[X] = (float) int16_val_little_endian(ctx->accRaw, 0);
+        acc->ADCRaw[Y] = (float) int16_val_little_endian(ctx->accRaw, 1);
+        acc->ADCRaw[Z] = (float) int16_val_little_endian(ctx->accRaw, 2);
         return true;
     }
 


### PR DESCRIPTION
Looks like a typo on bmi160 code.

@DzikuVx this does not seem like a very popular IMU. It was only i in the RADIX target, which lacks a CMakeLists.txt.

The driver itself has been sitting, mostly unchanged for 6-7 years (except a few changes 7 months ago) which introduced this typo.

Reported in issue #9562 

