### PR TITLE
Increase max number of pwm outputs by 1, if a LED pin is defined

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -53,8 +53,8 @@ enum {
 typedef struct {
     int maxTimMotorCount;
     int maxTimServoCount;
-    const timerHardware_t * timMotors[MAX_PWM_OUTPUT_PORTS];
-    const timerHardware_t * timServos[MAX_PWM_OUTPUT_PORTS];
+    const timerHardware_t * timMotors[MAX_PWM_OUTPUTS];
+    const timerHardware_t * timServos[MAX_PWM_OUTPUTS];
 } timMotorServoHardware_t;
 
 static pwmInitError_e pwmInitError = PWM_INIT_ERROR_NONE;

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -98,7 +98,7 @@ typedef struct {
     bool                requestTelemetry;
 } pwmOutputMotor_t;
 
-static DMA_RAM pwmOutputPort_t pwmOutputPorts[MAX_PWM_OUTPUT_PORTS];
+static DMA_RAM pwmOutputPort_t pwmOutputPorts[MAX_PWM_OUTPUTS];
 
 static pwmOutputMotor_t        motors[MAX_MOTORS];
 static motorPwmProtocolTypes_e initMotorProtocol;
@@ -142,7 +142,7 @@ static void pwmOutConfigTimer(pwmOutputPort_t * p, TCH_t * tch, uint32_t hz, uin
 
 static pwmOutputPort_t *pwmOutAllocatePort(void)
 {
-    if (allocatedOutputPortCount >= MAX_PWM_OUTPUT_PORTS) {
+    if (allocatedOutputPortCount >= MAX_PWM_OUTPUTS) {
         LOG_ERROR(PWM, "Attempt to allocate PWM output beyond MAX_PWM_OUTPUT_PORTS");
         return NULL;
     }

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -20,6 +20,12 @@
 #include "drivers/io_types.h"
 #include "drivers/time.h"
 
+
+#if defined(WS2811_PIN)
+#define MAX_PWM_OUTPUTS (MAX_PWM_OUTPUT_PORTS + 1)
+#else
+#define MAX_PWM_OUTPUTS (MAX_PWM_OUTPUT_PORTS)
+#endif
 typedef enum {
     DSHOT_CMD_SPIN_DIRECTION_NORMAL = 20,
     DSHOT_CMD_SPIN_DIRECTION_REVERSED = 21,


### PR DESCRIPTION
Now that the LED pin can be remmad, we may end up with 1 extra PWM output.

Adjust it so that we account for the extra output if a LED pin is defined.