### PR TITLE
Double barometers proposal

### DIFF
--- a/src/main/config/parameter_group_ids.h
+++ b/src/main/config/parameter_group_ids.h
@@ -76,7 +76,8 @@
 #define PG_VTX_CONFIG 54
 // #define PG_ELERES_CONFIG 55
 #define PG_TEMP_SENSOR_CONFIG 56
-#define PG_CF_END 56
+#define PG_MULTI_BAROMETER_CONFIG 57
+#define PG_CF_END 57
 
 // Driver configuration
 //#define PG_DRIVER_PWM_RX_CONFIG 100

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -3939,7 +3939,6 @@ static void cliDiff(char *cmdline)
     printConfig(cmdline, true);
 }
 
-
 #ifdef USE_BARO_MULTI
 static void cliBaroMulti(char *cmdline) 
 {

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -184,8 +184,12 @@ static const char * const blackboxIncludeFlagNames[] = {
 };
 #endif
 
+#ifdef USE_BARO
 #ifdef USE_BARO_MULTI
-static const char * const baroNames[] = { "NONE", "AUTO", "BMP085", "MS5611", "BMP280", "MS5607", "LPS25H", "SPL06", "BMP388", "DPS310", "B2SMPB", "MSP", "FAKE"};
+static const char * const baroNames[] = {
+    "NONE", "AUTO", "BMP085", "MS5611", "BMP280", "MS5607", "LPS25H", "SPL06", "BMP388", "DPS310", "B2SMPB", "MSP", "FAKE"
+};
+#endif
 #endif
 
 /* Sensor names (used in lookup tables for *_hardware settings and in status command output) */

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -184,10 +184,13 @@ static const char * const blackboxIncludeFlagNames[] = {
 };
 #endif
 
+#ifdef USE_BARO_MULTI
+static const char * const baroNames[] = { "NONE", "AUTO", "BMP085", "MS5611", "BMP280", "MS5607", "LPS25H", "SPL06", "BMP388", "DPS310", "B2SMPB", "MSP", "FAKE"};
+#endif
+
 /* Sensor names (used in lookup tables for *_hardware settings and in status command output) */
 // sync with gyroSensor_e
 static const char * const gyroNames[] = { "NONE", "AUTO", "MPU6000", "MPU6500", "MPU9250", "BMI160", "ICM20689", "BMI088", "ICM42605", "BMI270","LSM6DXX", "FAKE"};
-static const char * const baroNames[] = { "NONE", "AUTO", "BMP085", "MS5611", "BMP280", "MS5607", "LPS25H", "SPL06", "BMP388", "DPS310", "B2SMPB", "MSP", "FAKE"};
 
 // sync this with sensors_e
 static const char * const sensorTypeNames[] = {
@@ -3938,6 +3941,7 @@ static void cliDiff(char *cmdline)
 {
     printConfig(cmdline, true);
 }
+
 
 #ifdef USE_BARO_MULTI
 static void cliBaroMulti(char *cmdline) 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -127,6 +127,7 @@ bool cliMode = false;
 
 extern timeDelta_t cycleTime; // FIXME dependency on mw.c
 extern uint8_t detectedSensors[SENSOR_INDEX_COUNT];
+extern uint8_t detectedMultiSensors[SENSOR_MULTI_INDEX_COUNT];
 
 static serialPort_t *cliPort;
 
@@ -186,6 +187,7 @@ static const char * const blackboxIncludeFlagNames[] = {
 /* Sensor names (used in lookup tables for *_hardware settings and in status command output) */
 // sync with gyroSensor_e
 static const char * const gyroNames[] = { "NONE", "AUTO", "MPU6000", "MPU6500", "MPU9250", "BMI160", "ICM20689", "BMI088", "ICM42605", "BMI270","LSM6DXX", "FAKE"};
+static const char * const baroNames[] = { "NONE", "AUTO", "BMP085", "MS5611", "BMP280", "MS5607", "LPS25H", "SPL06", "BMP388", "DPS310", "B2SMPB", "MSP", "FAKE"};
 
 // sync this with sensors_e
 static const char * const sensorTypeNames[] = {
@@ -3937,6 +3939,24 @@ static void cliDiff(char *cmdline)
     printConfig(cmdline, true);
 }
 
+
+#ifdef USE_BARO_MULTI
+static void cliBaroMulti(char *cmdline) 
+{
+
+    UNUSED(cmdline);
+
+    cliPrintLinef("Barometers Data:");
+    cliPrintLinef("\tBarometer First: %s", baroNames[getBaroMultiFirstHardware()]);
+    cliPrintLinef("\t\tTemperature: %d", baroMultiGetTemperature(0));
+    cliPrintLinef("\t\tAltitude: %d", baroMultiGetLatestAltitude(0));
+    cliPrintLinef("\tBarometer Second: %s", baroNames[getBaroMultiSecondHardware()]);
+    cliPrintLinef("\t\tTemperature: %d", baroMultiGetTemperature(1));
+    cliPrintLinef("\t\tAltitude: %d", baroMultiGetLatestAltitude(1));
+    cliPrintLinefeed();
+}
+#endif
+
 #ifdef USE_USB_MSC
 static void cliMsc(char *cmdline)
 {
@@ -4110,6 +4130,11 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("osd_layout", "get or set the layout of OSD items", "[<layout> [<item> [<col> <row> [<visible>]]]]", cliOsdLayout),
 #endif
     CLI_COMMAND_DEF("timer_output_mode", "get or set the outputmode for a given timer.",  "[<timer> [<AUTO|MOTORS|SERVOS>]]", cliTimerOutputMode),
+#ifdef USE_BARO
+#ifdef USE_BARO_MULTI
+    CLI_COMMAND_DEF("baro", "get RAW barometer data for each of used with #USE_BARO_NULTI defined", NULL, cliBaroMulti),
+#endif
+#endif    
 };
 
 static void cliHelp(char *cmdline)

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -44,6 +44,7 @@
 #include "drivers/bus_i2c.h"
 
 #include "sensors/sensors.h"
+#include "sensors/barometer.h"
 #include "sensors/gyro.h"
 #include "sensors/compass.h"
 #include "sensors/acceleration.h"
@@ -556,4 +557,12 @@ uint32_t getPreferredBeeperOffMask(void)
 void setPreferredBeeperOffMask(uint32_t mask)
 {
     beeperConfigMutable()->preferred_beeper_off_flags = mask;
+}
+
+uint8_t getBaroMultiFirstHardware(void) {
+    return (uint8_t)barometerMultiConfigMutable()->multi_baro_hardware_1;
+}
+
+uint8_t getBaroMultiSecondHardware(void) {
+    return (uint8_t)barometerMultiConfigMutable()->multi_baro_hardware_2;
 }

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -153,5 +153,8 @@ void createDefaultConfig(void);
 void resetConfigs(void);
 void targetConfiguration(void);
 
+uint8_t getBaroMultiFirstHardware(void);
+uint8_t getBaroMultiSecondHardware(void);
+
 uint32_t getLooptime(void);
 uint32_t getGyroLooptime(void);

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -184,14 +184,20 @@ void taskUpdateCompass(timeUs_t currentTimeUs)
 #ifdef USE_BARO
 void taskUpdateBaro(timeUs_t currentTimeUs)
 {
+    LOG_DEBUG(SYSTEM, "taskUpdateBaro");
+
     if (!sensors(SENSOR_BARO)) {
+        LOG_DEBUG(SYSTEM, "!sensors(SENSOR_BARO) true");
         return;
     }
 
     const uint32_t newDeadline = baroUpdate();
     if (newDeadline != 0) {
+        LOG_DEBUG(SYSTEM, "rescheduleTask(TASK_SELF, newDeadline);");
+
         rescheduleTask(TASK_SELF, newDeadline);
     }
+    LOG_DEBUG(SYSTEM, "updatePositionEstimator_BaroTopic(currentTimeUs);");
 
     updatePositionEstimator_BaroTopic(currentTimeUs);
 }

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -184,20 +184,14 @@ void taskUpdateCompass(timeUs_t currentTimeUs)
 #ifdef USE_BARO
 void taskUpdateBaro(timeUs_t currentTimeUs)
 {
-    LOG_DEBUG(SYSTEM, "taskUpdateBaro");
-
     if (!sensors(SENSOR_BARO)) {
-        LOG_DEBUG(SYSTEM, "!sensors(SENSOR_BARO) true");
         return;
     }
 
     const uint32_t newDeadline = baroUpdate();
     if (newDeadline != 0) {
-        LOG_DEBUG(SYSTEM, "rescheduleTask(TASK_SELF, newDeadline);");
-
         rescheduleTask(TASK_SELF, newDeadline);
     }
-    LOG_DEBUG(SYSTEM, "updatePositionEstimator_BaroTopic(currentTimeUs);");
 
     updatePositionEstimator_BaroTopic(currentTimeUs);
 }

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -581,6 +581,38 @@ groups:
         min: 0
         max: 1000
 
+  - name: PG_MULTI_BAROMETER_CONFIG
+    type: barometerMultiConfig_t
+    headers: ["sensors/barometer.h"]
+    condition: USE_BARO_MULTI
+    members:
+      - name: multi_baro_count
+        description: "Multiple barometers_count"
+        default_value: 2
+        field: multi_baro_count
+        min: 1
+        max: 2    
+      - name: multi_baro_hardware_1
+        description: "Selection of first multi baro hardware. See Wiki Sensor auto detect and hardware failure detection for more info"
+        default_value: "AUTO"
+        table: baro_hardware
+      - name: multi_baro_cal_tolerance_1
+        description: "Baro calibration tolerance in cm. The default should allow the noisiest baro to complete calibration [cm]."
+        default_value: 150
+        field: multi_baro_calibration_tolerance_1
+        min: 0
+        max: 1000
+      - name: multi_baro_hardware_2
+        description: "Selection of first multi baro hardware. See Wiki Sensor auto detect and hardware failure detection for more info"
+        default_value: "AUTO"
+        table: baro_hardware
+      - name: multi_baro_cal_tolerance_2
+        description: "Baro calibration tolerance in cm. The default should allow the noisiest baro to complete calibration [cm]."
+        default_value: 150
+        field: multi_baro_calibration_tolerance_2
+        min: 0
+        max: 1000        
+
   - name: PG_PITOTMETER_CONFIG
     type: pitotmeterConfig_t
     headers: ["sensors/pitotmeter.h"]
@@ -2305,7 +2337,7 @@ groups:
         type: bool
       - name: inav_reset_altitude
         description: "Defines when relative estimated altitude is reset to zero. Variants - `NEVER` (once reference is acquired it's used regardless); `FIRST_ARM` (keep altitude at zero until firstly armed), `EACH_ARM` (altitude is reset to zero on each arming)"
-        default_value: "FIRST_ARM"
+        default_value: "NEVER"
         field: reset_altitude_type
         table: reset_type
       - name: inav_reset_home

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -66,6 +66,11 @@ PG_RESET_TEMPLATE(barometerConfig_t, barometerConfig,
     .baro_calibration_tolerance = SETTING_BARO_CAL_TOLERANCE_DEFAULT
 );
 
+#ifndef USE_BARO_MULTI
+static zeroCalibrationScalar_t zeroCalibration;
+static float baroGroundAltitude = 0;
+static float baroGroundPressure = 101325.0f; // 101325 pascal, 1 standard atmosphere
+#else
 PG_REGISTER_WITH_RESET_TEMPLATE(barometerMultiConfig_t, barometerMultiConfig, PG_MULTI_BAROMETER_CONFIG, 4);
 
 PG_RESET_TEMPLATE(barometerMultiConfig_t, barometerMultiConfig,
@@ -76,11 +81,6 @@ PG_RESET_TEMPLATE(barometerMultiConfig_t, barometerMultiConfig,
     .multi_baro_calibration_tolerance_2 = SETTING_MULTI_BARO_CAL_TOLERANCE_2_DEFAULT
 );
 
-#ifndef USE_BARO_MULTI
-static zeroCalibrationScalar_t zeroCalibration;
-static float baroGroundAltitude = 0;
-static float baroGroundPressure = 101325.0f; // 101325 pascal, 1 standard atmosphere
-#else
 static zeroCalibrationScalar_t multiZeroCalibration[2];
 static float baroMultiGroundAltitude[2] = {0, 0};
 static float baroMultiGroundPressure[2] = {101325.0f, 101325.0f}; // 101325 pascal, 1 standard atmosphere
@@ -492,6 +492,7 @@ int32_t baroMultiGetLatestAltitude(uint8_t baroIndex)
     #ifdef USE_BARO_MULTI
         return multiBaro[baroIndex].BaroAlt;
     #else
+        UNUSED(baroIndex);
         return 0;
     #endif
 }
@@ -514,6 +515,7 @@ int16_t baroMultiGetTemperature(uint8_t baroIndex)
 #ifdef USE_BARO_MULTI
     return CENTIDEGREES_TO_DECIDEGREES(multiBaro[baroIndex].baroTemperature);
 #else    
+    UNUSED(baroIndex);
     return 0;
 #endif
 }

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -55,6 +55,7 @@
 #endif
 
 baro_t baro;                        // barometer access functions
+baro_t multiBaro[2];
 
 #ifdef USE_BARO
 
@@ -65,11 +66,27 @@ PG_RESET_TEMPLATE(barometerConfig_t, barometerConfig,
     .baro_calibration_tolerance = SETTING_BARO_CAL_TOLERANCE_DEFAULT
 );
 
+PG_REGISTER_WITH_RESET_TEMPLATE(barometerMultiConfig_t, barometerMultiConfig, PG_MULTI_BAROMETER_CONFIG, 4);
+
+PG_RESET_TEMPLATE(barometerMultiConfig_t, barometerMultiConfig,
+    .multi_baro_count = SETTING_MULTI_BARO_COUNT_DEFAULT,
+    .multi_baro_hardware_1 = SETTING_MULTI_BARO_HARDWARE_1_DEFAULT,
+    .multi_baro_calibration_tolerance_1 = SETTING_MULTI_BARO_CAL_TOLERANCE_1_DEFAULT,
+    .multi_baro_hardware_2 = SETTING_MULTI_BARO_HARDWARE_2_DEFAULT,
+    .multi_baro_calibration_tolerance_2 = SETTING_MULTI_BARO_CAL_TOLERANCE_2_DEFAULT
+);
+
+#ifndef USE_BARO_MULTI
 static zeroCalibrationScalar_t zeroCalibration;
 static float baroGroundAltitude = 0;
 static float baroGroundPressure = 101325.0f; // 101325 pascal, 1 standard atmosphere
+#else
+static zeroCalibrationScalar_t multiZeroCalibration[2];
+static float baroMultiGroundAltitude[2] = {0, 0};
+static float baroMultiGroundPressure[2] = {101325.0f, 101325.0f}; // 101325 pascal, 1 standard atmosphere
+#endif
 
-bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse)
+bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse, int baro_index)
 {
     // Detect what pressure sensors are available. baro->update() is set to sensor-specific update function
 
@@ -232,17 +249,44 @@ bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse)
         return false;
     }
 
-    detectedSensors[SENSOR_INDEX_BARO] = baroHardware;
+    if(baro_index == BARO_FAKE) {
+        detectedSensors[SENSOR_INDEX_BARO] = baroHardware;
+    } else if (baro_index == SENSOR_MULTI_INDEX_BARO_FIRST) {
+        // Need to implement composite hardware type here for to assign into sensors
+        // instead of using first one
+        detectedSensors[SENSOR_INDEX_BARO] = baroHardware;
+        detectedMultiSensors[SENSOR_MULTI_INDEX_BARO_FIRST] = baroHardware;
+    } else if (baro_index == SENSOR_MULTI_INDEX_BARO_SECOND) {
+        detectedMultiSensors[SENSOR_MULTI_INDEX_BARO_SECOND] = baroHardware;
+    }
+
     sensorsSet(SENSOR_BARO);
     return true;
 }
 
 bool baroInit(void)
 {
-    if (!baroDetect(&baro.dev, barometerConfig()->baro_hardware)) {
+#ifdef USE_BARO_MULTI
+    uint8_t detectedBaroHardware;
+    for(int i = 0; i < barometerMultiConfig()->multi_baro_count; i++) {
+        if(i == 0) {
+            detectedBaroHardware = barometerMultiConfig()->multi_baro_hardware_1;
+        }
+        if(i == 1) {
+            detectedBaroHardware = barometerMultiConfig()->multi_baro_hardware_2;
+        }
+        if(!baroDetect(&multiBaro[i].dev, detectedBaroHardware, i)) {
+            return false;
+        }
+    }
+    baro.dev = multiBaro[0].dev;
+    return true;
+#else    
+    if (!baroDetect(&baro.dev, barometerConfig()->baro_hardware, BARO_FAKE)) {
         return false;
     }
     return true;
+#endif   
 }
 
 typedef enum {
@@ -252,7 +296,18 @@ typedef enum {
 
 uint32_t baroUpdate(void)
 {
+#ifdef USE_BARO_MULTI
+    int hardwareCount = barometerMultiConfig()->multi_baro_count;
+    int delays[4] = {0, 0, 0, 0};
+
+    static barometerState_e multiState[] = {
+        BAROMETER_NEEDS_SAMPLES,
+        BAROMETER_NEEDS_SAMPLES
+    }; //Here is multi state with maximum length of config value
+    
+#else
     static barometerState_e state = BAROMETER_NEEDS_SAMPLES;
+#endif
 
 #ifdef USE_SIMULATOR
     if (ARMING_FLAG(SIMULATOR_MODE_HITL)) {
@@ -260,6 +315,49 @@ uint32_t baroUpdate(void)
     }
 #endif
 
+#ifdef USE_BARO_MULTI
+    for(int i = 0; i < hardwareCount; i++) {
+        switch (multiState[i]) {
+            default:
+            case BAROMETER_NEEDS_SAMPLES:
+                
+                if (multiBaro[i].dev.get_ut) {
+                    multiBaro[i].dev.get_ut(&multiBaro[i].dev);
+                }
+                if (multiBaro[i].dev.start_up) {
+                    multiBaro[i].dev.start_up(&multiBaro[i].dev);
+                }
+                multiState[i] = BAROMETER_NEEDS_CALCULATION;
+                delays[i] = multiBaro[i].dev.up_delay;
+                delays[i+2] = 0;
+            break;
+
+            case BAROMETER_NEEDS_CALCULATION:
+                if (multiBaro[i].dev.get_up) {
+                    multiBaro[i].dev.get_up(&multiBaro[i].dev);
+                }
+                if (multiBaro[i].dev.start_ut) {
+                    multiBaro[i].dev.start_ut(&multiBaro[i].dev);
+                }
+                //output: baro.baroPressure, baro.baroTemperature
+                multiBaro[i].dev.calculate(&multiBaro[i].dev, &multiBaro[i].baroPressure, &multiBaro[i].baroTemperature);
+                multiState[i] = BAROMETER_NEEDS_SAMPLES;
+                delays[i] = 0;
+                delays[i+2] = multiBaro[i].dev.ut_delay;
+            break;
+        }
+    }
+
+    // return longest delay, must be refactored
+    if(delays[0] != 0 || delays[1] != 0) {
+        return (delays[0] >=  delays[1]) ? delays[0] : delays[1];
+    } else if (delays[2] != 0 || delays[3] != 0) {
+        return (delays[2] >=  delays[3]) ? delays[2] : delays[3];
+    } else {
+        return 0;
+    }
+
+#else
     switch (state) {
         default:
         case BAROMETER_NEEDS_SAMPLES:
@@ -286,7 +384,9 @@ uint32_t baroUpdate(void)
             return baro.dev.ut_delay;
         break;
     }
+#endif
 }
+
 
 static float pressureToAltitude(const float pressure)
 {
@@ -300,44 +400,122 @@ float altitudeToPressure(const float altCm)
 
 bool baroIsCalibrationComplete(void)
 {
+#ifdef USE_BARO_MULTI    
+    return 
+        zeroCalibrationIsCompleteS(&multiZeroCalibration[0]) && 
+        zeroCalibrationIsSuccessfulS(&multiZeroCalibration[0]) && 
+        zeroCalibrationIsCompleteS(&multiZeroCalibration[1]) &&
+        zeroCalibrationIsSuccessfulS(&multiZeroCalibration[1]);
+#else
     return zeroCalibrationIsCompleteS(&zeroCalibration) && zeroCalibrationIsSuccessfulS(&zeroCalibration);
+#endif    
 }
 
 void baroStartCalibration(void)
 {
+#ifdef USE_BARO_MULTI    
+    const float acceptedPressureVarianceFirst = (101325.0f - altitudeToPressure(barometerMultiConfig()->multi_baro_calibration_tolerance_1)); // max 30cm deviation during calibration (at sea level)
+    const float acceptedPressureVarianceSecond = (101325.0f - altitudeToPressure(barometerMultiConfig()->multi_baro_calibration_tolerance_2)); // max 30cm deviation during calibration (at sea level)
+    zeroCalibrationStartS(&multiZeroCalibration[0], CALIBRATING_BARO_TIME_MS, acceptedPressureVarianceFirst, false);
+    zeroCalibrationStartS(&multiZeroCalibration[1], CALIBRATING_BARO_TIME_MS, acceptedPressureVarianceSecond, false);
+#else
     const float acceptedPressureVariance = (101325.0f - altitudeToPressure(barometerConfig()->baro_calibration_tolerance)); // max 30cm deviation during calibration (at sea level)
     zeroCalibrationStartS(&zeroCalibration, CALIBRATING_BARO_TIME_MS, acceptedPressureVariance, false);
+#endif    
 }
+
 
 int32_t baroCalculateAltitude(void)
 {
-    if (!baroIsCalibrationComplete()) {
-        zeroCalibrationAddValueS(&zeroCalibration, baro.baroPressure);
+    #ifdef USE_BARO_MULTI
+        int32_t calcBaroAlt = 0;
 
-        if (zeroCalibrationIsCompleteS(&zeroCalibration)) {
-            zeroCalibrationGetZeroS(&zeroCalibration, &baroGroundPressure);
-            baroGroundAltitude = pressureToAltitude(baroGroundPressure);
-            LOG_DEBUG(BARO, "Barometer calibration complete (%d)", (int)lrintf(baroGroundAltitude));
+        if (!baroIsCalibrationComplete()) {
+            for(int i = 0; i < barometerMultiConfig()->multi_baro_count; i++) {
+                zeroCalibrationAddValueS(&multiZeroCalibration[i], multiBaro[i].baroPressure);
+
+                if (zeroCalibrationIsCompleteS(&multiZeroCalibration[i])) {
+                    zeroCalibrationGetZeroS(&multiZeroCalibration[i], &baroMultiGroundPressure[i]);
+                    baroMultiGroundAltitude[i] = pressureToAltitude(baroMultiGroundPressure[i]);
+                    LOG_DEBUG( SYSTEM, "Barometer calibration complete (%d)", (int)lrintf(baroMultiGroundAltitude[i]));
+                }
+
+                multiBaro[i].BaroAlt = 0;
+            }
+        } else {
+            // calculates height from ground via baro readings
+            
+            for (int i = 0; i < barometerMultiConfig()->multi_baro_count; i++) {
+                multiBaro[i].BaroAlt = pressureToAltitude(multiBaro[i].baroPressure) - baroMultiGroundAltitude[i];
+            }            
         }
+        for(int i = 0; i < barometerMultiConfig()->multi_baro_count; i++) {
+            calcBaroAlt += multiBaro[i].BaroAlt;
+        }
+        return calcBaroAlt / (int)barometerMultiConfig()->multi_baro_count;
+    #else
+        if (!baroIsCalibrationComplete()) {
+            zeroCalibrationAddValueS(&zeroCalibration, baro.baroPressure);
 
-        baro.BaroAlt = 0;
-    }
-    else {
-        // calculates height from ground via baro readings
-        baro.BaroAlt = pressureToAltitude(baro.baroPressure) - baroGroundAltitude;
-   }
-
-    return baro.BaroAlt;
+            if (zeroCalibrationIsCompleteS(&zeroCalibration)) {
+                zeroCalibrationGetZeroS(&zeroCalibration, &baroGroundPressure);
+                baroGroundAltitude = pressureToAltitude(baroGroundPressure);
+                LOG_DEBUG(BARO, "Barometer calibration complete (%d)", (int)lrintf(baroGroundAltitude));
+            }
+            baro.BaroAlt = 0;
+        } else {
+            // calculates height from ground via baro readings
+            baro.BaroAlt = pressureToAltitude(baro.baroPressure) - baroGroundAltitude;
+        }
+        return baro.BaroAlt;
+   #endif
 }
 
 int32_t baroGetLatestAltitude(void)
 {
-    return baro.BaroAlt;
+    #ifdef USE_BARO_MULTI
+        int32_t calcMultiBaroAlt = 0;
+        for(int i = 0; i < barometerMultiConfig()->multi_baro_count; i++) {
+            calcMultiBaroAlt += multiBaro[i].BaroAlt;
+        }
+        LOG_DEBUG( SYSTEM, "MultiBaro:latestAlt %u", (unsigned int)(calcMultiBaroAlt) );
+
+        return calcMultiBaroAlt / (int)barometerMultiConfig()->multi_baro_count;
+
+    #else
+        return baro.BaroAlt;
+    #endif
+}
+
+int32_t baroMultiGetLatestAltitude(uint8_t baroIndex)
+{   
+    #ifdef USE_BARO_MULTI
+        return multiBaro[baroIndex].BaroAlt;
+    #else
+        return 0;
+    #endif
 }
 
 int16_t baroGetTemperature(void)
 {   
+#ifdef USE_BARO_MULTI
+    int32_t calcMultiBaroTemperature = 0;
+    for(int i = 0; i < barometerMultiConfig()->multi_baro_count; i++) {
+        calcMultiBaroTemperature += CENTIDEGREES_TO_DECIDEGREES(multiBaro[i].baroTemperature);
+    }
+    return calcMultiBaroTemperature / (int)barometerMultiConfig()->multi_baro_count;
+#else    
     return CENTIDEGREES_TO_DECIDEGREES(baro.baroTemperature);
+#endif
+}
+
+int16_t baroMultiGetTemperature(uint8_t baroIndex)
+{   
+#ifdef USE_BARO_MULTI
+    return CENTIDEGREES_TO_DECIDEGREES(multiBaro[baroIndex].baroTemperature);
+#else    
+    return 0;
+#endif
 }
 
 bool baroIsHealthy(void)

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -46,6 +46,7 @@ typedef struct baro_s {
 } baro_t;
 
 extern baro_t baro;
+extern baro_t multiBaro[2];
 
 #ifdef USE_BARO
 
@@ -56,6 +57,15 @@ typedef struct barometerConfig_s {
 
 PG_DECLARE(barometerConfig_t, barometerConfig);
 
+typedef struct barometerMultiConfig_s {
+    uint8_t multi_baro_count;                       // Total Barometers count to use
+    uint8_t multi_baro_hardware_1;                  // First Barometer hardware to use
+    uint16_t multi_baro_calibration_tolerance_1;    // First Baro calibration tolerance (cm at sea level)
+    uint8_t multi_baro_hardware_2;                  // Second Barometer hardware to use
+    uint16_t multi_baro_calibration_tolerance_2;    // Second Baro calibration tolerance (cm at sea level)
+} barometerMultiConfig_t;
+
+PG_DECLARE(barometerMultiConfig_t, barometerMultiConfig);
 
 bool baroInit(void);
 bool baroIsCalibrationComplete(void);
@@ -64,6 +74,8 @@ uint32_t baroUpdate(void);
 int32_t baroCalculateAltitude(void);
 int32_t baroGetLatestAltitude(void);
 int16_t baroGetTemperature(void);
+int32_t baroMultiGetLatestAltitude(uint8_t baroIndex);
+int16_t baroMultiGetTemperature(uint8_t baroIndex);
 bool baroIsHealthy(void);
 
 #if defined(SITL_BUILD)

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -43,6 +43,7 @@
 
 uint8_t requestedSensors[SENSOR_INDEX_COUNT] = { GYRO_AUTODETECT, ACC_NONE, BARO_NONE, MAG_NONE, RANGEFINDER_NONE, PITOT_NONE, OPFLOW_NONE };
 uint8_t detectedSensors[SENSOR_INDEX_COUNT] = { GYRO_NONE, ACC_NONE, BARO_NONE, MAG_NONE, RANGEFINDER_NONE, PITOT_NONE, OPFLOW_NONE };
+uint8_t detectedMultiSensors[SENSOR_MULTI_INDEX_COUNT] = { BARO_NONE, BARO_NONE };
 
 bool sensorsAutodetect(void)
 {
@@ -86,6 +87,10 @@ bool sensorsAutodetect(void)
 #ifdef USE_BARO
     if (barometerConfig()->baro_hardware == BARO_AUTODETECT) {
         barometerConfigMutable()->baro_hardware = detectedSensors[SENSOR_INDEX_BARO];
+#ifdef USE_BARO_MULTI
+        barometerMultiConfigMutable()->multi_baro_hardware_1 = detectedMultiSensors[MULTI_SENSOR_BARO_FIRST];
+        barometerMultiConfigMutable()->multi_baro_hardware_2 = detectedMultiSensors[MULTI_SENSOR_BARO_FIRST];
+#endif        
         eepromUpdatePending = true;
     }
 #endif

--- a/src/main/sensors/sensors.h
+++ b/src/main/sensors/sensors.h
@@ -28,6 +28,12 @@ typedef enum {
     SENSOR_INDEX_COUNT
 } sensorIndex_e;
 
+typedef enum {
+    SENSOR_MULTI_INDEX_BARO_FIRST = 0,
+    SENSOR_MULTI_INDEX_BARO_SECOND,
+    SENSOR_MULTI_INDEX_COUNT
+} sensorMultiIndex_e;
+
 typedef struct int16_flightDynamicsTrims_s {
     int16_t roll;
     int16_t pitch;
@@ -59,5 +65,12 @@ typedef enum {
     SENSOR_TEMP = 1 << 9
 } sensors_e;
 
+// These bits have to be aligned with sensorMultiIndex_e
+typedef enum {
+    MULTI_SENSOR_BARO_FIRST = 1 << 0, // always present
+    MULTI_SENSOR_BARO_SECOND = 1 << 1
+} sensors_multi_e;
+
 extern uint8_t requestedSensors[SENSOR_INDEX_COUNT];
 extern uint8_t detectedSensors[SENSOR_INDEX_COUNT];
+extern uint8_t detectedMultiSensors[SENSOR_MULTI_INDEX_COUNT];

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -92,9 +92,9 @@
         #define BMP085_I2C_BUS BARO_I2C_BUS
     #endif
     #if !defined(BMP085_I2C_ADDR)
-        #define BMP085_I2C_ADDR (0x77)
+        #define BMP085_I2C_ADDR 0x77
     #endif    
-    BUSDEV_REGISTER_I2C(busdev_bmp085,      DEVHW_BMP085,       BMP085_I2C_BUS,     0x77,               NONE,           DEVFLAGS_NONE,      0);
+    BUSDEV_REGISTER_I2C(busdev_bmp085,      DEVHW_BMP085,       BMP085_I2C_BUS,     BMP085_I2C_ADDR,    NONE,           DEVFLAGS_NONE,      0);
 #endif
 
 #if defined(USE_BARO_BMP280)
@@ -105,7 +105,7 @@
         #define BMP280_I2C_BUS BARO_I2C_BUS
     #endif
     #if !defined(BMP280_I2C_ADDR)
-        #define BMP280_I2C_ADDR (0x76)
+        #define BMP280_I2C_ADDR 0x76
     #endif
     BUSDEV_REGISTER_I2C(busdev_bmp280,      DEVHW_BMP280,       BMP280_I2C_BUS,     BMP280_I2C_ADDR,	NONE,           DEVFLAGS_NONE,      0);
     #endif
@@ -121,7 +121,7 @@
     #if !defined(BMP388_I2C_ADDR)
         #define BMP388_I2C_ADDR 0x76
     #endif    
-    BUSDEV_REGISTER_I2C(busdev_bmp388,      DEVHW_BMP388,       BMP388_I2C_BUS,     BMP388_I2C_ADDR,               NONE,           DEVFLAGS_NONE,      0);
+    BUSDEV_REGISTER_I2C(busdev_bmp388,      DEVHW_BMP388,       BMP388_I2C_BUS,     BMP388_I2C_ADDR,    NONE,           DEVFLAGS_NONE,      0);
     #endif
 #endif
 
@@ -133,9 +133,9 @@
         #define SPL06_I2C_BUS BARO_I2C_BUS
       #endif
       #if !defined(SPL06_I2C_ADDR)
-          #define SPL06_I2C_ADDR (0x76)
+          #define SPL06_I2C_ADDR 0x76
       #endif      
-      BUSDEV_REGISTER_I2C(busdev_spl06,     DEVHW_SPL06,        SPL06_I2C_BUS,      SPL06_I2C_ADDR,               NONE,           DEVFLAGS_NONE,      0);
+      BUSDEV_REGISTER_I2C(busdev_spl06,     DEVHW_SPL06,        SPL06_I2C_BUS,      SPL06_I2C_ADDR,     NONE,           DEVFLAGS_NONE,      0);
     #endif
 #endif
 
@@ -152,7 +152,7 @@
     #if !defined(MS5607_I2C_ADDR)
         #define MS5607_I2C_ADDR 0x77
     #endif    
-    BUSDEV_REGISTER_I2C(busdev_ms5607,      DEVHW_MS5607,       MS5607_I2C_BUS,     0x77,               NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
+    BUSDEV_REGISTER_I2C(busdev_ms5607,      DEVHW_MS5607,       MS5607_I2C_BUS,     MS5607_I2C_ADDR,    NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
 #endif
 
 #if defined(USE_BARO_MS5611)
@@ -165,7 +165,7 @@
     #if !defined(MS5611_I2C_ADDR)
         #define MS5611_I2C_ADDR 0x77
     #endif    
-    BUSDEV_REGISTER_I2C(busdev_ms5611,      DEVHW_MS5611,       MS5611_I2C_BUS,     MS5611_I2C_ADDR,               NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
+    BUSDEV_REGISTER_I2C(busdev_ms5611,      DEVHW_MS5611,       MS5611_I2C_BUS,     MS5611_I2C_ADDR,    NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
     #endif
 #endif
 
@@ -179,13 +179,13 @@
     #if !defined(DPS310_I2C_ADDR)
         #define DPS310_I2C_ADDR 0x76
     #endif    
-    BUSDEV_REGISTER_I2C(busdev_dps310,      DEVHW_DPS310,       DPS310_I2C_BUS,     DPS310_I2C_ADDR,               NONE,           DEVFLAGS_NONE, 0);
+    BUSDEV_REGISTER_I2C(busdev_dps310,      DEVHW_DPS310,       DPS310_I2C_BUS,     DPS310_I2C_ADDR,    NONE,           DEVFLAGS_NONE, 0);
     #endif
 #endif
 
 #if defined(USE_BARO_B2SMPB)
     #if defined(B2SMPB_SPI_BUS)
-    BUSDEV_REGISTER_SPI(busdev_b2smpb,     DEVHW_B2SMPB,        B2SMPB_SPI_BUS,     B2SMPB_CS_PIN,       NONE,           DEVFLAGS_NONE, 0);
+    BUSDEV_REGISTER_SPI(busdev_b2smpb,     DEVHW_B2SMPB,        B2SMPB_SPI_BUS,     B2SMPB_CS_PIN,      NONE,           DEVFLAGS_NONE, 0);
     #elif defined(B2SMPB_I2C_BUS) || defined(BARO_I2C_BUS)
     #if !defined(B2SMPB_I2C_BUS)
         #define B2SMPB_I2C_BUS BARO_I2C_BUS
@@ -193,7 +193,7 @@
     #if !defined(B2SMPB_I2C_ADDR)
         #define B2SMPB_I2C_ADDR 0x70
     #endif    
-    BUSDEV_REGISTER_I2C(busdev_b2smpb,     DEVHW_B2SMPB,        B2SMPB_I2C_BUS,      B2SMPB_I2C_ADDR,                NONE,           DEVFLAGS_NONE, 0);
+    BUSDEV_REGISTER_I2C(busdev_b2smpb,     DEVHW_B2SMPB,        B2SMPB_I2C_BUS,      B2SMPB_I2C_ADDR,   NONE,           DEVFLAGS_NONE, 0);
     #endif
 #endif
 

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -91,6 +91,9 @@
     #if !defined(BMP085_I2C_BUS)
         #define BMP085_I2C_BUS BARO_I2C_BUS
     #endif
+    #if !defined(BMP085_I2C_ADDR)
+        #define BMP085_I2C_ADDR (0x77)
+    #endif    
     BUSDEV_REGISTER_I2C(busdev_bmp085,      DEVHW_BMP085,       BMP085_I2C_BUS,     0x77,               NONE,           DEVFLAGS_NONE,      0);
 #endif
 
@@ -102,7 +105,7 @@
         #define BMP280_I2C_BUS BARO_I2C_BUS
     #endif
     #if !defined(BMP280_I2C_ADDR)
-        #define BMP280_I2C_ADDR (0x77)
+        #define BMP280_I2C_ADDR (0x76)
     #endif
     BUSDEV_REGISTER_I2C(busdev_bmp280,      DEVHW_BMP280,       BMP280_I2C_BUS,     BMP280_I2C_ADDR,	NONE,           DEVFLAGS_NONE,      0);
     #endif

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -102,7 +102,7 @@
         #define BMP280_I2C_BUS BARO_I2C_BUS
     #endif
     #if !defined(BMP280_I2C_ADDR)
-        #define BMP280_I2C_ADDR (0x76)
+        #define BMP280_I2C_ADDR (0x77)
     #endif
     BUSDEV_REGISTER_I2C(busdev_bmp280,      DEVHW_BMP280,       BMP280_I2C_BUS,     BMP280_I2C_ADDR,	NONE,           DEVFLAGS_NONE,      0);
     #endif
@@ -115,7 +115,10 @@
     #if !defined(BMP388_I2C_BUS)
         #define BMP388_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_bmp388,      DEVHW_BMP388,       BMP388_I2C_BUS,     0x76,               NONE,           DEVFLAGS_NONE,      0);
+    #if !defined(BMP388_I2C_ADDR)
+        #define BMP388_I2C_ADDR 0x76
+    #endif    
+    BUSDEV_REGISTER_I2C(busdev_bmp388,      DEVHW_BMP388,       BMP388_I2C_BUS,     BMP388_I2C_ADDR,               NONE,           DEVFLAGS_NONE,      0);
     #endif
 #endif
 
@@ -126,7 +129,10 @@
       #if !defined(SPL06_I2C_BUS)
         #define SPL06_I2C_BUS BARO_I2C_BUS
       #endif
-      BUSDEV_REGISTER_I2C(busdev_spl06,     DEVHW_SPL06,        SPL06_I2C_BUS,      0x76,               NONE,           DEVFLAGS_NONE,      0);
+      #if !defined(SPL06_I2C_ADDR)
+          #define SPL06_I2C_ADDR (0x76)
+      #endif      
+      BUSDEV_REGISTER_I2C(busdev_spl06,     DEVHW_SPL06,        SPL06_I2C_BUS,      SPL06_I2C_ADDR,               NONE,           DEVFLAGS_NONE,      0);
     #endif
 #endif
 
@@ -140,6 +146,9 @@
     #if !defined(MS5607_I2C_BUS)
         #define MS5607_I2C_BUS BARO_I2C_BUS
     #endif
+    #if !defined(MS5607_I2C_ADDR)
+        #define MS5607_I2C_ADDR 0x77
+    #endif    
     BUSDEV_REGISTER_I2C(busdev_ms5607,      DEVHW_MS5607,       MS5607_I2C_BUS,     0x77,               NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
 #endif
 
@@ -150,7 +159,10 @@
     #if !defined(MS5611_I2C_BUS)
         #define MS5611_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_ms5611,      DEVHW_MS5611,       MS5611_I2C_BUS,     0x77,               NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
+    #if !defined(MS5611_I2C_ADDR)
+        #define MS5611_I2C_ADDR 0x77
+    #endif    
+    BUSDEV_REGISTER_I2C(busdev_ms5611,      DEVHW_MS5611,       MS5611_I2C_BUS,     MS5611_I2C_ADDR,               NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
     #endif
 #endif
 
@@ -161,7 +173,10 @@
     #if !defined(DPS310_I2C_BUS)
         #define DPS310_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_dps310,      DEVHW_DPS310,       DPS310_I2C_BUS,     0x76,               NONE,           DEVFLAGS_NONE, 0);
+    #if !defined(DPS310_I2C_ADDR)
+        #define DPS310_I2C_ADDR 0x76
+    #endif    
+    BUSDEV_REGISTER_I2C(busdev_dps310,      DEVHW_DPS310,       DPS310_I2C_BUS,     DPS310_I2C_ADDR,               NONE,           DEVFLAGS_NONE, 0);
     #endif
 #endif
 
@@ -172,7 +187,10 @@
     #if !defined(B2SMPB_I2C_BUS)
         #define B2SMPB_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_b2smpb,     DEVHW_B2SMPB,        B2SMPB_I2C_BUS,      0x70,                NONE,           DEVFLAGS_NONE, 0);
+    #if !defined(B2SMPB_I2C_ADDR)
+        #define B2SMPB_I2C_ADDR 0x70
+    #endif    
+    BUSDEV_REGISTER_I2C(busdev_b2smpb,     DEVHW_B2SMPB,        B2SMPB_I2C_BUS,      B2SMPB_I2C_ADDR,                NONE,           DEVFLAGS_NONE, 0);
     #endif
 #endif
 


### PR DESCRIPTION
Using baro in multirotor can be hard due to air interferences from prop blades with baro on flight controller. That's why I decide to implement ability to use two barometers on I2C lane and dumped out second barometer to separate board.

![image](https://github.com/iNavFlight/inav/assets/1165537/e54a6c72-aac7-4c92-ae3a-bd2eb12044f0)

My test setup is BMP280 baro on separate board and internal SPL06 baro, which come with Speedybee F405V3 flight controller. BMP280 switched to separate address (0x77)

Current logic is implemented to get mean value between 2 devices. Devices count and hardware list can be extended to support more barometers on same line, I just need to find more adequate way to define arrays in configuration.

![image](https://github.com/iNavFlight/inav/assets/1165537/d0326d06-df72-4cb4-8b5b-28518955dd34)

Tested on my table setup, works fine, both barometers react on my breath and change value in Sensors tab accordingly.

Will add flight test DVR's little bit later.

How to test it:

1.  Find BMP280 module and switch it to 0x77 address by soldering bridge between pin 5 and 3V3 power of baro.

2. Apply patch

3. define 
```
#define USE_BARO_MULTI
#define BMP280_I2C_ADDR 0x77
```
in target file of your flight controller with onboard baro (in my case it was SPL06)

4. Update firmware on flight controller

6. Use CLI to change settings `multi_baro_hardware_1` and `multi_baro_hardware_2` according to your hardware

8. Try to whirl some wind into first and second barometer and ensure that both barometers affects sensor data line in Sensors tab if configurator.

Also added one more CLI command to review raw baro data, can be removed if not necessary.

P.S. My first pull request to INAV, don't judge me too much please )