### PR TITLE
Add ICM42688P gyro to IFLIGHT_BLITZ_ATF4355

### DIFF
--- a/src/main/target/IFLIGHT_BLITZ_ATF435/target.h
+++ b/src/main/target/IFLIGHT_BLITZ_ATF435/target.h
@@ -69,6 +69,13 @@
 #define BMI270_SPI_BUS          BUS_SPI1
 #define BMI270_CS_PIN           PA4
 
+// ICM42605/ICM42688P
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW0_DEG
+#define ICM42605_SPI_BUS        BUS_SPI1
+#define ICM42605_CS_PIN         PA4
+
+
 // Other sensors
 
 #define USE_BARO


### PR DESCRIPTION
Users in #9782 report that the actual gyro on the board is ICM42688P instead of BMI270