### PR TITLE
Add JHEF405PRO (aka GHF405AIO-HD) support

### DIFF
--- a/src/main/target/JHEF405PRO/CMakeLists.txt
+++ b/src/main/target/JHEF405PRO/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f405xg(JHEF405PRO)

--- a/src/main/target/JHEF405PRO/CMakeLists.txt
+++ b/src/main/target/JHEF405PRO/CMakeLists.txt
@@ -1,1 +1,1 @@
-target_stm32f405xg(JHEF405PRO)
+target_stm32f405xg(JHEF405PRO SKIP_RELEASES)

--- a/src/main/target/JHEF405PRO/target.c
+++ b/src/main/target/JHEF405PRO/target.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+timerHardware_t timerHardware[] = {    
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR, 0, 0),  // S1
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR, 0, 0),  // S2
+    DEF_TIM(TIM2, CH4, PA3, TIM_USE_MOTOR, 0, 1),  // S3
+    DEF_TIM(TIM2, CH3, PA2, TIM_USE_MOTOR, 0, 0),  // S4
+
+    DEF_TIM(TIM4, CH3, PB8, TIM_USE_PPM, 0, 0),       // PPM
+    DEF_TIM(TIM1, CH2, PA9, TIM_USE_LED,  0, 1 ),     //LED
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/JHEF405PRO/target.h
+++ b/src/main/target/JHEF405PRO/target.h
@@ -1,0 +1,154 @@
+/*
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "JHEF405PRO"
+#define USBD_PRODUCT_STRING  "JHEF405PRO"
+
+#define LED0                PC14
+#define BEEPER              PC13
+#define BEEPER_INVERTED
+
+// *************** SPI1 Gyro & ACC **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_SCK_PIN        PA5
+#define SPI1_MISO_PIN   	PA6
+#define SPI1_MOSI_PIN       PA7
+
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW90_DEG
+#define ICM42605_CS_PIN         PB12
+#define ICM42605_SPI_BUS        BUS_SPI1
+
+#define USE_EXTI
+#define GYRO_INT_EXTI       PB13
+#define USE_MPU_DATA_READY_SIGNAL
+
+// *************** SPI3 OSD & Flash ***************************
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN        PC10
+#define SPI3_MISO_PIN       PC11
+#define SPI3_MOSI_PIN       PC12
+
+// OSD
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_BUS     BUS_SPI3
+#define MAX7456_CS_PIN      PB14
+
+// Flash
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN           PB3
+#define M25P16_SPI_BUS          BUS_SPI3
+
+// *************** I2C /Baro/Mag *********************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+#define DEFAULT_I2C_BUS         BUS_I2C1
+
+// Baro
+#define USE_BARO
+#define BARO_I2C_BUS            DEFAULT_I2C_BUS
+#define USE_BARO_DPS310
+
+// Mag
+#define USE_MAG
+#define USE_MAG_ALL
+#define MAG_I2C_BUS             DEFAULT_I2C_BUS
+
+// Temperature
+#define TEMPERATURE_I2C_BUS     DEFAULT_I2C_BUS
+
+// Range finder
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_HCSR04_I2C
+#define RANGEFINDER_I2C_BUS     DEFAULT_I2C_BUS
+
+// PITOT
+#define PITOT_I2C_BUS           DEFAULT_I2C_BUS
+
+// *************** UART *****************************
+#define USB_IO
+#define USE_VCP
+#define VBUS_SENSING_PIN        PA8 // TODO validate
+#define VBUS_SENSING_ENABLED
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PB6
+
+#define USE_UART2
+#define UART2_RX_PIN            PD6
+#define UART2_TX_PIN            PD5
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define SERIAL_PORT_COUNT       6
+
+// *************** ADC ***************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC3
+#define ADC_CHANNEL_2_PIN           PC2
+#define ADC_CHANNEL_3_PIN           PC0
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_3
+#define CURRENT_METER_SCALE         250
+
+// ***************  OTHERS *************************
+#define DEFAULT_FEATURES        (FEATURE_VBAT | FEATURE_CURRENT_METER | FEATURE_OSD | FEATURE_TELEMETRY)
+
+// Rx defaults
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+
+// *************** LED2812 ************************
+#define USE_LED_STRIP
+#define WS2811_PIN              PA9
+
+
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         0xffff
+
+//TIMER
+#define MAX_PWM_OUTPUT_PORTS       4
+
+#define USE_DSHOT


### PR DESCRIPTION
Add unofficial target for JHEF405PRO (aka GHF405AIO-HD)
![image](https://github.com/iNavFlight/inav/assets/5965360/0e46aaba-bcf7-482a-90eb-2cb5253076f6)

Betaflight counterpart: [https://github.com/betaflight/unified-targets/blob/master/configs/default/JHEF-JHEF405PRO.config](https://github.com/betaflight/unified-targets/blob/master/configs/default/JHEF-JHEF405PRO.config)
INAV similar **but different** FC (No I2C): [https://github.com/iNavFlight/inav/blob/master/src/main/target/JHEMCUF405/target.h
](https://github.com/iNavFlight/inav/blob/master/src/main/target/JHEMCUF405/target.h
)

**Test quad**
![image](https://github.com/iNavFlight/inav/assets/5965360/a556f26e-5b71-45d8-b6c1-5e0a36240536)
3.5" dry weight 2S/4S
JHEMCU GHF405AIO-HD 40A F405 Baro OSD Dual BEC Flight
LANNRC 1404 3800KV 3~6S
Gemfan Hurricane 3018 3x1.8 3 Inch 2 Paddle 
HappyModel Crux35 Crux35 HD 3.5inch
HGLRC Zeus nano VTX 350mW (IRC Tramp)
HappyModel EP1
CADDX ANT Nano 1200TVL
Walksnail WS-M181 GPS M10 GNSS BUILT-IN QMC5883 Compass

**Tested working:**
Accelorometer
Gyro
Baro
UARTs
GPS
Magnetometer
Altitdue Hold
RTH
OSD
Flash / Blackbox
Current sensing
VBat sensing
Telemetry

**Not tested but assumed working**
Leds / Range finder (I2C) / Pitot (I2C)

**diff all**
[INAV_7.1.1_cli_MRMT_20240522_190142.txt](https://github.com/iNavFlight/inav/files/15409903/INAV_7.1.1_cli_MRMT_20240522_190142.txt)

**Test binary (zipped hex)**
[inav_7.1.1_JHEF405PRO.zip](https://github.com/iNavFlight/inav/files/15409936/inav_7.1.1_JHEF405PRO.zip)

**CLI status**

```
status
INAV/JHEF405PRO 7.1.1 May 20 2024 / 23:04:26 (dd91a871)
GCC-10.3.1 20210824 (release)
System Uptime: 67 seconds
Current Time: 2041-06-28T02:04:00.000+01:00
Voltage: 7.82V (2S battery - OK)
CPU Clock=168MHz, GYRO=ICM42605, ACC=ICM42605, BARO=DPS310, MAG=QMC5883
STM32 system clocks:
  SYSCLK = 168 MHz
  HCLK   = 168 MHz
  PCLK1  = 42 MHz
  PCLK2  = 84 MHz
Sensor status: GYRO=OK, ACC=OK, MAG=OK, BARO=OK, RANGEFINDER=NONE, OPFLOW=NONE, GPS=OK
Stack size: 6144, Stack address: 0x10010000, Heap available: 1728
I2C Errors: 0, config size: 10407, max available config: 131072
ADC channel usage:
   BATTERY : configured = ADC 1, used = ADC 1
      RSSI : configured = ADC 3, used = none
   CURRENT : configured = ADC 2, used = ADC 2
  AIRSPEED : configured = none, used = none
System load: 10, cycle time: 503, PID rate: 1988, RX rate: 50, System rate: 9
Arming disabled flags: NAV THR CLI
OSD: MAX7456 [30 x 16]
VTX: not detected
GPS: HW Version: UBLOX10 Proto: 34.09 Baud: 115200
  GNSS Capabilities:
    GNSS Provider active/default
    GPS 1/1
    Galileo 1/1
    BeiDou 1/1
    Glonass 0/0
    Max concurrent: 3

# 
```