### PR TITLE
OSD Wind speed in m/s

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4302,6 +4302,16 @@ Use wind estimation for remaining flight time/distance estimation
 
 ---
 
+### osd_estimations_wind_mps
+
+Wind speed estimation in m/s
+
+| Default | Min | Max |
+| --- | --- | --- |
+| OFF | OFF | ON |
+
+---
+
 ### osd_failsafe_switch_layout
 
 If enabled the OSD automatically switches to the first layout during failsafe

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3463,6 +3463,12 @@ groups:
         condition: USE_WIND_ESTIMATOR
         field: estimations_wind_compensation
         type: bool
+      - name: osd_estimations_wind_mps
+        description: "Wind speed estimation in m/s"
+        default_value: OFF
+        condition: USE_WIND_ESTIMATOR
+        field: estimations_wind_mps
+        type: bool
 
       - name: osd_failsafe_switch_layout
         description: "If enabled the OSD automatically switches to the first layout during failsafe"

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -484,8 +484,16 @@ static void osdFormatWindSpeedStr(char *buff, int32_t ws, bool isValid)
             break;
         default:
         case OSD_UNIT_METRIC:
-            centivalue = CMSEC_TO_CENTIKPH(ws);
-            suffix = SYM_KMH;
+            if (osdConfig()->estimations_wind_mps)
+            {
+                centivalue = ws;
+                suffix = SYM_MS;
+            }
+            else
+            {
+                centivalue = CMSEC_TO_CENTIKPH(ws);
+                suffix = SYM_KMH;
+            }
             break;
     }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -209,7 +209,7 @@ static bool osdDisplayHasCanvas;
 
 #define AH_MAX_PITCH_DEFAULT 20 // Specify default maximum AHI pitch value displayed (degrees)
 
-PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 9);
+PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 10);
 PG_REGISTER_WITH_RESET_FN(osdLayoutsConfig_t, osdLayoutsConfig, PG_OSD_LAYOUTS_CONFIG, 1);
 
 void osdStartedSaveProcess(void) {

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -417,6 +417,7 @@ typedef struct osdConfig_s {
 
 #ifdef USE_WIND_ESTIMATOR
     bool            estimations_wind_compensation;      // use wind compensation for estimated remaining flight/distance
+    bool            estimations_wind_mps;               // wind speed estimation in m/s
 #endif
     uint8_t         coordinate_digits;
     bool            osd_failsafe_switch_layout;


### PR DESCRIPTION
Some of us prefer to see wind speed in m/s, not in km/h. This PR does it:
-m/s icon on OSD with corresponding speed in m/s
-CLI parameter `osd_estimations_wind_mps` , OFF by default.
-explanation in docs/Settings.md

Enabled only in OSD_UNIT_METRIC mode. Tested in flight (vision font).
![image](https://github.com/iNavFlight/inav/assets/16077103/5b3aec36-e281-4120-bc9f-7d61733eb513)
