### PR TITLE
Add new target CSKY405 and fix BMI088 driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ else()
     endif()
 endif()
 
-project(INAV VERSION 8.0.0)
+project(INAV VERSION 7.0.0)
 
 enable_language(ASM)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ else()
     endif()
 endif()
 
-project(INAV VERSION 7.0.0)
+project(INAV VERSION 8.0.0)
 
 enable_language(ASM)
 

--- a/src/main/drivers/accgyro/accgyro_bmi088.c
+++ b/src/main/drivers/accgyro/accgyro_bmi088.c
@@ -99,6 +99,10 @@ static void bmi088GyroInit(gyroDev_t *gyro)
     busWrite(gyro->busDev, REGG_INT_CTRL, 0x80);
     delay(1);
 
+    // gyro range
+    busWrite(gyro->busDev, REGG_RANGE, 0x00);
+    delay(1);
+
     busSetSpeed(gyro->busDev, BUS_SPEED_FAST);
 }
 
@@ -136,9 +140,9 @@ static bool bmi088GyroRead(gyroDev_t *gyro)
     uint8_t gyroRaw[6];
 
     if (busReadBuf(gyro->busDev, REGG_RATE_X_LSB, gyroRaw, 6)) {
-        gyro->gyroADCRaw[X] = (float) int16_val_little_endian(gyroRaw, 0);
-        gyro->gyroADCRaw[Y] = (float) int16_val_little_endian(gyroRaw, 1);
-        gyro->gyroADCRaw[Z] = (float) int16_val_little_endian(gyroRaw, 2);
+        gyro->gyroADCRaw[X] = (int16_t)((gyroRaw[1] << 8) | gyroRaw[0]);
+        gyro->gyroADCRaw[Y] = (int16_t)((gyroRaw[3] << 8) | gyroRaw[2]);
+        gyro->gyroADCRaw[Z] = (int16_t)((gyroRaw[5] << 8) | gyroRaw[4]);
         return true;
     }
 
@@ -151,9 +155,9 @@ static bool bmi088AccRead(accDev_t *acc)
 
     if (busReadBuf(acc->busDev, REGA_STATUS, buffer, 2) && (buffer[1] & 0x80) && busReadBuf(acc->busDev, REGA_X_LSB, buffer, 7)) {
         // first byte is discarded, see datasheet
-        acc->ADCRaw[X] = (float)(((int16_t)(buffer[2] << 8) | buffer[1]) * 3 / 4);
-        acc->ADCRaw[Y] = (float)(((int16_t)(buffer[4] << 8) | buffer[3]) * 3 / 4);
-        acc->ADCRaw[Z] = (float)(((int16_t)(buffer[6] << 8) | buffer[5]) * 3 / 4);
+        acc->ADCRaw[X] = (int32_t)(((int16_t)(buffer[4] << 8) | buffer[3]) * 3 / 4);
+        acc->ADCRaw[Y] = -(int32_t)(((int16_t)(buffer[2] << 8) | buffer[1]) * 3 / 4);
+        acc->ADCRaw[Z] = (int32_t)(((int16_t)(buffer[6] << 8) | buffer[5]) * 3 / 4);
         return true;
     }
 

--- a/src/main/drivers/barometer/barometer_bmp388.c
+++ b/src/main/drivers/barometer/barometer_bmp388.c
@@ -39,7 +39,12 @@
 
 #if defined(USE_BARO) && (defined(USE_BARO_BMP388) || defined(USE_BARO_SPI_BMP388))
 
-#define BMP388_I2C_ADDR                                 (0x76) // same as BMP280/BMP180
+#ifndef BMP388_I2C_ADDR_HW
+#define BMP388_I2C_ADDR                                 (0x77) // same as BMP280/BMP180
+#else
+#define BMP388_I2C_ADDR                                 (BMP388_I2C_ADDR_HW)
+#endif
+
 #define BMP388_DEFAULT_CHIP_ID                          (0x50) // from https://github.com/BoschSensortec/BMP3-Sensor-API/blob/master/bmp3_defs.h#L130
 
 #define BMP388_CMD_REG                                  (0x7E)
@@ -314,7 +319,7 @@ static bool deviceDetect(busDevice_t * busDev)
 
         bool ack = busReadBuf(busDev, BMP388_CHIP_ID_REG, chipId, nRead);
 
-        if (ack && *pId == BMP388_DEFAULT_CHIP_ID) {
+        if (ack && (*pId == BMP388_DEFAULT_CHIP_ID || *pId == 0x60)) {
             return true;
         }
     };

--- a/src/main/drivers/barometer/barometer_bmp388.c
+++ b/src/main/drivers/barometer/barometer_bmp388.c
@@ -40,7 +40,7 @@
 #if defined(USE_BARO) && (defined(USE_BARO_BMP388) || defined(USE_BARO_SPI_BMP388))
 
 #ifndef BMP388_I2C_ADDR_HW
-#define BMP388_I2C_ADDR                                 (0x77) // same as BMP280/BMP180
+#define BMP388_I2C_ADDR                                 (0x76) // same as BMP280/BMP180
 #else
 #define BMP388_I2C_ADDR                                 (BMP388_I2C_ADDR_HW)
 #endif

--- a/src/main/drivers/barometer/barometer_bmp388.c
+++ b/src/main/drivers/barometer/barometer_bmp388.c
@@ -39,12 +39,6 @@
 
 #if defined(USE_BARO) && (defined(USE_BARO_BMP388) || defined(USE_BARO_SPI_BMP388))
 
-#ifndef BMP388_I2C_ADDR_HW
-#define BMP388_I2C_ADDR                                 (0x76) // same as BMP280/BMP180
-#else
-#define BMP388_I2C_ADDR                                 (BMP388_I2C_ADDR_HW)
-#endif
-
 #define BMP388_DEFAULT_CHIP_ID                          (0x50) // from https://github.com/BoschSensortec/BMP3-Sensor-API/blob/master/bmp3_defs.h#L130
 
 #define BMP388_CMD_REG                                  (0x7E)

--- a/src/main/target/CLEARSKY405/CMakeLists.txt
+++ b/src/main/target/CLEARSKY405/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f405xg(CLEARSKY405)

--- a/src/main/target/CLEARSKY405/config.c
+++ b/src/main/target/CLEARSKY405/config.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "fc/fc_msp_box.h"
+#include "io/serial.h"
+#include "io/piniobox.h"
+
+void targetConfiguration(void)
+{ 
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+    pinioBoxConfigMutable()->permanentId[2] = BOX_PERMANENT_ID_USER3;
+    pinioBoxConfigMutable()->permanentId[3] = BOX_PERMANENT_ID_USER4;
+
+}

--- a/src/main/target/CLEARSKY405/target.c
+++ b/src/main/target/CLEARSKY405/target.c
@@ -1,0 +1,42 @@
+/*
+* This file is part of Cleanflight.
+*
+* Cleanflight is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Cleanflight is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+timerHardware_t timerHardware[] = {
+    //DEF_TIM(TIM9, CH2, PA3,  TIM_USE_PPM,   0, 0), // PPM
+
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_OUTPUT_AUTO, 0, 1),    // S1
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_OUTPUT_AUTO, 0, 0),    // S2  
+    DEF_TIM(TIM8, CH4, PC9,  TIM_USE_OUTPUT_AUTO, 0, 0),    // S3  
+    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_OUTPUT_AUTO, 0, 0),    // S4  
+
+    DEF_TIM(TIM2, CH4, PB11, TIM_USE_OUTPUT_AUTO, 0, 0),    // S5  
+    DEF_TIM(TIM2, CH3, PB10,  TIM_USE_OUTPUT_AUTO, 0, 0),   // S6  
+    DEF_TIM(TIM4, CH4, PB9,  TIM_USE_OUTPUT_AUTO, 0, 0),    // S7  
+    DEF_TIM(TIM12, CH2, PB15,  TIM_USE_OUTPUT_AUTO, 0, 0),  // S8
+
+    DEF_TIM(TIM12, CH1, PB14,  TIM_USE_OUTPUT_AUTO, 0, 0),  // S9
+    DEF_TIM(TIM2, CH1, PA5,  TIM_USE_OUTPUT_AUTO, 0, 0),    // S10
+    //DEF_TIM(TIM13, CH1, PA6,  TIM_USE_OUTPUT_AUTO, 0, 0),   // S12
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/CLEARSKY405/target.h
+++ b/src/main/target/CLEARSKY405/target.h
@@ -116,7 +116,7 @@
 #define USE_BARO
 #define BARO_I2C_BUS                DEFAULT_I2C_BUS
 #define USE_BARO_BMP388
-#define BMP388_I2C_ADDR_HW          0x77
+#define BMP388_I2C_ADDR          0x77
 #define USE_BARO_BMP280
 #define USE_BARO_MS5611
 #define USE_BARO_BMP085

--- a/src/main/target/CLEARSKY405/target.h
+++ b/src/main/target/CLEARSKY405/target.h
@@ -1,0 +1,175 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "CSKY4"
+
+#define USBD_PRODUCT_STRING  "CSKY405"
+
+#define LED0                    PA13
+#define LED1                    PA14
+
+// *************** PINIO ***************************
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN PB2 
+#define PINIO2_PIN PB8  
+#define PINIO3_PIN PC15  
+#define PINIO4_PIN PC0                          // BEC 12V SWITCHER
+#define PINIO4_FLAGS    PINIO_FLAGS_INVERTED    // Enable BEC 12V default
+
+// *************** BEEPER ***************************
+#define BEEPER                  PC13
+#define BEEPER_INVERTED
+#define BEEPER_PWM_FREQUENCY    2500
+
+// *************** Gyro & ACC **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_SCK_PIN            PB3
+#define SPI1_MISO_PIN   	    PB4
+#define SPI1_MOSI_PIN   	    PB5
+
+#define BMI088_GYRO_CS_PIN      PA4
+#define BMI088_ACC_CS_PIN       PC14
+#define BMI088_SPI_BUS          BUS_SPI1
+
+#define USE_IMU_BMI088
+#define IMU_BMI088_ALIGN       CW90_DEG
+
+// *************** SD Card **************************
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN   	    PC2
+#define SPI2_MOSI_PIN   	    PC3
+
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+#define SDCARD_SPI_BUS          BUS_SPI2
+#define SDCARD_CS_PIN           PC1
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+// *************** OSD *****************************
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          PB12
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PC11
+#define UART3_TX_PIN            PC10
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART5
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN            PC12
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define SERIAL_PORT_COUNT       7
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+// *************** I2C ****************************
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+
+#define DEFAULT_I2C_BUS         BUS_I2C1
+
+#define USE_BARO
+#define BARO_I2C_BUS                DEFAULT_I2C_BUS
+#define USE_BARO_BMP388
+#define BMP388_I2C_ADDR_HW          0x77
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_BMP085
+#define USE_BARO_DPS310
+#define USE_BARO_SPL06
+
+#define USE_MAG
+#define MAG_I2C_BUS                 DEFAULT_I2C_BUS
+#define USE_MAG_AK8963
+#define USE_MAG_AK8975
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define USE_MAG_IST8310
+#define USE_MAG_IST8308
+#define USE_MAG_MAG3110
+#define USE_MAG_LIS3MDL
+
+#define TEMPERATURE_I2C_BUS         DEFAULT_I2C_BUS
+
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_MSP
+#define RANGEFINDER_I2C_BUS     DEFAULT_I2C_BUS
+
+#define PITOT_I2C_BUS               DEFAULT_I2C_BUS
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC5
+#define ADC_CHANNEL_2_PIN           PC4
+#define ADC_CHANNEL_3_PIN           PA7
+#define RSSI_ADC_CHANNEL            ADC_CHN_1
+#define VBAT_ADC_CHANNEL            ADC_CHN_2
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_3
+
+
+#define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY )
+#define CURRENT_METER_SCALE   1142
+#define CURRENT_METER_OFFSET  17
+#define VBAT_SCALE_DEFAULT    2087
+
+#define USE_SPEKTRUM_BIND
+#define BIND_PIN                PA3 //  RX2
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+
+#define MAX_PWM_OUTPUT_PORTS       12

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -115,7 +115,10 @@
     #if !defined(BMP388_I2C_BUS)
         #define BMP388_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_bmp388,      DEVHW_BMP388,       BMP388_I2C_BUS,     0x76,               NONE,           DEVFLAGS_NONE,      0);
+    #ifndef BMP388_I2C_ADDR_HW
+    #define BMP388_I2C_ADDR_HW  0x76
+    #endif
+    BUSDEV_REGISTER_I2C(busdev_bmp388,      DEVHW_BMP388,       BMP388_I2C_BUS,     BMP388_I2C_ADDR_HW,               NONE,           DEVFLAGS_NONE,      0);
     #endif
 #endif
 

--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -115,10 +115,10 @@
     #if !defined(BMP388_I2C_BUS)
         #define BMP388_I2C_BUS BARO_I2C_BUS
     #endif
-    #ifndef BMP388_I2C_ADDR_HW
-    #define BMP388_I2C_ADDR_HW  0x76
+    #ifndef BMP388_I2C_ADDR
+    #define BMP388_I2C_ADDR  0x76
     #endif
-    BUSDEV_REGISTER_I2C(busdev_bmp388,      DEVHW_BMP388,       BMP388_I2C_BUS,     BMP388_I2C_ADDR_HW,               NONE,           DEVFLAGS_NONE,      0);
+    BUSDEV_REGISTER_I2C(busdev_bmp388,      DEVHW_BMP388,       BMP388_I2C_BUS,     BMP388_I2C_ADDR,               NONE,           DEVFLAGS_NONE,      0);
     #endif
 #endif
 


### PR DESCRIPTION
I have added the configuration file of the board that our company produces. 
I also added the ability to set the address of the BMP388 barometer, since in my case it is necessary.
In addition, the BMI088 sensor refused to work properly with the supplied driver. It seems there was an error in the alignment of the axes of the gyroscope and accelerometer. With the current changes, my single sensor board BMI088 is working fine. It would be great if someone else can check this on another board.