### PR TITLE
BFCOMPAT: Add auto-throttle label and BF font symbols for pitch and roll

### DIFF
--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -328,28 +328,28 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 
     case SYM_ZERO_HALF_LEADING_DOT:
         return BF_SYM_ZERO_HALF_LEADING_DOT;
+*/
 
     case SYM_AUTO_THR0:
-        return BF_SYM_AUTO_THR0;
+        return 'A';
 
     case SYM_AUTO_THR1:
-        return BF_SYM_AUTO_THR1;
+        return 'T';
 
     case SYM_ROLL_LEFT:
-        return BF_SYM_ROLL_LEFT;
+        return BF_SYM_ROLL;
 
     case SYM_ROLL_LEVEL:
-        return BF_SYM_ROLL_LEVEL;
+        return BF_SYM_ROLL;
 
     case SYM_ROLL_RIGHT:
-        return BF_SYM_ROLL_RIGHT;
+        return BF_SYM_ROLL;
 
     case SYM_PITCH_UP:
-        return BF_SYM_PITCH_UP;
+        return BF_SYM_PITCH;
 
     case SYM_PITCH_DOWN:
-        return BF_SYM_PITCH_DOWN;
- */
+        return BF_SYM_PITCH;
 
     case SYM_GFORCE:
         return 'G';

--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -334,7 +334,7 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
         return 'A';
 
     case SYM_AUTO_THR1:
-        return 'T';
+        return BF_SYM_THR;
 
     case SYM_ROLL_LEFT:
         return BF_SYM_ROLL;


### PR DESCRIPTION
This adds a text based label for auto-throttle (using the already existing two character slot), so when it is enabled, the throttle icon changes to 'AT'.

Manual throttle icon:
![Inav_MT_OSD](https://github.com/iNavFlight/inav/assets/9812730/ca44f99e-4940-4a48-a342-56433afaafc7)

Auto-throttle engaged, with the changes in this PR:
 ![Inav_AT_OSD](https://github.com/iNavFlight/inav/assets/9812730/6bc38a01-9572-45f3-971c-53fa3b7dcf9c)

Also enables the BF font icons for pitch and roll. However, as implemented in the font, there's no distinction between left, right and centered roll or up and down pitch. Here's how it looks like:

![Inav_PitchRoll_OSD](https://github.com/iNavFlight/inav/assets/9812730/a1de043b-c94e-49f6-9d10-56bd4c1e019a)

Attempting to keep a minimal impact, changes restricted to `displayport_msp_bf_compat.c` file only.