### PR TITLE
Adjust SW blink interval

### DIFF
--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -24,7 +24,7 @@
 
 #include "config/parameter_group.h"
 
-#define SW_BLINK_CYCLE_MS 200 // 200ms on / 200ms off
+#define SW_BLINK_CYCLE_MS 500 // Xms on / Xms off
 
 #define getBlinkOnOff()  ( (millis() / SW_BLINK_CYCLE_MS) & 1 )
 

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -309,7 +309,7 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         do {
             bitArrayClr(dirty, pos);
             subcmd[len] = isBfCompatibleVideoSystem(osdConfig()) ? getBfCharacter(screen[pos++], page): screen[pos++];
-	    if (bitArrayGet(blinkChar, pos) && displayConfig()->force_sw_blink && blinkStatus) {
+            if (bitArrayGet(blinkChar, pos) && displayConfig()->force_sw_blink && blinkStatus) {
                 subcmd[len] = SYM_BLANK;
             }
             len++;
@@ -349,7 +349,7 @@ static int drawScreen(displayPort_t *displayPort) // 250Hz
         vtxReset = false;
     }
 
-return 0;
+    return 0;
 }
 
 static void resync(displayPort_t *displayPort)


### PR DESCRIPTION
200ms seems to iteract badly with some digital systems, causing unreliable blinking.

I will turn the cycle interval into a configuration variable in 8.0.

200ms = original value, unreliable blinking
500ms = acceptable blinking with walksnail
1000ms = was also tested and worked ok

For software blink emulation, Blinking changes a character appearance at a given frequency, the OSD code on digital systems updates the OSD at a different arbitrary frequency. Depending on the relationship between the two you may not see the text, or it may not blink. Similar to how lights can blink if you have mismatched frequencies when recording video (50Hz mains, 60fps video).

I also suspect that the way some of the digital systems handle blinking characters may rely on the clear screen command, which also happens at a given frequency in INAV.

This is a temporary workaround for #9552 

I will make the value configurable in INAV 8.0