### PR TITLE
Change MAVLink component ID to be a "proper" autopilot 

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -184,7 +184,7 @@ static mavlink_message_t mavRecvMsg;
 static mavlink_status_t mavRecvStatus;
 
 static uint8_t mavSystemId = 1;
-static uint8_t mavComponentId = MAV_COMP_ID_SYSTEM_CONTROL;
+static uint8_t mavComponentId = MAV_COMP_ID_AUTOPILOT1;
 
 static APM_COPTER_MODE inavToArduCopterMap(flightModeForTelemetry_e flightMode)
 {


### PR DESCRIPTION
MAVLink component IDs define what a MAVLink speaker's purpose is - see https://mavlink.io/en/messages/minimal.html#MAV_COMPONENT

Setting INAV to behave as an autopilot makes QGC & mLRS work properly, `MAV_COMP_ID_SYSTEM_CONTROL` is now deprecated, and doesn't really make sense in the first place.