### PR TITLE
Multirotor landing G bump detection improvements

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3474,7 +3474,7 @@ Defines at what altitude the descent velocity should start to be `nav_land_minal
 
 ### nav_landing_bump_detection
 
-Allows immediate landing detection based on G bump at touchdown when set to ON. Requires a barometer and currently only works for multirotors.
+Allows immediate landing detection based on G bump at touchdown when set to ON. Requires a barometer and GPS and currently only works for multirotors (Note: will work during Failsafe without need for a GPS).
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2463,7 +2463,7 @@ groups:
         min: 1
         max: 15
       - name: nav_landing_bump_detection
-        description: "Allows immediate landing detection based on G bump at touchdown when set to ON. Requires a barometer and currently only works for multirotors."
+        description: "Allows immediate landing detection based on G bump at touchdown when set to ON. Requires a barometer and GPS and currently only works for multirotors (Note: will work during Failsafe without need for a GPS)."
         default_value: OFF
         field: general.flags.landing_bump_detection
         type: bool

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -802,9 +802,12 @@ bool isMulticopterLandingDetected(void)
     const timeMs_t currentTimeMs = millis();
 
 #if defined(USE_BARO)
-    /* Only allow landing G bump detection when xy velocity is low */
-    if (sensors(SENSOR_BARO) && navConfig()->general.flags.landing_bump_detection && posControl.actualState.velXY < MC_LAND_CHECK_VEL_XY_MOVING) {
-        return isLandingGbumpDetected(currentTimeMs);    // Landing flagged immediately if landing bump detected
+    /* G bump landing detection only active when xy velocity is usable and low */
+    if (sensors(SENSOR_BARO) && navConfig()->general.flags.landing_bump_detection &&
+        posControl.flags.estPosStatus >= EST_USABLE && posControl.actualState.velXY < MC_LAND_CHECK_VEL_XY_MOVING &&
+        isLandingGbumpDetected(currentTimeMs)) { // CR129
+
+        return true;    // Landing flagged immediately if landing bump detected
     }
 #endif
 

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -802,11 +802,12 @@ bool isMulticopterLandingDetected(void)
     const timeMs_t currentTimeMs = millis();
 
 #if defined(USE_BARO)
-    /* G bump landing detection only active when xy velocity is usable and low */
-    if (sensors(SENSOR_BARO) && navConfig()->general.flags.landing_bump_detection &&
-        posControl.flags.estPosStatus >= EST_USABLE && posControl.actualState.velXY < MC_LAND_CHECK_VEL_XY_MOVING &&
-        isLandingGbumpDetected(currentTimeMs)) { // CR129
+    /* G bump landing detection only used when xy velocity is usable and low or failsafe is active */
+    bool gBumpDetectionUsable = navConfig()->general.flags.landing_bump_detection && sensors(SENSOR_BARO) &&
+                                ((posControl.flags.estPosStatus >= EST_USABLE && posControl.actualState.velXY < MC_LAND_CHECK_VEL_XY_MOVING) ||
+                                FLIGHT_MODE(FAILSAFE_MODE));
 
+    if (gBumpDetectionUsable && isLandingGbumpDetected(currentTimeMs)) {
         return true;    // Landing flagged immediately if landing bump detected
     }
 #endif

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -802,8 +802,9 @@ bool isMulticopterLandingDetected(void)
     const timeMs_t currentTimeMs = millis();
 
 #if defined(USE_BARO)
-    if (sensors(SENSOR_BARO) && navConfig()->general.flags.landing_bump_detection && isLandingGbumpDetected(currentTimeMs)) {
-        return true;    // Landing flagged immediately if landing bump detected
+    /* Only allow landing G bump detection when xy velocity is low */
+    if (sensors(SENSOR_BARO) && navConfig()->general.flags.landing_bump_detection && posControl.actualState.velXY < MC_LAND_CHECK_VEL_XY_MOVING) {
+        return isLandingGbumpDetected(currentTimeMs);    // Landing flagged immediately if landing bump detected
     }
 #endif
 


### PR DESCRIPTION
Adds additional speed check for multirotor landing G bump detection to limit detection to low speeds only. Should reduce chances of false detection when flying/manoeuvring at speed. Speed limit doesn't apply when in Failsafe to still allow bump detection to work when there is the possibility of crashing at speed.

Closes https://github.com/iNavFlight/inav/issues/9843.

