### PR TITLE
Revert GPS/Baro weight parameters to 7.0 values

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1928,7 +1928,7 @@ Weight of barometer measurements in estimated altitude and climb rate. Setting i
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0.4 | 0 | 10 |
+| 0.35 | 0 | 10 |
 
 ---
 
@@ -1938,7 +1938,7 @@ Weight of GPS altitude measurements in estimated altitude. Setting is used on bo
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0.4 | 0 | 10 |
+| 0.2 | 0 | 10 |
 
 ---
 
@@ -1948,7 +1948,7 @@ Weight of GPS climb rate measurements in estimated climb rate. Setting is used o
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 0.8 | 0 | 10 |
+| 0.1 | 0 | 10 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2337,19 +2337,19 @@ groups:
         field: w_z_baro_p
         min: 0
         max: 10
-        default_value: 0.4
+        default_value: 0.35
       - name: inav_w_z_gps_p
         description: "Weight of GPS altitude measurements in estimated altitude. Setting is used on both airplanes and multirotors."
         field: w_z_gps_p
         min: 0
         max: 10
-        default_value: 0.4
+        default_value: 0.2
       - name: inav_w_z_gps_v
         description: "Weight of GPS climb rate measurements in estimated climb rate. Setting is used on both airplanes and multirotors."
         field: w_z_gps_v
         min: 0
         max: 10
-        default_value: 0.8
+        default_value: 0.1
       - name: inav_w_xy_gps_p
         description: "Weight of GPS coordinates in estimated UAV position and speed."
         default_value: 1.0


### PR DESCRIPTION
Revert `inav_w_z_baro_p`, `inav_w_z_gps_p`, and `inav_w_z_gps_v` to the defaults from INAV 7.0. Changed in #9387

Altitude estimation is less accurate with the new 9387 settings.