### PR TITLE
[WIP] Enable  rovers & boats to slow for nav turns, multicopter-style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,12 +16,13 @@ startup_stm32f10x_md_gcc.s
 cov-int*
 /build/
 /build_SITL/
+/debug/
+/downloads/
 /obj/
 /patches/
-/tools/
-/downloads/
-/debug/
 /release/
+/testing/
+/tools/
 
 # script-generated files
 docs/Manual.pdf

--- a/AUTHORS
+++ b/AUTHORS
@@ -27,6 +27,7 @@ Darren Lines (Mr.D - RC)
 Dave Pitman
 David Bieber
 Davide Bertola
+dc (@packetpilot)
 Denis Kisselev
 Dominic Clifton
 Frank Zhao

--- a/docs/development/Building in macOS.md
+++ b/docs/development/Building in macOS.md
@@ -1,6 +1,6 @@
-# Building in Mac OS X
+# Building in macOS
 
-Building in Mac OS X can be accomplished in just a few steps:
+Building in macOS can be accomplished in just a few steps:
 
 * Install general development tools (clang, make, git)
 * Install cmake

--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -2,7 +2,7 @@
 
 This document is primarily for developers only.
 
-## General principals
+## General principles
 
 1. Name everything well.
 2. Strike a balance between simplicity and not-repeating code.


### PR DESCRIPTION
The only substantive piece of this PR is lifted directly from the multicopter flavor of this navigation source, in order to let lowly and often dirty surface vehicles run WP missions without either doing so at a snail's pace (boring!) or roll over at the first turn.

Big thanks to @sensei-hacker for pointing me in the right direction in the discord "server" (a word discord misuses egregiously -- sorry, back to the point).

Other minutiae relates to branding/spelling/ordering/testing -- speaking of testing, I did run the tests, and did not know whether this change warranted any new test creation since no code is "new" -- that said, I've literally never written, let alone manipulated/adapted, a single line of C before  -- only build pipelines and infra around the C itself -- so _please_ look carefully to see if I've done something very dumb, because I'm just an sysadmin turned ops plumber w/ skills mainly in "boring" stuff like CI/containers/infra.

In terms of _meatspace_, testing has been carried out on two Matek FCs, an F722-WPX and an old F411WING.

Hopes are high that I'll make more rover-oriented contributions in the future so course-correction is very welcome and so is direct criticism, so long as it's constructive.