### PR TITLE
Increase the maximum number of addressable LEDs 7.1

### DIFF
--- a/docs/LedStrip.md
+++ b/docs/LedStrip.md
@@ -7,7 +7,7 @@ require that all the LEDs in the strip show the same color.
 Addressable LED strips can be used to show information from the flight controller system, the current implementation
 supports the following:
 
-* Up to 32 LEDs.
+* Up to 128 LEDs. _If using more than 20 LEDs, you should look to use a separate power supply._
 * Indicators showing pitch/roll stick positions.
 * Heading/Orientation lights.
 * Flight mode specific color schemes.
@@ -17,12 +17,12 @@ supports the following:
 * RSSI level.
 * Battery level.
 
-Support for more than 32 LEDs is possible, it just requires additional development.
+Support for more than 128 LEDs is possible, it just requires additional development.
 
 ## Supported hardware
 
-Only strips of 32 WS2811/WS2812 LEDs are supported currently.  If the strip is longer than 32 LEDs it does not matter,
-but only the first 32 are used.
+Only strips of 128 WS2811/WS2812 LEDs are supported currently.  If the strip is longer than 128 LEDs it does not matter,
+but only the first 128 are used.
 
 WS2812 LEDs require an 800khz signal and precise timings and thus requires the use of a dedicated hardware timer.
 
@@ -42,11 +42,11 @@ It could be possible to be able to specify the timings required via CLI if users
 
 WS2812 LED strips generally require a single data line, 5V and GND.
 
-WS2812 LEDs on full brightness can consume quite a bit of current.  It is recommended to verify the current draw and ensure your
-supply can cope with the load.  On a multirotor that uses multiple BEC ESC's you can try use a different BEC to the one the FC
-uses.  e.g. ESC1/BEC1 -> FC, ESC2/BEC2 -> LED strip.   It's also possible to power one half of the strip from one BEC and the other half
-from another BEC.  Just ensure that the GROUND is the same for all BEC outputs and LEDs.
+WS2812 LEDs on full brightness can consume quite a bit of current.  **It is recommended to verify the current draw of you LEDs and ensure your supply can cope with the load. Remember, your flight controller will likely be using the same BEC to operate.** Check the specs of the LED chips. Some are more power hungry than others. Remember that if using the flight controller's 5v supply. This is also powering other components on your flight controller. Make sure there is enough overhead so that they don't brownout.
 
+On a multirotor that uses multiple BEC ESC's you can try use a different BEC to the one the FC uses. e.g. ESC1/BEC1 -> FC, ESC2/BEC2 -> LED strip. It's also possible to power one half of the strip from one BEC and the other half from another BEC. Just ensure that the GROUND is the same for all BEC outputs and LEDs.
+
+If using a large number of LEDs. It would be more efficient to use 12v LEDs and power them with a separate regulated supply. Especially if using long strips. You would use the data line (LED pad) from the flight controller. Make sure there is continuity between the ground on the LEDS and the ground on the flight controller.
 
 | Target                | Pin  | LED Strip | Signal |
 | --------------------- | ---- | --------- | -------|

--- a/src/main/drivers/light_ws2811strip.h
+++ b/src/main/drivers/light_ws2811strip.h
@@ -19,7 +19,7 @@
 #include "common/color.h"
 #include "config/parameter_group.h"
 
-#define WS2811_LED_STRIP_LENGTH 32
+#define WS2811_LED_STRIP_LENGTH 128
 #define WS2811_BITS_PER_LED 24
 #define WS2811_DELAY_BUFFER_LENGTH 42 // for 50us delay 
 

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -21,7 +21,7 @@
 #include "common/color.h"
 #include "rx/rx.h"
 
-#define LED_MAX_STRIP_LENGTH           32
+#define LED_MAX_STRIP_LENGTH           128
 #define LED_CONFIGURABLE_COLOR_COUNT   16
 #define LED_MODE_COUNT                  6
 #define LED_DIRECTION_COUNT             6


### PR DESCRIPTION
INAV 7.1 based version of #9701

Rebasing at this stage is a nightmare.

This is a non-breaking change. So should not be a problem for 7.1

-- Original info from #9701

Increase the number of addressable LEDs from 32 to 128.

The extra 96 LEDs adds only 10560 B (5.37% on an F722) of RAM usage, and an extra 64 B (0.01% on F722) of Flash. If necessary, this could be changed so that it is only available on processors with > 512 KB flash.

![image](https://github.com/iNavFlight/inav/assets/17590174/ebac9acb-6a4a-42cb-a739-5826f8cb693f)


Why so many LEDs? Why not? On larger aircraft, a single LED strip along a wing will have many chips. Here, for example is the tail boom extensions for a Drak. 
![image](https://github.com/iNavFlight/inav/assets/17590174/adfa2874-0731-4ee1-af15-f554b653f57e)

Here's the CPU usage with the LEDs switched off.
![image](https://github.com/iNavFlight/inav/assets/17590174/9256972e-fbb9-4ea9-9703-3edf45bbb717)

Here's the CPU usage with 96 LEDs with a Larson scanner running.
![image](https://github.com/iNavFlight/inav/assets/17590174/2d14c1b8-156a-41f7-bc8e-4936150fc2b6)