### PR TITLE
Add battery profile to programming framework

### DIFF
--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -815,6 +815,10 @@ static int logicConditionGetFlightOperandValue(int operand) {
         case LOGIC_CONDITION_OPERAND_FLIGHT_ACTIVE_PROFILE: // int
             return getConfigProfile() + 1;
             break;
+
+        case LOGIC_CONDITION_OPERAND_FLIGHT_BATT_PROFILE: //int
+            return getConfigBatteryProfile() + 1;
+            break;
         
         case LOGIC_CONDITION_OPERAND_FLIGHT_ACTIVE_MIXER_PROFILE: // int
             return currentMixerProfileIndex + 1;

--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -142,6 +142,7 @@ typedef enum {
     LOGIC_CONDITION_OPERAND_FLIGHT_MIXER_TRANSITION_ACTIVE, //0,1           // 39
     LOGIC_CONDITION_OPERAND_FLIGHT_ATTITUDE_YAW, // deg                     // 40
     LOGIC_CONDITION_OPERAND_FLIGHT_FW_LAND_STATE,                           // 41
+    LOGIC_CONDITION_OPERAND_FLIGHT_BATT_PROFILE, // int                     // 42
 } logicFlightOperands_e;
 
 typedef enum {


### PR DESCRIPTION
Useful for programming options based on the pack you're using. Also useful for creating custom OSD elements with the new framework.

https://github.com/iNavFlight/inav-configurator/pull/2103