### PR TITLE
USB MSC: Fix SCIS mode sense write protection bit

### DIFF
--- a/lib/main/STM32F4/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_scsi.c
+++ b/lib/main/STM32F4/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_scsi.c
@@ -343,6 +343,12 @@ static int8_t SCSI_ModeSense6 (USBD_HandleTypeDef  *pdev, uint8_t lun, uint8_t *
     len--;
     hmsc->bot_data[len] = MSC_Mode_Sense6_data[len];
   }
+
+  // set bit 7 of the device configuration byte to indicate write protection
+  if (((USBD_StorageTypeDef *)pdev->pMSC_UserData)->IsWriteProtected(lun) != 0) {
+      hmsc->bot_data[2] = hmsc->bot_data[2] | (1 << 7);
+  }
+
   return 0;
 }
 
@@ -365,6 +371,12 @@ static int8_t SCSI_ModeSense10 (USBD_HandleTypeDef  *pdev, uint8_t lun, uint8_t 
     len--;
     hmsc->bot_data[len] = MSC_Mode_Sense10_data[len];
   }
+
+  // set bit 7 of the device configuration byte to indicate write protection
+  if (((USBD_StorageTypeDef *)pdev->pMSC_UserData)->IsWriteProtected(lun) != 0) {
+      hmsc->bot_data[3] = hmsc->bot_data[3] | (1 << 7);
+  }
+
   return 0;
 }
 

--- a/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_scsi.c
+++ b/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_scsi.c
@@ -347,6 +347,12 @@ static int8_t SCSI_ModeSense6 (USBD_HandleTypeDef  *pdev, uint8_t lun, uint8_t *
     len--;
     hmsc->bot_data[len] = MSC_Mode_Sense6_data[len];
   }
+
+  // set bit 7 of the device configuration byte to indicate write protection
+  if (((USBD_StorageTypeDef *)pdev->pMSC_UserData)->IsWriteProtected(lun) != 0) {
+      hmsc->bot_data[2] = hmsc->bot_data[2] | (1 << 7);
+  }
+
   return 0;
 }
 
@@ -370,6 +376,12 @@ static int8_t SCSI_ModeSense10 (USBD_HandleTypeDef  *pdev, uint8_t lun, uint8_t 
     len--;
     hmsc->bot_data[len] = MSC_Mode_Sense10_data[len];
   }
+
+  // set bit 7 of the device configuration byte to indicate write protection
+  if (((USBD_StorageTypeDef *)pdev->pMSC_UserData)->IsWriteProtected(lun) != 0) {
+      hmsc->bot_data[3] = hmsc->bot_data[3] | (1 << 7);
+  }
+
   return 0;
 }
 

--- a/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_scsi.c
+++ b/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_scsi.c
@@ -346,6 +346,12 @@ static int8_t SCSI_ModeSense6(USBD_HandleTypeDef  *pdev, uint8_t lun, uint8_t *p
     len--;
     hmsc->bot_data[len] = MSC_Mode_Sense6_data[len];
   }
+
+  // set bit 7 of the device configuration byte to indicate write protection
+  if (((USBD_StorageTypeDef *)pdev->pMSC_UserData)->IsWriteProtected(lun) != 0) {
+      hmsc->bot_data[2] = hmsc->bot_data[2] | (1 << 7);
+  }
+
   return 0;
 }
 
@@ -369,6 +375,11 @@ static int8_t SCSI_ModeSense10(USBD_HandleTypeDef  *pdev, uint8_t lun, uint8_t *
   {
     len--;
     hmsc->bot_data[len] = MSC_Mode_Sense10_data[len];
+  }
+
+  // set bit 7 of the device configuration byte to indicate write protection
+  if (((USBD_StorageTypeDef *)pdev->pMSC_UserData)->IsWriteProtected(lun) != 0) {
+      hmsc->bot_data[3] = hmsc->bot_data[3] | (1 << 7);
   }
 
   return 0;


### PR DESCRIPTION
The USB MSC / SCSI layer currently doesn't set the write protect bit in the SCSI ModeSense response. Due to this, the Emulated FAT file system used for the internal flash doesn't get mounted read-only. When mounting the drive on Linux, the host attempts to write to the drive (I assume for the access time) , which fails and then the mounting doesn't succeed.

This fix sets the relevant bit in the SCSI ModeSense responses. The host doesn't attempt to write to the drive and the mounting works as expected.

This is only for H7 targets. The fix also should be added to F7 etc. 

Fixes #9160

Before:
      [1191094.145018] scsi 3:0:0:0: Direct-Access     INAV FC  Onboard Flash         PQ: 0 ANSI: 2
      [1191094.145670] sd 3:0:0:0: [sdc] 527470 512-byte logical blocks: (270 MB/258 MiB)
      [1191094.145815] sd 3:0:0:0: [sdc] Write Protect is off
      [1191094.145817] sd 3:0:0:0: [sdc] Mode Sense: 00 00 00 00

With this fix:
      [19418.047443] scsi 4:0:0:0: Direct-Access     INAV FC  Onboard Flash         PQ: 0 ANSI: 2
      [19418.048021] sd 4:0:0:0: [sdd] 527470 512-byte logical blocks: (270 MB/258 MiB)
      [19418.048224] sd 4:0:0:0: [sdd] Write Protect is on
      [19418.048229] sd 4:0:0:0: [sdd] Mode Sense: 00 00 80 00
