### PR TITLE
Add blackbox device FILE for SITL build

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1443,6 +1443,9 @@ static void blackboxValidateConfig(void)
 #ifdef USE_SDCARD
     case BLACKBOX_DEVICE_SDCARD:
 #endif
+#if defined(SITL_BUILD)
+    case BLACKBOX_DEVICE_FILE:
+#endif
     case BLACKBOX_DEVICE_SERIAL:
         // Device supported, leave the setting alone
         break;

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -584,6 +584,10 @@ bool isBlackboxDeviceWorking(void)
         case BLACKBOX_DEVICE_FLASH:
             return flashfsIsReady();
 #endif
+#if defined(SITL_BUILD)
+        case BLACKBOX_DEVICE_FILE:
+            return blackboxFile.file_handler != NULL;
+#endif
     default:
         return false;
     }

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -19,6 +19,11 @@
 #include <stdarg.h>
 #include <string.h>
 
+#if defined(SITL_BUILD)
+#include <stdio.h>
+#include <time.h>
+#endif
+
 #include "platform.h"
 
 #ifdef USE_BLACKBOX
@@ -81,6 +86,12 @@ static struct {
 
 #endif
 
+#if defined(SITL_BUILD)
+static struct {
+    FILE *file_handler;
+} blackboxFile;
+#endif
+
 #ifndef UNIT_TEST
 void blackboxOpen(void)
 {
@@ -102,6 +113,11 @@ void blackboxWrite(uint8_t value)
 #ifdef USE_SDCARD
     case BLACKBOX_DEVICE_SDCARD:
         afatfs_fputc(blackboxSDCard.logFile, value);
+        break;
+#endif
+#if defined(SITL_BUILD)
+    case BLACKBOX_DEVICE_FILE:
+        fputc(value, blackboxFile.file_handler);
         break;
 #endif
     case BLACKBOX_DEVICE_SERIAL:
@@ -130,6 +146,13 @@ int blackboxPrint(const char *s)
     case BLACKBOX_DEVICE_SDCARD:
         length = strlen(s);
         afatfs_fwrite(blackboxSDCard.logFile, (const uint8_t*) s, length); // Ignore failures due to buffers filling up
+        break;
+#endif
+
+#if defined(SITL_BUILD)
+    case BLACKBOX_DEVICE_FILE:
+        length = strlen(s);
+        fputs(s, blackboxFile.file_handler);
         break;
 #endif
 
@@ -194,6 +217,12 @@ bool blackboxDeviceFlushForce(void)
          * if it's done yet or not!
          */
         return afatfs_flush();
+#endif
+
+#if defined(SITL_BUILD)
+    case BLACKBOX_DEVICE_FILE:
+        fflush(blackboxFile.file_handler);
+        return true;
 #endif
 
     default:
@@ -271,6 +300,26 @@ bool blackboxDeviceOpen(void)
         return true;
         break;
 #endif
+#if defined(SITL_BUILD)
+    case BLACKBOX_DEVICE_FILE:
+        {
+            const time_t now = time(NULL);
+            const struct tm *t = localtime(&now);
+            char filename[32];
+            strftime(filename, sizeof(filename), "%Y_%m_%d_%H%M%S.TXT", t);
+
+            blackboxFile.file_handler = fopen(filename, "wb");
+            if (blackboxFile.file_handler == NULL) {
+                fprintf(stderr, "[BlackBox] Failed to create log file\n");
+                return false;
+            }
+            fprintf(stderr, "[BlackBox] Created %s\n", filename);
+        }
+
+        blackboxMaxHeaderBytesPerIteration = BLACKBOX_TARGET_HEADER_BUDGET_PER_ITERATION;
+        return true;
+        break;
+#endif
     default:
         return false;
     }
@@ -301,6 +350,11 @@ void blackboxDeviceClose(void)
     case BLACKBOX_DEVICE_FLASH:
         // Some flash device, e.g., NAND devices, require explicit close to flush internally buffered data.
         flashfsClose();
+        break;
+#endif
+#if defined(SITL_BUILD)
+    case BLACKBOX_DEVICE_FILE:
+        fclose(blackboxFile.file_handler);
         break;
 #endif
     default:
@@ -506,6 +560,11 @@ bool isBlackboxDeviceFull(void)
         return afatfs_isFull();
 #endif
 
+#if defined (SITL_BUILD)
+    case BLACKBOX_DEVICE_FILE:
+        return false;
+#endif
+
     default:
         return false;
     }
@@ -561,6 +620,11 @@ void blackboxReplenishHeaderBudget(void)
 #ifdef USE_SDCARD
     case BLACKBOX_DEVICE_SDCARD:
         freeSpace = afatfs_getFreeBufferSpace();
+        break;
+#endif
+#if defined(SITL_BUILD)
+    case BLACKBOX_DEVICE_FILE:
+        freeSpace = BLACKBOX_MAX_ACCUMULATED_HEADER_BUDGET;
         break;
 #endif
     default:
@@ -628,6 +692,12 @@ blackboxBufferReserveStatus_e blackboxDeviceReserveBufferSpace(int32_t bytes)
 #ifdef USE_SDCARD
     case BLACKBOX_DEVICE_SDCARD:
         // Assume that all writes will fit in the SDCard's buffers
+        return BLACKBOX_RESERVE_TEMPORARY_FAILURE;
+#endif
+
+#if defined(SITL_BUILD)
+    case BLACKBOX_DEVICE_FILE:
+        // Assume that all writes will fit in the file's buffers
         return BLACKBOX_RESERVE_TEMPORARY_FAILURE;
 #endif
 

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -355,6 +355,7 @@ void blackboxDeviceClose(void)
 #if defined(SITL_BUILD)
     case BLACKBOX_DEVICE_FILE:
         fclose(blackboxFile.file_handler);
+        blackboxFile.file_handler = NULL;
         break;
 #endif
     default:

--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -31,6 +31,9 @@ typedef enum BlackboxDevice {
 #ifdef USE_SDCARD
     BLACKBOX_DEVICE_SDCARD = 2,
 #endif
+#if defined(SITL_BUILD)
+    BLACKBOX_DEVICE_FILE = 3,
+#endif
 
     BLACKBOX_DEVICE_END
 } BlackboxDevice;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -25,7 +25,7 @@ tables:
   - name: serial_rx
     values: ["SPEK1024", "SPEK2048", "SBUS", "SUMD", "IBUS", "JETIEXBUS", "CRSF", "FPORT", "SBUS_FAST", "FPORT2", "SRXL2", "GHST", "MAVLINK", "FBUS"]
   - name: blackbox_device
-    values: ["SERIAL", "SPIFLASH", "SDCARD"]
+    values: ["SERIAL", "SPIFLASH", "SDCARD", "FILE"]
   - name: motor_pwm_protocol
     values: ["STANDARD", "ONESHOT125", "MULTISHOT", "BRUSHED", "DSHOT150", "DSHOT300", "DSHOT600"]
   - name: servo_protocol


### PR DESCRIPTION
To make logging for software-in-the-loop (SITL) easier, I added `BLACKBOX_DEVICE_FILE` as output option for Blackbox. This creates a file YYYY_MM_DD_HHMMSS.TXT when the controller is armed.

I tested this on 7.1.2,  but on master I'm running into other issues which prevent me from arming the drone.