### PR TITLE
Removing questionmarks for OSD Elements when using DJI O3

### DIFF
--- a/src/main/io/bf_osd_symbols.h
+++ b/src/main/io/bf_osd_symbols.h
@@ -33,11 +33,16 @@
 #define BF_SYM_PITCH                   0x15
 #define BF_SYM_TEMPERATURE             0x7A
 
+// Glide symbols
+#define BF_SYM_GLIDESLOPE              0x05 
+#define BF_SYM_GLIDE_DIST              0x24
+#define BF_SYM_GLIDE_MINS              0x9C
+
 // GPS and navigation
 #define BF_SYM_LAT                     0x89
 #define BF_SYM_LON                     0x98
 #define BF_SYM_ALTITUDE                0x7F
-#define BF_SYM_TOTAL_DISTANCE          0x71
+#define BF_SYM_TOTAL_DISTANCE          0x12
 #define BF_SYM_OVER_HOME               0x05
 
 // RSSI
@@ -94,9 +99,10 @@
 #define BF_SYM_ARROW_14                0x6D
 #define BF_SYM_ARROW_15                0x6E
 #define BF_SYM_ARROW_16                0x6F
-
 #define BF_SYM_ARROW_SMALL_UP          0x75
 #define BF_SYM_ARROW_SMALL_DOWN        0x76
+#define BF_SYM_ARROW_SMALL_RIGHT       0x77
+#define BF_SYM_ARROW_SMALL_LEFT        0x78
 
 // AH Bars
 #define BF_SYM_AH_BAR9_0               0x80

--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -38,6 +38,7 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
     }
 
     switch (ech) {
+        
     case SYM_RSSI:
         return BF_SYM_RSSI;
 
@@ -62,10 +63,9 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
     case SYM_DEGREES:
         return BF_SYM_GPS_DEGREE;
 
-/*
     case SYM_HEADING:
-        return BF_SYM_HEADING;
-
+        return BF_SYM_NONE;
+/*
     case SYM_SCALE:
         return BF_SYM_SCALE;
 
@@ -81,16 +81,15 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
     case SYM_2RSS:
         return BF_SYM_RSSI;
 
-/*
     case SYM_DB:
-        return BF_SYM_DB
+        return BF_SYM_RSSI;
 
     case SYM_DBM:
-        return BF_SYM_DBM;
+        return 'D';
 
     case SYM_SNR:
-        return BF_SYM_SNR;
-
+        return 'S';
+/*
     case SYM_AH_DECORATION_UP:
         return BF_SYM_AH_DECORATION_UP;
 
@@ -210,21 +209,21 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 
     case SYM_TOTAL:
         return BF_SYM_TOTAL_DISTANCE;
-/*
-    case SYM_ALT_KM:
-        return BF_SYM_ALT_KM;
 
-    case SYM_ALT_KFT:
-        return BF_SYM_ALT_KFT;
+    case SYM_ALT_KM:
+        return 'K';
 
     case SYM_DIST_M:
-        return BF_SYM_DIST_M;
+        return 'K';
 
     case SYM_DIST_KM:
-        return BF_SYM_DIST_KM;
-
+        return 'K';
+/*
     case SYM_DIST_FT:
         return BF_SYM_DIST_FT;
+        
+    case SYM_ALT_KFT:
+        return BF_SYM_ALT_KFT;
 
     case SYM_DIST_MI:
         return BF_SYM_DIST_MI;
@@ -246,7 +245,6 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 */
     case SYM_WIND_HORIZONTAL:
         return 'W';     // W for wind
-
 /*
     case SYM_WIND_VERTICAL:
         return BF_SYM_WIND_VERTICAL;
@@ -292,6 +290,21 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 */
     case SYM_THR:
         return BF_SYM_THR;
+        
+    case SYM_AUTO_THR0:
+        return BF_SYM_AMP;
+
+    case SYM_AUTO_THR1:
+        return BF_SYM_THR;
+
+    case SYM_GLIDESLOPE:
+        return BF_SYM_GLIDESLOPE;
+
+    case SYM_GLIDE_DIST:
+        return BF_SYM_GLIDE_DIST;
+
+    case SYM_GLIDE_MINS:
+        return BF_SYM_GLIDE_MINS;
 
     case SYM_TEMP_F:
         return BF_SYM_F;
@@ -314,9 +327,6 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
     case SYM_FLY_M:
         return BF_SYM_FLY_M;
 /*
-    case SYM_GLIDESLOPE:
-        return BF_SYM_GLIDESLOPE;
-
     case SYM_WAYPOINT:
         return BF_SYM_WAYPOINT;
 
@@ -328,12 +338,6 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 
     case SYM_ZERO_HALF_LEADING_DOT:
         return BF_SYM_ZERO_HALF_LEADING_DOT;
-
-    case SYM_AUTO_THR0:
-        return BF_SYM_AUTO_THR0;
-
-    case SYM_AUTO_THR1:
-        return BF_SYM_AUTO_THR1;
 
     case SYM_ROLL_LEFT:
         return BF_SYM_ROLL_LEFT;
@@ -350,10 +354,8 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
     case SYM_PITCH_DOWN:
         return BF_SYM_PITCH_DOWN;
  */
-
     case SYM_GFORCE:
         return 'G';
-
 /*
     case SYM_GFORCE_X:
         return BF_SYM_GFORCE_X;
@@ -421,12 +423,6 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
     case SYM_AH:
         return BF_SYM_AH;
 
-    case SYM_GLIDE_DIST:
-        return BF_SYM_GLIDE_DIST;
-
-    case SYM_GLIDE_MINS:
-        return BF_SYM_GLIDE_MINS;
-
     case SYM_AH_V_FT_0:
         return BF_SYM_AH_V_FT_0;
 
@@ -465,7 +461,6 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 
     case SYM_AH_RIGHT:
         return BF_SYM_AH_RIGHT;
-
 /*
     case SYM_AH_DECORATION_COUNT:
         return BF_SYM_AH_DECORATION_COUNT;


### PR DESCRIPTION
### Why?
There are a number of people who are using the DJI O3 system and are seeing questionmarks where there are missing symbols. 

### What has been done?
Changes have been made to remove those questionmarks for as many items as possible so that the OSD a litte bit better. 

### Is this any good?
This is only a temporary solution and I hope that DJI will eventually work with the INAV devs to make the OSD the way that we all like to have it. 


### Links & Video:
Link to compiled firmware and OSD CLI dump for testing:
[Google Drive](https://drive.google.com/drive/folders/1m7BdapKCqP-QVGanmJ5b92Ln4vnqLav_?usp=sharing)

Link to video demo:
[Video Demonstration](https://youtu.be/fXBLdGebb6o)