### PR TITLE
[FIX] BMI088 driver: get BMI088 acc aligned

### DIFF
--- a/src/main/drivers/accgyro/accgyro_bmi088.c
+++ b/src/main/drivers/accgyro/accgyro_bmi088.c
@@ -214,6 +214,7 @@ bool bmi088AccDetect(accDev_t *acc)
 
     acc->initFn = bmi088AccInit;
     acc->readFn = bmi088AccRead;
+    acc->accAlign = acc->busDev->param;
 
     return true;
 }


### PR DESCRIPTION
A minor bug causes the BMI088 to not quickly return to the correct posture. Checked the driver and got acc aligned to fix it. Tested it well in my FC board.