### PR TITLE
Adding Crosshair Styles for DJI OSD

### DIFF
--- a/src/main/io/displayport_msp_dji_compat.c
+++ b/src/main/io/displayport_msp_dji_compat.c
@@ -469,40 +469,75 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_AH_RIGHT:
             return DJI_SYM_AH_RIGHT;
-
 /*
         case SYM_AH_DECORATION_COUNT:
             return DJI_SYM_AH_DECORATION_COUNT;
 */
         case SYM_AH_CH_LEFT:
-        case SYM_AH_CH_TYPE3:
-        case SYM_AH_CH_TYPE4:
-        case SYM_AH_CH_TYPE5:
-        case SYM_AH_CH_TYPE6:
-        case SYM_AH_CH_TYPE7:
-        case SYM_AH_CH_TYPE8:
         case SYM_AH_CH_AIRCRAFT1:
             return DJI_SYM_CROSSHAIR_LEFT;
 
+        case SYM_AH_CH_TYPE3:
+            return DJI_SYM_AH_CH_TYPE3;
+        
+        case SYM_AH_CH_TYPE4:
+            return DJI_SYM_AH_CH_TYPE4;
+        
+        case SYM_AH_CH_TYPE5:
+            return DJI_SYM_AH_CH_TYPE5;
+        
+        case SYM_AH_CH_TYPE6:
+            return DJI_SYM_AH_CH_TYPE6;
+        
+        case SYM_AH_CH_TYPE7:
+            return DJI_SYM_AH_CH_TYPE7;
+        
+        case SYM_AH_CH_TYPE8:
+            return DJI_SYM_AH_CH_TYPE8;
+
         case SYM_AH_CH_CENTER:
-        case (SYM_AH_CH_TYPE3+1):
-        case (SYM_AH_CH_TYPE4+1):
-        case (SYM_AH_CH_TYPE5+1):
-        case (SYM_AH_CH_TYPE6+1):
-        case (SYM_AH_CH_TYPE7+1):
-        case (SYM_AH_CH_TYPE8+1):
         case SYM_AH_CH_AIRCRAFT2:
             return DJI_SYM_CROSSHAIR_CENTRE;
 
+        case (SYM_AH_CH_TYPE3+1):
+            return DJI_SYM_AH_CH_TYPE3_1;
+        
+        case (SYM_AH_CH_TYPE4+1):
+            return DJI_SYM_AH_CH_TYPE4_1;
+        
+        case (SYM_AH_CH_TYPE5+1):
+            return DJI_SYM_AH_CH_TYPE5_1;
+        
+        case (SYM_AH_CH_TYPE6+1):
+            return DJI_SYM_AH_CH_TYPE6_1;
+        
+        case (SYM_AH_CH_TYPE7+1):
+            return DJI_SYM_AH_CH_TYPE7_1;
+        
+        case (SYM_AH_CH_TYPE8+1):
+            return DJI_SYM_AH_CH_TYPE8_1;
+
         case SYM_AH_CH_RIGHT:
-        case (SYM_AH_CH_TYPE3+2):
-        case (SYM_AH_CH_TYPE4+2):
-        case (SYM_AH_CH_TYPE5+2):
-        case (SYM_AH_CH_TYPE6+2):
-        case (SYM_AH_CH_TYPE7+2):
-        case (SYM_AH_CH_TYPE8+2):
         case SYM_AH_CH_AIRCRAFT3:
             return DJI_SYM_CROSSHAIR_RIGHT;
+
+        case (SYM_AH_CH_TYPE3+2):
+            return DJI_SYM_AH_CH_TYPE3_2;
+        
+        case (SYM_AH_CH_TYPE4+2):
+            return DJI_SYM_AH_CH_TYPE4_2;
+        
+        case (SYM_AH_CH_TYPE5+2):
+            return DJI_SYM_AH_CH_TYPE5_2;
+        
+        case (SYM_AH_CH_TYPE6+2):
+            return DJI_SYM_AH_CH_TYPE6_2;
+        
+        case (SYM_AH_CH_TYPE7+2):
+            return DJI_SYM_AH_CH_TYPE7_2;
+        
+        case (SYM_AH_CH_TYPE8+2):
+            return DJI_SYM_AH_CH_TYPE8_2;
         
         case SYM_AH_CH_AIRCRAFT0:
         case SYM_AH_CH_AIRCRAFT4:

--- a/src/main/io/dji_osd_symbols.h
+++ b/src/main/io/dji_osd_symbols.h
@@ -71,26 +71,6 @@
 #define DJI_SYM_AH_DECORATION           0x13
 #define DJI_SYM_SMALL_CROSSHAIR         0x7E
 
-// Crosshair Styles
-#define DJI_SYM_AH_CH_TYPE3             0x00
-#define DJI_SYM_AH_CH_TYPE3_1           0x7E
-#define DJI_SYM_AH_CH_TYPE3_2           0x00
-#define DJI_SYM_AH_CH_TYPE4             0x2D
-#define DJI_SYM_AH_CH_TYPE4_1           0x7E
-#define DJI_SYM_AH_CH_TYPE4_2           0x2D
-#define DJI_SYM_AH_CH_TYPE5             0x17
-#define DJI_SYM_AH_CH_TYPE5_1           0x7E
-#define DJI_SYM_AH_CH_TYPE5_2           0x17
-#define DJI_SYM_AH_CH_TYPE6             0x00
-#define DJI_SYM_AH_CH_TYPE6_1           0x09
-#define DJI_SYM_AH_CH_TYPE6_2           0x00
-#define DJI_SYM_AH_CH_TYPE7             0x78
-#define DJI_SYM_AH_CH_TYPE7_1           0x7E
-#define DJI_SYM_AH_CH_TYPE7_2           0x77
-#define DJI_SYM_AH_CH_TYPE8             0x02
-#define DJI_SYM_AH_CH_TYPE8_1           0x7E
-#define DJI_SYM_AH_CH_TYPE8_2           0x03
-
 // Satellite Graphics
 #define DJI_SYM_SAT_L                   0x1E
 #define DJI_SYM_SAT_R                   0x1F
@@ -182,3 +162,23 @@
 #define DJI_SYM_GPS_DEGREE              DJI_SYM_STICK_OVERLAY_SPRITE_HIGH  // kind of looks like the degree symbol
 #define DJI_SYM_GPS_MINUTE              0x27 // '
 #define DJI_SYM_GPS_SECOND              0x22 // "
+
+// Crosshair Styles
+#define DJI_SYM_AH_CH_TYPE3             DJI_SYM_NONE
+#define DJI_SYM_AH_CH_TYPE3_1           DJI_SYM_SMALL_CROSSHAIR
+#define DJI_SYM_AH_CH_TYPE3_2           DJI_SYM_NONE
+#define DJI_SYM_AH_CH_TYPE4             DJI_SYM_HYPHEN
+#define DJI_SYM_AH_CH_TYPE4_1           DJI_SYM_SMALL_CROSSHAIR
+#define DJI_SYM_AH_CH_TYPE4_2           DJI_SYM_HYPHEN
+#define DJI_SYM_AH_CH_TYPE5             DJI_SYM_STICK_OVERLAY_HORIZONTAL
+#define DJI_SYM_AH_CH_TYPE5_1           DJI_SYM_SMALL_CROSSHAIR
+#define DJI_SYM_AH_CH_TYPE5_2           DJI_SYM_STICK_OVERLAY_HORIZONTAL
+#define DJI_SYM_AH_CH_TYPE6             DJI_SYM_NONE
+#define DJI_SYM_AH_CH_TYPE6_1           DJI_SYM_STICK_OVERLAY_SPRITE_MID
+#define DJI_SYM_AH_CH_TYPE6_2           DJI_SYM_NONE
+#define DJI_SYM_AH_CH_TYPE7             DJI_SYM_ARROW_SMALL_LEFT
+#define DJI_SYM_AH_CH_TYPE7_1           DJI_SYM_SMALL_CROSSHAIR
+#define DJI_SYM_AH_CH_TYPE7_2           DJI_SYM_ARROW_SMALL_RIGHT
+#define DJI_SYM_AH_CH_TYPE8             DJI_SYM_AH_LEFT
+#define DJI_SYM_AH_CH_TYPE8_1           DJI_SYM_SMALL_CROSSHAIR
+#define DJI_SYM_AH_CH_TYPE8_2           DJI_SYM_AH_RIGHT

--- a/src/main/io/dji_osd_symbols.h
+++ b/src/main/io/dji_osd_symbols.h
@@ -71,6 +71,26 @@
 #define DJI_SYM_AH_DECORATION           0x13
 #define DJI_SYM_SMALL_CROSSHAIR         0x7E
 
+// Crosshair Styles
+#define DJI_SYM_AH_CH_TYPE3             0x00
+#define DJI_SYM_AH_CH_TYPE3_1           0x7E
+#define DJI_SYM_AH_CH_TYPE3_2           0x00
+#define DJI_SYM_AH_CH_TYPE4             0x2D
+#define DJI_SYM_AH_CH_TYPE4_1           0x7E
+#define DJI_SYM_AH_CH_TYPE4_2           0x2D
+#define DJI_SYM_AH_CH_TYPE5             0x17
+#define DJI_SYM_AH_CH_TYPE5_1           0x7E
+#define DJI_SYM_AH_CH_TYPE5_2           0x17
+#define DJI_SYM_AH_CH_TYPE6             0x00
+#define DJI_SYM_AH_CH_TYPE6_1           0x09
+#define DJI_SYM_AH_CH_TYPE6_2           0x00
+#define DJI_SYM_AH_CH_TYPE7             0x78
+#define DJI_SYM_AH_CH_TYPE7_1           0x7E
+#define DJI_SYM_AH_CH_TYPE7_2           0x77
+#define DJI_SYM_AH_CH_TYPE8             0x02
+#define DJI_SYM_AH_CH_TYPE8_1           0x7E
+#define DJI_SYM_AH_CH_TYPE8_2           0x03
+
 // Satellite Graphics
 #define DJI_SYM_SAT_L                   0x1E
 #define DJI_SYM_SAT_R                   0x1F


### PR DESCRIPTION
I would like to suggest adding crosshair styles for the DJI OSD.

As per @DzikuVx 's request, this is how they look like:

| Crosshairs Style | Preview |
| ----------------- | --------- |
| DEFAULT | ![image](https://github.com/iNavFlight/inav/assets/23706061/7ce89209-56ea-4b39-9b5e-871ac7e86e9a) |
| TYPE3 | ![image](https://github.com/iNavFlight/inav/assets/23706061/d3d8bf9a-ccc2-4642-b1af-a026e68e69b9) |
| TYPE4 | ![image](https://github.com/iNavFlight/inav/assets/23706061/a67a6a62-4662-462e-9421-e673a4288431) |
| TYPE5 | ![image](https://github.com/iNavFlight/inav/assets/23706061/c27248bd-7149-47d6-91c9-d109eb65ea35) |
| TYPE6 | ![image](https://github.com/iNavFlight/inav/assets/23706061/859003ac-f767-4149-ba88-b1240b3db9de) |
| TYPE7 | ![image](https://github.com/iNavFlight/inav/assets/23706061/dec67417-5350-47e8-b577-88cd6dc87197) |
| TYPE8 | ![image](https://github.com/iNavFlight/inav/assets/23706061/e6e37c2a-3de9-43e0-a74d-1e6cdb93f8f7) |

More combinations are possinble of course (happy to take suggestions), but I think this might be a good start just to give users a few more options.