### PR TITLE
gyro_adaptive_filter_min_hz min value error

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1618,7 +1618,7 @@ Maximum frequency for adaptive filter
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 150 | 100 | 500 |
+| 150 | 0 | 505 |
 
 ---
 
@@ -1628,7 +1628,7 @@ Minimum frequency for adaptive filter
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 50 | 30 | 250 |
+| 50 | 0 | 250 |
 
 ---
 

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -428,7 +428,11 @@ void fcTasksInit(void)
 #endif
 
 #ifdef USE_ADAPTIVE_FILTER
-    setTaskEnabled(TASK_ADAPTIVE_FILTER, (gyroConfig()->gyroFilterMode == GYRO_FILTER_MODE_ADAPTIVE));
+    setTaskEnabled(TASK_ADAPTIVE_FILTER, (
+        gyroConfig()->gyroFilterMode == GYRO_FILTER_MODE_ADAPTIVE && 
+        gyroConfig()->adaptiveFilterMinHz > 0 && 
+        gyroConfig()->adaptiveFilterMaxHz > 0
+    ));
 #endif
 
 #if defined(SITL_BUILD)

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -344,15 +344,15 @@ groups:
         description: "Minimum frequency for adaptive filter"
         default_value: 50
         field: adaptiveFilterMinHz
-        min: 30
+        min: 0
         max: 250
         condition: USE_ADAPTIVE_FILTER
       - name: gyro_adaptive_filter_max_hz
         description: "Maximum frequency for adaptive filter"
         default_value: 150
         field: adaptiveFilterMaxHz
-        min: 100
-        max: 500
+        min: 0
+        max: 505
         condition: USE_ADAPTIVE_FILTER
       - name: gyro_adaptive_filter_std_lpf_hz
         description: "Standard deviation low pass filter cutoff frequency"


### PR DESCRIPTION
Settings.yaml defines min values as 30, default gyro lpf filter, forces value to 20.

Old values failed checks for +/-5Hz from main gyro lpf frequency