### PR TITLE
Inhibit active failsafe procedures on landing detection

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -84,7 +84,7 @@ PG_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig,
     .failsafe_mission_delay = SETTING_FAILSAFE_MISSION_DELAY_DEFAULT,                   // Time delay before Failsafe activated during WP mission (s)
 #ifdef USE_GPS_FIX_ESTIMATION
     .failsafe_gps_fix_estimation_delay = SETTING_FAILSAFE_GPS_FIX_ESTIMATION_DELAY_DEFAULT, // Time delay before Failsafe activated when GPS Fix estimation is allied
-#endif    
+#endif
 );
 
 typedef enum {
@@ -350,16 +350,16 @@ static failsafeProcedure_e failsafeChooseFailsafeProcedure(void)
         }
     }
 
-    // Inhibit Failsafe if emergency landing triggered manually
-    if (posControl.flags.manualEmergLandActive) {
+    // Inhibit Failsafe if emergency landing triggered manually or if landing is detected
+    if (posControl.flags.manualEmergLandActive || STATE(LANDING_DETECTED)) {
         return FAILSAFE_PROCEDURE_NONE;
     }
 
     // Craft is closer than minimum failsafe procedure distance (if set to non-zero)
     // GPS must also be working, and home position set
     if (failsafeConfig()->failsafe_min_distance > 0 &&
-            ((sensors(SENSOR_GPS) && STATE(GPS_FIX)) 
-#ifdef USE_GPS_FIX_ESTIMATION    
+            ((sensors(SENSOR_GPS) && STATE(GPS_FIX))
+#ifdef USE_GPS_FIX_ESTIMATION
                 || STATE(GPS_ESTIMATED_FIX)
 #endif
                 ) && STATE(GPS_FIX_HOME)) {
@@ -429,8 +429,8 @@ void failsafeUpdateState(void)
 #ifdef USE_GPS_FIX_ESTIMATION
                     if ( checkGPSFixFailsafe() ) {
                         reprocessState = true;
-                    } else 
-#endif                    
+                    } else
+#endif
                     if (!receivingRxDataAndNotFailsafeMode) {
                         if ((failsafeConfig()->failsafe_throttle_low_delay && (millis() > failsafeState.throttleLowPeriod)) || STATE(NAV_MOTOR_STOP_OR_IDLE)) {
                             // JustDisarm: throttle was LOW for at least 'failsafe_throttle_low_delay' seconds or waiting for launch
@@ -499,7 +499,7 @@ void failsafeUpdateState(void)
                 } else if (failsafeChooseFailsafeProcedure() != FAILSAFE_PROCEDURE_NONE) {  // trigger new failsafe procedure if changed
                     failsafeState.phase = FAILSAFE_RX_LOSS_DETECTED;
                     reprocessState = true;
-                } 
+                }
 #ifdef USE_GPS_FIX_ESTIMATION
                 else {
                     if ( checkGPSFixFailsafe() ) {

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3353,7 +3353,7 @@ void updateLandingStatus(timeMs_t currentTimeMs)
             if (STATE(AIRPLANE) && isFlightDetected()) {
                 // Cancel landing detection flag if fixed wing redetected in flight
                 resetLandingDetector();
-            } else {
+            } else if (STATE(MULTIROTOR)) {
                 // For multirotor - reactivate landing detector without disarm when throttle raised toward hover throttle
                 landingDetectorIsActive = rxGetChannelValue(THROTTLE) < (0.5 * (currentBatteryProfile->nav.mc.hover_throttle + getThrottleIdleValue()));
             }


### PR DESCRIPTION
Closes https://github.com/iNavFlight/inav/issues/10019 and https://github.com/iNavFlight/inav/issues/9759.

Inhibits active Failsafe procedures if landing has been detected by setting Failsafe procedure to NONE.

Change also resets the landing detected flag on fixed wing if flight is redetected before disarm. This prevents a false in flight landing detection being locked in which would inhibit Failsafe for the rest of the flight.

Tested OK on HITL.