### PR TITLE
Add option to use display_force_sw_blink  in msp displayport

### DIFF
--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -64,7 +64,7 @@ static bool displayEmulateTextAttributes(displayPort_t *instance,
     // We only emulate blink for now, so there's no need to test
     // for it again.
     TEXT_ATTRIBUTES_REMOVE_BLINK(*attr);
-    if ((millis() / SW_BLINK_CYCLE_MS) % 2) {
+    if (getBlinkOnOff()) {
         memset(buf, ' ', length);
         buf[length] = '\0';
         // Tell the caller to use buf

--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -33,8 +33,6 @@
 #include "fc/settings.h"
 #include "fc/runtime_config.h"
 
-#define SW_BLINK_CYCLE_MS 200 // 200ms on / 200ms off
-
 // XXX: This is the number of characters in a MAX7456 line.
 // Increment this number appropiately or enable support for
 // multiple iterations in displayWriteWithAttr() if bigger

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -22,6 +22,8 @@
 
 #include "config/parameter_group.h"
 
+#define SW_BLINK_CYCLE_MS 200 // 200ms on / 200ms off
+
 typedef struct osdCharacter_s osdCharacter_t;
 
 typedef struct displayConfig_s {

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -20,11 +20,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "drivers/time.h"
+
 #include "config/parameter_group.h"
 
 #define SW_BLINK_CYCLE_MS 200 // 200ms on / 200ms off
 
-#define getBlinkOnOff() ((millis() / SW_BLINK_CYCLE_MS) & 1)
+#define getBlinkOnOff()  ( (millis() / SW_BLINK_CYCLE_MS) & 1 )
 
 typedef struct osdCharacter_s osdCharacter_t;
 

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -24,6 +24,8 @@
 
 #define SW_BLINK_CYCLE_MS 200 // 200ms on / 200ms off
 
+#define getBlinkOnOff() ((millis() / SW_BLINK_CYCLE_MS) & 1)
+
 typedef struct osdCharacter_s osdCharacter_t;
 
 typedef struct displayConfig_s {

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -299,7 +299,7 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         do {
             bitArrayClr(dirty, pos);
             subcmd[len] = isBfCompatibleVideoSystem(osdConfig()) ? getBfCharacter(screen[pos++], page): screen[pos++];
-            if(displayConfig()->force_sw_blink && getBlinkOnOff()) {
+            if (displayConfig()->force_sw_blink && getBlinkOnOff()) {
                 subcmd[len] = SYM_BLANK;
             }
             len++;

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -254,6 +254,8 @@ static int writeString(displayPort_t *displayPort, uint8_t col, uint8_t row, con
 static int drawScreen(displayPort_t *displayPort) // 250Hz
 {
     static uint8_t counter = 0;
+    static bool lastBlinkStatus = getBlinkOnOff();
+    bool blinkStatus = getBlinkOnOff();
 
     if ((!cmsInMenu && IS_RC_MODE_ACTIVE(BOXOSD)) || (counter++ % DRAW_FREQ_DENOM)) { // 62.5Hz
         return 0;
@@ -275,13 +277,17 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         sendSubFrameMs = (osdConfig()->msp_displayport_fullframe_interval > 0) ? (millis() + DS2MS(osdConfig()->msp_displayport_fullframe_interval)) : 0;
     }
 
-    if (displayConfig()->force_sw_blink) {
-        // Make sure any blinking characters are updated
-        for (unsigned int pos = 0; pos < sizeof(screen); pos++) {
-            if (bitArrayGet(blinkChar, pos)) {
-                bitArraySet(dirty, pos);
+    if (lastBlinkStatus != blinkStatus) {
+        if (displayConfig()->force_sw_blink) {
+            // Make sure any blinking characters are updated
+            for (unsigned int pos = 0; pos < sizeof(screen); pos++) {
+                if (bitArrayGet(blinkChar, pos)) {
+                    bitArraySet(dirty, pos);
+                }
             }
         }
+
+        lastBlinkStatus = blinkStatus;
     }
 
     uint8_t subcmd[COLS + 4];
@@ -303,7 +309,7 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         do {
             bitArrayClr(dirty, pos);
             subcmd[len] = isBfCompatibleVideoSystem(osdConfig()) ? getBfCharacter(screen[pos++], page): screen[pos++];
-            if (bitArrayGet(blinkChar, pos) && displayConfig()->force_sw_blink && getBlinkOnOff()) {
+            if (bitArrayGet(blinkChar, pos) && displayConfig()->force_sw_blink && blinkStatus) {
                 subcmd[len] = SYM_BLANK;
             }
             len++;

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -280,6 +280,15 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         sendSubFrameMs = (osdConfig()->msp_displayport_fullframe_interval > 0) ? (millis() + DS2MS(osdConfig()->msp_displayport_fullframe_interval)) : 0;
     }
 
+    if (displayConfig()->force_sw_blink) {
+        // Makesure any blinking characters are updated
+        for (unsigned int pos = 0; pos < sizeof(screen); pos++) {
+            if (bitArrayGet(blinkChar, pos)) {
+                bitArraySet(dirty, pos);
+            }
+        }
+    }
+
     uint8_t subcmd[COLS + 4];
     uint8_t updateCount = 0;
     subcmd[0] = MSP_DP_WRITE_STRING;
@@ -299,7 +308,7 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         do {
             bitArrayClr(dirty, pos);
             subcmd[len] = isBfCompatibleVideoSystem(osdConfig()) ? getBfCharacter(screen[pos++], page): screen[pos++];
-            if (displayConfig()->force_sw_blink && getBlinkOnOff()) {
+            if (bitArrayGet(blinkChar, pos) && displayConfig()->force_sw_blink && getBlinkOnOff()) {
                 subcmd[len] = SYM_BLANK;
             }
             len++;

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -254,7 +254,7 @@ static int writeString(displayPort_t *displayPort, uint8_t col, uint8_t row, con
 static int drawScreen(displayPort_t *displayPort) // 250Hz
 {
     static uint8_t counter = 0;
-    static bool lastBlinkStatus = getBlinkOnOff();
+    static bool lastBlinkStatus = false;
     bool blinkStatus = getBlinkOnOff();
 
     if ((!cmsInMenu && IS_RC_MODE_ACTIVE(BOXOSD)) || (counter++ % DRAW_FREQ_DENOM)) { // 62.5Hz

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -248,11 +248,6 @@ static int writeString(displayPort_t *displayPort, uint8_t col, uint8_t row, con
     return 0;
 }
 
-static int getBlinkOnOff(void)
-{
-    return (millis() / SW_BLINK_CYCLE_MS) % 2;
-}
-
 /**
  * Write only changed characters to the VTX
  */
@@ -281,7 +276,7 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
     }
 
     if (displayConfig()->force_sw_blink) {
-        // Makesure any blinking characters are updated
+        // Make sure any blinking characters are updated
         for (unsigned int pos = 0; pos < sizeof(screen); pos++) {
             if (bitArrayGet(blinkChar, pos)) {
                 bitArraySet(dirty, pos);

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -248,7 +248,7 @@ static int writeString(displayPort_t *displayPort, uint8_t col, uint8_t row, con
     return 0;
 }
 
-static int getBlinkOnOff()
+static int getBlinkOnOff(void)
 {
     return (millis() / SW_BLINK_CYCLE_MS) % 2;
 }


### PR DESCRIPTION
Looks like some MSP DisplayPort implementaions have bugs related to the blink attribute.

Allow a user to force software emulation of the blink attribute.

May address #9552 