### PR TITLE
Fix mixer tab

### DIFF
--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -28,7 +28,7 @@
 #define MAX_MOTORS  12
 #endif
 
-#define MAX_SERVOS  34
+#define MAX_SERVOS  18
 
 #define PWM_TIMER_HZ    1000000
 

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -20,7 +20,7 @@
 #include "config/parameter_group.h"
 #include "programming/logic_condition.h"
 
-#define MAX_SUPPORTED_SERVOS 34
+#define MAX_SUPPORTED_SERVOS 18
 
 // These must be consecutive
 typedef enum {


### PR DESCRIPTION
Temporarily revert max servos to 18. No need to set it to 34 servos, as we can't output that many yet and it appears to break MSP2_INAV_SERVO_MIXER message.

Blackbox is unaffected for now, as I will try to increase max servo count when using sbus + pwm output on a separate pr and will prune any unused blackbox entries.