### PR TITLE
Show a timeout for in flight rearming

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -507,6 +507,18 @@ bool emergencyArmingUpdate(bool armingSwitchIsOn, bool forceArm)
     return counter >= EMERGENCY_ARMING_MIN_ARM_COUNT;
 }
 
+uint16_t emergencyInFlightRearmTimeMS(void)
+{
+    uint16_t rearmMS = 0;
+
+    if (STATE(IN_FLIGHT_EMERG_REARM)) {
+        timeMs_t currentTimeMs = millis();
+        rearmMS = (uint16_t)((US2MS(lastDisarmTimeUs) + EMERGENCY_INFLIGHT_REARM_TIME_WINDOW_MS) - currentTimeMs);
+    }
+
+    return rearmMS;
+}
+
 bool emergInflightRearmEnabled(void)
 {
     /* Emergency rearm allowed within 5s timeout period after disarm if craft still flying */
@@ -880,7 +892,6 @@ static void applyThrottleTiltCompensation(void)
 
 void taskMainPidLoop(timeUs_t currentTimeUs)
 {
-
     cycleTime = getTaskDeltaTime(TASK_SELF);
     dT = (float)cycleTime * 0.000001f;
 
@@ -899,7 +910,8 @@ void taskMainPidLoop(timeUs_t currentTimeUs)
         }
     }
 
-    if (armTime > 1 * USECS_PER_SEC) {     // reset in flight emerg rearm flag 1 sec after arming once it's served its purpose
+    if (armTime > 1 * USECS_PER_SEC) {  
+        // reset in flight emerg rearm flag 1 sec after arming once it's served its purpose
         DISABLE_STATE(IN_FLIGHT_EMERG_REARM);
     }
 

--- a/src/main/fc/fc_core.h
+++ b/src/main/fc/fc_core.h
@@ -42,7 +42,9 @@ timeUs_t getLastDisarmTimeUs(void);
 void tryArm(void);
 disarmReason_t getDisarmReason(void);
 
+uint16_t emergencyInFlightRearmTimeMS(void);
 bool emergencyArmingUpdate(bool armingSwitchIsOn, bool forceArm);
+bool emergInflightRearmEnabled(void);
 
 bool areSensorsCalibrating(void);
 float getFlightTime(void);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -4561,19 +4561,16 @@ static void osdShowStats(bool isSinglePageStatsCompatible, uint8_t page)
         displayWrite(osdDisplayPort, statValuesX + multiValueLengthOffset, top++, buff);
     }
 
-    if (emergInflightRearmEnabled()) {
-        uint16_t rearmMs = emergencyInFlightRearmTimeMS();
-        if (rearmMs > 0) {
-            char emReArmMsg[23];
-            tfp_sprintf(emReArmMsg, "** REARM PERIOD: ");
-            tfp_sprintf(emReArmMsg + strlen(emReArmMsg), "%02d", (uint8_t)MS2S(rearmMs));
-            strcat(emReArmMsg, " **\0");
-            displayWrite(osdDisplayPort, statNameX, top++, OSD_MESSAGE_STR(emReArmMsg));
-        }
-    }
+    uint16_t rearmMs = (emergInflightRearmEnabled()) ? emergencyInFlightRearmTimeMS() : 0;
 
     if (savingSettings == true) {
         displayWrite(osdDisplayPort, statNameX, top++, OSD_MESSAGE_STR(OSD_MSG_SAVING_SETTNGS));
+    } else if (rearmMs > 0) { // Show rearming time if settings not actively being saved. Ignore the settings saved message if rearm available.
+        char emReArmMsg[23];
+        tfp_sprintf(emReArmMsg, "** REARM PERIOD: ");
+        tfp_sprintf(emReArmMsg + strlen(emReArmMsg), "%02d", (uint8_t)MS2S(rearmMs));
+        strcat(emReArmMsg, " **\0");
+        displayWrite(osdDisplayPort, statNameX, top++, OSD_MESSAGE_STR(emReArmMsg));
     } else if (notify_settings_saved > 0) {
         if (millis() > notify_settings_saved) {
             notify_settings_saved = 0;
@@ -5318,9 +5315,16 @@ textAttributes_t osdGetSystemMessage(char *buff, size_t buff_size, bool isCenter
         }
 
         /* Messages that are shown regardless of Arming state */
+        uint16_t rearmMs = (emergInflightRearmEnabled()) ? emergencyInFlightRearmTimeMS() : 0;
 
         if (savingSettings == true) {
            messages[messageCount++] = OSD_MESSAGE_STR(OSD_MSG_SAVING_SETTNGS);
+        } else if (rearmMs > 0) { // Show rearming time if settings not actively being saved. Ignore the settings saved message if rearm available.
+            char emReArmMsg[23];
+            tfp_sprintf(emReArmMsg, "** REARM PERIOD: ");
+            tfp_sprintf(emReArmMsg + strlen(emReArmMsg), "%02d", (uint8_t)MS2S(rearmMs));
+            strcat(emReArmMsg, " **\0");
+            messages[messageCount++] = OSD_MESSAGE_STR(emReArmMsg);
         } else if (notify_settings_saved > 0) {
             if (millis() > notify_settings_saved) {
                 notify_settings_saved = 0;
@@ -5329,14 +5333,6 @@ textAttributes_t osdGetSystemMessage(char *buff, size_t buff_size, bool isCenter
             }
         }
 
-        uint16_t rearmMs = emergencyInFlightRearmTimeMS();
-        if (rearmMs > 0) {
-            char emReArmMsg[23];
-            tfp_sprintf(emReArmMsg, "** REARM PERIOD: ");
-            tfp_sprintf(emReArmMsg + strlen(emReArmMsg), "%02d", (uint8_t)MS2S(rearmMs));
-            strcat(emReArmMsg, " **\0");
-            messages[messageCount++] = OSD_MESSAGE_STR(emReArmMsg);
-        }
 
         if (messageCount > 0) {
             message = messages[OSD_ALTERNATING_CHOICES(systemMessageCycleTime(messageCount, messages), messageCount)];


### PR DESCRIPTION
If possible, this will show a countdown time for how long the pilot has to rearm in flight. This was a part of #9688, which wasn't working as expected. This part should work, and give the pilots useful information.

Tested in HITL. Will test in flight asap.