### PR TITLE
Offset GPS coords on OSD

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4414,7 +4414,7 @@ Value under which the OSD axis g force indicators will blink (g)
 
 ### osd_gps_offset_lat
 
-Offset GPS latitude  on OSD by this number (lat + osd_gps_offset_lat/100)
+Offset GPS latitude on OSD by this number (lat + osd_gps_offset_lat/100)
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4412,6 +4412,26 @@ Value under which the OSD axis g force indicators will blink (g)
 
 ---
 
+### osd_gps_offset_lat
+
+Offset GPS latitude  on OSD by this number (lat + osd_gps_offset_lat/100)
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | -9999 | 9999 |
+
+---
+
+### osd_gps_offset_lon
+
+Offset GPS longitude on OSD by this number (lon + osd_gps_offset_lon/100)
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | -9999 | 9999 |
+
+---
+
 ### osd_home_position_arm_screen
 
 Should home position coordinates be displayed on the arming screen.

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3220,7 +3220,7 @@ groups:
         min: -20
         max: 20
       - name: osd_gps_offset_lat
-        description: "Offset GPS latitude  on OSD by this number (lat + osd_gps_offset_lat/100)"
+        description: "Offset GPS latitude on OSD by this number (lat + osd_gps_offset_lat/100)"
         default_value: 0
         field: gps_offset_lat
         min: -9999

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3219,6 +3219,18 @@ groups:
         field: gforce_axis_alarm_max
         min: -20
         max: 20
+      - name: osd_gps_offset_lat
+        description: "Offset GPS latitude  on OSD by this number (lat + osd_gps_offset_lat/100)"
+        default_value: 0
+        field: gps_offset_lat
+        min: -9999
+        max: 9999
+      - name: osd_gps_offset_lon
+        description: "Offset GPS longitude on OSD by this number (lon + osd_gps_offset_lon/100)"
+        default_value: 0
+        field: gps_offset_lon
+        min: -9999
+        max: 9999
       - name: osd_imu_temp_alarm_min
         description: "Temperature under which the IMU temperature OSD element will start blinking (decidegrees centigrade)"
         default_value: -200

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -223,7 +223,7 @@ static bool osdDisplayHasCanvas;
 
 #define AH_MAX_PITCH_DEFAULT 20 // Specify default maximum AHI pitch value displayed (degrees)
 
-PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 10);
+PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 11);
 PG_REGISTER_WITH_RESET_FN(osdLayoutsConfig_t, osdLayoutsConfig, PG_OSD_LAYOUTS_CONFIG, 1);
 
 void osdStartedSaveProcess(void) {
@@ -782,7 +782,18 @@ static void osdFormatCoordinate(char *buff, char sym, int32_t val)
 {
     // up to 4 for number + 1 for the symbol + null terminator + fill the rest with decimals
     const int coordinateLength = osdConfig()->coordinate_digits + 1;
-
+    if (val != 0) {
+    switch (sym) {
+        case SYM_LAT:
+            val = val + osdConfig()->gps_offset_lat * 100000;
+            break;
+        case SYM_LON:
+            val = val + osdConfig()->gps_offset_lon * 100000;
+            break;
+        default:
+            break;
+        }
+	}
     buff[0] = sym;
     int32_t integerPart = val / GPS_DEGREES_DIVIDER;
     // Latitude maximum integer width is 3 (-90) while

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3468,7 +3468,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     || STATE(GPS_ESTIMATED_FIX)
 #endif
             )) {
-                olc_encode(gpsSol.llh.lat, gpsSol.llh.lon, digits, buff, sizeof(buff));
+                olc_encode(gpsSol.llh.lat + osdConfig()->gps_offset_lat * 100000, gpsSol.llh.lon + osdConfig()->gps_offset_lon * 100000, digits, buff, sizeof(buff));
             } else {
                 // +codes with > 8 digits have a + at the 9th digit
                 // and we only support 10 and up.

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -363,6 +363,8 @@ typedef struct osdConfig_s {
     float           gforce_alarm;
     float           gforce_axis_alarm_min;
     float           gforce_axis_alarm_max;
+    int16_t         gps_offset_lat;                     // offset OSD lat by this value (lat + osd_gps_offset_lat/100)
+    int16_t         gps_offset_lon;                     // offset OSD lon by this value (lon + osd_gps_offset_lon/100)
 #ifdef USE_SERIALRX_CRSF
     int8_t          snr_alarm;                          //CRSF SNR alarm in dB
     int8_t          link_quality_alarm;


### PR DESCRIPTION
This feature was previously mentioned in https://github.com/iNavFlight/inav/pull/7908 
Thanks Sergey!

But since the author didn't rebase it for quite some time - I had to do it. Now updated to current master.

Tested in HITL:

Let's teleport to 0.000000, 0.000000

![image](https://github.com/iNavFlight/inav/assets/16077103/a20ed20d-1a6a-4558-a6dc-3c83b9a44116)

Enable the offset feature

![image](https://github.com/iNavFlight/inav/assets/16077103/69e57396-c590-44eb-8c67-6ba5450a074b)

And here we go

![image](https://github.com/iNavFlight/inav/assets/16077103/34cd5fc7-4e39-4df3-9f25-918f44a4599a)

