### PR TITLE
Further serial gimbal/headtracker improvements

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1472,6 +1472,16 @@ Gimbal pan rc channel index. 0 is no channel.
 
 ---
 
+### gimbal_pan_trim
+
+Trim gimbal pan center position.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | -500 | 500 |
+
+---
+
 ### gimbal_roll_channel
 
 Gimbal roll rc channel index. 0 is no channel.
@@ -1479,6 +1489,16 @@ Gimbal roll rc channel index. 0 is no channel.
 | Default | Min | Max |
 | --- | --- | --- |
 | 0 | 0 | 32 |
+
+---
+
+### gimbal_roll_trim
+
+Trim gimbal roll center position.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | -500 | 500 |
 
 ---
 
@@ -1509,6 +1529,16 @@ Gimbal tilt rc channel index. 0 is no channel.
 | Default | Min | Max |
 | --- | --- | --- |
 | 0 | 0 | 32 |
+
+---
+
+### gimbal_tilt_trim
+
+Trim gimbal tilt center position.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | -500 | 500 |
 
 ---
 

--- a/src/main/common/log.c
+++ b/src/main/common/log.c
@@ -20,11 +20,12 @@
 #include <stdarg.h>
 #include <ctype.h>
 
-#if defined(SEMIHOSTING)
+#if defined(SEMIHOSTING) || defined(SITL_BUILD)
 #include <stdio.h>
 #endif
 
 #include "build/version.h"
+#include "build/debug.h"
 
 #include "drivers/serial.h"
 #include "drivers/time.h"
@@ -125,6 +126,7 @@ static void logPrint(const char *buf, size_t size)
         fputc(buf[ii], stdout);
     }
 #endif
+    SD(printf("%s\n", buf));
     if (logPort) {
         // Send data via UART (if configured & connected - a safeguard against zombie VCP)
         if (serialIsConnected(logPort)) {

--- a/src/main/drivers/gimbal_common.c
+++ b/src/main/drivers/gimbal_common.c
@@ -32,9 +32,20 @@
 
 #include "drivers/gimbal_common.h"
 
+#include "settings_generated.h"
 
-PG_REGISTER(gimbalConfig_t, gimbalConfig, PG_GIMBAL_CONFIG, 0);
 
+PG_REGISTER_WITH_RESET_TEMPLATE(gimbalConfig_t, gimbalConfig, PG_GIMBAL_CONFIG, 1);
+
+PG_RESET_TEMPLATE(gimbalConfig_t, gimbalConfig, 
+    .panChannel = SETTING_GIMBAL_PAN_CHANNEL_DEFAULT,
+    .tiltChannel = SETTING_GIMBAL_TILT_CHANNEL_DEFAULT,
+    .rollChannel = SETTING_GIMBAL_ROLL_CHANNEL_DEFAULT,
+    .sensitivity = SETTING_GIMBAL_SENSITIVITY_DEFAULT,
+    .panTrim = SETTING_GIMBAL_PAN_TRIM_DEFAULT,
+    .tiltTrim = SETTING_GIMBAL_TILT_TRIM_DEFAULT,
+    .rollTrim = SETTING_GIMBAL_ROLL_TRIM_DEFAULT
+);
 
 static gimbalDevice_t *commonGimbalDevice = NULL;
 

--- a/src/main/drivers/gimbal_common.c
+++ b/src/main/drivers/gimbal_common.c
@@ -133,7 +133,7 @@ int16_t gimbalCommonGetPanPwm(const gimbalDevice_t *gimbalDevice)
         return gimbalDevice->vTable->getGimbalPanPWM(gimbalDevice);
     }
 
-    return gimbalDevice ? gimbalDevice->currentPanPWM : PWM_RANGE_MIDDLE;
+    return gimbalDevice ? gimbalDevice->currentPanPWM : PWM_RANGE_MIDDLE + gimbalConfig()->panTrim;
 }
 
 #endif

--- a/src/main/drivers/gimbal_common.c
+++ b/src/main/drivers/gimbal_common.c
@@ -31,6 +31,7 @@
 #include "fc/cli.h"
 
 #include "drivers/gimbal_common.h"
+#include "rx/rx.h"
 
 #include "settings_generated.h"
 
@@ -123,6 +124,16 @@ bool gimbalCommonHtrkIsEnabled(void)
     }
 
     return false;
+}
+
+
+int16_t gimbalCommonGetPanPwm(const gimbalDevice_t *gimbalDevice)
+{
+    if (gimbalDevice && gimbalDevice->vTable->getGimbalPanPWM) {
+        return gimbalDevice->vTable->getGimbalPanPWM(gimbalDevice);
+    }
+
+    return gimbalDevice ? gimbalDevice->currentPanPWM : PWM_RANGE_MIDDLE;
 }
 
 #endif

--- a/src/main/drivers/gimbal_common.h
+++ b/src/main/drivers/gimbal_common.h
@@ -60,6 +60,9 @@ typedef struct gimbalConfig_s {
     uint8_t tiltChannel;
     uint8_t rollChannel;
     uint8_t sensitivity;
+    uint16_t panTrim;
+    uint16_t tiltTrim;
+    uint16_t rollTrim;
 } gimbalConfig_t;
 
 PG_DECLARE(gimbalConfig_t, gimbalConfig);

--- a/src/main/drivers/gimbal_common.h
+++ b/src/main/drivers/gimbal_common.h
@@ -41,6 +41,7 @@ struct gimbalVTable_s;
 
 typedef struct gimbalDevice_s {
     const struct gimbalVTable_s *vTable;
+    int16_t currentPanPWM;
 } gimbalDevice_t;
 
 // {set,get}BandAndChannel: band and channel are 1 origin
@@ -52,6 +53,7 @@ typedef struct gimbalVTable_s {
     gimbalDevType_e (*getDeviceType)(const gimbalDevice_t *gimbalDevice);
     bool (*isReady)(const gimbalDevice_t *gimbalDevice);
     bool (*hasHeadTracker)(const gimbalDevice_t *gimbalDevice);
+    int16_t (*getGimbalPanPWM)(const gimbalDevice_t *gimbalDevice);
 } gimbalVTable_t;
 
 
@@ -92,6 +94,8 @@ void taskUpdateGimbal(timeUs_t currentTimeUs);
 
 bool gimbalCommonIsEnabled(void);
 bool gimbalCommonHtrkIsEnabled(void);
+
+int16_t gimbalCommonGetPanPwm(const gimbalDevice_t *gimbalDevice);
 
 #ifdef __cplusplus
 }

--- a/src/main/drivers/headtracker_common.h
+++ b/src/main/drivers/headtracker_common.h
@@ -19,6 +19,10 @@
 
 #include "platform.h"
 
+#define MAX_HEADTRACKER_DATA_AGE_US HZ2US(25)
+#define HEADTRACKER_RANGE_MIN   -2048
+#define HEADTRACKER_RANGE_MAX   2047
+
 #ifdef USE_HEADTRACKER
 
 #include <stdint.h>
@@ -29,9 +33,6 @@
 
 #include "config/feature.h"
 
-#define MAX_HEADTRACKER_DATA_AGE_US HZ2US(25)
-#define HEADTRACKER_RANGE_MIN   -2048
-#define HEADTRACKER_RANGE_MAX   2047
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -4230,6 +4230,24 @@ groups:
         field: sensitivity
         min: -16
         max: 15
+      - name: gimbal_pan_trim
+        field: panTrim
+        description: "Trim gimbal pan center position."
+        default_value: 0
+        min: -500
+        max: 500
+      - name: gimbal_tilt_trim
+        field: tiltTrim
+        description: "Trim gimbal tilt center position."
+        default_value: 0
+        min: -500
+        max: 500
+      - name: gimbal_roll_trim
+        field: rollTrim
+        description: "Trim gimbal roll center position."
+        default_value: 0
+        min: -500
+        max: 500
   - name: PG_GIMBAL_SERIAL_CONFIG
     type: gimbalSerialConfig_t
     headers: ["io/gimbal_serial.h"]

--- a/src/main/io/gimbal_serial.c
+++ b/src/main/io/gimbal_serial.c
@@ -213,17 +213,17 @@ void gimbalSerialProcess(gimbalDevice_t *gimbalDevice, timeUs_t currentTime)
     
     if (rxAreFlightChannelsValid() && !IS_RC_MODE_ACTIVE(BOXGIMBALCENTER)) {
         if (cfg->panChannel > 0) {
-            panPWM = rxGetChannelValue(cfg->panChannel - 1);
+            panPWM = rxGetChannelValue(cfg->panChannel - 1) + cfg->panTrim;
             panPWM = constrain(panPWM, PWM_RANGE_MIN, PWM_RANGE_MAX);
         }
 
         if (cfg->tiltChannel > 0) {
-            tiltPWM = rxGetChannelValue(cfg->tiltChannel - 1);
+            tiltPWM = rxGetChannelValue(cfg->tiltChannel - 1) + cfg->tiltTrim;
             tiltPWM = constrain(tiltPWM, PWM_RANGE_MIN, PWM_RANGE_MAX);
         }
 
         if (cfg->rollChannel > 0) {
-            rollPWM = rxGetChannelValue(cfg->rollChannel - 1);
+            rollPWM = rxGetChannelValue(cfg->rollChannel - 1) + cfg->rollTrim;
             rollPWM = constrain(rollPWM, PWM_RANGE_MIN, PWM_RANGE_MAX);
         }
     }

--- a/src/main/io/gimbal_serial.c
+++ b/src/main/io/gimbal_serial.c
@@ -60,6 +60,7 @@ static volatile uint8_t txBuffer[GIMBAL_SERIAL_BUFFER_SIZE];
 #if defined(USE_HEADTRACKER) && defined(USE_HEADTRACKER_SERIAL)
 static gimbalSerialHtrkState_t headTrackerState = { 
     .payloadSize = 0,
+    .attitude = {},
     .state = WAITING_HDR1,
 };
 #endif
@@ -189,7 +190,10 @@ void gimbalSerialProcess(gimbalDevice_t *gimbalDevice, timeUs_t currentTime)
 
     gimbalHtkAttitudePkt_t attitude = {
         .sync = {HTKATTITUDE_SYNC0, HTKATTITUDE_SYNC1},
-        .mode = GIMBAL_MODE_DEFAULT
+        .mode = GIMBAL_MODE_DEFAULT,
+        .pan = 0,
+        .tilt = 0,
+        .roll = 0
     };
 
     const gimbalConfig_t *cfg = gimbalConfig();
@@ -238,9 +242,9 @@ void gimbalSerialProcess(gimbalDevice_t *gimbalDevice, timeUs_t currentTime)
 
             DEBUG_SET(DEBUG_HEADTRACKING, 4, 1);
         } else {
-            attitude.pan = constrain(gimbal_scale12(PWM_RANGE_MIN, PWM_RANGE_MAX, PWM_RANGE_MIDDLE + cfg->panTrim), PWM_RANGE_MIN, PWM_RANGE_MAX);
-            attitude.tilt = constrain(gimbal_scale12(PWM_RANGE_MIN, PWM_RANGE_MAX, PWM_RANGE_MIDDLE + cfg->tiltTrim), PWM_RANGE_MIN, PWM_RANGE_MAX);
-            attitude.roll = constrain(gimbal_scale12(PWM_RANGE_MIN, PWM_RANGE_MAX, PWM_RANGE_MIDDLE + cfg->rollTrim), PWM_RANGE_MIN, PWM_RANGE_MAX);
+            attitude.pan = constrain(gimbal_scale12(PWM_RANGE_MIN, PWM_RANGE_MAX, PWM_RANGE_MIDDLE + cfg->panTrim), HEADTRACKER_RANGE_MIN, HEADTRACKER_RANGE_MAX);
+            attitude.tilt = constrain(gimbal_scale12(PWM_RANGE_MIN, PWM_RANGE_MAX, PWM_RANGE_MIDDLE + cfg->tiltTrim), HEADTRACKER_RANGE_MIN, HEADTRACKER_RANGE_MAX);
+            attitude.roll = constrain(gimbal_scale12(PWM_RANGE_MIN, PWM_RANGE_MAX, PWM_RANGE_MIDDLE + cfg->rollTrim), HEADTRACKER_RANGE_MIN, HEADTRACKER_RANGE_MAX);
             DEBUG_SET(DEBUG_HEADTRACKING, 4, -1);
         }
     } else {

--- a/src/main/io/gimbal_serial.c
+++ b/src/main/io/gimbal_serial.c
@@ -193,9 +193,9 @@ void gimbalSerialProcess(gimbalDevice_t *gimbalDevice, timeUs_t currentTime)
 
     const gimbalConfig_t *cfg = gimbalConfig();
 
-    int pan = PWM_RANGE_MIDDLE;
-    int tilt = PWM_RANGE_MIDDLE;
-    int roll = PWM_RANGE_MIDDLE;
+    int pan = PWM_RANGE_MIDDLE + cfg->panTrim;
+    int tilt = PWM_RANGE_MIDDLE + cfg->tiltTrim;
+    int roll = PWM_RANGE_MIDDLE + cfg->rollTrim;
 
     if (IS_RC_MODE_ACTIVE(BOXGIMBALTLOCK)) {
         attitude.mode |= GIMBAL_MODE_TILT_LOCK;

--- a/src/main/io/gimbal_serial.h
+++ b/src/main/io/gimbal_serial.h
@@ -70,8 +70,9 @@ typedef struct gimbalSerialConfig_s {
 
 PG_DECLARE(gimbalSerialConfig_t, gimbalSerialConfig);
 
-
 int16_t gimbal_scale12(int16_t inputMin, int16_t inputMax, int16_t value);
+
+int16_t gimbal2pwm(int16_t value);
 
 bool gimbalSerialInit(void);
 bool gimbalSerialDetect(void);

--- a/src/main/io/headtracker_msp.c
+++ b/src/main/io/headtracker_msp.c
@@ -30,18 +30,6 @@
 
 #include "io/headtracker_msp.h"
 
-/*
-typedef struct headTrackerVTable_s {
-    void (*process)(headTrackerDevice_t *headTrackerDevice, timeUs_t currentTimeUs);
-    headTrackerDevType_e (*getDeviceType)(const headTrackerDevice_t *headTrackerDevice);
-    bool (*isReady)(const headTrackerDevice_t *headTrackerDevice);
-    bool (*isValid)(const headTrackerDevice_t *headTrackerDevice);
-    int (*getPanPWM)(const headTrackerDevice_t *headTrackerDevice);
-    int (*getTiltPWM)(const headTrackerDevice_t *headTrackerDevice);
-    int (*getRollPWM)(const headTrackerDevice_t *headTrackerDevice);
-} headtrackerVTable_t;
-*/
-
 static headTrackerVTable_t headTrackerMspVTable = {
     .process = NULL,
     .getDeviceType = heatTrackerMspGetDeviceType,
@@ -77,9 +65,6 @@ void mspHeadTrackerReceiverNewData(uint8_t *data, int dataSize)
     headTrackerMspDevice.tilt = constrain(status->tilt, HEADTRACKER_RANGE_MIN, HEADTRACKER_RANGE_MAX);
     headTrackerMspDevice.roll = constrain(status->roll, HEADTRACKER_RANGE_MIN, HEADTRACKER_RANGE_MAX);
     headTrackerMspDevice.expires = micros() + MAX_HEADTRACKER_DATA_AGE_US;
-
-    SD(fprintf(stderr, "[headTracker]: pan: %d tilt: %d roll: %d\n", status->pan, status->tilt, status->roll));
-    SD(fprintf(stderr, "[headTracker]: scaled pan: %d tilt: %d roll: %d\n", headTrackerMspDevice.pan, headTrackerMspDevice.tilt, headTrackerMspDevice.roll));
 
     UNUSED(status);
 }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1210,7 +1210,7 @@ int16_t osdGetPanServoOffset(void)
     gimbalDevice_t *dev = gimbalCommonDevice();
     if (dev && gimbalCommonIsReady(dev)) {
         servoPosition = gimbalCommonGetPanPwm(dev);
-        servoMiddle = PWM_RANGE_MIDDLE;
+        servoMiddle = PWM_RANGE_MIDDLE + gimbalConfig()->panTrim;
     }
 
     return (int16_t)CENTIDEGREES_TO_DEGREES((servoPosition - servoMiddle) * osdConfig()->pan_servo_pwm2centideg);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -62,6 +62,7 @@
 #include "drivers/osd_symbols.h"
 #include "drivers/time.h"
 #include "drivers/vtx_common.h"
+#include "drivers/gimbal_common.h"
 
 #include "io/adsb.h"
 #include "io/flashfs.h"
@@ -1203,8 +1204,15 @@ int16_t osdGetHeading(void)
 int16_t osdGetPanServoOffset(void)
 {
     int8_t servoIndex = osdConfig()->pan_servo_index;
-    int16_t servoPosition = servo[servoIndex];
     int16_t servoMiddle = servoParams(servoIndex)->middle;
+    int16_t servoPosition = servo[servoIndex];
+
+    gimbalDevice_t *dev = gimbalCommonDevice();
+    if (dev && gimbalCommonIsReady(dev)) {
+        servoPosition = gimbalCommonGetPanPwm(dev);
+        servoMiddle = PWM_RANGE_MIDDLE;
+    }
+
     return (int16_t)CENTIDEGREES_TO_DEGREES((servoPosition - servoMiddle) * osdConfig()->pan_servo_pwm2centideg);
 }
 

--- a/src/test/unit/gimbal_serial_unittest.cc
+++ b/src/test/unit/gimbal_serial_unittest.cc
@@ -24,6 +24,7 @@
 #include "unittest_macros.h"
 
 #include "io/gimbal_serial.h"
+#include "drivers/headtracker_common.h"
 
 void dumpMemory(uint8_t *mem, int size)
 {


### PR DESCRIPTION
A follow up to #10109, for further improvement.

* [x] Add trim to gimbal to allow Uptilt on quad setups. This only applies to locked center mode.
```
set gimbal_pan_trim = 0
set gimbal_tilt_trim = 0
set gimbal_roll_trim = 0
```

* [x] Integrate with OSD pan compensation