### PR TITLE
increased VBATT_PRESENT_THRESHOLD

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -66,7 +66,7 @@
 #define ADCVREF 3300                            // in mV (3300 = 3.3V)
 
 #define VBATT_CELL_FULL_MAX_DIFF 10             // Max difference with cell max voltage for the battery to be considered full (10mV steps)
-#define VBATT_PRESENT_THRESHOLD 100             // Minimum voltage to consider battery present
+#define VBATT_PRESENT_THRESHOLD 220             // Minimum voltage to consider battery present
 #define VBATT_STABLE_DELAY 40                   // Delay after connecting battery to begin monitoring
 #define VBATT_HYSTERESIS 10                     // Batt Hysteresis of +/-100mV for changing battery state
 #define VBATT_LPF_FREQ  1                       // Battery voltage filtering cutoff


### PR DESCRIPTION
Some FCs sense >1V battery voltage when connected by USB. Increased battery detection threshold from 1V to 2.2V.

Fixes #https://github.com/iNavFlight/inav/issues/9930