### PR TITLE
IFLIGHT_BLITZ_ATF435 MAX_PWM_OUTPUT_PORTS should 8

### DIFF
--- a/src/main/target/IFLIGHT_BLITZ_ATF435/target.h
+++ b/src/main/target/IFLIGHT_BLITZ_ATF435/target.h
@@ -159,6 +159,6 @@
 #define TARGET_IO_PORTD             0xffff
 #define TARGET_IO_PORTE             BIT(2)
 
-#define MAX_PWM_OUTPUT_PORTS        4
+#define MAX_PWM_OUTPUT_PORTS        8
 #define USE_DSHOT
 #define USE_ESC_SENSOR


### PR DESCRIPTION
This FC has 8 PWM outputs, as defined in target.c
Setting MAX_PWM_OUTPUT_PORTS to match.  Tested by a user on Discord.