### PR TITLE
SITL: accelerometer/mag data is not processed when using SITL with inav-HITL-plugin

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -905,7 +905,7 @@ void taskMainPidLoop(timeUs_t currentTimeUs)
     }
 
 #if defined(SITL_BUILD)
-    if (lockMainPID()) {
+    if (ARMING_FLAG(SIMULATOR_MODE_HITL) || lockMainPID()) {
 #endif
 
     gyroFilter();


### PR DESCRIPTION
When HITL plugin is used with SITL,  plane is "dolphining" in navigation modes.
Actual problem is that accelerometer/gyroscope data from simulator is not processed at all.
Fixed.