### PR TITLE
Add auto enabled flight modes to blackbox

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1308,9 +1308,15 @@ static void writeSlowFrame(void)
 static void loadSlowState(blackboxSlowState_t *slow)
 {
     memcpy(&slow->flightModeFlags, &rcModeActivationMask, sizeof(slow->flightModeFlags)); //was flightModeFlags;
-    // Also log Nav auto selected flight modes rather than just those selected by boxmode
-    if (!IS_RC_MODE_ACTIVE(BOXANGLE) && FLIGHT_MODE(ANGLE_MODE)) {
+    // Also log Nav auto enabled flight modes rather than just those selected by boxmode
+    if (FLIGHT_MODE(ANGLE_MODE)) {
         slow->flightModeFlags |= (1 << BOXANGLE);
+    }
+    if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
+        slow->flightModeFlags |= (1 << BOXNAVALTHOLD);
+    }
+    if (FLIGHT_MODE(NAV_RTH_MODE)) {
+        slow->flightModeFlags |= (1 << BOXNAVRTH);
     }
     if (navigationGetHeadingControlState() == NAV_HEADING_CONTROL_AUTO) {
         slow->flightModeFlags |= (1 << BOXHEADINGHOLD);


### PR DESCRIPTION
Adds what should be the last 2 remaining auto enabled flight modes, RTH (during failsafe) and Althold, to Blackbox FlightModeFlags.