### PR TITLE
Adding Sidebar Scroll Arrows for DJI 03 OSD and some other updates.

### DIFF
--- a/src/main/io/displayport_msp_bf_compat.c
+++ b/src/main/io/displayport_msp_bf_compat.c
@@ -90,13 +90,13 @@ uint8_t getBfCharacter(uint8_t ch, uint8_t page)
 
     case SYM_SNR:
         return BF_SYM_SNR;
-
-    case SYM_AH_DECORATION_UP:
-        return BF_SYM_AH_DECORATION_UP;
-
-    case SYM_AH_DECORATION_DOWN:
-        return BF_SYM_AH_DECORATION_DOWN;
 */
+    case SYM_AH_DIRECTION_UP:
+        return BF_SYM_ARROW_SMALL_UP;
+
+    case SYM_AH_DIRECTION_DOWN:
+        return BF_SYM_ARROW_SMALL_DOWN;
+
     case SYM_DIRECTION:
         return BF_SYM_ARROW_NORTH;
     


### PR DESCRIPTION
I think that there is just a small mismatch between the configurator documentation and the fimware variables.

The configurator uses the term `DECORATION` while the firmware variabe uses `DIRECTTION` for the same pointers `0x15` and `0x16`.

When uncommenting these lines in the `displayport_msp_bf_compat.c` file, there is a build error because the `SYM_AH_DECORATION_UP` and `SYM_AH_DECORATION_DOWN` do not exist in `osd_symbols.h`. 

I suggest going with what is in the firmware and just updating the [INAV Character Map.md](https://github.com/iNavFlight/inav-configurator/blob/b717b2b394fd0f9e6c66927342ad2fc3c93a40f7/resources/osd/INAV%20Character%20Map.md?plain=1) (I'll open another PR for that one) and the file from this PR so that they all match up.

I hope this change can be accepted. :)

