### PR TITLE
Blackbox rc/flight modes update

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -402,15 +402,22 @@ static const blackboxSimpleFieldDefinition_t blackboxGpsHFields[] = {
 
 // Rarely-updated fields
 static const blackboxSimpleFieldDefinition_t blackboxSlowFields[] = {
-    {"activeWpNumber",        -1, UNSIGNED, PREDICT(0),      ENCODING(UNSIGNED_VB)},    
+    /* "flightModeFlags" renamed internally to more correct ref of rcModeFlags, since it logs rc boxmode selections,
+     * but name kept for external compatibility reasons.
+     * "activeFlightModeFlags" logs actual active flight modes rather than rc boxmodes.
+     * 'active' should at least distinguish it from the existing "flightModeFlags" */
+     
+    {"activeWpNumber",        -1, UNSIGNED, PREDICT(0),      ENCODING(UNSIGNED_VB)},
     {"flightModeFlags",       -1, UNSIGNED, PREDICT(0),      ENCODING(UNSIGNED_VB)},
+    {"flightModeFlags2",      -1, UNSIGNED, PREDICT(0),      ENCODING(UNSIGNED_VB)},
+    {"activeFlightModeFlags", -1, UNSIGNED, PREDICT(0),      ENCODING(UNSIGNED_VB)},
     {"stateFlags",            -1, UNSIGNED, PREDICT(0),      ENCODING(UNSIGNED_VB)},
 
     {"failsafePhase",         -1, UNSIGNED, PREDICT(0),      ENCODING(TAG2_3S32)},
     {"rxSignalReceived",      -1, UNSIGNED, PREDICT(0),      ENCODING(TAG2_3S32)},
     {"rxFlightChannelsValid", -1, UNSIGNED, PREDICT(0),      ENCODING(TAG2_3S32)},
     {"rxUpdateRate",          -1, UNSIGNED, PREDICT(PREVIOUS),      ENCODING(UNSIGNED_VB)},
-    
+
     {"hwHealthStatus",        -1, UNSIGNED, PREDICT(0),      ENCODING(UNSIGNED_VB)},
     {"powerSupplyImpedance",  -1, UNSIGNED, PREDICT(0),      ENCODING(UNSIGNED_VB)},
     {"sagCompensatedVBat",    -1, UNSIGNED, PREDICT(0),      ENCODING(UNSIGNED_VB)},
@@ -533,7 +540,9 @@ typedef struct blackboxGpsState_s {
 
 // This data is updated really infrequently:
 typedef struct blackboxSlowState_s {
-    uint32_t flightModeFlags; // extend this data size (from uint16_t)
+    uint32_t rcModeFlags;
+    uint32_t rcModeFlags2;
+    uint32_t activeFlightModeFlags;
     uint32_t stateFlags;
     uint8_t failsafePhase;
     bool rxSignalReceived;
@@ -566,7 +575,7 @@ extern boxBitmask_t rcModeActivationMask;
 static BlackboxState blackboxState = BLACKBOX_STATE_DISABLED;
 
 static uint32_t blackboxLastArmingBeep = 0;
-static uint32_t blackboxLastFlightModeFlags = 0;
+static uint32_t blackboxLastRcModeFlags = 0;
 
 static struct {
     uint32_t headerIndex;
@@ -1259,9 +1268,11 @@ static void writeSlowFrame(void)
     int32_t values[3];
 
     blackboxWrite('S');
-    
+
     blackboxWriteUnsignedVB(slowHistory.activeWpNumber);
-    blackboxWriteUnsignedVB(slowHistory.flightModeFlags);
+    blackboxWriteUnsignedVB(slowHistory.rcModeFlags);
+    blackboxWriteUnsignedVB(slowHistory.rcModeFlags2);
+    blackboxWriteUnsignedVB(slowHistory.activeFlightModeFlags);
     blackboxWriteUnsignedVB(slowHistory.stateFlags);
 
     /*
@@ -1269,10 +1280,10 @@ static void writeSlowFrame(void)
      */
     values[0] = slowHistory.failsafePhase;
     values[1] = slowHistory.rxSignalReceived ? 1 : 0;
-    values[2] = slowHistory.rxFlightChannelsValid ? 1 : 0;    
+    values[2] = slowHistory.rxFlightChannelsValid ? 1 : 0;
     blackboxWriteTag2_3S32(values);
 
-    blackboxWriteUnsignedVB(slowHistory.rxUpdateRate);    
+    blackboxWriteUnsignedVB(slowHistory.rxUpdateRate);
 
     blackboxWriteUnsignedVB(slowHistory.hwHealthStatus);
 
@@ -1309,28 +1320,20 @@ static void writeSlowFrame(void)
 static void loadSlowState(blackboxSlowState_t *slow)
 {
     slow->activeWpNumber = getActiveWpNumber();
-    memcpy(&slow->flightModeFlags, &rcModeActivationMask, sizeof(slow->flightModeFlags)); //was flightModeFlags;
+
+    slow->rcModeFlags = rcModeActivationMask.bits[0];   // first 32 bits of boxId_e
+    slow->rcModeFlags2 = rcModeActivationMask.bits[1];  // remaining bits of boxId_e
+
     // Also log Nav auto enabled flight modes rather than just those selected by boxmode
-    if (FLIGHT_MODE(ANGLE_MODE)) {
-        slow->flightModeFlags |= (1 << BOXANGLE);
-    }
-    if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
-        slow->flightModeFlags |= (1 << BOXNAVALTHOLD);
-    }
-    if (FLIGHT_MODE(NAV_RTH_MODE)) {
-        slow->flightModeFlags |= (1 << BOXNAVRTH);
-    }
     if (navigationGetHeadingControlState() == NAV_HEADING_CONTROL_AUTO) {
-        slow->flightModeFlags |= (1 << BOXHEADINGHOLD);
+        slow->rcModeFlags |= (1 << BOXHEADINGHOLD);
     }
-    if (navigationRequiresTurnAssistance()) {
-        slow->flightModeFlags |= (1 << BOXTURNASSIST);
-    }
+    slow->activeFlightModeFlags = flightModeFlags;
     slow->stateFlags = stateFlags;
     slow->failsafePhase = failsafePhase();
     slow->rxSignalReceived = rxIsReceivingSignal();
     slow->rxFlightChannelsValid = rxAreFlightChannelsValid();
-    slow->rxUpdateRate = getRcUpdateFrequency();    
+    slow->rxUpdateRate = getRcUpdateFrequency();
     slow->hwHealthStatus = (getHwGyroStatus()           << 2 * 0) |     // Pack hardware health status into a bit field.
                            (getHwAccelerometerStatus()  << 2 * 1) |     // Use raw hardwareSensorStatus_e values and pack them using 2 bits per value
                            (getHwCompassStatus()        << 2 * 2) |     // Report GYRO in 2 lowest bits, then ACC, COMPASS, BARO, GPS, RANGEFINDER and PITOT
@@ -1498,7 +1501,7 @@ void blackboxStart(void)
      * it finally plays the beep for this arming event.
      */
     blackboxLastArmingBeep = getArmingBeepTimeMicros();
-    memcpy(&blackboxLastFlightModeFlags, &rcModeActivationMask, sizeof(blackboxLastFlightModeFlags)); // record startup status
+    memcpy(&blackboxLastRcModeFlags, &rcModeActivationMask, sizeof(blackboxLastRcModeFlags)); // record startup status
 
     blackboxSetState(BLACKBOX_STATE_PREPARE_LOG_FILE);
 }
@@ -2023,10 +2026,10 @@ static void blackboxCheckAndLogArmingBeep(void)
 static void blackboxCheckAndLogFlightMode(void)
 {
     // Use != so that we can still detect a change if the counter wraps
-    if (memcmp(&rcModeActivationMask, &blackboxLastFlightModeFlags, sizeof(blackboxLastFlightModeFlags))) {
+    if (memcmp(&rcModeActivationMask, &blackboxLastRcModeFlags, sizeof(blackboxLastRcModeFlags))) {
         flightLogEvent_flightMode_t eventData; // Add new data for current flight mode flags
-        eventData.lastFlags = blackboxLastFlightModeFlags;
-        memcpy(&blackboxLastFlightModeFlags, &rcModeActivationMask, sizeof(blackboxLastFlightModeFlags));
+        eventData.lastFlags = blackboxLastRcModeFlags;
+        memcpy(&blackboxLastRcModeFlags, &rcModeActivationMask, sizeof(blackboxLastRcModeFlags));
         memcpy(&eventData.flags, &rcModeActivationMask, sizeof(eventData.flags));
         blackboxLogEvent(FLIGHT_LOG_EVENT_FLIGHTMODE, (flightLogEventData_t *)&eventData);
     }

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -704,7 +704,7 @@ void processRx(timeUs_t currentTimeUs)
     }
 
     /* Turn assistant mode */
-    if (IS_RC_MODE_ACTIVE(BOXTURNASSIST)) {
+    if (IS_RC_MODE_ACTIVE(BOXTURNASSIST) || navigationRequiresTurnAssistance()) {
          ENABLE_FLIGHT_MODE(TURN_ASSISTANT);
     } else {
         DISABLE_FLIGHT_MODE(TURN_ASSISTANT);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1099,7 +1099,7 @@ void checkItermFreezingActive(pidState_t *pidState, flight_dynamics_index_t axis
     if (usedPidControllerType == PID_TYPE_PIFF && pidProfile()->fixedWingYawItermBankFreeze != 0 && axis == FD_YAW) {
         // Do not allow yaw I-term to grow when bank angle is too large
         float bankAngle = DECIDEGREES_TO_DEGREES(attitude.values.roll);
-        if (fabsf(bankAngle) > pidProfile()->fixedWingYawItermBankFreeze && !(FLIGHT_MODE(AUTO_TUNE) || FLIGHT_MODE(TURN_ASSISTANT) || navigationRequiresTurnAssistance())){
+        if (fabsf(bankAngle) > pidProfile()->fixedWingYawItermBankFreeze && !(FLIGHT_MODE(AUTO_TUNE) || FLIGHT_MODE(TURN_ASSISTANT))) {
             pidState->itermFreezeActive = true;
         } else
         {
@@ -1242,7 +1242,7 @@ void FAST_CODE pidController(float dT)
     }
 
     // Apply Turn Assistance
-    if ((FLIGHT_MODE(TURN_ASSISTANT) || navigationRequiresTurnAssistance()) && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE))) {
+    if (FLIGHT_MODE(TURN_ASSISTANT) && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE))) {
         float bankAngleTarget = DECIDEGREES_TO_RADIANS(pidRcCommandToAngle(rcCommand[FD_ROLL], pidProfile()->max_angle_inclination[FD_ROLL]));
         float pitchAngleTarget = DECIDEGREES_TO_RADIANS(pidRcCommandToAngle(rcCommand[FD_PITCH], pidProfile()->max_angle_inclination[FD_PITCH]));
         pidTurnAssistant(pidState, bankAngleTarget, pitchAngleTarget);


### PR DESCRIPTION
Adds additional RC modes > current 32 bit limit to Blackbox flight log and also adds active flight modes.

`flightModeFlags `has been renamed internally to `rcModeFlags ` given it actually logs RC boxmode selections. This is to avoid confusion with the active flight mode field that has been added (which does log actual active flight modes).

Currently doesn't log Events for RC mode selections beyond the 32 bit limit [TODO].