### PR TITLE
Skip `pollVersion()` and `pollGnssCapabilities()` if `gps_auto_config = OFF`

### DIFF
--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -1061,11 +1061,11 @@ STATIC_PROTOTHREAD(gpsProtocolStateThread)
         // M7 and earlier will never get pass this step, so skip it (#9440).
         // UBLOX documents that this is M8N and later
         if (gpsState.hwVersion > UBX_HW_VERSION_UBLOX7) {
-        do {
-            pollGnssCapabilities();
-            gpsState.autoConfigStep++;
-            ptWaitTimeout((ubx_capabilities.capMaxGnss != 0), GPS_CFG_CMD_TIMEOUT_MS);
-        } while (gpsState.autoConfigStep < GPS_VERSION_RETRY_TIMES && ubx_capabilities.capMaxGnss == 0);
+            do {
+                pollGnssCapabilities();
+                gpsState.autoConfigStep++;
+                ptWaitTimeout((ubx_capabilities.capMaxGnss != 0), GPS_CFG_CMD_TIMEOUT_MS);
+            } while (gpsState.autoConfigStep < GPS_VERSION_RETRY_TIMES && ubx_capabilities.capMaxGnss == 0);
         }
 
         // Configure GPS

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -1048,25 +1048,26 @@ STATIC_PROTOTHREAD(gpsProtocolStateThread)
     gpsState.hwVersion = UBX_HW_VERSION_UNKNOWN;
     gpsState.autoConfigStep = 0;
 
-    do {
-        pollVersion();
-        gpsState.autoConfigStep++;
-        ptWaitTimeout((gpsState.hwVersion != UBX_HW_VERSION_UNKNOWN), GPS_CFG_CMD_TIMEOUT_MS);
-    } while(gpsState.autoConfigStep < GPS_VERSION_RETRY_TIMES && gpsState.hwVersion == UBX_HW_VERSION_UNKNOWN);
-
-    gpsState.autoConfigStep = 0;
-    ubx_capabilities.supported = ubx_capabilities.enabledGnss = ubx_capabilities.defaultGnss = 0;
-    // M7 and earlier will never get pass this step, so skip it (#9440).
-    // UBLOX documents that this is M8N and later
-    if (gpsState.hwVersion > UBX_HW_VERSION_UBLOX7) {
-	do {
-	    pollGnssCapabilities();
-	    gpsState.autoConfigStep++;
-	    ptWaitTimeout((ubx_capabilities.capMaxGnss != 0), GPS_CFG_CMD_TIMEOUT_MS);
-	} while (gpsState.autoConfigStep < GPS_VERSION_RETRY_TIMES && ubx_capabilities.capMaxGnss == 0);
-    }
     // Configure GPS module if enabled
     if (gpsState.gpsConfig->autoConfig) {
+        do {
+            pollVersion();
+            gpsState.autoConfigStep++;
+            ptWaitTimeout((gpsState.hwVersion != UBX_HW_VERSION_UNKNOWN), GPS_CFG_CMD_TIMEOUT_MS);
+        } while(gpsState.autoConfigStep < GPS_VERSION_RETRY_TIMES && gpsState.hwVersion == UBX_HW_VERSION_UNKNOWN);
+
+        gpsState.autoConfigStep = 0;
+        ubx_capabilities.supported = ubx_capabilities.enabledGnss = ubx_capabilities.defaultGnss = 0;
+        // M7 and earlier will never get pass this step, so skip it (#9440).
+        // UBLOX documents that this is M8N and later
+        if (gpsState.hwVersion > UBX_HW_VERSION_UBLOX7) {
+        do {
+            pollGnssCapabilities();
+            gpsState.autoConfigStep++;
+            ptWaitTimeout((ubx_capabilities.capMaxGnss != 0), GPS_CFG_CMD_TIMEOUT_MS);
+        } while (gpsState.autoConfigStep < GPS_VERSION_RETRY_TIMES && ubx_capabilities.capMaxGnss == 0);
+        }
+
         // Configure GPS
         ptSpawn(gpsConfigure);
     }
@@ -1079,7 +1080,7 @@ STATIC_PROTOTHREAD(gpsProtocolStateThread)
         ptSemaphoreWait(semNewDataReady);
         gpsProcessNewSolutionData(false);
 
-        if ((gpsState.gpsConfig->provider == GPS_UBLOX || gpsState.gpsConfig->provider == GPS_UBLOX7PLUS)) {
+        if ((gpsState.gpsConfig->autoConfig) && (gpsState.gpsConfig->provider == GPS_UBLOX || gpsState.gpsConfig->provider == GPS_UBLOX7PLUS)) {
             if ((millis() - gpsState.lastCapaPoolMs) > GPS_CAPA_INTERVAL) {
                 gpsState.lastCapaPoolMs = millis();
 


### PR DESCRIPTION
Modified gps_ublox.c to skip `pollVersion()` and `pollGnssCapabilities()` if `gps_auto_config = OFF`. This is to support an RX only UART connection of the GPS module.


I need to use my preconfigured GPS without connecting it to the FC UART RX (just TX), so via the CLI I have set `set gps_auto_config = OFF`. 

`set gps_auto_config = OFF` alone doesn't work since `pollVersion()` and `pollGnssCapabilities()` are still continually polled.

If the GPS RX isn't connected the `UBX_ACK_GOT_ACK` isn't received by the FC which results in repeated a GPS timeout waiting for a "GPS Version" response despite valid GPS data being received.

My solution is to skip `pollVersion()` and `pollGnssCapabilities()` if GPS auto config is disabled.

This solution resolved the above problem but may or may not cause other problems if the GPS Version and GNSS capabilities are needed (while GPS auto config is disabled) for something else that I am unaware of.