### PR TITLE
Fix function prototypes and macos warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           path: ./build_SITL/*_SITL
 
   build-SITL-Mac:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           path: ./build_SITL/*_SITL
 
   build-SITL-Mac:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies

--- a/src/main/build/build_config.h
+++ b/src/main/build/build_config.h
@@ -40,7 +40,7 @@
 #endif
 
 #ifdef __APPLE__
-#define FASTRAM                     __attribute__ ((section("__DATA,__.fastram_bss"), aligned(4)))
+#define FASTRAM                     __attribute__ ((section("__DATA,__.fastram_bss"), aligned(8)))
 #else
 #define FASTRAM                     __attribute__ ((section(".fastram_bss"), aligned(4)))
 #endif

--- a/src/main/cms/cms_types.h
+++ b/src/main/cms/cms_types.h
@@ -26,6 +26,12 @@
 
 //type of elements
 
+#ifndef __APPLE__
+#define OSD_ENTRY_ATTR __attribute__((packed))
+#else
+#define OSD_ENTRY_ATTR
+#endif
+
 typedef enum
 {
     OME_Label,
@@ -71,7 +77,7 @@ typedef struct
     const void * const data;
     const uint8_t type; // from OSD_MenuElement
     uint8_t flags;
-} __attribute__((packed)) OSD_Entry;
+} OSD_ENTRY_ATTR OSD_Entry;
 
 // Bits in flags
 #define PRINT_VALUE    (1 << 0)  // Value has been changed, need to redraw

--- a/src/main/config/parameter_group.h
+++ b/src/main/config/parameter_group.h
@@ -64,7 +64,7 @@ static inline uint16_t pgIsProfile(const pgRegistry_t* reg) {return (reg->size &
 #ifdef __APPLE__
 extern const pgRegistry_t __pg_registry_start[] __asm("section$start$__DATA$__pg_registry");
 extern const pgRegistry_t __pg_registry_end[] __asm("section$end$__DATA$__pg_registry");
-#define PG_REGISTER_ATTRIBUTES __attribute__ ((section("__DATA,__pg_registry"), used, aligned(4)))
+#define PG_REGISTER_ATTRIBUTES __attribute__ ((section("__DATA,__pg_registry"), used, aligned(8)))
 
 extern const uint8_t __pg_resetdata_start[] __asm("section$start$__DATA$__pg_resetdata");
 extern const uint8_t __pg_resetdata_end[] __asm("section$end$__DATA$__pg_resetdata");

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -1171,7 +1171,7 @@ static void cliRxRange(char *cmdline)
         ptr = cmdline;
         i = fastA2I(ptr);
         if (i >= 0 && i < NON_AUX_CHANNEL_COUNT) {
-            int rangeMin, rangeMax;
+            int rangeMin = 0, rangeMax = 0;
 
             ptr = nextArg(ptr);
             if (ptr) {

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -728,7 +728,7 @@ bool areMotorsRunning(void)
     return false;
 }
 
-uint16_t getMaxThrottle() {
+uint16_t getMaxThrottle(void) {
 
     static uint16_t throttle = 0;
 

--- a/src/main/flight/mixer_profile.c
+++ b/src/main/flight/mixer_profile.c
@@ -79,7 +79,7 @@ void pgResetFn_mixerProfiles(mixerProfile_t *instance)
     }
 }
 
-void activateMixerConfig(){
+void activateMixerConfig(void){
     currentMixerProfileIndex = getConfigMixerProfile();
     currentMixerConfig = *mixerConfig();
     nextMixerProfileIndex = (currentMixerProfileIndex + 1) % MAX_MIXER_PROFILE_COUNT;

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -525,7 +525,7 @@ void mspOsdSerialProcess(mspProcessCommandFnPtr mspProcessCommandFn)
     }
 }
 
-mspPort_t *getMspOsdPort()
+mspPort_t *getMspOsdPort(void)
 {
     if (mspPort.port) {
         return &mspPort;

--- a/src/main/io/osd_hud.c
+++ b/src/main/io/osd_hud.c
@@ -122,8 +122,8 @@ int8_t radarGetNearestPOI(void)
  */
 void osdHudDrawPoi(uint32_t poiDistance, int16_t poiDirection, int32_t poiAltitude, uint8_t poiType, uint16_t poiSymbol, int16_t poiP1, int16_t poiP2)
 {
-    int poi_x;
-    int poi_y;
+    int poi_x = -1;
+    int poi_y = -1;
     uint8_t center_x;
     uint8_t center_y;
     bool poi_is_oos = 0;


### PR DESCRIPTION
As a bonus, this appears to get SITL working on macos.

Still need to add it to configurator.