### PR TITLE
do not remove nav modes if connected by usb

### DIFF
--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -213,7 +213,7 @@ void initActiveBoxIds(void)
         ADD_ACTIVE_BOX(BOXFPVANGLEMIX);
     }
 
-    bool navReadyAltControl = sensors(SENSOR_BARO);
+    bool navReadyAltControl = getHwBarometerStatus() != HW_SENSOR_NONE;
 #ifdef USE_GPS
     navReadyAltControl = navReadyAltControl || (feature(FEATURE_GPS) && (STATE(AIRPLANE) || positionEstimationConfig()->use_gps_no_baro));
 


### PR DESCRIPTION
If flight controller is connected by usb, without battery, some sensors like BARO, MAG, GPS may not be powered and have "failure" state.
It should not be possible to enable navigation modes with failed sensors, but it should still be possible to configure ranges in the Modes tab. Otherwise users loose nav modes ranges while changing settings in the configurator.

Is:
- navigaton modes are still present in Modes tab if **airplane** is connected by usb :heavy_check_mark:
- navigation modes are removed from Modes tab if **quadcopter** is connected by usb :x:

Should: 
- navigation modes should still be present in configurator if baro is in failed state

Solves https://github.com/iNavFlight/inav-configurator/issues/1646

Temporary workaround:
```set inav_use_gps_no_baro=on```