### PR TITLE
Fix motor output glitch by initializing IO after timer

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -172,6 +172,8 @@ static pwmOutputPort_t *pwmOutConfig(const timerHardware_t *timHw, resourceOwner
     const IO_t io = IOGetByTag(timHw->tag);
     IOInit(io, owner, RESOURCE_OUTPUT, allocatedOutputPortCount);
 
+    pwmOutConfigTimer(p, tch, hz, period, value);
+
     if (enableOutput) {
         IOConfigGPIOAF(io, IOCFG_AF_PP, timHw->alternateFunction);
     }
@@ -181,7 +183,6 @@ static pwmOutputPort_t *pwmOutConfig(const timerHardware_t *timHw, resourceOwner
         IOLo(io);
     }
 
-    pwmOutConfigTimer(p, tch, hz, period, value);
     return p;
 }
 


### PR DESCRIPTION
We have reports of some ESC's not arming when DSHOT is selected. When connecting to the ESC, it would show that the ESC detected multishot instead of DSHOT. This problem seems to happen only with ESC's that use AT32 microcontrollers. E.g., it happens with the Hobbywing XRotor G2 65A 4-in-1, but not with the Hobbywing 60 A 4-in-1. The former uses an AT32, the latter an STM32.

I inspected the motor signals with a logic analyzer during boot and there were short glitches where the output goes high for about 1.2 to 2.4 us during the timer configuration. When moving the IO configuration after the timer configuration, the glitches don't happen and the ESC's arm as expected.