### PR TITLE
add SERVOS to blackbox optional fields list

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -99,7 +99,7 @@
 #define BLACKBOX_INVERTED_CARD_DETECTION 0
 #endif
 
-PG_REGISTER_WITH_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 3);
 
 PG_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig,
     .device = DEFAULT_BLACKBOX_DEVICE,
@@ -108,7 +108,8 @@ PG_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig,
     .invertedCardDetection = BLACKBOX_INVERTED_CARD_DETECTION,
     .includeFlags = BLACKBOX_FEATURE_NAV_PID | BLACKBOX_FEATURE_NAV_POS |
         BLACKBOX_FEATURE_MAG | BLACKBOX_FEATURE_ACC | BLACKBOX_FEATURE_ATTITUDE |
-        BLACKBOX_FEATURE_RC_DATA | BLACKBOX_FEATURE_RC_COMMAND | BLACKBOX_FEATURE_MOTORS,
+        BLACKBOX_FEATURE_RC_DATA | BLACKBOX_FEATURE_RC_COMMAND |
+        BLACKBOX_FEATURE_MOTORS | BLACKBOX_FEATURE_SERVOS,
 );
 
 void blackboxIncludeFlagSet(uint32_t mask)
@@ -654,7 +655,7 @@ static bool testBlackboxConditionUncached(FlightLogFieldCondition condition)
         return (getMotorCount() >= condition - FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_MOTORS_1 + 1) && blackboxIncludeFlag(BLACKBOX_FEATURE_MOTORS);
 
     case FLIGHT_LOG_FIELD_CONDITION_SERVOS:
-        return isMixerUsingServos();
+        return blackboxIncludeFlag(BLACKBOX_FEATURE_SERVOS) && isMixerUsingServos();
 
     case FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_SERVOS_1:
     case FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_SERVOS_2:
@@ -674,7 +675,7 @@ static bool testBlackboxConditionUncached(FlightLogFieldCondition condition)
     case FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_SERVOS_16:
     case FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_SERVOS_17:
     case FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_SERVOS_18:
-	return ((FlightLogFieldCondition)getServoCount() >= condition - FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_SERVOS_1 + 1);
+	return ((FlightLogFieldCondition)getServoCount() >= condition - FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_SERVOS_1 + 1) && blackboxIncludeFlag(BLACKBOX_FEATURE_SERVOS);
 
     case FLIGHT_LOG_FIELD_CONDITION_NONZERO_PID_D_0:
     case FLIGHT_LOG_FIELD_CONDITION_NONZERO_PID_D_1:

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -35,6 +35,7 @@ typedef enum {
     BLACKBOX_FEATURE_GYRO_PEAKS_ROLL    = 1 << 10,
     BLACKBOX_FEATURE_GYRO_PEAKS_PITCH   = 1 << 11,
     BLACKBOX_FEATURE_GYRO_PEAKS_YAW     = 1 << 12,
+    BLACKBOX_FEATURE_SERVOS             = 1 << 13,
 } blackboxFeatureMask_e;
 typedef struct blackboxConfig_s {
     uint16_t rate_num;

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -183,6 +183,7 @@ static const char * const blackboxIncludeFlagNames[] = {
     "PEAKS_R",
     "PEAKS_P",
     "PEAKS_Y",
+    "SERVOS",
     NULL
 };
 #endif
@@ -1087,7 +1088,7 @@ static void cliAdjustmentRange(char *cmdline)
 }
 
 static void printMotorMix(uint8_t dumpMask, const motorMixer_t *primaryMotorMixer, const motorMixer_t *defaultprimaryMotorMixer)
-{   
+{
     const char *format = "mmix %d %s %s %s %s";
     char buf0[FTOA_BUFFER_SIZE];
     char buf1[FTOA_BUFFER_SIZE];
@@ -1351,7 +1352,7 @@ static void cliTempSensor(char *cmdline)
 #endif
 
 #ifdef USE_FW_AUTOLAND
-static void printFwAutolandApproach(uint8_t dumpMask, const navFwAutolandApproach_t *navFwAutolandApproach, const navFwAutolandApproach_t *defaultFwAutolandApproach) 
+static void printFwAutolandApproach(uint8_t dumpMask, const navFwAutolandApproach_t *navFwAutolandApproach, const navFwAutolandApproach_t *defaultFwAutolandApproach)
 {
     const char *format = "fwapproach %u %d %d %u %d %d %u";
     for (uint8_t i = 0; i < MAX_FW_LAND_APPOACH_SETTINGS; i++) {
@@ -1398,7 +1399,7 @@ static void cliFwAutolandApproach(char * cmdline)
 
             if ((ptr = nextArg(ptr))) {
                 landDirection = fastA2I(ptr);
-                
+
                 if (landDirection != 0 && landDirection != 1) {
                     cliShowParseError();
                     return;
@@ -1428,7 +1429,7 @@ static void cliFwAutolandApproach(char * cmdline)
 
                 validArgumentCount++;
             }
-            
+
             if ((ptr = nextArg(ptr))) {
                 isSeaLevelRef = fastA2I(ptr);
                 validArgumentCount++;
@@ -1842,7 +1843,7 @@ static void cliLedPinPWM(char *cmdline)
     if (isEmpty(cmdline)) {
         ledPinStopPWM();
         cliPrintLine("PWM stopped");
-    } else {       
+    } else {
         i = fastA2I(cmdline);
         ledPinStartPWM(i);
         cliPrintLinef("PWM started: %d%%",i);
@@ -3739,8 +3740,8 @@ static void cliStatus(char *cmdline)
 #if defined(AT32F43x)
     cliPrintLine("AT32 system clocks:");
     crm_clocks_freq_type clocks;
-    crm_clocks_freq_get(&clocks); 
-    
+    crm_clocks_freq_get(&clocks);
+
     cliPrintLinef("  SYSCLK = %d MHz", clocks.sclk_freq / 1000000);
     cliPrintLinef("  ABH    = %d MHz", clocks.ahb_freq  / 1000000);
     cliPrintLinef("  ABP1   = %d MHz", clocks.apb1_freq / 1000000);
@@ -4382,7 +4383,7 @@ static const char *_ubloxGetQuality(uint8_t quality)
         case UBLOX_SIG_QUALITY_CODE_LOCK_TIME_SYNC: return "Code locked and time sync";
         case UBLOX_SIG_QUALITY_CODE_CARRIER_LOCK_TIME_SYNC:
         case UBLOX_SIG_QUALITY_CODE_CARRIER_LOCK_TIME_SYNC2:
-        case UBLOX_SIG_QUALITY_CODE_CARRIER_LOCK_TIME_SYNC3: 
+        case UBLOX_SIG_QUALITY_CODE_CARRIER_LOCK_TIME_SYNC3:
             return "Code and carrier locked and time sync";
         default: return "Unknown";
     }


### PR DESCRIPTION
Prior behaviour: If servos were defined in the mixer, servos were always logged (all servos before INAV8, defined servos INAV8+). In most cases, servo logging was not needed.
New Behaviour: 'SERVOS' has been added as an option to the CLI `blackbox` list. By default SERVOS are enabled for logging. The user can disable SERVO logging with `blackbox -SERVOS` (or a TBD Configurator entry).

### Usage
```
# blackbox 
Enabled: NAV_POS NAV_PID MAG ACC ATTI RC_DATA RC_COMMAND MOTORS SERVOS
```
For a flying wing generates BBL headers `... motor[0],servo[0],servo[1],navStat ...`
```
# blackbox -SERVOS
Disabled SERVOS
# blackbox
Enabled: NAV_POS NAV_PID MAG ACC ATTI RC_DATA RC_COMMAND MOTORS 
```
For the same FW results in `... motor[0],navState ...`


