### PR TITLE
Add flights counter to stats

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -5792,6 +5792,16 @@ General switch of the statistics recording feature (a.k.a. odometer)
 
 ---
 
+### stats_flight_count
+
+Total number of flights. The value is updated on every disarm when "stats" are enabled.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 |  | 65535 |
+
+---
+
 ### stats_total_dist
 
 Total flight distance [in meters]. The value is updated on every disarm when "stats" are enabled.

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -87,6 +87,7 @@
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
 #include "fc/firmware_update.h"
+#include "fc/stats.h"
 
 #include "flight/failsafe.h"
 #include "flight/imu.h"
@@ -719,6 +720,8 @@ void init(void)
     // Considering that the persistent reset reason is only used during init
     persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
 #endif
+
+    statsInit();
 
     systemState |= SYSTEM_STATE_READY;
 }

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3787,6 +3787,10 @@ groups:
         max: INT32_MAX
         condition: USE_ADC
         default_value: 0
+      - name: stats_flight_count
+        description: "Total number of flights. The value is updated on every disarm when \"stats\" are enabled."
+        default_value: 0
+        max: INT32_MAX
 
   - name: PG_TIME_CONFIG
     type: timeConfig_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3790,7 +3790,7 @@ groups:
       - name: stats_flight_count
         description: "Total number of flights. The value is updated on every disarm when \"stats\" are enabled."
         default_value: 0
-        max: INT32_MAX
+        max: UINT16_MAX
 
   - name: PG_TIME_CONFIG
     type: timeConfig_t

--- a/src/main/fc/stats.c
+++ b/src/main/fc/stats.c
@@ -70,9 +70,12 @@ void statsOnDisarm(void)
 #ifdef USE_GPS
             // flight counter is incremented at most once per power on
             if (sensors(SENSOR_GPS)) {
-                if ((getTotalTravelDistance() - arm_distance_cm) / 100 >= MIN_FLIGHT_DISTANCE_M)
+                if ((getTotalTravelDistance() - arm_distance_cm) / 100 >= MIN_FLIGHT_DISTANCE_M) {
                     statsConfigMutable()->stats_flight_count = prev_flight_count + 1;
-            } else statsConfigMutable()->stats_flight_count = prev_flight_count + 1;
+                }
+            } else {
+                statsConfigMutable()->stats_flight_count = prev_flight_count + 1;
+            }
 #else
             statsConfigMutable()->stats_flight_count = prev_flight_count + 1;
 #endif // USE_GPS

--- a/src/main/fc/stats.c
+++ b/src/main/fc/stats.c
@@ -32,7 +32,7 @@ PG_RESET_TEMPLATE(statsConfig_t, statsConfig,
 
 static uint32_t arm_millis;
 static uint32_t arm_distance_cm;
-static uint32_t prev_flight_count;
+static uint16_t prev_flight_count;
 
 #ifdef USE_ADC
 static uint32_t arm_mWhDrawn;

--- a/src/main/fc/stats.c
+++ b/src/main/fc/stats.c
@@ -24,6 +24,7 @@ PG_RESET_TEMPLATE(statsConfig_t, statsConfig,
     .stats_enabled = SETTING_STATS_DEFAULT,
     .stats_total_time = SETTING_STATS_TOTAL_TIME_DEFAULT,
     .stats_total_dist = SETTING_STATS_TOTAL_DIST_DEFAULT,
+    .stats_flight_count = SETTING_STATS_FLIGHT_COUNT_DEFAULT,
 #ifdef USE_ADC
     .stats_total_energy = SETTING_STATS_TOTAL_ENERGY_DEFAULT
 #endif
@@ -31,6 +32,7 @@ PG_RESET_TEMPLATE(statsConfig_t, statsConfig,
 
 static uint32_t arm_millis;
 static uint32_t arm_distance_cm;
+static uint32_t prev_flight_count;
 
 #ifdef USE_ADC
 static uint32_t arm_mWhDrawn;
@@ -40,6 +42,11 @@ uint32_t getFlyingEnergy(void) {
     return flyingEnergy;
 }
 #endif
+
+void statsInit(void)
+{
+    prev_flight_count = statsConfig()->stats_flight_count;
+}
 
 void statsOnArm(void)
 {
@@ -55,6 +62,7 @@ void statsOnDisarm(void)
     if (statsConfig()->stats_enabled) {
         uint32_t dt = (millis() - arm_millis) / 1000;
         if (dt >= MIN_FLIGHT_TIME_TO_RECORD_STATS_S) {
+            statsConfigMutable()->stats_flight_count = prev_flight_count + 1; // only increment once per power on
             statsConfigMutable()->stats_total_time += dt;   //[s]
             statsConfigMutable()->stats_total_dist += (getTotalTravelDistance() - arm_distance_cm) / 100;   //[m]
 #ifdef USE_ADC

--- a/src/main/fc/stats.c
+++ b/src/main/fc/stats.c
@@ -18,7 +18,7 @@
 #define MIN_FLIGHT_TIME_TO_RECORD_STATS_S 10    //prevent recording stats for that short "flights" [s]
 
 
-PG_REGISTER_WITH_RESET_TEMPLATE(statsConfig_t, statsConfig, PG_STATS_CONFIG, 1);
+PG_REGISTER_WITH_RESET_TEMPLATE(statsConfig_t, statsConfig, PG_STATS_CONFIG, 2);
 
 PG_RESET_TEMPLATE(statsConfig_t, statsConfig,
     .stats_enabled = SETTING_STATS_DEFAULT,

--- a/src/main/fc/stats.c
+++ b/src/main/fc/stats.c
@@ -18,7 +18,7 @@
 #include "config/parameter_group_ids.h"
 
 #define MIN_FLIGHT_TIME_TO_RECORD_STATS_S 10    //prevent recording stats for that short "flights" [s]
-#define MIN_FLIGHT_DISTANCE_M 10    // minimum distance flown for a flight to be registered [m]
+#define MIN_FLIGHT_DISTANCE_M 30    // minimum distance flown for a flight to be registered [m]
 
 
 PG_REGISTER_WITH_RESET_TEMPLATE(statsConfig_t, statsConfig, PG_STATS_CONFIG, 2);

--- a/src/main/fc/stats.h
+++ b/src/main/fc/stats.h
@@ -5,7 +5,7 @@
 typedef struct statsConfig_s {
     uint32_t stats_total_time; // [Seconds]
     uint32_t stats_total_dist; // [Metres]
-    uint32_t stats_flight_count;
+    uint16_t stats_flight_count;
 #ifdef USE_ADC
     uint32_t stats_total_energy; // deciWatt hour (x0.1Wh)
 #endif
@@ -19,7 +19,7 @@ void statsOnDisarm(void);
 
 #else
 
-#define statsInit() do {} while (0)
+#define statsInit()     do {} while (0)
 #define statsOnArm()    do {} while (0)
 #define statsOnDisarm() do {} while (0)
 

--- a/src/main/fc/stats.h
+++ b/src/main/fc/stats.h
@@ -5,6 +5,7 @@
 typedef struct statsConfig_s {
     uint32_t stats_total_time; // [Seconds]
     uint32_t stats_total_dist; // [Metres]
+    uint32_t stats_flight_count;
 #ifdef USE_ADC
     uint32_t stats_total_energy; // deciWatt hour (x0.1Wh)
 #endif
@@ -12,11 +13,13 @@ typedef struct statsConfig_s {
 } statsConfig_t;
 
 uint32_t getFlyingEnergy(void);
+void statsInit(void);
 void statsOnArm(void);
 void statsOnDisarm(void);
 
 #else
 
+#define statsInit() do {} while (0)
 #define statsOnArm()    do {} while (0)
 #define statsOnDisarm() do {} while (0)
 


### PR DESCRIPTION
I'm proposing a new field to be added to stats, flight counter, i.e. number of flights. I used an assumption that a flight counts once the craft is armed and disarmed and a certain time passes between the two (same as other fields); but only once per each battery pack. I also used uint32 for the field, which I feel is a bit excessive; for uint16 max number of flights would be 32768, I'm leaning on your judgement on that matter.