### PR TITLE
Include trusted altitude for healthy position estimation

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -4437,7 +4437,7 @@ uint32_t distanceToFirstWP(void)
 
 bool navigationPositionEstimateIsHealthy(void)
 {
-    return (posControl.flags.estPosStatus >= EST_USABLE) && STATE(GPS_FIX_HOME);
+    return posControl.flags.estPosStatus >= EST_USABLE && posControl.flags.estAltStatus >= EST_USABLE && STATE(GPS_FIX_HOME);
 }
 
 navArmingBlocker_e navigationIsBlockingArming(bool *usedBypass)


### PR DESCRIPTION
Closes https://github.com/iNavFlight/inav/issues/10075.

Seems sensible to include altitude for a healthy position estimate given most Nav modes won't work without it. This will only delay arming if a Baro isn't used given a reliable GPS altitude may take longer to be obtained than a reliable xy position.