### PR TITLE
We already support 4 page fonts, bump max chars to 1024

### DIFF
--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -368,7 +368,7 @@ static uint32_t txBytesFree(const displayPort_t *displayPort)
 static bool getFontMetadata(displayFontMetadata_t *metadata, const displayPort_t *displayPort)
 {
     UNUSED(displayPort);
-    metadata->charCount = 512;
+    metadata->charCount = 1024;
     metadata->version = FONT_VERSION;
     return true;
 }


### PR DESCRIPTION
bump max number of chars for displayport_msp.

This should allow unofficial 4 page font support. (Don't tell MrD-RC  he can have a full screen pilot logo ;) )