### PR TITLE
fixed "Set LED Pin PWM" functionality in programming framework

### DIFF
--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -476,8 +476,9 @@ static int logicConditionCompute(
             }
             break;
 
-#ifdef LED_PIN
+#ifdef USE_LED_STRIP
         case LOGIC_CONDITION_LED_PIN_PWM:
+
             if (operandA >=0 && operandA <= 100) {
                 ledPinStartPWM((uint8_t)operandA);
             } else {


### PR DESCRIPTION
Fixes "Set LED pin PWM" logic condition doesn't work in programming framework due to incorrect #define
https://github.com/iNavFlight/inav/blob/master/docs/LED%20pin%20PWM.md


@DzikuVx  It would be nice if this small fix also get merged into 7.1.