### PR TITLE
Add option to use display_force_sw_blink in msp displayport

### DIFF
--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -33,8 +33,6 @@
 #include "fc/settings.h"
 #include "fc/runtime_config.h"
 
-#define SW_BLINK_CYCLE_MS 200 // 200ms on / 200ms off
-
 // XXX: This is the number of characters in a MAX7456 line.
 // Increment this number appropiately or enable support for
 // multiple iterations in displayWriteWithAttr() if bigger
@@ -66,7 +64,7 @@ static bool displayEmulateTextAttributes(displayPort_t *instance,
     // We only emulate blink for now, so there's no need to test
     // for it again.
     TEXT_ATTRIBUTES_REMOVE_BLINK(*attr);
-    if ((millis() / SW_BLINK_CYCLE_MS) % 2) {
+    if (getBlinkOnOff()) {
         memset(buf, ' ', length);
         buf[length] = '\0';
         // Tell the caller to use buf

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -20,7 +20,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "drivers/time.h"
+
 #include "config/parameter_group.h"
+
+#define SW_BLINK_CYCLE_MS 200 // 200ms on / 200ms off
+
+#define getBlinkOnOff()  ( (millis() / SW_BLINK_CYCLE_MS) & 1 )
 
 typedef struct osdCharacter_s osdCharacter_t;
 

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -254,6 +254,8 @@ static int writeString(displayPort_t *displayPort, uint8_t col, uint8_t row, con
 static int drawScreen(displayPort_t *displayPort) // 250Hz
 {
     static uint8_t counter = 0;
+    static bool lastBlinkStatus = false;
+    bool blinkStatus = getBlinkOnOff();
 
     if ((!cmsInMenu && IS_RC_MODE_ACTIVE(BOXOSD)) || (counter++ % DRAW_FREQ_DENOM)) { // 62.5Hz
         return 0;
@@ -275,6 +277,19 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         sendSubFrameMs = (osdConfig()->msp_displayport_fullframe_interval > 0) ? (millis() + DS2MS(osdConfig()->msp_displayport_fullframe_interval)) : 0;
     }
 
+    if (lastBlinkStatus != blinkStatus) {
+        if (displayConfig()->force_sw_blink) {
+            // Make sure any blinking characters are updated
+            for (unsigned int pos = 0; pos < sizeof(screen); pos++) {
+                if (bitArrayGet(blinkChar, pos)) {
+                    bitArraySet(dirty, pos);
+                }
+            }
+        }
+
+        lastBlinkStatus = blinkStatus;
+    }
+
     uint8_t subcmd[COLS + 4];
     uint8_t updateCount = 0;
     subcmd[0] = MSP_DP_WRITE_STRING;
@@ -293,7 +308,11 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         uint8_t len = 4;
         do {
             bitArrayClr(dirty, pos);
-            subcmd[len++] = isBfCompatibleVideoSystem(osdConfig()) ? getBfCharacter(screen[pos++], page): screen[pos++];
+            subcmd[len] = isBfCompatibleVideoSystem(osdConfig()) ? getBfCharacter(screen[pos++], page): screen[pos++];
+	    if (bitArrayGet(blinkChar, pos) && displayConfig()->force_sw_blink && blinkStatus) {
+                subcmd[len] = SYM_BLANK;
+            }
+            len++;
 
             if (bitArrayGet(dirty, pos)) {
                 next = pos;
@@ -304,7 +323,7 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
             attributes |= (page << DISPLAYPORT_MSP_ATTR_FONTPAGE);
         }
 
-        if (blink) {
+        if (blink && !displayConfig()->force_sw_blink) {
             attributes |= (1 << DISPLAYPORT_MSP_ATTR_BLINK);
         }
 


### PR DESCRIPTION
rebased to release_7.1.0

Looks like some MSP DisplayPort implementaions have bugs related to the blink attribute.

Allow a user to force software emulation of the blink attribute by using ```set display_force_sw_blink = true``` on the cli.

Fixes #9552 

Replaces #9625 

