### PR TITLE
Spektrum telemetry minor fix to address false Fastboot alerts on radios with latest update

### DIFF
--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -165,11 +165,13 @@ typedef struct
     INT8 dBm_A, // Average signal for A antenna in dBm
     INT8 dBm_B; // Average signal for B antenna in dBm.
     // If only 1 antenna, set B = A
+    UINT16 spare[2];
+    UINT16 fastbootUptime; // bit 15 = fastboot flag.  Bits 0-14= uptime in seconds.  0x0000 --> no data
 } STRU_TELE_RPM;
 */
 
 #define STRU_TELE_RPM_EMPTY_FIELDS_COUNT 8
-#define STRU_TELE_RPM_EMPTY_FIELDS_VALUE 0xff
+#define STRU_TELE_RPM_EMPTY_FIELDS_VALUE 0x00
 
 #define SPEKTRUM_RPM_UNUSED 0xffff
 #define SPEKTRUM_TEMP_UNUSED 0x7fff


### PR DESCRIPTION
Our recent radio update has an addition to the STRU_TELE_RPM telemetry packet type, which causes a telemetry alarm if the previous spare bytes were populated with 0xFF's instead of 0x00's.

This pull request adds the new variable (fastbootUptime) to the commented description of the struct, and changes the fill value to 0's.

I've tested this change on a REVO board

Same issue has been submitted and merged in betaflight. 
https://github.com/betaflight/betaflight/pull/13383