### PR TITLE
IRC Tramp table power selection for VTX Foxeer Reaper 2,5W & Reaper Infinity 5W

### DIFF
--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -603,7 +603,7 @@ static void vtxProtoUpdatePowerMetadata(uint16_t maxPower)
                 vtxState.metadata.powerTableCount = VTX_TRAMP_5G8_MAX_POWER_COUNT;
             
                 impl_vtxDevice.capability.powerNames = (char **)trampPowerNames_5G8_800;
-                impl_vtxDevice.capability.powerCount = VTX_TRAMP_5G8_MAX_POWER_COUNT;
+                impl_vtxDevice.capability.powerCount = 5;
             } else if (maxPower >= 5000) {
                 // Max power 5000mW: Use 50, 500, 1000, 2500, 5000 table
                 vtxState.metadata.powerTablePtr  = trampPowerTable_5G8_5000;

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -575,6 +575,9 @@ const char * const trampPowerNames_5G8_800[VTX_TRAMP_5G8_MAX_POWER_COUNT + 1] = 
 const uint16_t trampPowerTable_5G8_2500[VTX_TRAMP_5G8_MAX_POWER_COUNT]         = { 25, 200, 500, 1500, 2500 };
 const char * const trampPowerNames_5G8_2500[VTX_TRAMP_5G8_MAX_POWER_COUNT + 1] = { "----", "25  ", "200 ", "500 ", "1500", "2500" };
 
+const uint16_t trampPowerTable_5G8_5000[VTX_TRAMP_5G8_MAX_POWER_COUNT]         = { 50, 500, 1000, 2500, 5000 };
+const char * const trampPowerNames_5G8_5000[VTX_TRAMP_5G8_MAX_POWER_COUNT + 1] = { "---", "50 ", "500", "1000", "2500", "5000" };
+
 const uint16_t trampPowerTable_1G3_800[VTX_TRAMP_1G3_MAX_POWER_COUNT]         = { 25, 200, 800 };
 const char * const trampPowerNames_1G3_800[VTX_TRAMP_1G3_MAX_POWER_COUNT + 1] = { "----", "25  ", "200 ", "800 " };
 
@@ -598,9 +601,16 @@ static void vtxProtoUpdatePowerMetadata(uint16_t maxPower)
                 // Max power 800mW: Use 25, 200, 500, 1500, 2500 table
                 vtxState.metadata.powerTablePtr  = trampPowerTable_5G8_2500;
                 vtxState.metadata.powerTableCount = VTX_TRAMP_5G8_MAX_POWER_COUNT;
-                
+            
                 impl_vtxDevice.capability.powerNames = (char **)trampPowerNames_5G8_800;
                 impl_vtxDevice.capability.powerCount = VTX_TRAMP_5G8_MAX_POWER_COUNT;
+            } else if (maxPower >= 5000) {
+                // Max power 5000mW: Use 50, 500, 1000, 2500, 5000 table
+                vtxState.metadata.powerTablePtr  = trampPowerTable_5G8_5000;
+                vtxState.metadata.powerTableCount = VTX_TRAMP_5G8_MAX_POWER_COUNT;
+
+                impl_vtxDevice.capability.powerNames = (char **)trampPowerNames_5G8_5000;
+                impl_vtxDevice.capability.powerCount = 5;
             } else if (maxPower >= 800) {
                 // Max power 800mW: Use 25, 100, 200, 500, 800 table
                 vtxState.metadata.powerTablePtr  = trampPowerTable_5G8_800;


### PR DESCRIPTION
Increasing power levels up to 5000mV for VTX Foxeer Infinity 5W