### PR TITLE
Decrease minimum launch acceleration

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2958,7 +2958,7 @@ Forward acceleration threshold for bungee launch or throw launch [cm/s/s], 1G = 
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 1863 | 1500 | 20000 |
+| 1863 | 1350 | 20000 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2866,7 +2866,7 @@ groups:
         description: "Forward acceleration threshold for bungee launch or throw launch [cm/s/s], 1G = 981 cm/s/s"
         default_value: 1863
         field: fw.launch_accel_thresh
-        min: 1500
+        min: 1350
         max: 20000
       - name: nav_fw_launch_max_angle
         description: "Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg]"


### PR DESCRIPTION
@jetrell pointed out that the current minimum `nav_fw_launch_accel` is too high for some of his larger aircraft. This PR reduces the minimum value to allow for this. 