### PR TITLE
GPS: Beidou should use B1, B1C as appropriate for concurrent Glonass

### DIFF
--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -380,6 +380,39 @@ static int configureGNSS_GLONASS(ubx_gnss_element_t * gnss_block)
 }
 
 
+static void configureGNSS9_old(void)
+{
+        ubx_config_data8_payload_t gnssConfigValues[] = {
+            // SBAS
+            {UBLOX_CFG_SIGNAL_SBAS_ENA, gpsState.gpsConfig->sbasMode == SBAS_NONE ? 0 : 1},
+            {UBLOX_CFG_SIGNAL_SBAS_L1CA_ENA, gpsState.gpsConfig->sbasMode == SBAS_NONE ? 0 : 1},
+
+            /*
+            // Galileo
+            {UBLOX_CFG_SIGNAL_GAL_ENA, gpsState.gpsConfig->ubloxUseGalileo},
+            {UBLOX_CFG_SIGNAL_GAL_E1_ENA, gpsState.gpsConfig->ubloxUseGalileo},
+
+            // Beidou
+            {UBLOX_CFG_SIGNAL_BDS_ENA, gpsState.gpsConfig->ubloxUseBeidou},
+            {UBLOX_CFG_SIGNAL_BDS_B1_ENA, gpsState.gpsConfig->ubloxUseBeidou},
+            */
+
+            // Should be enabled with GPS
+            {UBLOX_CFG_QZSS_ENA, 1},
+            {UBLOX_CFG_QZSS_L1CA_ENA, 1},
+            {UBLOX_CFG_QZSS_L1S_ENA, 1},
+
+            /*
+            // Glonass
+            {UBLOX_CFG_GLO_ENA, gpsState.gpsConfig->ubloxUseGlonass},
+            {UBLOX_CFG_GLO_L1_ENA, gpsState.gpsConfig->ubloxUseGlonass}
+			*/
+        };
+
+        ubloxSendSetCfgBytes(gnssConfigValues, 5);
+}
+
+
 static void configureGNSS9(void)
 {
         ubx_config_data8_payload_t gnssConfigValues[] = {
@@ -394,6 +427,7 @@ static void configureGNSS9(void)
             // Beidou
             {UBLOX_CFG_SIGNAL_BDS_ENA, gpsState.gpsConfig->ubloxUseBeidou},
             {UBLOX_CFG_SIGNAL_BDS_B1_ENA, gpsState.gpsConfig->ubloxUseBeidou},
+            {UBLOX_CFG_SIGNAL_BDS_B1C_ENA, 0},
 
             // Should be enabled with GPS
             {UBLOX_CFG_QZSS_ENA, 1},
@@ -405,8 +439,9 @@ static void configureGNSS9(void)
             {UBLOX_CFG_GLO_L1_ENA, gpsState.gpsConfig->ubloxUseGlonass}
         };
 
-        ubloxSendSetCfgBytes(gnssConfigValues, 11);
+        ubloxSendSetCfgBytes(gnssConfigValues, 12);
 }
+
 
 
 static void configureGNSS10(void)
@@ -1003,10 +1038,12 @@ STATIC_PROTOTHREAD(gpsConfigure)
     if (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX8) {
         gpsSetProtocolTimeout(GPS_SHORT_TIMEOUT);
         if( (gpsState.swVersionMajor >= 24) || (gpsState.swVersionMajor == 23 && gpsState.swVersionMinor > 1) ) {
-            if (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX10) {
-                configureGNSS10();
-            } else {
+		    // This line is true for my M9
+		    if ( gpsState.hwVersion == UBX_HW_VERSION_UBLOX9 ) {
+			    /// This line is true for my M9
                 configureGNSS9();
+            } else {
+                configureGNSS10();
             }
         } else {
             configureGNSS();

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -956,7 +956,7 @@ STATIC_PROTOTHREAD(gpsConfigure)
     // Configure GNSS for M8N and later
     if (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX8) {
         gpsSetProtocolTimeout(GPS_SHORT_TIMEOUT);
-        if(gpsState.hwVersion >= UBX_HW_VERSION_UBLOX10 || (gpsState.swVersionMajor>=23 && gpsState.swVersionMinor >= 1)) {
+        if( (gpsState.swVersionMajor > 24) || (gpsState.swVersionMajor == 23 && gpsState.swVersionMinor >= 1) ) {
             configureGNSS10();
         } else {
             configureGNSS();

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -379,6 +379,36 @@ static int configureGNSS_GLONASS(ubx_gnss_element_t * gnss_block)
     return 1;
 }
 
+static void configureGNSS9(void)
+{
+        ubx_config_data8_payload_t gnssConfigValues[] = {
+            // SBAS
+            {UBLOX_CFG_SIGNAL_SBAS_ENA, gpsState.gpsConfig->sbasMode == SBAS_NONE ? 0 : 1},
+            {UBLOX_CFG_SIGNAL_SBAS_L1CA_ENA, gpsState.gpsConfig->sbasMode == SBAS_NONE ? 0 : 1} // ,
+			/*
+            // Galileo
+            {UBLOX_CFG_SIGNAL_GAL_ENA, gpsState.gpsConfig->ubloxUseGalileo},
+            {UBLOX_CFG_SIGNAL_GAL_E1_ENA, gpsState.gpsConfig->ubloxUseGalileo},
+
+            // Beidou
+            {UBLOX_CFG_SIGNAL_BDS_ENA, gpsState.gpsConfig->ubloxUseBeidou},
+            {UBLOX_CFG_SIGNAL_BDS_B1_ENA, gpsState.gpsConfig->ubloxUseBeidou},
+            // {UBLOX_CFG_SIGNAL_BDS_B1C_ENA, 0},
+
+            // Should be enabled with GPS
+            {UBLOX_CFG_QZSS_ENA, 1},
+            {UBLOX_CFG_QZSS_L1CA_ENA, 1},
+            {UBLOX_CFG_QZSS_L1S_ENA, 1},
+
+            // Glonass
+            {UBLOX_CFG_GLO_ENA, gpsState.gpsConfig->ubloxUseGlonass},
+            {UBLOX_CFG_GLO_L1_ENA, gpsState.gpsConfig->ubloxUseGlonass}
+			*/
+        };
+
+        ubloxSendSetCfgBytes(gnssConfigValues, 2);
+}
+
 
 static void configureGNSS10(void)
 {
@@ -957,17 +987,6 @@ STATIC_PROTOTHREAD(gpsConfigure)
 
     // Configure GNSS for M8N and later
     if (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX8) {
-        gpsSetProtocolTimeout(GPS_SHORT_TIMEOUT);
-		/*
-        if( (gpsState.swVersionMajor >= 24) || (gpsState.swVersionMajor == 23 && gpsState.swVersionMinor > 1) ) {
-		    // This line is true for my M9
-            if ( gpsState.hwVersion == UBX_HW_VERSION_UBLOX9 ) {
-                /// This line is true for my M9
-                configureGNSS9();
-            } else {
-                configureGNSS10();
-            }
-		*/
         if(gpsState.hwVersion >= UBX_HW_VERSION_UBLOX10 || (gpsState.swVersionMajor>=23 && gpsState.swVersionMinor >= 1)) {
             configureGNSS10();
         } else {

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -394,8 +394,8 @@ static void configureGNSS10(bool swapB1IwithB1C)
             // Beidou
             {UBLOX_CFG_SIGNAL_BDS_ENA, gpsState.gpsConfig->ubloxUseBeidou},
             // Use B1I for Beidou without Glonass; B1C needed for concurrent use of Beidou and Glonass
-            {UBLOX_CFG_SIGNAL_BDS_B1_ENA,  (gpsState.gpsConfig->ubloxUseBeidou && ! gpsState.gpsConfig->ubloxUseGlonass) ^ swapB1IwithB1C},
-            {UBLOX_CFG_SIGNAL_BDS_B1C_ENA, (gpsState.gpsConfig->ubloxUseBeidou && gpsState.gpsConfig->ubloxUseGlonass) ^ swapB1IwithB1C},
+            {UBLOX_CFG_SIGNAL_BDS_B1_ENA,  gpsState.gpsConfig->ubloxUseBeidou && (gpsState.gpsConfig->ubloxUseGlonass ^ swapB1IwithB1C )},
+            {UBLOX_CFG_SIGNAL_BDS_B1C_ENA, gpsState.gpsConfig->ubloxUseBeidou && (! gpsState.gpsConfig->ubloxUseGlonass ^ swapB1IwithB1C)},
 
             // Should be enabled with GPS
             {UBLOX_CFG_QZSS_ENA, 1},
@@ -975,10 +975,10 @@ STATIC_PROTOTHREAD(gpsConfigure)
     if (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX8) {
         gpsSetProtocolTimeout(GPS_SHORT_TIMEOUT);
         if( (gpsState.swVersionMajor >= 24) || (gpsState.swVersionMajor == 23 && gpsState.swVersionMinor >= 1) ) {
-            configureGNSS10(false);
+            configureGNSS10(true);
 						ptWaitTimeout((_ack_state == UBX_ACK_GOT_ACK || _ack_state == UBX_ACK_GOT_NAK), GPS_CFG_CMD_TIMEOUT_MS);
 						if(_ack_state == UBX_ACK_GOT_NAK) {
-						    configureGNSS10(true);
+						    configureGNSS10(false);
 						}
         } else {
             configureGNSS();

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -380,40 +380,7 @@ static int configureGNSS_GLONASS(ubx_gnss_element_t * gnss_block)
 }
 
 
-static void configureGNSS9_old(void)
-{
-        ubx_config_data8_payload_t gnssConfigValues[] = {
-            // SBAS
-            {UBLOX_CFG_SIGNAL_SBAS_ENA, gpsState.gpsConfig->sbasMode == SBAS_NONE ? 0 : 1},
-            {UBLOX_CFG_SIGNAL_SBAS_L1CA_ENA, gpsState.gpsConfig->sbasMode == SBAS_NONE ? 0 : 1},
-
-            /*
-            // Galileo
-            {UBLOX_CFG_SIGNAL_GAL_ENA, gpsState.gpsConfig->ubloxUseGalileo},
-            {UBLOX_CFG_SIGNAL_GAL_E1_ENA, gpsState.gpsConfig->ubloxUseGalileo},
-
-            // Beidou
-            {UBLOX_CFG_SIGNAL_BDS_ENA, gpsState.gpsConfig->ubloxUseBeidou},
-            {UBLOX_CFG_SIGNAL_BDS_B1_ENA, gpsState.gpsConfig->ubloxUseBeidou},
-            */
-
-            // Should be enabled with GPS
-            {UBLOX_CFG_QZSS_ENA, 1},
-            {UBLOX_CFG_QZSS_L1CA_ENA, 1},
-            {UBLOX_CFG_QZSS_L1S_ENA, 1},
-
-            /*
-            // Glonass
-            {UBLOX_CFG_GLO_ENA, gpsState.gpsConfig->ubloxUseGlonass},
-            {UBLOX_CFG_GLO_L1_ENA, gpsState.gpsConfig->ubloxUseGlonass}
-			*/
-        };
-
-        ubloxSendSetCfgBytes(gnssConfigValues, 5);
-}
-
-
-static void configureGNSS9(void)
+static void configureGNSS10(void)
 {
         ubx_config_data8_payload_t gnssConfigValues[] = {
             // SBAS
@@ -443,52 +410,6 @@ static void configureGNSS9(void)
 }
 
 
-
-static void configureGNSS10(void)
-{
-        ubx_config_data8_payload_t gnssConfigValues[] = {
-            // SBAS
-            {UBLOX_CFG_SIGNAL_SBAS_ENA, gpsState.gpsConfig->sbasMode == SBAS_NONE ? 0 : 1},
-            {UBLOX_CFG_SIGNAL_SBAS_L1CA_ENA, gpsState.gpsConfig->sbasMode == SBAS_NONE ? 0 : 1},
-
-            // Galileo
-            {UBLOX_CFG_SIGNAL_GAL_ENA, gpsState.gpsConfig->ubloxUseGalileo},
-            {UBLOX_CFG_SIGNAL_GAL_E1_ENA, gpsState.gpsConfig->ubloxUseGalileo},
-
-            // Beidou
-            {UBLOX_CFG_SIGNAL_BDS_ENA, gpsState.gpsConfig->ubloxUseBeidou},
-            // Use B1I for Beidou without Glonass; B1C needed for concurrent use of Beidou and Glonass on M10
-            {UBLOX_CFG_SIGNAL_BDS_B1_ENA, gpsState.gpsConfig->ubloxUseBeidou && (! gpsState.gpsConfig->ubloxUseGlonass)},
-            {UBLOX_CFG_SIGNAL_BDS_B1C_ENA, gpsState.gpsConfig->ubloxUseBeidou && gpsState.gpsConfig->ubloxUseGlonass },
-
-            // Should be enabled with GPS
-            {UBLOX_CFG_QZSS_ENA, 1},
-            {UBLOX_CFG_QZSS_L1CA_ENA, 1},
-            {UBLOX_CFG_QZSS_L1S_ENA, 1},
-
-            // Glonass
-            {UBLOX_CFG_GLO_ENA, gpsState.gpsConfig->ubloxUseGlonass},
-            {UBLOX_CFG_GLO_L1_ENA, gpsState.gpsConfig->ubloxUseGlonass}
-        };
-
-        ubloxSendSetCfgBytes(gnssConfigValues, 12);
-        /*
-        ptWaitTimeout((_ack_state == UBX_ACK_GOT_ACK || _ack_state == UBX_ACK_GOT_NAK), GPS_CFG_CMD_TIMEOUT_MS);
-
-        if(_ack_state == UBX_ACK_GOT_NAK) {
-            // If those channel settings aren't supported, flip B1 with B1C
-            for (uint i = 0; i < sizeof(gnssConfigValues) / sizeof(ubx_config_data8_payload_t); i++) {
-                if (
-                      (gnssConfigValues[i].key == UBLOX_CFG_SIGNAL_BDS_B1_ENA) ||
-                      (gnssConfigValues[i].key == UBLOX_CFG_SIGNAL_BDS_B1C_ENA)
-                ) {
-                   gnssConfigValues[i].value ^= 1;
-                }
-            }
-            ubloxSendSetCfgBytes(gnssConfigValues, 12);
-        }
-		*/
-}
 
 static void configureGNSS(void)
 {
@@ -1037,14 +958,18 @@ STATIC_PROTOTHREAD(gpsConfigure)
     // Configure GNSS for M8N and later
     if (gpsState.hwVersion >= UBX_HW_VERSION_UBLOX8) {
         gpsSetProtocolTimeout(GPS_SHORT_TIMEOUT);
+		/*
         if( (gpsState.swVersionMajor >= 24) || (gpsState.swVersionMajor == 23 && gpsState.swVersionMinor > 1) ) {
 		    // This line is true for my M9
-		    if ( gpsState.hwVersion == UBX_HW_VERSION_UBLOX9 ) {
-			    /// This line is true for my M9
+            if ( gpsState.hwVersion == UBX_HW_VERSION_UBLOX9 ) {
+                /// This line is true for my M9
                 configureGNSS9();
             } else {
                 configureGNSS10();
             }
+		*/
+        if(gpsState.hwVersion >= UBX_HW_VERSION_UBLOX10 || (gpsState.swVersionMajor>=23 && gpsState.swVersionMinor >= 1)) {
+            configureGNSS10();
         } else {
             configureGNSS();
         }

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -392,8 +392,9 @@ static void configureGNSS10(void)
 
             // Beidou
             {UBLOX_CFG_SIGNAL_BDS_ENA, gpsState.gpsConfig->ubloxUseBeidou},
-            {UBLOX_CFG_SIGNAL_BDS_B1_ENA, gpsState.gpsConfig->ubloxUseBeidou},
-            {UBLOX_CFG_SIGNAL_BDS_B1C_ENA, 0},
+            // Use B1 for Beidou without Glonass; B1C needed for concurrent use of Beidou and Glonass
+            {UBLOX_CFG_SIGNAL_BDS_B1_ENA,  gpsState.gpsConfig->ubloxUseBeidou &&  ! gpsState.gpsConfig->ubloxUseGlonass},
+            {UBLOX_CFG_SIGNAL_BDS_B1C_ENA, gpsState.gpsConfig->ubloxUseBeidou && gpsState.gpsConfig->ubloxUseGlonass},
 
             // Should be enabled with GPS
             {UBLOX_CFG_QZSS_ENA, 1},


### PR DESCRIPTION
Beidou has two options, B1 or B1C. B1 is faster to first fix, but the M10 cannot use B1 concurrently with Glonass.
Using B1C instead allows Beidou to be used concurrently with Glonass on M10.

This commit uses B1 when Beidou is active without Glonass, for best Beidou performance.
When Glonass is also active, it uses B1C to allow both Beidou and Glonass to be used together.


### Additional background information from u-blox datasheet:
From https://content.u-blox.com/sites/default/files/MAX-M10S_IntegrationManual_UBX-20053088.pdf

> 2.1.3.1 BeiDou B1I and B1C signals
BeiDou B1I and B1C signals differ in terms of the center frequency, bandwidth, and modulation.
Therefore, there are differences in performance and supported GNSS signals and features.
Benefits of using BeiDou B1I signal:
BeiDou B1I offers superior GNSS performance. High start-up sensitivity and fast time-to-first-fix
(TTFF) enable acquisition of a large number of BeiDou satellites. The tracking and reacquisition
sensitivity for acquired signals is approximately at the same level for BeiDou B1I and B1C.
• Faster TTFF and higher start-up sensitivity. BeiDou B1I signals are acquired significantly
faster and at a lower signal level than BeiDou B1C signals.
• Better availability. Higher start-up sensitivity results in a larger number of BeiDou satellites
tracked and used in navigation solution especially at low signal level.
• AssistNow Online support. Enhanced start-up sensitivity and TTFF.
• Power save mode (PSM) support. PSM cyclic tracking (PSMCT) and on/off (PSMOO) mode
operation are supported.
Benefits of using BeiDou B1C signal:
BeiDou B1C signal has the same center frequency as GPS L1 C/A enabling concurrent use of 4 GNSS
constellations. Multi-GNSS configurations with BeiDou B1C also have a lower power consumption
compared to those with BeiDou B1I.
• Concurrent reception of 4 GNSS with GPS L1 C/A, Galileo E1, BeiDou B1C, and GLONASS L1OF.
• Lower power consumption. No additional frequency band required for BeiDou B1C in multiGNSS constellations resulting in a lower power consumption during acquisition and tracking
phases.