### PR TITLE
fix ist8308 compass local frame

### DIFF
--- a/src/main/drivers/compass/compass_ist8308.c
+++ b/src/main/drivers/compass/compass_ist8308.c
@@ -121,8 +121,9 @@ static bool ist8308Read(magDev_t * mag)
         return false;
     }
 
+    // Invert Y axis to co convert from left to right coordinate system
     mag->magADCRaw[X] = (int16_t)(buf[1] << 8 | buf[0]) * LSB2FSV;
-    mag->magADCRaw[Y] = (int16_t)(buf[3] << 8 | buf[2]) * LSB2FSV;
+    mag->magADCRaw[Y] = -(int16_t)(buf[3] << 8 | buf[2]) * LSB2FSV;
     mag->magADCRaw[Z] = (int16_t)(buf[5] << 8 | buf[4]) * LSB2FSV;
 
     return true;

--- a/src/main/drivers/compass/compass_ist8310.c
+++ b/src/main/drivers/compass/compass_ist8310.c
@@ -139,7 +139,7 @@ static bool ist8310Read(magDev_t * mag)
         return false;
     }
 
-    // Looks like datasheet is incorrect and we need to invert Y axis to conform to right hand rule
+    // Invert Y axis to co convert from left to right coordinate system
     mag->magADCRaw[X] =  (int16_t)(buf[1] << 8 | buf[0]) * LSB2FSV;
     mag->magADCRaw[Y] = -(int16_t)(buf[3] << 8 | buf[2]) * LSB2FSV;
     mag->magADCRaw[Z] =  (int16_t)(buf[5] << 8 | buf[4]) * LSB2FSV;


### PR DESCRIPTION
Inav is using right-handed cooridnate system, example is qmc5883l compass:
![image](https://github.com/iNavFlight/inav/assets/11955117/57ffe20f-e258-4e84-be54-a877b434aa20)


IST8308 is using left-handed coordinate system:

![image](https://github.com/iNavFlight/inav/assets/11955117/bc306f5e-9124-4039-9dbb-f3beec600cb4)

Y axis should be inverted to convert from left-handed to right-handed coordinate system in driver, similar to IST8310 which uses the same left-handed coordinate system and have correct code in driver:

https://github.com/iNavFlight/inav/blob/1dc91058761816cc2427495e48f373393e62cf32/src/main/drivers/compass/compass_ist8310.c#L144

![image](https://github.com/iNavFlight/inav/assets/11955117/46d414d2-c71e-4ba2-b6c0-0f13d2e3b43f)


References:
qmc5883 datasheet:
http://wiki.sunfounder.cc/images/7/72/QMC5883L-Datasheet-1.0.pdf

ist8308 datasheeet:
https://isentek.com/userfiles/files/IST8308Datasheet_3DMagneticSensors.pdf

ist8310 datasheet:
https://intofpv.com/attachment.php?aid=8104

ist8310 Betaflight driver:
https://github.com/betaflight/betaflight/blob/d1ffa46aa65d21d8a14bf1a965d97c94755b0723/src/main/drivers/compass/compass_ist8310.c#L156

Betaflight docs:
https://betaflight.com/docs/wiki/guides/current/magnetometer

