### PR TITLE
rudimentary rover/boat WP slowdown & trivial text tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,12 +16,13 @@ startup_stm32f10x_md_gcc.s
 cov-int*
 /build/
 /build_SITL/
+/debug/
+/downloads/
 /obj/
 /patches/
-/tools/
-/downloads/
-/debug/
 /release/
+/testing/
+/tools/
 
 # script-generated files
 docs/Manual.pdf

--- a/AUTHORS
+++ b/AUTHORS
@@ -27,6 +27,7 @@ Darren Lines (Mr.D - RC)
 Dave Pitman
 David Bieber
 Davide Bertola
+dc (@packetpilot)
 Denis Kisselev
 Dominic Clifton
 Frank Zhao

--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -2,7 +2,7 @@
 
 This document is primarily for developers only.
 
-## General principals
+## General principles
 
 1. Name everything well.
 2. Strike a balance between simplicity and not-repeating code.


### PR DESCRIPTION
Please, feel free to clue a guy in on C.

My objective here was to get the multicopter setting to slow down for waypoint turns -- on by default for rovers -- to work, and to do so within the constraints of the min & max nav throttle values for fixed wing craft.

Admittedly the basic arithmetic at play to actually reduce the throttle is far from ideal (it's only subtracting the degrees of heading error from the `nav_fw_cruise` value), but I'd like to think someone who's written C before could drop some wisdom over that at some point in the future.

A video of what this does is "in the discord". Zero saltiness if I've done dumb things and/or need to toil over whitespace (can we call it emptyspace yet?) etc -- just lmk here or in discord.

obligatory reference to #9658 if more context is your jam.