### PR TITLE
fix cygwin/sitl build with cmake 3.28.3

### DIFF
--- a/cmake/sitl.cmake
+++ b/cmake/sitl.cmake
@@ -34,7 +34,7 @@ set(SITL_LINK_OPTIONS
     -Wl,-L${STM32_LINKER_DIR}
 )
 
-if(${WIN32} OR ${CYGWIN})
+if(${CYGWIN})
     set(SITL_LINK_OPTIONS ${SITL_LINK_OPTIONS} "-static-libgcc")
 endif()
 
@@ -131,7 +131,7 @@ function (target_sitl name)
         target_link_options(${exe_target} PRIVATE -T${script_path})
     endif()
 
-    if(${WIN32} OR ${CYGWIN})
+    if(${CYGWIN})
         set(exe_filename ${CMAKE_BINARY_DIR}/${binary_name}.exe)
     else()
         set(exe_filename ${CMAKE_BINARY_DIR}/${binary_name})


### PR DESCRIPTION
Fixes Windows / Cygwin SITL build with latest cygwin / cmake 3.28.3

Note that:

* It (may) still break due to an encoding issue  in `settings.rb`
* The fixes will need backporting to release_7.1.0 as it's a tool chain issue