### PR TITLE
Updated resource mapping for neutronrcf435mini target

### DIFF
--- a/src/main/target/NEUTRONRCF435MINI/target.h
+++ b/src/main/target/NEUTRONRCF435MINI/target.h
@@ -144,8 +144,8 @@
 #define UART2_TX_PIN            PA2
 
 #define USE_UART3
-#define UART3_RX_PIN            PB11
-#define UART3_TX_PIN            PB10
+#define UART3_RX_PIN            PB10    //Changed from PB11->PB10
+#define UART3_TX_PIN            PB11    //Changed from PB11->PB10
 
 #define USE_UART5
 #define UART5_RX_PIN            PB8


### PR DESCRIPTION
This PR is in response to the issue #10059 . I have checked the resource mapping of the board and compared it with the config file in BF and indeed there is a deviation in the resource mapping of the UART port.

Changes I made 
<img width="488" alt="image" src="https://github.com/iNavFlight/inav/assets/115360638/1c9f7852-8d7e-408d-a469-961ccda6749b">

Referenced from BF
<img width="285" alt="image" src="https://github.com/iNavFlight/inav/assets/115360638/f4b926be-b7fc-4023-842a-db518fc792c3">
