### PR TITLE
FOXEERF722DUAL enable 5V power by default

### DIFF
--- a/src/main/target/FOXEERF722DUAL/config.c
+++ b/src/main/target/FOXEERF722DUAL/config.c
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "fc/fc_msp_box.h"
+
+#if defined(FOXEERF722V2)
+#include "io/piniobox.h"
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+}
+#endif

--- a/src/main/target/FOXEERF722DUAL/target.c
+++ b/src/main/target/FOXEERF722DUAL/target.c
@@ -22,6 +22,7 @@
 #include "drivers/timer.h"
 #include "drivers/sensor.h"
 #include "drivers/pwm_mapping.h"
+#include "drivers/pinio.h"
 
 BUSDEV_REGISTER_SPI_TAG(busdev_mpu6000,     DEVHW_MPU6000,      MPU6000_SPI_BUS,    MPU6000_CS_PIN,     NONE,       0,  DEVFLAGS_NONE,  IMU_MPU6000_ALIGN);
 #if defined(FOXEERF722DUAL)

--- a/src/main/target/FOXEERF722DUAL/target.h
+++ b/src/main/target/FOXEERF722DUAL/target.h
@@ -147,3 +147,13 @@
 #define TARGET_IO_PORTC         0xffff
 #define TARGET_IO_PORTD         (BIT(2))
 
+
+// *************** PINIO ***************************
+#if defined(FOXEERF722V2)
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                  PC6 // Enable GPS power
+#define PINIO1_FLAGS            PINIO_FLAGS_INVERTED
+#endif
+
+


### PR DESCRIPTION
This is the 7.1 version of https://github.com/iNavFlight/inav/pull/8302

I don't know if you want to include this in 7.1 or leave it for 8.0.