### PR TITLE
Make sure DEFAULT_I2C_DEVICE is always valid

### DIFF
--- a/src/main/target/KAKUTEF4WING/target.h
+++ b/src/main/target/KAKUTEF4WING/target.h
@@ -45,6 +45,8 @@
 #define I2C2_SCL                PB10     
 #define I2C2_SDA                PB11      
 
+#define DEFAULT_I2C_BUS         BUS_I2C2
+
 // ********** External MAG On I2C2******
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2

--- a/src/main/target/KAKUTEF4WING/target.h
+++ b/src/main/target/KAKUTEF4WING/target.h
@@ -45,8 +45,6 @@
 #define I2C2_SCL                PB10     
 #define I2C2_SDA                PB11      
 
-#define DEFAULT_I2C_BUS         BUS_I2C2
-
 // ********** External MAG On I2C2******
 #define USE_MAG
 #define MAG_I2C_BUS             BUS_I2C2

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -56,11 +56,13 @@ extern uint8_t __config_end;
 
 // Temperature sensors
 #if !defined(TEMPERATURE_I2C_BUS) && defined(DEFAULT_I2C_BUS)
-
 #define TEMPERATURE_I2C_BUS DEFAULT_I2C_BUS
-
 #endif
 
+// Rangefinder sensors
+#if !defined(RANGEFINDER_I2C_BUS) && defined(DEFAULT_I2C_BUS)
+#define RANGEFINDER_I2C_BUS DEFAULT_I2C_BUS
+#endif
 
 // Enable MSP_DISPLAYPORT for F3 targets without builtin OSD,
 // since it's used to display CMS on MWOSD
@@ -100,6 +102,10 @@ extern uint8_t __config_end;
 
 #endif // USE_MAG_ALL
 
+#if defined(DEFAULT_I2C_BUS) && !defined(MAG_I2C_BUS)
+#define MAG_I2C_BUS DEFAULT_I2C_BUS
+#endif
+
 #endif // USE_MAG
 
 #if defined(USE_BARO)
@@ -115,6 +121,10 @@ extern uint8_t __config_end;
 #define USE_BARO_MS5611
 //#define USE_BARO_SPI_BMP280
 #define USE_BARO_SPL06
+#endif
+
+#if defined(DEFAULT_I2C_BUS) && !defined(BARO_I2C_BUS)
+#define BARO_I2C_BUS DEFAULT_I2C_BUS
 #endif
 
 #endif

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -29,6 +29,22 @@ extern uint8_t __config_end;
 # undef USE_OLED_UG2864
 #endif
 
+
+// Make sure DEFAULT_I2C_BUS is valid
+#ifndef DEFAULT_I2C_BUS
+
+#ifdef USE_I2C_DEVICE_1
+#define DEFAULT_I2C_BUS BUS_I2C1
+#elif USE_I2C_DEVICE_2
+#define DEFAULT_I2C_BUS BUS_I2C2
+#elif USE_I2C_DEVICE_3
+#define DEFAULT_I2C_BUS BUS_I2C3
+#elif USE_I2C_DEVICE_4
+#define DEFAULT_I2C_BUS BUS_I2C4
+#endif
+
+#endif
+
 // Enable MSP_DISPLAYPORT for F3 targets without builtin OSD,
 // since it's used to display CMS on MWOSD
 #if !defined(USE_MSP_DISPLAYPORT) && !defined(USE_OSD)

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -33,17 +33,34 @@ extern uint8_t __config_end;
 // Make sure DEFAULT_I2C_BUS is valid
 #ifndef DEFAULT_I2C_BUS
 
-#ifdef USE_I2C_DEVICE_1
+#if defined(USE_I2C_DEVICE_1)
 #define DEFAULT_I2C_BUS BUS_I2C1
-#elif USE_I2C_DEVICE_2
+#elif defined(USE_I2C_DEVICE_2)
 #define DEFAULT_I2C_BUS BUS_I2C2
-#elif USE_I2C_DEVICE_3
+#elif defined(USE_I2C_DEVICE_3)
 #define DEFAULT_I2C_BUS BUS_I2C3
-#elif USE_I2C_DEVICE_4
+#elif defined(USE_I2C_DEVICE_4)
 #define DEFAULT_I2C_BUS BUS_I2C4
 #endif
 
 #endif
+
+// Airspeed sensors
+#if defined(USE_PITOT) && defined(DEFAULT_I2C_BUS)
+
+#ifndef PITOT_I2C_BUS
+#define PITOT_I2C_BUS DEFAULT_I2C_BUS
+#endif
+
+#endif
+
+// Temperature sensors
+#if !defined(TEMPERATURE_I2C_BUS) && defined(DEFAULT_I2C_BUS)
+
+#define TEMPERATURE_I2C_BUS DEFAULT_I2C_BUS
+
+#endif
+
 
 // Enable MSP_DISPLAYPORT for F3 targets without builtin OSD,
 // since it's used to display CMS on MWOSD


### PR DESCRIPTION
Some devices don't have I2C1 and it may cause some less common i2c devices to not work.
