### PR TITLE
fix broken links to modes.md

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -21,7 +21,6 @@ doc_files=(
 	'Buzzer.md'
 	'Sonar.md'
 	'Profiles.md'
-	'Modes.md'
 	'Inflight Adjustments.md'
 	'Controls.md'
 	'Gtune.md'
@@ -49,7 +48,7 @@ if which gimli >/dev/null; then
 	done
 	rm -f ${filename}.pdf
 	gimli -f ${filename}.md -stylesheet override.css \
-	  -w '--toc --title "Cleanflight Manual" --footer-right "[page]" --toc-depth 1'
+	  -w '--toc --title "INAV Manual" --footer-right "[page]" --toc-depth 1'
 	rm ${filename}.md
 	popd >/dev/null
 else

--- a/docs/API/MSP_extensions.md
+++ b/docs/API/MSP_extensions.md
@@ -23,7 +23,7 @@ Unassigned slots have rangeStartStep == rangeEndStep. Each element contains the 
 
 | Data | Type | Notes |
 |------|------|-------|
-| permanentId | uint8 | See Modes.md for a definition of the permanent ids |
+| permanentId | uint8 | See [Modes in the wiki](https://github.com/iNavFlight/inav/wiki/Modes) for a definition of the permanent ids |
 | auxChannelIndex | uint8 | The Aux switch number (indexed from 0) |
 | rangeStartStep | uint8 | The start value for this element in 'blocks' of 25  where 0 == 900 and 48 == 2100 |
 | rangeEndStep | uint8 | The end value for this element in 'blocks' of 25 where 0 == 900 and 48 == 2100 |
@@ -45,7 +45,7 @@ sending this message for all auxiliary slots.
 | Data | Type | Notes |
 |------|------|-------|
 | sequence id | uint8 | A monotonically increasing ID, from 0 to the number of slots -1 |
-| permanentId | uint8 | See Modes.md for a definition of the permanent ids |
+| permanentId | uint8 | See [Modes in the wiki](https://github.com/iNavFlight/inav/wiki/Modes) for a definition of the permanent ids |
 | auxChannelIndex | uint8 | The Aux channel number (indexed from 0) |
 | rangeStartStep | uint8 | The start value for this element in 'blocks' of 25  where 0 == 900 and 48 == 2100 |
 | rangeEndStep | uint8 | The end value for this element in 'blocks' of 25 where 0 == 900 and 48 == 2100 |
@@ -157,5 +157,5 @@ INAV.
 
 See also
 --------
-Modes.md describes the user visible implementation for the INAV
+[The wiki](https://github.com/iNavFlight/inav/wiki/Modes) describes the user visible implementation for the INAV
 modes extension.

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -70,7 +70,7 @@ Now, there are two ways to [configure CF](Configuration.md); via  the Configurat
     * Verify the range of each channel goes from ~1000 to ~2000.  See also [controls](Controls.md). and `rx_min_usec` and `rx_max_usec`.
     * You can also set EXPO here instead of your Tx.
     * Click Save!
-* Modes tab: Setup the desired modes. See the [modes](Modes.md) chapter for what each mode does, but for the beginning you mainly need HORIZON, if any.
+* Modes tab: Setup the desired modes. See the [Modes in the wiki](https://github.com/iNavFlight/inav/wiki/Modes) for what each mode does.
 
 * Before finishing this section, you should calibrate the ESCs, install the FC to the frame, and connect the RSSI cable, buzzer and battery if you have chosen to use those.
 

--- a/docs/Safety.md
+++ b/docs/Safety.md
@@ -6,7 +6,7 @@ As many can attest, multirotors and RC models in general can be very dangerous, 
 
 ## Before Installing
 
-Please consult the [Cli](Cli.md), [Controls](Controls.md), [Failsafe](Failsafe.md) and [Modes](Modes.md) 
+Please consult the [Cli](Cli.md), [Controls](Controls.md), [Failsafe](Failsafe.md) and [Modes](https://github.com/iNavFlight/inav/wiki/Modes) 
 pages for further important information.
 
 You are highly advised to use the Receiver tab in the INAV Configurator, making sure your Rx channel 


### PR DESCRIPTION
Modes.md was deleted in 4a65f8f  #1197. In 2017
This PR updates the links to Modes.md to point to that info in the wiki.
