### PR TITLE
Add new targets: MicoAir405Mini, MicoAir405v2 and MicoAir743

### DIFF
--- a/src/main/target/MICOAIR405MINI/CMakeLists.txt
+++ b/src/main/target/MICOAIR405MINI/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f405xg(MICOAIR405MINI)

--- a/src/main/target/MICOAIR405MINI/config.c
+++ b/src/main/target/MICOAIR405MINI/config.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include "platform.h"
+#include "config/config_master.h"
+#include "config/feature.h"
+#include "io/serial.h"
+#include "fc/config.h"
+#include "sensors/gyro.h"
+
+
+void targetConfiguration(void)
+{
+    serialConfigMutable()->portConfigs[1].functionMask = FUNCTION_MSP;
+    serialConfigMutable()->portConfigs[1].msp_baudrateIndex = BAUD_57600;
+    serialConfigMutable()->portConfigs[2].functionMask = FUNCTION_MSP_OSD;
+    serialConfigMutable()->portConfigs[3].functionMask = FUNCTION_GPS;
+    serialConfigMutable()->portConfigs[5].functionMask = FUNCTION_ESCSERIAL;
+}

--- a/src/main/target/MICOAIR405MINI/target.c
+++ b/src/main/target/MICOAIR405MINI/target.c
@@ -1,0 +1,36 @@
+/*
+* This file is part of Cleanflight.
+*
+* Cleanflight is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Cleanflight is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_OUTPUT_AUTO, 0, 0), // S1
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_OUTPUT_AUTO, 0, 0), // S2
+    DEF_TIM(TIM2,  CH1, PA15, TIM_USE_OUTPUT_AUTO, 0, 0), // S3
+    DEF_TIM(TIM2,  CH2, PB3,  TIM_USE_OUTPUT_AUTO, 0, 0), // S4
+    DEF_TIM(TIM3,  CH1, PB4,  TIM_USE_OUTPUT_AUTO, 0, 0), // S5
+    DEF_TIM(TIM3,  CH2, PB5,  TIM_USE_OUTPUT_AUTO, 0, 0), // S6
+    DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_OUTPUT_AUTO, 0, 0), // S7
+    DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_OUTPUT_AUTO, 0, 0), // S8
+    DEF_TIM(TIM12, CH1, PB14, TIM_USE_OUTPUT_AUTO, 0, 0), // S9
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/MICOAIR405MINI/target.h
+++ b/src/main/target/MICOAIR405MINI/target.h
@@ -1,0 +1,142 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "MINI"
+
+#define USBD_PRODUCT_STRING  "MICOAIR405MINI"
+
+// *************** LED **********************
+#define LED0                    PC5
+#define LED1                    PC4
+#define LED2                    PA8
+
+// *************** SPI: Gyro & ACC & BARO & OSD & SDCARD **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define USE_SPI_DEVICE_2
+#define USE_SPI_DEVICE_3
+
+#define SPI1_SCK_PIN        PA5
+#define SPI1_MISO_PIN   	PA6
+#define SPI1_MOSI_PIN   	PA7
+
+#define SPI2_SCK_PIN        PB13
+#define SPI2_MISO_PIN   	PC2
+#define SPI2_MOSI_PIN   	PC3
+
+#define SPI3_SCK_PIN        PC10
+#define SPI3_MISO_PIN       PC11
+#define SPI3_MOSI_PIN       PC12
+
+#define USE_IMU_BMI270
+#define IMU_BMI270_ALIGN        CW0_DEG
+#define BMI270_SPI_BUS          BUS_SPI2
+#define BMI270_CS_PIN           PC14
+
+#define USE_BARO
+#define USE_BARO_DPS310
+#define DPS310_SPI_BUS           BUS_SPI2
+#define DPS310_CS_PIN            PC13
+
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI1
+#define MAX7456_CS_PIN          PB12
+
+#define USE_BLACKBOX
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+#define SDCARD_SPI_BUS          BUS_SPI3
+#define SDCARD_CS_PIN           PC9
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART5
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN            NONE
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6 
+#define INVERTER_PIN_UART6_RX   PC15
+
+#define SERIAL_PORT_COUNT       7      //VCP, UART1, UART2, UART3, UART4, UART5, UART6
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART6
+#define USE_UART_INVERTER
+
+// *************** I2C ****************************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+#define DEFAULT_I2C_BUS         BUS_I2C1
+
+#define USE_MAG
+#define MAG_I2C_BUS             DEFAULT_I2C_BUS
+#define USE_MAG_ALL
+
+// *************** ENABLE OPTICAL FLOW & RANGEFINDER *****************************
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_MSP
+#define USE_OPFLOW
+#define USE_OPFLOW_MSP
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC0
+#define ADC_CHANNEL_2_PIN           PC1
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define VBAT_SCALE_DEFAULT          2121
+#define CURRENT_METER_SCALE         402
+
+#define DEFAULT_FEATURES        (FEATURE_VBAT | FEATURE_CURRENT_METER | FEATURE_OSD | FEATURE_TELEMETRY)
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define MAX_PWM_OUTPUT_PORTS       9

--- a/src/main/target/MICOAIR405V2/CMakeLists.txt
+++ b/src/main/target/MICOAIR405V2/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f405xg(MICOAIR405V2)

--- a/src/main/target/MICOAIR405V2/config.c
+++ b/src/main/target/MICOAIR405V2/config.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include "platform.h"
+#include "config/config_master.h"
+#include "config/feature.h"
+#include "io/serial.h"
+#include "fc/config.h"
+#include "sensors/gyro.h"
+
+
+void targetConfiguration(void)
+{
+    serialConfigMutable()->portConfigs[1].functionMask = FUNCTION_MSP;
+    serialConfigMutable()->portConfigs[1].msp_baudrateIndex = BAUD_57600;
+    serialConfigMutable()->portConfigs[2].functionMask = FUNCTION_MSP_OSD;
+    serialConfigMutable()->portConfigs[3].functionMask = FUNCTION_GPS;
+    serialConfigMutable()->portConfigs[5].functionMask = FUNCTION_ESCSERIAL;
+}

--- a/src/main/target/MICOAIR405V2/target.c
+++ b/src/main/target/MICOAIR405V2/target.c
@@ -1,0 +1,37 @@
+/*
+* This file is part of Cleanflight.
+*
+* Cleanflight is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Cleanflight is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_OUTPUT_AUTO, 0, 0), // S1  D(1,7)
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_OUTPUT_AUTO, 0, 0), // S2  D(1,2)
+    DEF_TIM(TIM2,  CH1, PA15, TIM_USE_OUTPUT_AUTO, 0, 0), // S3  -D(1,5)
+    DEF_TIM(TIM2,  CH2, PB3,  TIM_USE_OUTPUT_AUTO, 0, 0), // S4  D(1,6)
+    DEF_TIM(TIM3,  CH1, PB4,  TIM_USE_OUTPUT_AUTO, 0, 0), // S5  D(1,4)
+    DEF_TIM(TIM3,  CH2, PB5,  TIM_USE_OUTPUT_AUTO, 0, 0), // S6  -D(1,5)
+    DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_OUTPUT_AUTO, 0, 0), // S7
+    DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_OUTPUT_AUTO, 0, 0), // S8
+    DEF_TIM(TIM12, CH1, PB14, TIM_USE_OUTPUT_AUTO, 0, 0), // S9
+    DEF_TIM(TIM12, CH2, PB15, TIM_USE_OUTPUT_AUTO, 0, 0), // S10
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/MICOAIR405V2/target.h
+++ b/src/main/target/MICOAIR405V2/target.h
@@ -1,0 +1,143 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "M405"
+
+#define USBD_PRODUCT_STRING  "MICOAIR405V2"
+
+// *************** LED **********************
+#define LED0                    PC5
+#define LED1                    PC4
+#define LED2                    PA8
+
+// *************** SPI: Gyro & ACC & BARO & OSD & SDCARD **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define USE_SPI_DEVICE_2
+#define USE_SPI_DEVICE_3
+
+#define SPI1_SCK_PIN        PA5
+#define SPI1_MISO_PIN   	PA6
+#define SPI1_MOSI_PIN   	PA7
+
+#define SPI2_SCK_PIN        PB13
+#define SPI2_MISO_PIN   	PC2
+#define SPI2_MOSI_PIN   	PC3
+
+#define SPI3_SCK_PIN        PC10
+#define SPI3_MISO_PIN       PC11
+#define SPI3_MOSI_PIN       PC12
+
+#define USE_IMU_BMI088
+#define IMU_BMI088_ALIGN        CW270_DEG
+#define BMI088_SPI_BUS          BUS_SPI2
+#define BMI088_GYRO_CS_PIN      PC14
+#define BMI088_ACC_CS_PIN       PC13
+
+#define USE_BARO
+#define USE_BARO_SPL06
+#define SPL06_SPI_BUS           BUS_SPI2
+#define SPL06_CS_PIN            PA4
+
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI1
+#define MAX7456_CS_PIN          PB12
+
+#define USE_BLACKBOX
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+#define SDCARD_SPI_BUS          BUS_SPI3
+#define SDCARD_CS_PIN           PC9
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART5
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN            NONE
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6 
+#define INVERTER_PIN_UART6_RX   PC15
+
+#define SERIAL_PORT_COUNT       7      //VCP, UART1, UART2, UART3, UART4, UART5, UART6
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART6
+#define USE_UART_INVERTER
+
+// *************** I2C ****************************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+#define DEFAULT_I2C_BUS         BUS_I2C1
+
+#define USE_MAG
+#define MAG_I2C_BUS             DEFAULT_I2C_BUS
+#define USE_MAG_ALL
+
+// *************** ENABLE OPTICAL FLOW & RANGEFINDER *****************************
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_MSP
+#define USE_OPFLOW
+#define USE_OPFLOW_MSP
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC0
+#define ADC_CHANNEL_2_PIN           PC1
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define VBAT_SCALE_DEFAULT          2121
+#define CURRENT_METER_SCALE         402
+
+#define DEFAULT_FEATURES        (FEATURE_VBAT | FEATURE_CURRENT_METER | FEATURE_OSD | FEATURE_TELEMETRY)
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define MAX_PWM_OUTPUT_PORTS       10

--- a/src/main/target/MICOAIR743/CMakeLists.txt
+++ b/src/main/target/MICOAIR743/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32h743xi(MICOAIR743)

--- a/src/main/target/MICOAIR743/config.c
+++ b/src/main/target/MICOAIR743/config.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include "platform.h"
+#include "config/config_master.h"
+#include "config/feature.h"
+#include "io/serial.h"
+#include "fc/config.h"
+#include "sensors/gyro.h"
+
+
+void targetConfiguration(void)
+{
+    serialConfigMutable()->portConfigs[1].functionMask = FUNCTION_MSP;
+    serialConfigMutable()->portConfigs[1].msp_baudrateIndex = BAUD_57600;    
+    serialConfigMutable()->portConfigs[2].functionMask = FUNCTION_MSP_OSD;
+    serialConfigMutable()->portConfigs[3].functionMask = FUNCTION_GPS;
+    serialConfigMutable()->portConfigs[6].functionMask = FUNCTION_ESCSERIAL;
+}

--- a/src/main/target/MICOAIR743/target.c
+++ b/src/main/target/MICOAIR743/target.c
@@ -1,0 +1,42 @@
+/*
+* This file is part of Cleanflight.
+*
+* Cleanflight is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Cleanflight is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/pinio.h"
+#include "drivers/sensor.h"
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM1,  CH4, PE14,  TIM_USE_OUTPUT_AUTO, 0, 0), // S1
+    DEF_TIM(TIM1,  CH3, PE13,  TIM_USE_OUTPUT_AUTO, 0, 1), // S2
+    DEF_TIM(TIM1,  CH2, PE11,  TIM_USE_OUTPUT_AUTO, 0, 2), // S3
+    DEF_TIM(TIM1,  CH1, PE9,   TIM_USE_OUTPUT_AUTO, 0, 3), // S4
+    DEF_TIM(TIM3,  CH4, PB1,   TIM_USE_OUTPUT_AUTO, 0, 4), // S5
+    DEF_TIM(TIM3,  CH3, PB0,   TIM_USE_OUTPUT_AUTO, 0, 5), // S6
+    DEF_TIM(TIM4,  CH1, PD12,  TIM_USE_OUTPUT_AUTO, 0, 6), // S7
+    DEF_TIM(TIM4,  CH2, PD13,  TIM_USE_OUTPUT_AUTO, 0, 7), // S8
+    DEF_TIM(TIM4,  CH3, PD14,  TIM_USE_OUTPUT_AUTO, 0, 0), // S9
+    DEF_TIM(TIM4,  CH4, PD15,  TIM_USE_OUTPUT_AUTO, 0, 0), // S10 DMA_NONE
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/MICOAIR743/target.h
+++ b/src/main/target/MICOAIR743/target.h
@@ -1,0 +1,141 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "M743"
+
+#define USBD_PRODUCT_STRING  "MICOAIR743"
+
+// *************** LED **********************
+#define LED0                    PE5
+#define LED1                    PE6
+#define LED2                    PE4
+
+// *************** SPI: Gyro & ACC & OSD **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define USE_SPI_DEVICE_2
+
+#define SPI1_SCK_PIN        PA5
+#define SPI1_MISO_PIN   	PA6
+#define SPI1_MOSI_PIN   	PA7
+
+#define SPI2_SCK_PIN        PD3
+#define SPI2_MISO_PIN   	PC2
+#define SPI2_MOSI_PIN   	PC3
+
+#define USE_IMU_BMI088
+#define IMU_BMI088_ALIGN        CW270_DEG
+#define BMI088_SPI_BUS          BUS_SPI2
+#define BMI088_GYRO_CS_PIN      PD5
+#define BMI088_ACC_CS_PIN       PD4
+
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI1
+#define MAX7456_CS_PIN          PB12
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PD9
+#define UART3_TX_PIN            PD8
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6 
+#define INVERTER_PIN_UART6_RX   PD0
+
+#define USE_UART7
+#define UART7_RX_PIN            PE7
+
+#define USE_UART8
+#define UART8_RX_PIN            PE0
+#define UART8_TX_PIN            PE1
+
+#define SERIAL_PORT_COUNT       8      //VCP, UART1, UART2, UART3, UART4, UART6, UART7, UART8
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART6
+
+// *************** I2C: BARO & MAG ****************************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define USE_I2C_DEVICE_2
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+#define I2C2_SCL                PB10
+#define I2C2_SDA                PB11
+
+#define USE_BARO
+#define USE_BARO_DPS310
+#define BARO_I2C_BUS            BUS_I2C2
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+// *************** ENABLE OPTICAL FLOW & RANGEFINDER *****************************
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_MSP
+#define USE_OPFLOW
+#define USE_OPFLOW_MSP
+
+// *************** SDIO SD BLACKBOX*******************
+#define USE_SDCARD
+#define USE_SDCARD_SDIO
+#define SDCARD_SDIO_DEVICE      SDIODEV_1
+#define SDCARD_SDIO_4BIT
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC_CHANNEL_1_PIN           PC0
+#define ADC_CHANNEL_2_PIN           PC1
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define VBAT_SCALE_DEFAULT          2121
+#define CURRENT_METER_SCALE         402
+
+#define DEFAULT_FEATURES        (FEATURE_VBAT | FEATURE_CURRENT_METER | FEATURE_OSD | FEATURE_TELEMETRY)
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0xffff
+#define TARGET_IO_PORTE 0xffff
+
+#define MAX_PWM_OUTPUT_PORTS       10


### PR DESCRIPTION
Dear INAV developers,

We are MicoAir Tech., a newly established team who are drone enthusiasts and create accessories and tutorials for drone DIYers. Our website is [MicoAir](https://micoair.com/). 
Our FC boards are compatible with INAV and we have contacted the developer, followed the New Hardware Policy and sent the hardware samples for evaluation. The delivery will arrive later.
We have tested the FC boards with INAV 7.1.2 and INAV Configurator 7.1.0. It performed well and this PR is the configure file.

PS: using INAV Configurator 7.1.1 will stuck in "Device - Saving default settings" page, needs reconnect to solve it;
Detail infomation about FC boards
[MicoAir743](https://micoair.com/flightcontroller_micoair743/)
[MicoAir405v2](https://micoair.com/flightcontroller_micoair405v2/)
[MicoAir405Mini](https://micoair.com/flightcontroller_micoair405mini/)