### PR TITLE
Configuration symbol for barometer address

### DIFF
--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -91,7 +91,10 @@
     #if !defined(BMP085_I2C_BUS)
         #define BMP085_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_bmp085,      DEVHW_BMP085,       BMP085_I2C_BUS,     0x77,               NONE,           DEVFLAGS_NONE,      0);
+    #if !defined(BMP085_I2C_ADDR)
+        #define BMP085_I2C_ADDR (0x77)
+    #endif
+    BUSDEV_REGISTER_I2C(busdev_bmp085,      DEVHW_BMP085,       BMP085_I2C_BUS,     BMP085_I2C_ADDR,    NONE,           DEVFLAGS_NONE,      0);
 #endif
 
 #if defined(USE_BARO_BMP280)
@@ -115,7 +118,10 @@
     #if !defined(BMP388_I2C_BUS)
         #define BMP388_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_bmp388,      DEVHW_BMP388,       BMP388_I2C_BUS,     0x76,               NONE,           DEVFLAGS_NONE,      0);
+    #if !defined(BMP388_I2C_ADDR)
+        #define BMP388_I2C_ADDR (0x76)
+    #endif
+    BUSDEV_REGISTER_I2C(busdev_bmp388,      DEVHW_BMP388,       BMP388_I2C_BUS,     BMP388_I2C_ADDR,    NONE,           DEVFLAGS_NONE,      0);
     #endif
 #endif
 
@@ -126,7 +132,10 @@
       #if !defined(SPL06_I2C_BUS)
         #define SPL06_I2C_BUS BARO_I2C_BUS
       #endif
-      BUSDEV_REGISTER_I2C(busdev_spl06,     DEVHW_SPL06,        SPL06_I2C_BUS,      0x76,               NONE,           DEVFLAGS_NONE,      0);
+      #if !defined(SPL06_I2C_ADDR)
+        #define SPL06_I2C_ADDR (0x76)
+      #endif
+      BUSDEV_REGISTER_I2C(busdev_spl06,     DEVHW_SPL06,        SPL06_I2C_BUS,      SPL06_I2C_ADDR,     NONE,           DEVFLAGS_NONE,      0);
     #endif
 #endif
 
@@ -140,7 +149,10 @@
     #if !defined(MS5607_I2C_BUS)
         #define MS5607_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_ms5607,      DEVHW_MS5607,       MS5607_I2C_BUS,     0x77,               NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
+    #if !defined(MS5607_I2C_ADDR)
+        #define MS5607_I2C_ADDR (0x77)
+    #endif
+    BUSDEV_REGISTER_I2C(busdev_ms5607,      DEVHW_MS5607,       MS5607_I2C_BUS,     MS5607_I2C_ADDR,    NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
 #endif
 
 #if defined(USE_BARO_MS5611)
@@ -150,7 +162,10 @@
     #if !defined(MS5611_I2C_BUS)
         #define MS5611_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_ms5611,      DEVHW_MS5611,       MS5611_I2C_BUS,     0x77,               NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
+    #if !defined(MS5611_I2C_ADDR)
+        #define MS5611_I2C_ADDR (0x77)
+    #endif
+    BUSDEV_REGISTER_I2C(busdev_ms5611,      DEVHW_MS5611,       MS5611_I2C_BUS,     MS5611_I2C_ADDR,    NONE,           DEVFLAGS_USE_RAW_REGISTERS, 0);
     #endif
 #endif
 
@@ -161,18 +176,24 @@
     #if !defined(DPS310_I2C_BUS)
         #define DPS310_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_dps310,      DEVHW_DPS310,       DPS310_I2C_BUS,     0x76,               NONE,           DEVFLAGS_NONE, 0);
+    #if !defined(DPS310_I2C_ADDR)
+        #define DPS310_I2C_ADDR (0x76)
+    #endif
+    BUSDEV_REGISTER_I2C(busdev_dps310,      DEVHW_DPS310,       DPS310_I2C_BUS,     DPS310_I2C_ADDR,    NONE,           DEVFLAGS_NONE, 0);
     #endif
 #endif
 
 #if defined(USE_BARO_B2SMPB)
     #if defined(B2SMPB_SPI_BUS)
-    BUSDEV_REGISTER_SPI(busdev_b2smpb,     DEVHW_B2SMPB,        B2SMPB_SPI_BUS,     B2SMPB_CS_PIN,       NONE,           DEVFLAGS_NONE, 0);
+    BUSDEV_REGISTER_SPI(busdev_b2smpb,     DEVHW_B2SMPB,        B2SMPB_SPI_BUS,     B2SMPB_CS_PIN,      NONE,           DEVFLAGS_NONE, 0);
     #elif defined(B2SMPB_I2C_BUS) || defined(BARO_I2C_BUS)
     #if !defined(B2SMPB_I2C_BUS)
         #define B2SMPB_I2C_BUS BARO_I2C_BUS
     #endif
-    BUSDEV_REGISTER_I2C(busdev_b2smpb,     DEVHW_B2SMPB,        B2SMPB_I2C_BUS,      0x70,                NONE,           DEVFLAGS_NONE, 0);
+    #if !defined(B2SMPB_I2C_ADDR)
+        #define B2SMPB_I2C_ADDR (0x70)
+    #endif
+    BUSDEV_REGISTER_I2C(busdev_b2smpb,     DEVHW_B2SMPB,        B2SMPB_I2C_BUS,      B2SMPB_I2C_ADDR,   NONE,           DEVFLAGS_NONE, 0);
     #endif
 #endif
 


### PR DESCRIPTION
Configuration symbol for barometer i2c address introduced for all supported barometers.

This would help to set the correct address in the specific target.h files.

Default adresses were not modifed.