### PR TITLE
Change LPF filter setting for accgyro_icm42605.c and enable/configure hardware AA filter

### DIFF
--- a/src/main/drivers/accgyro/accgyro_icm42605.c
+++ b/src/main/drivers/accgyro/accgyro_icm42605.c
@@ -244,7 +244,9 @@ static void icm42605AccAndGyroInit(gyroDev_t *gyro)
     delay(15);
 
     /* LPF bandwidth */
-    busWrite(dev, ICM42605_RA_GYRO_ACCEL_CONFIG0, (config->gyroConfigValues[0]) | (config->gyroConfigValues[0] << 4));
+    //busWrite(dev, ICM42605_RA_GYRO_ACCEL_CONFIG0, (config->gyroConfigValues[0]) | (config->gyroConfigValues[0] << 4));
+    // low latency, same as BF
+    busWrite(dev, ICM42605_RA_GYRO_ACCEL_CONFIG0, ICM42605_ACCEL_UI_FILT_BW_LOW_LATENCY | ICM42605_GYRO_UI_FILT_BW_LOW_LATENCY);
     delay(15);
 
     /* AA Filter */

--- a/src/main/drivers/accgyro/accgyro_icm42605.c
+++ b/src/main/drivers/accgyro/accgyro_icm42605.c
@@ -170,7 +170,7 @@ static void icm42605AccAndGyroInit(gyroDev_t *gyro)
     delay(15);
 
     /* LPF bandwidth */
-    busWrite(dev, ICM42605_RA_GYRO_ACCEL_CONFIG0, (config->gyroConfigValues[1]) | (config->gyroConfigValues[1] << 4));
+    busWrite(dev, ICM42605_RA_GYRO_ACCEL_CONFIG0, (config->gyroConfigValues[0]) | (config->gyroConfigValues[0] << 4));
     delay(15);
 
     busWrite(dev, ICM42605_RA_INT_CONFIG, ICM42605_INT1_MODE_PULSED | ICM42605_INT1_DRIVE_CIRCUIT_PP | ICM42605_INT1_POLARITY_ACTIVE_HIGH);

--- a/src/main/drivers/accgyro/accgyro_icm42605.c
+++ b/src/main/drivers/accgyro/accgyro_icm42605.c
@@ -406,7 +406,8 @@ static const aafConfig_t *getGyroAafConfig(bool is42688, const uint16_t desiredL
         }
     }
 
-    LOG_VERBOSE(GYRO, "ICM426XX AAF CONFIG { %d, %d } -> { %d }; delt: %d deltSqr: %d, shift: %d",
+    LOG_VERBOSE(GYRO, "ICM426%s AAF CONFIG { %d, %d } -> { %d }; delt: %d deltSqr: %d, shift: %d",
+		(is42688P ? "88" : "05"),
                 desiredLpf, desiredFreq,
                 candidate->freq,
                 candidate->delt, candidate->deltSqr, candidate->bitshift);


### PR DESCRIPTION
Looks like there was a typo in icm42605, or an outdated comment.

config->gyroConfigValues[1] is supposed to be ODR related
and config->gyroConfigValues[0] is supposed to be LPF related.

ICM42605_RA_GYRO_ACCEL_CONFIG0 is setting up the LPF bandwidth.

Reported by eredinnt_40163 on Discord.

While reviewing this, I decided to test the combination of AAF + Low lattency filter settings that BF uses.

AP appears to do the same.