### PR TITLE
mixer.h: PLATFORM_OTHER isn't valid, remove

### DIFF
--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -40,8 +40,7 @@ typedef enum {
     PLATFORM_HELICOPTER     = 2,
     PLATFORM_TRICOPTER      = 3,
     PLATFORM_ROVER          = 4,
-    PLATFORM_BOAT           = 5,
-    PLATFORM_OTHER          = 6
+    PLATFORM_BOAT           = 5
 } flyingPlatformType_e;
 
 


### PR DESCRIPTION
Looking at the history, it looks like PLATFORM_OTHER was added to mixer.h in 2018, but has never been valid per settings.yaml