### PR TITLE
Delay save settings to prevent ESC lockup on emergency rearm

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -902,7 +902,7 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
     setServoOutputEnabled(true);
 
     if ((exitType == CMS_EXIT_SAVEREBOOT) || (exitType == CMS_POPUP_SAVEREBOOT)) {
-        processDelayedSave();
+        processDelayedSave(true);
         displayClearScreen(pDisplay);
         displayWrite(pDisplay, 5, 3, "REBOOTING...");
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -68,6 +68,7 @@
 
 #include "fc/config.h"
 #include "fc/controlrate_profile.h"
+#include "fc/fc_core.h"
 #include "fc/rc_adjustments.h"
 #include "fc/rc_controls.h"
 #include "fc/rc_curves.h"
@@ -396,10 +397,10 @@ void saveConfig(void)
     }
 }
 
-void processDelayedSave(void)
+void processDelayedSave(bool readyToSave)
 {
     if (saveState == SAVESTATE_SAVEANDNOTIFY) {
-         if (STATE(IN_FLIGHT_EMERG_REARM)) {
+         if (emergInflightRearmEnabled() || !readyToSave) {
             // Do not process save if we are potentially still flying. Once armed, this function will not be called until the next disarm.
 #ifdef USE_OSD
     osdSaveWaitingProcess();
@@ -408,14 +409,18 @@ void processDelayedSave(void)
 #ifdef USE_OSD
     osdStartedSaveProcess();
 #endif
-            processSaveConfigAndNotify();
-            saveState = SAVESTATE_NONE;
+            if (readyToSave) {
+                processSaveConfigAndNotify();
+                saveState = SAVESTATE_NONE;
+            }
         }
     } else if (saveState == SAVESTATE_SAVEONLY) {
-        suspendRxSignal();
-        writeEEPROM();
-        resumeRxSignal();
-        saveState = SAVESTATE_NONE;
+        if (readyToSave) {
+            suspendRxSignal();
+            writeEEPROM();
+            resumeRxSignal();
+            saveState = SAVESTATE_NONE;
+        }
     }
 }
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -399,8 +399,18 @@ void saveConfig(void)
 void processDelayedSave(void)
 {
     if (saveState == SAVESTATE_SAVEANDNOTIFY) {
-        processSaveConfigAndNotify();
-        saveState = SAVESTATE_NONE;
+         if (STATE(IN_FLIGHT_EMERG_REARM)) {
+            // Do not process save if we are potentially still flying. Once armed, this function will not be called until the next disarm.
+#ifdef USE_OSD
+    osdSaveWaitingProcess();
+#endif 
+        } else {
+#ifdef USE_OSD
+    osdStartedSaveProcess();
+#endif
+            processSaveConfigAndNotify();
+            saveState = SAVESTATE_NONE;
+        }
     } else if (saveState == SAVESTATE_SAVEONLY) {
         suspendRxSignal();
         writeEEPROM();

--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -124,7 +124,7 @@ void resetEEPROM(void);
 void readEEPROM(void);
 void writeEEPROM(void);
 void ensureEEPROMContainsValidData(void);
-void processDelayedSave(void);
+void processDelayedSave(bool readyToSave);
 
 void saveConfig(void);
 void saveConfigAndNotify(void);

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -894,7 +894,7 @@ void taskMainPidLoop(timeUs_t currentTimeUs)
     if (!ARMING_FLAG(ARMED)) {
         armTime = 0;
 
-        // Delay saving for 0.5s to allow other functions to process save actions on disarm
+        // Delay saving for 0.5s to allow other functions to finish processing data to be stored on disarm
         if (currentTimeUs - lastDisarmTimeUs > USECS_PER_SEC / 2) {
             processDelayedSave();
         }

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -65,6 +65,7 @@
 #include "io/beeper.h"
 #include "io/dashboard.h"
 #include "io/gps.h"
+#include "io/osd.h"
 #include "io/serial.h"
 #include "io/statusindicator.h"
 #include "io/asyncfatfs/asyncfatfs.h"
@@ -895,12 +896,14 @@ void taskMainPidLoop(timeUs_t currentTimeUs)
         armTime = 0;
 
         // Delay saving for 0.5s to allow other functions to finish processing data to be stored on disarm
-        if (currentTimeUs - lastDisarmTimeUs > USECS_PER_SEC / 2) {
-            processDelayedSave();
-        }
+        processDelayedSave((currentTimeUs - lastDisarmTimeUs > USECS_PER_SEC / 2));
     }
 
     if (armTime > 1 * USECS_PER_SEC) {     // reset in flight emerg rearm flag 1 sec after arming once it's served its purpose
+#ifdef USE_OSD
+        if (STATE(IN_FLIGHT_EMERG_REARM))
+            osdSaveProcessAborted();
+#endif
         DISABLE_STATE(IN_FLIGHT_EMERG_REARM);
     }
 

--- a/src/main/fc/fc_core.h
+++ b/src/main/fc/fc_core.h
@@ -43,6 +43,7 @@ void tryArm(void);
 disarmReason_t getDisarmReason(void);
 
 bool emergencyArmingUpdate(bool armingSwitchIsOn, bool forceArm);
+bool emergInflightRearmEnabled(void);
 
 bool areSensorsCalibrating(void);
 float getFlightTime(void);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -155,8 +155,15 @@
 #define OSD_MIN_FONT_VERSION 3
 
 static timeMs_t linearDescentMessageMs  = 0;
+
+typedef enum {
+    OSD_SAVE_MESSAGE_NONE,
+    OSD_SAVE_MESSAGE_WAITING,
+    OSD_SAVE_MESSAGE_SAVING
+} osd_saveMessage_e;
+
 static timeMs_t notify_settings_saved   = 0;
-static bool     savingSettings          = false;
+static uint8_t  savingSettings          = OSD_SAVE_MESSAGE_NONE;
 
 static unsigned currentLayout = 0;
 static int layoutOverride = -1;
@@ -212,12 +219,16 @@ static bool osdDisplayHasCanvas;
 PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 9);
 PG_REGISTER_WITH_RESET_FN(osdLayoutsConfig_t, osdLayoutsConfig, PG_OSD_LAYOUTS_CONFIG, 1);
 
+void osdSaveWaitingProcess(void) {
+    savingSettings = OSD_SAVE_MESSAGE_WAITING;
+}
+
 void osdStartedSaveProcess(void) {
-    savingSettings = true;
+    savingSettings = OSD_SAVE_MESSAGE_SAVING;
 }
 
 void osdShowEEPROMSavedNotification(void) {
-    savingSettings = false;
+    savingSettings = OSD_SAVE_MESSAGE_NONE;
     notify_settings_saved = millis() + 5000;
 }
 
@@ -4534,8 +4545,10 @@ static void osdShowStats(bool isSinglePageStatsCompatible, uint8_t page)
         displayWrite(osdDisplayPort, statValuesX + multiValueLengthOffset, top++, buff);
     }
 
-    if (savingSettings == true) {
+    if (savingSettings == OSD_SAVE_MESSAGE_SAVING) {
         displayWrite(osdDisplayPort, statNameX, top++, OSD_MESSAGE_STR(OSD_MSG_SAVING_SETTNGS));
+    } else if (savingSettings == OSD_SAVE_MESSAGE_WAITING) {
+        displayWrite(osdDisplayPort, statNameX, top++, OSD_MESSAGE_STR(OSD_MSG_WAITING_TO_SAVE));
     } else if (notify_settings_saved > 0) {
         if (millis() > notify_settings_saved) {
             notify_settings_saved = 0;
@@ -5265,8 +5278,10 @@ textAttributes_t osdGetSystemMessage(char *buff, size_t buff_size, bool isCenter
 
         /* Messages that are shown regardless of Arming state */
 
-        if (savingSettings == true) {
+        if (savingSettings == OSD_SAVE_MESSAGE_SAVING) {
            messages[messageCount++] = OSD_MESSAGE_STR(OSD_MSG_SAVING_SETTNGS);
+        } else if (savingSettings == OSD_SAVE_MESSAGE_WAITING) {
+            messages[messageCount++] = OSD_MESSAGE_STR(OSD_MSG_WAITING_TO_SAVE);
         } else if (notify_settings_saved > 0) {
             if (millis() > notify_settings_saved) {
                 notify_settings_saved = 0;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -487,6 +487,7 @@ int32_t osdGetAltitude(void);
 
 bool osdUsingScaledThrottle(void);
 
+void osdSaveProcessAborted(void);
 void osdSaveWaitingProcess(void);
 void osdStartedSaveProcess(void);
 void osdShowEEPROMSavedNotification(void);

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -119,6 +119,7 @@
 #define OSD_MSG_UNABLE_ARM          "UNABLE TO ARM"
 #define OSD_MSG_SAVING_SETTNGS      "** SAVING SETTINGS **"
 #define OSD_MSG_SETTINGS_SAVED      "** SETTINGS SAVED **"
+#define OSD_MSG_WAITING_TO_SAVE     "** WAITING TO SAVE **"
 #define OSD_MSG_ANGLEHOLD_ROLL      "(ANGLEHOLD ROLL)"
 #define OSD_MSG_ANGLEHOLD_PITCH     "(ANGLEHOLD PITCH)"
 #define OSD_MSG_ANGLEHOLD_LEVEL     "(ANGLEHOLD LEVEL)"
@@ -486,6 +487,7 @@ int32_t osdGetAltitude(void);
 
 bool osdUsingScaledThrottle(void);
 
+void osdSaveWaitingProcess(void);
 void osdStartedSaveProcess(void);
 void osdShowEEPROMSavedNotification(void);
 


### PR DESCRIPTION
The PR pauses the save after disarm if an emergency rearm is possible. This is to stop things like the RX pausing and the ESC restarting if you disarm in flight. If you are still flying, you will have 5 seconds to rearm. After that, the save will happen. The save will not happen if you rearm within the 5 seconds. If you're on the ground. The emergency rearm system will deactivate quickly. So the save will happen soon after landing. OSD messages are shown to show the state of the save process.

Fixes https://github.com/iNavFlight/inav/issues/9441