### PR TITLE
GEPRC_F722_AIO include UART3

### DIFF
--- a/src/main/target/GEPRC_F722_AIO/target.h
+++ b/src/main/target/GEPRC_F722_AIO/target.h
@@ -108,6 +108,10 @@
 #define UART2_RX_PIN            PA3
 #define UART2_TX_PIN            PA2
 
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
 #define USE_UART4
 #define UART4_RX_PIN            PC11
 #define UART4_TX_PIN            PC10
@@ -116,7 +120,7 @@
 #define UART5_RX_PIN            PD2
 #define UART5_TX_PIN            PC12
 
-#define SERIAL_PORT_COUNT       5
+#define SERIAL_PORT_COUNT       6
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_SBUS


### PR DESCRIPTION
Adds the definition for UART3. Tested by a user. This also makes it consistent with the BF target.