### PR TITLE
Show STOP instead of IDLE if motor stop enabled

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1150,7 +1150,7 @@ static void osdFormatThrottlePosition(char *buff, bool useScaled, textAttributes
 #endif
     int8_t throttlePercent = getThrottlePercent(useScaled);
     if ((useScaled && throttlePercent <= 0) || !ARMING_FLAG(ARMED)) {
-        const char* message = ARMING_FLAG(ARMED) ? throttlePercent == 0 ? "IDLE" : "STOP" : "DARM";
+        const char* message = ARMING_FLAG(ARMED) ? (throttlePercent == 0 && !ifMotorstopFeatureEnabled()) ? "IDLE" : "STOP" : "DARM";
         buff[0] = SYM_THR;
         strcpy(buff + 1, message);
         return;


### PR DESCRIPTION
On a fixed wing, you can have the "`throttle_idle`" set to 0. That combined with `max_throttle` set to 2000 gets rid of the silly scaling that goes on. If this is the case, the OSD does not show the correct message. It shows IDLE instead of STOP when the throttle is all the way down. This adds a check for if motor stop is enabled.