### PR TITLE
Update osd.c L3438 to L3441 from DIRECTION to DECORATION

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3435,10 +3435,10 @@ static bool osdDrawSingleElement(uint8_t item)
             float verticalWindSpeed;
             verticalWindSpeed = -getEstimatedWindSpeed(Z);  //from NED to NEU
             if (verticalWindSpeed < 0) {
-                buff[1] = SYM_AH_DIRECTION_DOWN;
+                buff[1] = SYM_AH_DECORATION_DOWN;
                 verticalWindSpeed = -verticalWindSpeed;
             } else {
-                buff[1] = SYM_AH_DIRECTION_UP;
+                buff[1] = SYM_AH_DECORATION_UP;
             }
             osdFormatWindSpeedStr(buff + 2, verticalWindSpeed, valid);
             break;


### PR DESCRIPTION
I've updated all the locations where SYM_AH_DIRECTION_UP and SYM_AH_DIRECTION_DOWN were used to match the other PR.