### PR TITLE
Improve MAVLink behavior with flow control capable links

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2518,7 +2518,7 @@ Rate of the extra1 message for MAVLink telemetry
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 10 | 0 | 255 |
+| 2 | 0 | 255 |
 
 ---
 
@@ -2558,7 +2558,7 @@ Rate of the RC channels message for MAVLink telemetry
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 5 | 0 | 255 |
+| 1 | 0 | 255 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3155,7 +3155,7 @@ groups:
         type: uint8_t
         min: 0
         max: 255
-        default_value: 5
+        default_value: 1
       - name: mavlink_pos_rate
         description: "Rate of the position message for MAVLink telemetry"
         field: mavlink.position_rate
@@ -3169,7 +3169,7 @@ groups:
         type: uint8_t
         min: 0
         max: 255
-        default_value: 10
+        default_value: 2
       - name: mavlink_extra2_rate
         description: "Rate of the extra2 message for MAVLink telemetry"
         field: mavlink.extra2_rate

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -163,14 +163,15 @@ static serialPortConfig_t *portConfig;
 static bool mavlinkTelemetryEnabled =  false;
 static portSharing_e mavlinkPortSharing;
 static uint8_t txbuff_free = 100;
+static bool txbuff_valid = false;
 
 /* MAVLink datastream rates in Hz */
 static uint8_t mavRates[] = {
     [MAV_DATA_STREAM_EXTENDED_STATUS] = 2,      // 2Hz
-    [MAV_DATA_STREAM_RC_CHANNELS] = 5,          // 5Hz
+    [MAV_DATA_STREAM_RC_CHANNELS] = 1,          // 1Hz
     [MAV_DATA_STREAM_POSITION] = 2,             // 2Hz
-    [MAV_DATA_STREAM_EXTRA1] = 10,              // 10Hz
-    [MAV_DATA_STREAM_EXTRA2] = 2,               // 2Hz
+    [MAV_DATA_STREAM_EXTRA1] = 3,               // 3Hz
+    [MAV_DATA_STREAM_EXTRA2] = 2,               // 2Hz, HEARTBEATs are important
     [MAV_DATA_STREAM_EXTRA3] = 1                // 1Hz
 };
 
@@ -1112,9 +1113,23 @@ static bool handleIncoming_RC_CHANNELS_OVERRIDE(void) {
     return true;
 }
 
+static bool handleIncoming_PARAM_REQUEST_LIST(void) {
+    mavlink_param_request_list_t msg;
+    mavlink_msg_param_request_list_decode(&mavRecvMsg, &msg);
+
+    // Respond that we don't have any parameters to force Mission Planner to give up quickly
+    if (msg.target_system == mavSystemId) {
+        // mavlink_msg_param_value_pack(system_id, component_id, msg, param_value->param_id, param_value->param_value, param_value->param_type, param_value->param_count, param_value->param_index);
+        mavlink_msg_param_value_pack(mavSystemId, mavComponentId, &mavSendMsg, 0, 0, 0, 0, 0);
+        mavlinkSendMessage();
+    }
+    return true;
+}
+
 static bool handleIncoming_RADIO_STATUS(void) {
     mavlink_radio_status_t msg;
     mavlink_msg_radio_status_decode(&mavRecvMsg, &msg);
+    txbuff_valid = true;
     txbuff_free = msg.txbuf;
     return true;
 }
@@ -1163,6 +1178,7 @@ static bool handleIncoming_ADSB_VEHICLE(void) {
 }
 #endif
 
+// Returns whether a message was processed
 static bool processMAVLinkIncomingTelemetry(void)
 {
     while (serialRxBytesWaiting(mavlinkPort) > 0) {
@@ -1173,6 +1189,8 @@ static bool processMAVLinkIncomingTelemetry(void)
             switch (mavRecvMsg.msgid) {
                 case MAVLINK_MSG_ID_HEARTBEAT:
                     break;
+                case MAVLINK_MSG_ID_PARAM_REQUEST_LIST:
+                    return handleIncoming_PARAM_REQUEST_LIST();
                 case MAVLINK_MSG_ID_MISSION_CLEAR_ALL:
                     return handleIncoming_MISSION_CLEAR_ALL();
                 case MAVLINK_MSG_ID_MISSION_COUNT:
@@ -1184,13 +1202,17 @@ static bool processMAVLinkIncomingTelemetry(void)
                 case MAVLINK_MSG_ID_MISSION_REQUEST:
                     return handleIncoming_MISSION_REQUEST();
                 case MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE:
-                    return handleIncoming_RC_CHANNELS_OVERRIDE();
+                    handleIncoming_RC_CHANNELS_OVERRIDE();
+                    // Don't set that we handled a message, otherwise RC channel packets will block telemetry messages
+                    return false;
 #ifdef USE_ADSB
                 case MAVLINK_MSG_ID_ADSB_VEHICLE:
                     return handleIncoming_ADSB_VEHICLE();
 #endif
                 case MAVLINK_MSG_ID_RADIO_STATUS:
-                    return handleIncoming_RADIO_STATUS();
+                    handleIncoming_RADIO_STATUS();
+                    // Don't set that we handled a message, otherwise radio status packets will block telemetry messages
+                    return false;
                 default:
                     return false;
             }
@@ -1202,8 +1224,6 @@ static bool processMAVLinkIncomingTelemetry(void)
 
 void handleMAVLinkTelemetry(timeUs_t currentTimeUs)
 {
-    static bool incomingRequestServed;
-
     if (!mavlinkTelemetryEnabled) {
         return;
     }
@@ -1212,24 +1232,23 @@ void handleMAVLinkTelemetry(timeUs_t currentTimeUs)
         return;
     }
 
-    // If we did serve data on incoming request - skip next scheduled messages batch to avoid link clogging
-    if (processMAVLinkIncomingTelemetry()) {
-        incomingRequestServed = true;
+    // Process incoming MAVLink - ignore the return indicating whether or not a message was processed
+    // Very few telemetry links are dynamic uplink/downlink split so uplink telemetry shouldn't reduce downlink bandwidth availability
+    processMAVLinkIncomingTelemetry();
+
+    // Determine whether to send telemetry back
+    bool shouldSendTelemetry = false;
+    if (txbuff_valid) {
+        // Use flow control if available
+        shouldSendTelemetry = txbuff_free >= 33;
+    } else {
+        // If not, use blind frame pacing
+        shouldSendTelemetry = (currentTimeUs - lastMavlinkMessage) >= TELEMETRY_MAVLINK_DELAY;
     }
 
-    if ((currentTimeUs - lastMavlinkMessage) >= TELEMETRY_MAVLINK_DELAY && txbuff_free >= 90) {
-        // Only process scheduled data if we didn't serve any incoming request this cycle
-        if (!incomingRequestServed ||
-            (
-                 (rxConfig()->receiverType == RX_TYPE_SERIAL) &&
-                 (rxConfig()->serialrx_provider == SERIALRX_MAVLINK) &&
-                 !tristateWithDefaultOnIsActive(rxConfig()->halfDuplex)
-            )
-        ) {
-            processMAVLinkTelemetry(currentTimeUs);
-        }
+    if (shouldSendTelemetry) {
+        processMAVLinkTelemetry(currentTimeUs);
         lastMavlinkMessage = currentTimeUs;
-        incomingRequestServed = false;
     }
 }
 


### PR DESCRIPTION
With these changes, INAV can now be used with ExpressLRS MAVLink, including both RC & telemetry all in one!

You can watch a demo here: https://www.youtube.com/watch?v=d55q5sUbIkc

This _should_ be solid for both ELRS and other MAVLink telemetry radios, though I haven't tested with them yet. Wanted to get the PR created so folks can take a look at it. :)