### PR TITLE
Remove unused define from DJI OSD symbols

### DIFF
--- a/src/main/io/dji_osd_symbols.h
+++ b/src/main/io/dji_osd_symbols.h
@@ -147,9 +147,6 @@
 #define DJI_SYM_MPS                     0x9F
 #define DJI_SYM_FTPS                    0x99
 
-// Menu cursor
-#define DJI_SYM_CURSOR                  DJI_SYM_AH_LEFT
-
 // Stick overlays
 #define DJI_SYM_STICK_OVERLAY_SPRITE_HIGH 0x08
 #define DJI_SYM_STICK_OVERLAY_SPRITE_MID  0x09


### PR DESCRIPTION
I searched the code and DJI_SYM_CURSOR isn't used anywhere. The only OSD use of cursor at all is in the CMS, which just uses the '>' character.

So this define can go. After that the dji_osd_symbols.h file is a pure character to variable map.