### PR TITLE
Building a USB-Rescue firmware without editing sources

### DIFF
--- a/cmake/at32.cmake
+++ b/cmake/at32.cmake
@@ -326,6 +326,11 @@ function(target_at32)
 
     math(EXPR hse_value "${hse_mhz} * 1000000")
     list(APPEND target_definitions "HSE_VALUE=${hse_value}")
+
+    if (MSP_UART) 
+        list(APPEND target_definitions "MSP_UART=${MSP_UART}")
+    endif()
+
     if(args_COMPILE_DEFINITIONS)
         list(APPEND target_definitions ${args_COMPILE_DEFINITIONS})
     endif()

--- a/cmake/sitl.cmake
+++ b/cmake/sitl.cmake
@@ -99,6 +99,10 @@ function (target_sitl name)
     math(EXPR hse_value "${hse_mhz} * 1000000")
     list(APPEND target_definitions "HSE_VALUE=${hse_value}")
 
+    if (MSP_UART) 
+        list(APPEND target_definitions "MSP_UART=${MSP_UART}")
+    endif()
+
     string(TOLOWER ${PROJECT_NAME} lowercase_project_name)
     set(binary_name ${lowercase_project_name}_${FIRMWARE_VERSION}_${name})
     if(DEFINED BUILD_SUFFIX AND NOT "" STREQUAL "${BUILD_SUFFIX}")

--- a/cmake/stm32.cmake
+++ b/cmake/stm32.cmake
@@ -333,6 +333,11 @@ function(target_stm32)
 
     math(EXPR hse_value "${hse_mhz} * 1000000")
     list(APPEND target_definitions "HSE_VALUE=${hse_value}")
+
+    if (MSP_UART) 
+        list(APPEND target_definitions "MSP_UART=${MSP_UART}")
+    endif()
+
     if(args_COMPILE_DEFINITIONS)
         list(APPEND target_definitions ${args_COMPILE_DEFINITIONS})
     endif()

--- a/docs/Broken USB recovery.md
+++ b/docs/Broken USB recovery.md
@@ -53,55 +53,16 @@ The following procedure describes the process under Windows 10/11:
 Please read [Building in Windows 2010 or 11 with Linux Subsystem](https://github.com/iNavFlight/inav/blob/master/docs/development/Building%20in%20Windows%2010%20or%2011%20with%20Linux%20Subsystem.md)
 and follow the instructions up to "Building with Make".
 
-To activate MSP by default, go to the directory `src/main/target/[your target]`.
-If no config.c exists, create a new text file with this name and the following content:
+In the step 'prepare build environment' add the option `-DMSP_UART=SERIAL_PORT_USARTX` to `cmake`
 
-```
-/*
- * This file is part of INAV.
- *
- * INAV is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * INAV is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-#include <stdint.h>
-
-#include "platform.h"
-#include "io/serial.h"
-
-void targetConfiguration(void)
-{
-    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USARTX)].functionMask = FUNCTION_MSP;
-    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USARTX)].msp_baudrateIndex = BAUD_115200;
-}
-
-```
-
-If the file already exists, add the following lines in the function `void targetConfiguration(void)` (before the last `}`)
-
-```
-serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USARTX)].functionMask = FUNCTION_MSP;
-serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USARTX)].msp_baudrateIndex = BAUD_115200;
-```
-
-Replace the X in SERIAL_PORT_USARTX (in both lines) with the number of UART/serial port on which MSP is to be activated.
+Replace the X in SERIAL_PORT_USARTX with the number of UART/serial port on which MSP is to be activated.
 
 Example:
-For UART 2: `SERIAL_PORT_USART2`
-For UART 3: `SERIAL_PORT_USART3`
+For UART 2: `cmake -DMSP_UART=SERIAL_PORT_USART2 ..`
+For UART 3: `cmake -DMSP_UART=SERIAL_PORT_USART3 ..`
 etc.
 
-Save the file and build the firmware as described in the document above.
+Build the firmware as described in the document above (`make [YOUR_TARGET]`).
 
 ## Flashing via Uart:
 

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -284,6 +284,14 @@ void createDefaultConfig(void)
     featureSet(FEATURE_AIRMODE);
 
     targetConfiguration();
+
+#ifdef MSP_UART
+    int port = findSerialPortIndexByIdentifier(MSP_UART);
+    if (port) {
+        serialConfigMutable()->portConfigs[port].functionMask = FUNCTION_MSP;
+        serialConfigMutable()->portConfigs[port].msp_baudrateIndex = BAUD_115200;
+    }
+#endif
 }
 
 void resetConfigs(void)


### PR DESCRIPTION
Adds the option `MSP_UART=[UART]` to cmake to build a "USB-Rescue" firmware, without having to edit the source files.