### PR TITLE
Add ICM for IFLIGHT_BLITZ_F722 V1.2

### DIFF
--- a/src/main/target/IFLIGHT_BLITZ_F722/target.h
+++ b/src/main/target/IFLIGHT_BLITZ_F722/target.h
@@ -42,6 +42,11 @@
 #define MPU6000_CS_PIN          PA4
 #define MPU6000_SPI_BUS         BUS_SPI1
 
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW0_DEG
+#define ICM42605_SPI_BUS        BUS_SPI1
+#define ICM42605_CS_PIN         PA4
+
 // *************** I2C /Baro/Mag *********************
 #define USE_I2C
 #define USE_I2C_DEVICE_1

--- a/src/main/target/IFLIGHT_BLITZ_F722/target.h
+++ b/src/main/target/IFLIGHT_BLITZ_F722/target.h
@@ -55,9 +55,7 @@
 
 #define USE_BARO
 #define BARO_I2C_BUS            BUS_I2C1
-#define USE_BARO_BMP280
-#define USE_BARO_MS5611
-#define USE_BARO_DPS310
+#define USE_BARO_ALL
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1

--- a/src/main/target/IFLIGHT_BLITZ_F722/target.h
+++ b/src/main/target/IFLIGHT_BLITZ_F722/target.h
@@ -55,7 +55,9 @@
 
 #define USE_BARO
 #define BARO_I2C_BUS            BUS_I2C1
-#define USE_BARO_ALL
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_DPS310
 
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C1


### PR DESCRIPTION
iFlight Blitz F722 V1.2 switched to ICM42688 IMU.