### PR TITLE
[crsf] move LAND flight mode into ARMED section

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -354,11 +354,11 @@ static void crsfFrameFlightMode(sbuf_t *dst)
             flightMode = "HOR";
         } else if (FLIGHT_MODE(ANGLEHOLD_MODE)) {
             flightMode = "ANGH";
-        }
 #ifdef USE_FW_AUTOLAND
-    } else if (FLIGHT_MODE(NAV_FW_AUTOLAND)) {
-        flightMode = "LAND";
+        } else if (FLIGHT_MODE(NAV_FW_AUTOLAND)) {
+            flightMode = "LAND";
 #endif
+        }
 #ifdef USE_GPS
     } else if (feature(FEATURE_GPS) && navConfig()->general.flags.extra_arming_safety && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
         flightMode = "WAIT"; // Waiting for GPS lock


### PR DESCRIPTION
The CRSF telemetry flight mode `LAND` was outside of the `ARMED` clause. Move it into the correct place.
