### PR TITLE
Fix compiler existence checking in case if PATH contains tilde

### DIFF
--- a/src/utils/compiler.rb
+++ b/src/utils/compiler.rb
@@ -47,7 +47,7 @@ class Compiler
         dirs.each do |dir|
             p = File.join(dir, bin)
             ['', '.exe'].each do |suffix|
-                f = p + suffix
+                f = File.expand_path(p + suffix)
                 if File.executable?(f)
                     if @verbose
                         puts "Found #{bin} at #{f}"


### PR DESCRIPTION
Fix (expand_path) compiler existence checking in case if PATH contains tilde:

```
inav.git/build]$ make MATEKF411
Generating MATEKF411/settings_generated.h, MATEKF411/settings_generated.c
/Users/bojack/tmp/inav.git/src/utils/compiler.rb:60:in `initialize': Could not find arm-none-eabi-g++ in PATH, looked in ["", "~/homebrew/bin", "~/homebrew/sbin", "/opt/local/bin", "/opt/local/sbin", "/usr/local/opt/asdf/libexec/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin", "/Library/Apple/usr/bin", "/Users/bojack/bin", "/opt/local/bin", "/opt/local/sbin"] (RuntimeError)
```

```
$ ruby -e 'print(File.executable?("~/homebrew/bin/arm-none-eabi-g++"))'
false
$ ruby -e 'print(File.executable?("/Users/bojack/homebrew/bin/arm-none-eabi-g++"))'
true
```