### PR TITLE
Prevent high throttle auto cancelling OSD stats screen on disarm

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -4864,7 +4864,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
     static uint8_t statsCurrentPage = 0;
     static bool statsDisplayed = false;
     static bool statsAutoPagingEnabled = true;
-    static bool throttleHigh = false;
+    static bool isThrottleHigh = false;
 
     // Detect arm/disarm
     if (armState != ARMING_FLAG(ARMED)) {
@@ -4890,7 +4890,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
             statsAutoPagingEnabled = osdConfig()->stats_page_auto_swap_time > 0 ? true : false;
             osdShowStats(statsSinglePageCompatible, statsCurrentPage);
             osdSetNextRefreshIn(STATS_SCREEN_DISPLAY_TIME);
-            throttleHigh = checkStickPosition(THR_HI);
+            isThrottleHigh = checkStickPosition(THR_HI);
         }
 
         armState = ARMING_FLAG(ARMED);
@@ -4956,7 +4956,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
         }
 
         // Handle events when either "Splash", "Armed" or "Stats" screens are displayed.
-        if (currentTimeUs > resumeRefreshAt || (OSD_RESUME_UPDATES_STICK_COMMAND && !throttleHigh)) {
+        if (currentTimeUs > resumeRefreshAt || (OSD_RESUME_UPDATES_STICK_COMMAND && !isThrottleHigh)) {
             // Time elapsed or canceled by stick commands.
             // Exit to normal OSD operation.
             displayClearScreen(osdDisplayPort);
@@ -4965,7 +4965,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
         } else {
             // Continue "Splash", "Armed" or "Stats" screens.
             displayHeartbeat(osdDisplayPort);
-            throttleHigh = checkStickPosition(THR_HI);
+            isThrottleHigh = checkStickPosition(THR_HI);
         }
 
         return;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1003,7 +1003,7 @@ static const char * divertingToSafehomeMessage(void)
 	    return OSD_MESSAGE_STR(OSD_MSG_DIVERT_SAFEHOME);
 	}
 #endif
-	return NULL;   
+	return NULL;
 }
 
 
@@ -1028,7 +1028,7 @@ static const char * navigationStateMessage(void)
                         linearDescentMessageMs = millis() + 5000; // Show message for 5 seconds.
 
                     return OSD_MESSAGE_STR(OSD_MSG_RTH_LINEAR_DESCENT);
-                } else 
+                } else
                     return OSD_MESSAGE_STR(OSD_MSG_HEADING_HOME);
             }
         case MW_NAV_STATE_HOLD_INFINIT:
@@ -1069,7 +1069,7 @@ static const char * navigationStateMessage(void)
             // If there is a FS landing delay occurring. That is handled by the calling function.
             if (posControl.landingDelay > 0)
                 break;
-            
+
             return OSD_MESSAGE_STR(OSD_MSG_PREPARING_LAND);
         }
         case MW_NAV_STATE_LAND_START_DESCENT:
@@ -2277,7 +2277,7 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             char *p = "ACRO";
 #ifdef USE_FW_AUTOLAND
-            if (FLIGHT_MODE(NAV_FW_AUTOLAND)) 
+            if (FLIGHT_MODE(NAV_FW_AUTOLAND))
                 p = "LAND";
             else
 #endif
@@ -4864,6 +4864,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
     static uint8_t statsCurrentPage = 0;
     static bool statsDisplayed = false;
     static bool statsAutoPagingEnabled = true;
+    static bool throttleHigh = false;
 
     // Detect arm/disarm
     if (armState != ARMING_FLAG(ARMED)) {
@@ -4889,6 +4890,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
             statsAutoPagingEnabled = osdConfig()->stats_page_auto_swap_time > 0 ? true : false;
             osdShowStats(statsSinglePageCompatible, statsCurrentPage);
             osdSetNextRefreshIn(STATS_SCREEN_DISPLAY_TIME);
+            throttleHigh = checkStickPosition(THR_HI);
         }
 
         armState = ARMING_FLAG(ARMED);
@@ -4954,7 +4956,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
         }
 
         // Handle events when either "Splash", "Armed" or "Stats" screens are displayed.
-        if ((currentTimeUs > resumeRefreshAt) || OSD_RESUME_UPDATES_STICK_COMMAND) {
+        if (currentTimeUs > resumeRefreshAt || (OSD_RESUME_UPDATES_STICK_COMMAND && !throttleHigh)) {
             // Time elapsed or canceled by stick commands.
             // Exit to normal OSD operation.
             displayClearScreen(osdDisplayPort);
@@ -4963,6 +4965,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
         } else {
             // Continue "Splash", "Armed" or "Stats" screens.
             displayHeartbeat(osdDisplayPort);
+            throttleHigh = checkStickPosition(THR_HI);
         }
 
         return;
@@ -5177,7 +5180,7 @@ textAttributes_t osdGetSystemMessage(char *buff, size_t buff_size, bool isCenter
                     tfp_sprintf(messageBuf, "LANDING DELAY: %3u SECONDS", remainingHoldSec);
 
                     messages[messageCount++] = messageBuf;
-                } 
+                }
 
                 else {
 #ifdef USE_FW_AUTOLAND


### PR DESCRIPTION
If auto landing disarm occurs with the throttle in the high position the stats screen doesn't display because it's immediately auto cancelled by the high throttle stick position. PR prevents this by requiring the throttle stick to be reduced below high before it can be used to cancel the stats screen.

An alternative to avoid this problem is to only allow the stats screen to be cancelled by the pitch stick, a much simpler solution.