### PR TITLE
LULU filter port to iNav as a single replacement for most filters in iNav, simplifying filter configuration drastically

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -808,7 +808,7 @@ Enable/disable dynamic gyro notch also known as Matrix Filter
 
 | Default | Min | Max |
 | --- | --- | --- |
-| ON | OFF | ON |
+| OFF | OFF | ON |
 
 ---
 
@@ -1698,13 +1698,23 @@ Specifies the type of the software LPF of the gyro signals.
 
 | Default | Min | Max |
 | --- | --- | --- |
-| STATIC |  |  |
+| LULU |  |  |
+
+---
+
+### gyro_lulu_sample_count
+
+Gyro lulu sample count, in number of samples.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 3 |  | 15 |
 
 ---
 
 ### gyro_main_lpf_hz
 
-Software based gyro main lowpass filter. Value is cutoff frequency (Hz)
+Software based gyro main lowpass filter. Value is Hz
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -2198,7 +2208,7 @@ This is the main loop time (in us). Changing this affects PID effect with some P
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 1000 |  | 9000 |
+| 500 |  | 9000 |
 
 ---
 
@@ -5728,7 +5738,7 @@ Enable Kalman filter on the gyro data
 
 | Default | Min | Max |
 | --- | --- | --- |
-| ON | OFF | ON |
+| OFF | OFF | ON |
 
 ---
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1714,7 +1714,7 @@ Gyro lulu sample count, in number of samples.
 
 ### gyro_main_lpf_hz
 
-Software based gyro main lowpass filter. Value is Hz
+Software based gyro main lowpass filter. Value is cutoff frequency (Hz)
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -31,6 +31,8 @@ main_sources(COMMON_SRC
     common/gps_conversion.h
     common/log.c
     common/log.h
+    common/lulu.c
+    common/lulu.h
     common/maths.c
     common/maths.h
     common/memory.c

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -327,7 +327,7 @@ void initFilter(const uint8_t filterType, filter_t *filter, const float cutoffFr
         } if (filterType == FILTER_PT3) {
             pt3FilterInit(&filter->pt3, pt3FilterGain(cutoffFrequency, dT));
         } if (filterType == FILTER_LULU) {
-            pt3FilterInit(&filter->lulu, cutoffFrequency);
+            luluFilterInit(&filter->lulu, cutoffFrequency);
         } else {
             biquadFilterInitLPF(&filter->biquad, cutoffFrequency, refreshRate);
         }

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -23,10 +23,10 @@
 #include "platform.h"
 
 #include "common/filter.h"
+#include "common/lulu.h"
 #include "common/maths.h"
 #include "common/utils.h"
 #include "common/time.h"
-
 // NULL filter
 float nullFilterApply(void *filter, float input)
 {
@@ -326,6 +326,8 @@ void initFilter(const uint8_t filterType, filter_t *filter, const float cutoffFr
             pt2FilterInit(&filter->pt2, pt2FilterGain(cutoffFrequency, dT));
         } if (filterType == FILTER_PT3) {
             pt3FilterInit(&filter->pt3, pt3FilterGain(cutoffFrequency, dT));
+        } if (filterType == FILTER_LULU) {
+            pt3FilterInit(&filter->lulu, cutoffFrequency);
         } else {
             biquadFilterInitLPF(&filter->biquad, cutoffFrequency, refreshRate);
         }
@@ -341,6 +343,8 @@ void assignFilterApplyFn(uint8_t filterType, float cutoffFrequency, filterApplyF
             *applyFn = (filterApplyFnPtr) pt2FilterApply;
         } if (filterType == FILTER_PT3) {
             *applyFn = (filterApplyFnPtr) pt3FilterApply;
+        } if (filterType == FILTER_LULU) {
+            *applyFn = (filterApplyFnPtr) luluFilterApply;
         } else {
             *applyFn = (filterApplyFnPtr) biquadFilterApply;
         }

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "lulu.h"
+
 typedef struct rateLimitFilter_s {
     float state;
 } rateLimitFilter_t;
@@ -50,13 +52,15 @@ typedef union {
     pt1Filter_t pt1;
     pt2Filter_t pt2;
     pt3Filter_t pt3;
+    luluFilter_t lulu;
 } filter_t;
 
 typedef enum {
     FILTER_PT1 = 0,
     FILTER_BIQUAD,
     FILTER_PT2,
-    FILTER_PT3
+    FILTER_PT3,
+    FILTER_LULU
 } filterType_e;
 
 typedef enum {

--- a/src/main/common/lulu.c
+++ b/src/main/common/lulu.c
@@ -18,15 +18,7 @@
 
 void luluFilterInit(luluFilter_t *filter, int N)
 {
-	if (N > 15)
-	{
-		N = 15;
-	}
-	if (N < 1)
-	{
-		N = 1;
-	}
-	filter->N = N;
+	filter->N = constrain(N, 1, 15);
 	filter->windowSize = filter->N * 2 + 1;
 	filter->windowBufIndex = 0;
 

--- a/src/main/common/lulu.c
+++ b/src/main/common/lulu.c
@@ -1,0 +1,186 @@
+#include "lulu.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+
+#include "platform.h"
+
+#include "common/filter.h"
+#include "common/maths.h"
+#include "common/utils.h"
+
+#ifdef __ARM_ACLE
+#include <arm_acle.h>
+#endif /* __ARM_ACLE */
+#include <fenv.h>
+
+void luluFilterInit(luluFilter_t *filter, int N)
+{
+	if (N > 15)
+	{
+		N = 15;
+	}
+	if (N < 1)
+	{
+		N = 1;
+	}
+	filter->N = N;
+	filter->windowSize = filter->N * 2 + 1;
+	filter->windowBufIndex = 0;
+
+	memset(filter->luluInterim, 0, sizeof(float) * (filter->windowSize));
+	memset(filter->luluInterimB, 0, sizeof(float) * (filter->windowSize));
+}
+
+FAST_CODE float fixRoad(float *series, float *seriesB, int index, int filterN, int windowSize)
+{
+	register float curVal = 0;
+	register float curValB = 0;
+	for (int N = 1; N <= filterN; N++)
+	{
+		int indexNeg = (index + windowSize - 2 * N) % windowSize;
+		register int curIndex = (indexNeg + 1) % windowSize;
+		register float prevVal = series[indexNeg];
+		register float prevValB = seriesB[indexNeg];
+		register int indexPos = (curIndex + N) % windowSize;
+		for (int i = windowSize - 2 * N; i < windowSize - N; i++)
+		{
+			if (indexPos >= windowSize)
+			{
+				indexPos = 0;
+			}
+			if (curIndex >= windowSize)
+			{
+				curIndex = 0;
+			}
+			// curIndex = (2 - 1) % 3 = 1
+			curVal = series[curIndex];
+			curValB = seriesB[curIndex];
+			register float nextVal = series[indexPos];
+			register float nextValB = seriesB[indexPos];
+			// onbump (s, 1, 1, 3)
+			// if(onBump(series, curIndex, N, windowSize))
+			if (prevVal < curVal && curVal > nextVal)
+			{
+				float maxValue = MAX(prevVal, nextVal);
+
+				series[curIndex] = maxValue;
+				register int k = curIndex;
+				for (int j = 1; j < N; j++)
+				{
+					if (++k >= windowSize)
+					{
+						k = 0;
+					}
+					series[k] = maxValue;
+				}
+			}
+
+			if (prevValB < curValB && curValB > nextValB)
+			{
+				float maxValue = MAX(prevValB, nextValB);
+
+				curVal = maxValue;
+				seriesB[curIndex] = maxValue;
+				register int k = curIndex;
+				for (int j = 1; j < N; j++)
+				{
+					if (++k >= windowSize)
+					{
+						k = 0;
+					}
+					seriesB[k] = maxValue;
+				}
+			}
+			prevVal = curVal;
+			prevValB = curValB;
+			curIndex++;
+			indexPos++;
+		}
+
+		curIndex = (indexNeg + 1) % windowSize;
+		prevVal = series[indexNeg];
+		prevValB = seriesB[indexNeg];
+		indexPos = (curIndex + N) % windowSize;
+		for (int i = windowSize - 2 * N; i < windowSize - N; i++)
+		{
+			if (indexPos >= windowSize)
+			{
+				indexPos = 0;
+			}
+			if (curIndex >= windowSize)
+			{
+				curIndex = 0;
+			}
+			// curIndex = (2 - 1) % 3 = 1
+			curVal = series[curIndex];
+			curValB = seriesB[curIndex];
+			register float nextVal = series[indexPos];
+			register float nextValB = seriesB[indexPos];
+
+			if (prevVal > curVal && curVal < nextVal)
+			{
+				float minValue = MIN(prevVal, nextVal);
+
+				curVal = minValue;
+				series[curIndex] = minValue;
+				register int k = curIndex;
+				for (int j = 1; j < N; j++)
+				{
+					if (++k >= windowSize)
+					{
+						k = 0;
+					}
+					series[k] = minValue;
+				}
+			}
+
+			if (prevValB > curValB && curValB < nextValB)
+			{
+				float minValue = MIN(prevValB, nextValB);
+				curValB = minValue;
+				seriesB[curIndex] = minValue;
+				register int k = curIndex;
+				for (int j = 1; j < N; j++)
+				{
+					if (++k >= windowSize)
+					{
+						k = 0;
+					}
+					seriesB[k] = minValue;
+				}
+			}
+			prevVal = curVal;
+			prevValB = curValB; 
+			curIndex++;
+			indexPos++;
+		}
+	}
+	return (curVal - curValB) / 2;
+}
+
+FAST_CODE float luluFilterPartialApply(luluFilter_t *filter, float input)
+{
+	// This is the value N of the LULU filter.
+	register int filterN = filter->N;
+	// This is the total window size for the rolling buffer
+	register int filterWindow = filter->windowSize;
+
+	register int windowIndex = filter->windowBufIndex;
+	register float inputVal = input;
+	register int newIndex = (windowIndex + 1) % filterWindow;
+	filter->windowBufIndex = newIndex;
+	filter->luluInterim[windowIndex] = inputVal;
+	filter->luluInterimB[windowIndex] = -inputVal;
+	return fixRoad(filter->luluInterim, filter->luluInterimB, windowIndex, filterN, filterWindow);
+}
+
+FAST_CODE float luluFilterApply(luluFilter_t *filter, float input)
+{
+	// This is the UL filter
+	float resultA = luluFilterPartialApply(filter, input);
+	// We use the median interpretation of this filter to remove bias in the output
+	return resultA;
+}

--- a/src/main/common/lulu.h
+++ b/src/main/common/lulu.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Max N = 15
+typedef struct
+{
+    int windowSize;
+    int windowBufIndex;
+    int N;
+    float luluInterim[32] __attribute__((aligned(128)));
+    float luluInterimB[32];
+} luluFilter_t;
+
+void luluFilterInit(luluFilter_t *filter, int N);
+float luluFilterApply(luluFilter_t *filter, float input);

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -193,13 +193,13 @@ void validateAndFixConfig(void)
 
 #ifdef USE_ADAPTIVE_FILTER
     // gyroConfig()->adaptiveFilterMinHz has to be at least 5 units lower than gyroConfig()->gyro_main_lpf_hz
-    if (gyroConfig()->adaptiveFilterMinHz + 5 > gyroConfig()->gyro_main_lpf_hz) {
-        gyroConfigMutable()->adaptiveFilterMinHz = gyroConfig()->gyro_main_lpf_hz - 5;
-    }
+//    if (gyroConfig()->adaptiveFilterMinHz + 5 > gyroConfig()->gyro_main_lpf_hz) {
+//        gyroConfigMutable()->adaptiveFilterMinHz = gyroConfig()->gyro_main_lpf_hz - 5;
+//    }
     //gyroConfig()->adaptiveFilterMaxHz has to be at least 5 units higher than gyroConfig()->gyro_main_lpf_hz
-    if (gyroConfig()->adaptiveFilterMaxHz - 5 < gyroConfig()->gyro_main_lpf_hz) {
-        gyroConfigMutable()->adaptiveFilterMaxHz = gyroConfig()->gyro_main_lpf_hz + 5;
-    }
+//    if (gyroConfig()->adaptiveFilterMaxHz - 5 < gyroConfig()->gyro_main_lpf_hz) {
+//        gyroConfigMutable()->adaptiveFilterMaxHz = gyroConfig()->gyro_main_lpf_hz + 5;
+//    }
 #endif
 
     if (accelerometerConfig()->acc_notch_cutoff >= accelerometerConfig()->acc_notch_hz) {

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -192,14 +192,14 @@ void validateAndFixConfig(void)
 {
 
 #ifdef USE_ADAPTIVE_FILTER
-    // gyroConfig()->adaptiveFilterMinHz has to be at least 5 units lower than gyroConfig()->gyro_main_lpf_hz
-//    if (gyroConfig()->adaptiveFilterMinHz + 5 > gyroConfig()->gyro_main_lpf_hz) {
-//        gyroConfigMutable()->adaptiveFilterMinHz = gyroConfig()->gyro_main_lpf_hz - 5;
-//    }
+//     gyroConfig()->adaptiveFilterMinHz has to be at least 5 units lower than gyroConfig()->gyro_main_lpf_hz
+     if (gyroConfig()->adaptiveFilterMinHz + 5 > gyroConfig()->gyro_main_lpf_hz) {
+        gyroConfigMutable()->adaptiveFilterMinHz = gyroConfig()->gyro_main_lpf_hz - 5;
+    }
     //gyroConfig()->adaptiveFilterMaxHz has to be at least 5 units higher than gyroConfig()->gyro_main_lpf_hz
-//    if (gyroConfig()->adaptiveFilterMaxHz - 5 < gyroConfig()->gyro_main_lpf_hz) {
-//        gyroConfigMutable()->adaptiveFilterMaxHz = gyroConfig()->gyro_main_lpf_hz + 5;
-//    }
+    if (gyroConfig()->adaptiveFilterMaxHz - 5 < gyroConfig()->gyro_main_lpf_hz) {
+        gyroConfigMutable()->adaptiveFilterMaxHz = gyroConfig()->gyro_main_lpf_hz + 5;
+    }
 #endif
 
     if (accelerometerConfig()->acc_notch_cutoff >= accelerometerConfig()->acc_notch_hz) {

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -119,7 +119,7 @@ tables:
   - name: filter_type
     values: ["PT1", "BIQUAD"]
   - name: filter_type_full
-    values: ["PT1", "BIQUAD", "PT2", "PT3"]
+    values: ["PT1", "BIQUAD", "PT2", "PT3", "LULU"]
   - name: log_level
     values: ["ERROR", "WARNING", "INFO", "VERBOSE", "DEBUG"]
   - name: iterm_relax
@@ -219,13 +219,13 @@ groups:
         default_value: 1000
         max: 9000
       - name: gyro_anti_aliasing_lpf_hz
-        description: "Gyro processing anti-aliasing filter cutoff frequency. In normal operation this filter setting should never be changed. In Hz"
-        default_value: 250
+        description: "Gyro processing anti-aliasing filter cutoff frequency. In normal operation this filter setting should never be changed. In samples"
+        default_value: 1
         field: gyro_anti_aliasing_lpf_hz
         max: 1000
       - name: gyro_main_lpf_hz
-        description: "Software based gyro main lowpass filter. Value is cutoff frequency (Hz)"
-        default_value: 60
+        description: "Software based gyro main lowpass filter. Value is samples"
+        default_value: 3
         field: gyro_main_lpf_hz
         min: 0
         max: 500
@@ -254,7 +254,7 @@ groups:
         max: 10
       - name: dynamic_gyro_notch_enabled
         description: "Enable/disable dynamic gyro notch also known as Matrix Filter"
-        default_value: ON
+        default_value: OFF
         field: dynamicGyroNotchEnabled
         condition: USE_DYNAMIC_FILTERS
         type: bool
@@ -293,7 +293,7 @@ groups:
         default_value: 0
       - name: setpoint_kalman_enabled
         description: "Enable Kalman filter on the gyro data"
-        default_value: ON
+        default_value: OFF
         condition: USE_GYRO_KALMAN
         field: kalmanEnabled
         type: bool

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -229,7 +229,7 @@ groups:
         field: gyroLuluSampleCount
         max: 15
       - name: gyro_main_lpf_hz
-        description: "Software based gyro main lowpass filter. Value is Hz"
+        description: "Software based gyro main lowpass filter. Value is cutoff frequency (Hz)"
         default_value: 60
         field: gyro_main_lpf_hz
         min: 0

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -192,7 +192,7 @@ tables:
     values: ["SHARED_LOW", "SHARED_HIGH", "LOW", "HIGH"]
     enum: led_pin_pwm_mode_e
   - name: gyro_filter_mode
-    values: ["STATIC", "DYNAMIC", "ADAPTIVE"]
+    values: ["STATIC", "DYNAMIC", "ADAPTIVE", "LULU"]
     enum: gyroFilterType_e
 
 constants:
@@ -216,22 +216,27 @@ groups:
     members:
       - name: looptime
         description: "This is the main loop time (in us). Changing this affects PID effect with some PID controllers (see PID section for details). A very conservative value of 3500us/285Hz should work for everyone. Setting it to zero does not limit loop time, so it will go as fast as possible."
-        default_value: 1000
+        default_value: 500
         max: 9000
       - name: gyro_anti_aliasing_lpf_hz
-        description: "Gyro processing anti-aliasing filter cutoff frequency. In normal operation this filter setting should never be changed. In samples"
-        default_value: 1
+        description: "Gyro processing anti-aliasing filter cutoff frequency. In normal operation this filter setting should never be changed. In Hz"
+        default_value: 250
         field: gyro_anti_aliasing_lpf_hz
         max: 1000
-      - name: gyro_main_lpf_hz
-        description: "Software based gyro main lowpass filter. Value is samples"
+      - name: gyro_lulu_sample_count
+        description: "Gyro lulu sample count, in number of samples."
         default_value: 3
+        field: gyroLuluSampleCount
+        max: 15
+      - name: gyro_main_lpf_hz
+        description: "Software based gyro main lowpass filter. Value is Hz"
+        default_value: 60
         field: gyro_main_lpf_hz
         min: 0
         max: 500
       - name: gyro_filter_mode
         description: "Specifies the type of the software LPF of the gyro signals."
-        default_value: "STATIC"
+        default_value: "LULU"
         field: gyroFilterMode
         table: gyro_filter_mode
       - name: gyro_dyn_lpf_min_hz

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -244,9 +244,10 @@ static void initGyroFilter(filterApplyFnPtr *applyFn, filter_t state[], uint16_t
 {
     *applyFn = nullFilterApply;
     if (cutoff > 0) {
-        *applyFn = (filterApplyFnPtr)pt1FilterApply;
+        *applyFn = (filterApplyFnPtr)luluFilterApply;
         for (int axis = 0; axis < 3; axis++) {
-            pt1FilterInit(&state[axis].pt1, cutoff, US2S(looptime));
+//            pt1FilterInit(&state[axis].pt1, cutoff, US2S(looptime));
+            luluFilterInit(&state[axis].lulu, cutoff);
         }
     }
 }

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -55,7 +55,8 @@ typedef enum {
 typedef enum {
     GYRO_FILTER_MODE_STATIC = 0,
     GYRO_FILTER_MODE_DYNAMIC = 1,
-    GYRO_FILTER_MODE_ADAPTIVE = 2
+    GYRO_FILTER_MODE_ADAPTIVE = 2,
+    GYRO_FILTER_MODE_LULU = 3
 } gyroFilterMode_e;
 
 typedef struct gyro_s {
@@ -102,6 +103,8 @@ typedef struct gyroConfig_s {
     float adaptiveFilterIntegratorThresholdLow;
 #endif
     uint8_t gyroFilterMode;
+
+    uint8_t gyroLuluSampleCount;
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);

--- a/src/main/target/BETAFPVF411/target.h
+++ b/src/main/target/BETAFPVF411/target.h
@@ -71,7 +71,7 @@
 // *************** SPI FLASH **************************
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
-#define M25P16_CS_PIN           PA0
+#define M25P16_CS_PIN           PB2
 #define M25P16_SPI_BUS          BUS_SPI2
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 

--- a/src/main/target/BETAFPVF411/target.h
+++ b/src/main/target/BETAFPVF411/target.h
@@ -71,7 +71,7 @@
 // *************** SPI FLASH **************************
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
-#define M25P16_CS_PIN           PB2
+#define M25P16_CS_PIN           PA0
 #define M25P16_SPI_BUS          BUS_SPI2
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 


### PR DESCRIPTION
I implemented a new type of filter based on the LULU filter by C.H. Rohwer, a mathematician at a local university.  Refer to this wikipedia entry for details on the maths: https://en.wikipedia.org/wiki/Lulu_smoothing

It took real time to optimize this to run effectively.

I would really appreciate if anyone could verify if this works OK on more craft?  I'm on Discord if anyone has questions about it.  I've tested a local betaflight port on multiple craft and it seems to work nicely with really low delay, and now ported to iNav I hope that it will simplify filtering.

I’ve ported this to Inav and I have found the following:
As a single filter, it’s easy enough to set the filter type to LULU for the gyro and gyro antialiasing filters, while disabling all other filtering.
Recommended starting point: Set **looptime to 500**hz, set **anti-aliasing lpf to 1**, set **gyro main filter lpf to 3**, set **dterm lpf to static 120hz pt1**, **rpmfilter on one harmonic** and **disable all dynamic filtering**.

This will cause any spikes and pits that are more than 3 samples wide to disappear.  For oscillating-type noise, like is to be expected from a gyroscope, this means that any sinusoid top or bottom half will be simply snipped off, keeping only the approximate middle value of the sinusoid after filtering.

The gyro lpf is now not measured in hz, but samples, as is the antialiasing lpf.  More samples = more filtering but more delay.
Using the lulu on dterm seems to be a mess as the lulu on gyrofilter causes spikes on it, so recommended to use lulu on gyro only.
I've attached a flight log of a really bad frame 40mm whoop.

The bottom line is the smoother knocks out spiky noise in full, by the amount of samples specified by the “lowpass hz” for the implementation. For example, if you set the “gyro lowpass hz” to 4, and you set the filter to LULU in CLI, you will find that any spike or dip in signal for 4 samples or less will disappear.

The LULU filter is a really low latency filter and you’ll see that if you set the sample number to 3 for the gyro LPF and the antialiasing filter samples to 1, it should work in many cases. 

Below is a 40mm toothpick with a terrible frame and construction on inav running LULU at 1 sample antialiasing filter and 3 samples gyro LPF.

[blackbox_log_2024-06-17_122915.TXT](https://github.com/user-attachments/files/15865765/blackbox_log_2024-06-17_122915.TXT)
![image](https://github.com/iNavFlight/inav/assets/25793978/4d0a1b56-713f-42a4-ad22-2ac324f51f3c)

If you look closely, you’ll see the gyro filter has some sudden changes in slope.  This is unfortunately a reality of the dterm as a sinusoidal type noise filtered by LULU causes sudden jumps in the gyro value.

To mitigate the problems caused by the spiky dterm, we set a single gyro lowpass filter when needed.  Rigid frames have less of an issue than this terrible ABS plastic frame, but I’ve found for rigid carbon fibre frames it can be run with a very high Hz PT1, while for frames like this 40mm one it works better with a 120Hz PT1.  This removes the spiky noise and smoothes it out nicely.

On the example above, there is no other filtering done except the LULU and a 120Hz PT1, and one harmonic RPMfilter.   I have disabled all dynamic filters on this whoop as well.

Config dump attached for this specific craft for completion's sake
[INAV_8.0.0_cli_20240617_123346.txt](https://github.com/user-attachments/files/15865784/INAV_8.0.0_cli_20240617_123346.txt)

