### PR TITLE
Remove legacy option of rebooting fc without using MSP

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -5332,16 +5332,6 @@ Exposition value used for the YAW axis by all the stabilized flights modes (all 
 
 ---
 
-### reboot_character
-
-Special character used to trigger reboot
-
-| Default | Min | Max |
-| --- | --- | --- |
-| 82 | 48 | 126 |
-
----
-
 ### receiver_type
 
 Selection of receiver (RX) type. Additional configuration of a `serialrx_provider` and a UART will be needed for `SERIAL`

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1399,16 +1399,6 @@ groups:
         description: "The end  stick weight for Rate Dynamics"
         condition: USE_RATE_DYNAMICS
 
-  - name: PG_SERIAL_CONFIG
-    type: serialConfig_t
-    headers: ["io/serial.h"]
-    members:
-      - name: reboot_character
-        description: "Special character used to trigger reboot"
-        default_value: 82
-        min: 48
-        max: 126
-
   - name: PG_IMU_CONFIG
     type: imuConfig_t
     headers: ["flight/imu.h"]

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -106,7 +106,7 @@ const uint32_t baudRates[] = { 0, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 1
 
 #define BAUD_RATE_COUNT ARRAYLEN(baudRates)
 
-PG_REGISTER_WITH_RESET_FN(serialConfig_t, serialConfig, PG_SERIAL_CONFIG, 1);
+PG_REGISTER_WITH_RESET_FN(serialConfig_t, serialConfig, PG_SERIAL_CONFIG, 2);
 
 void pgResetFn_serialConfig(serialConfig_t *serialConfig)
 {

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -151,8 +151,6 @@ void pgResetFn_serialConfig(serialConfig_t *serialConfig)
         }
     }
 #endif
-
-    serialConfig->reboot_character = SETTING_REBOOT_CHARACTER_DEFAULT;
 }
 
 baudRate_e lookupBaudRateIndex(uint32_t baudRate)

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -131,7 +131,6 @@ typedef struct serialPortConfig_s {
 
 typedef struct serialConfig_s {
     serialPortConfig_t portConfigs[SERIAL_PORT_COUNT];
-    uint8_t reboot_character;               // which byte is used to reboot. Default 'R', could be changed carefully to something else.
 } serialConfig_t;
 
 PG_DECLARE(serialConfig_t, serialConfig);

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -426,11 +426,6 @@ static void mspEvaluateNonMspData(mspPort_t * mspPort, uint8_t receivedChar)
         mspPort->pendingRequest = MSP_PENDING_CLI;
         return;
     }
-
-    if (receivedChar == serialConfig()->reboot_character) {
-        mspPort->pendingRequest = MSP_PENDING_BOOTLOADER;
-        return;
-    }
 }
 
 static void mspProcessPendingRequest(mspPort_t * mspPort)
@@ -441,10 +436,6 @@ static void mspProcessPendingRequest(mspPort_t * mspPort)
     }
 
     switch(mspPort->pendingRequest) {
-        case MSP_PENDING_BOOTLOADER:
-            systemResetToBootloader();
-            break;
-
         case MSP_PENDING_CLI:
             if (!cliMode) {
                 // When we enter CLI mode - disable this MSP port. Don't care about preserving the port since CLI can only be exited via reboot


### PR DESCRIPTION
This can cause some issues with some devices, eg.:

https://github.com/betaflight/betaflight/pull/13572

Kudos to @hydra for identifying this on BF.