### PR TITLE
Lower sbus2 telemetry task priority

### DIFF
--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -733,10 +733,10 @@ cfTask_t cfTasks[TASK_COUNT] = {
 
 #if defined(USE_TELEMETRY) && defined(USE_TELEMETRY_SBUS2)
     [TASK_TELEMETRY_SBUS2] = {
-        .taskName = "SBUS2_TELEMETRY",
+        .taskName = "SBUS2 TLM",
         .taskFunc = taskSendSbus2Telemetry,
         .desiredPeriod = TASK_PERIOD_US(125), // 8kHz 2ms dead time + 650us window / sensor.
-        .staticPriority = TASK_PRIORITY_REALTIME, // timing is critical. Ideally, should be a timer interrupt triggered by sbus packet
+        .staticPriority = TASK_PRIORITY_LOW, // timing is critical. Ideally, should be a timer interrupt triggered by sbus packet
     },
 #endif
 


### PR DESCRIPTION
With the latest changes to the timing, we no longer need realtime priority.