### PR TITLE
Fixes SB F405 Wing ADC for RSSI and Aspd swapped

### DIFF
--- a/src/main/target/SPEEDYBEEF405WING/target.h
+++ b/src/main/target/SPEEDYBEEF405WING/target.h
@@ -148,8 +148,8 @@
 #define ADC_CHANNEL_4_PIN           PC4
 #define VBAT_ADC_CHANNEL            ADC_CHN_1
 #define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
-#define RSSI_ADC_CHANNEL            ADC_CHN_4
-#define AIRSPEED_ADC_CHANNEL        ADC_CHN_3
+#define RSSI_ADC_CHANNEL            ADC_CHN_3
+#define AIRSPEED_ADC_CHANNEL        ADC_CHN_4
 
 // *************** LED2812 ************************
 #define USE_LED_STRIP


### PR DESCRIPTION
Can someone please test this, as I have not a single Analog 0-3.3V device I can try it with. 

should fix https://github.com/iNavFlight/inav/issues/9084