### PR TITLE
fixed: gps sensor can not recover from timeout in gps fix estimation mode

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -399,11 +399,13 @@ void gpsProcessNewSolutionData(bool timeout)
     // Update time
     gpsUpdateTime();
 
-    // Update timeout
-    gpsSetProtocolTimeout(gpsState.baseTimeoutMs);
+    if (!timeout) {
+        // Update timeout
+        gpsSetProtocolTimeout(gpsState.baseTimeoutMs);
 
-    // Update statistics
-    gpsStats.lastMessageDt = gpsState.lastMessageMs - gpsState.lastLastMessageMs;
+        // Update statistics
+        gpsStats.lastMessageDt = gpsState.lastMessageMs - gpsState.lastLastMessageMs;
+    }
     gpsSol.flags.hasNewData = true;
 
     // Toggle heartbeat


### PR DESCRIPTION
if gps sensor reset for some reason(hw problem?) and got into timeout state, and gps fix estimation mode is enabled, gps sensor is unable to reinitialize because timeout is reset to small value.