### PR TITLE
Support SBUS2 FASSTest 12 channel short frame time

### DIFF
--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -439,7 +439,7 @@ void fcTasksInit(void)
 #endif
 
 #if defined(USE_TELEMETRY) && defined(USE_TELEMETRY_SBUS2)
-    setTaskEnabled(TASK_TELEMETRY_SBUS2,rxConfig()->receiverType == RX_TYPE_SERIAL && rxConfig()->serialrx_provider == SERIALRX_SBUS2);
+    setTaskEnabled(TASK_TELEMETRY_SBUS2,feature(FEATURE_TELEMETRY) && rxConfig()->receiverType == RX_TYPE_SERIAL && rxConfig()->serialrx_provider == SERIALRX_SBUS2);
 #endif
 
 #ifdef USE_ADAPTIVE_FILTER

--- a/src/main/rx/sbus.h
+++ b/src/main/rx/sbus.h
@@ -18,12 +18,13 @@
 #pragma once
 
 #define SBUS_DEFAULT_INTERFRAME_DELAY_US    3000    // According to FrSky interframe is 6.67ms, we go smaller just in case
-#define SBUS_MIN_SYNC_DELAY_US              MS2US(2) // 2ms
 
 #include "rx/rx.h"
 
 bool sbusInit(const rxConfig_t *initialRxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
 bool sbusInitFast(const rxConfig_t *initialRxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
+
+#define SBUS_BYTE_TIME_US(bytes)    MS2US(10 * 12 * bytes) // 10us per bit * (1 start + 8 data + 1 parity + 2 stop) * number of bytes
 
 #ifdef USE_TELEMETRY_SBUS2
 uint8_t sbusGetCurrentTelemetryPage(void);

--- a/src/main/telemetry/sbus2.c
+++ b/src/main/telemetry/sbus2.c
@@ -25,6 +25,10 @@
 #include "common/time.h"
 #include "common/axis.h"
 
+#include "config/feature.h"
+
+#include "fc/config.h"
+
 #include "telemetry/telemetry.h"
 #include "telemetry/sbus2.h"
 #include "telemetry/sbus2_sensors.h"
@@ -164,7 +168,7 @@ void sbus2IncrementTelemetrySlot(timeUs_t currentTimeUs)
 
 FAST_CODE void taskSendSbus2Telemetry(timeUs_t currentTimeUs)
 {
-    if (!telemetrySharedPort || rxConfig()->receiverType != RX_TYPE_SERIAL ||
+    if (!feature(FEATURE_TELEMETRY) || !telemetrySharedPort || rxConfig()->receiverType != RX_TYPE_SERIAL ||
         rxConfig()->serialrx_provider != SERIALRX_SBUS2) {
         return;
     }


### PR DESCRIPTION
Fixes #10274

Futaba's FASSTest 12ch does not allow for extra telemetry sensors, but has lower latency with a much shorter interval between SBUS frames and uses a different endbyte.

This auto detects short frame interval and reduces sync time.