### PR TITLE
remove excessive `SD` debug from MSP processing

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1034,7 +1034,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
     case MSP_MIXER:
         sbufWriteU8(dst, 3); // mixerMode no longer supported, send 3 (QuadX) as fallback
         break;
-    
+
 
     case MSP_RX_CONFIG:
         sbufWriteU8(dst, rxConfig()->serialrx_provider);
@@ -1274,7 +1274,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         sbufWriteU16(dst, accelerometerConfig()->acc_notch_cutoff);
 
         sbufWriteU16(dst, 0);    //Was gyroConfig()->gyro_stage2_lowpass_hz
-        break; 
+        break;
 
     case MSP_PID_ADVANCED:
         sbufWriteU16(dst, 0); // pidProfile()->rollPitchItermIgnoreRate
@@ -1618,7 +1618,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
             }
         }
         break;
-    
+
 
     case MSP2_INAV_MC_BRAKING:
 #ifdef USE_MR_BRAKING_MODE
@@ -2892,7 +2892,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         } else
             return MSP_RESULT_ERROR;
         break;
-    
+
     case MSP_SET_FAILSAFE_CONFIG:
         if (dataSize == 20) {
             failsafeConfigMutable()->failsafe_delay = sbufReadU8(src);
@@ -3291,11 +3291,9 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #endif
     case MSP2_INAV_GPS_UBLOX_COMMAND:
         if(dataSize < 8 || !isGpsUblox()) {
-            SD(fprintf(stderr, "[GPS] Not ublox!\n"));
             return MSP_RESULT_ERROR;
         }
 
-        SD(fprintf(stderr, "[GPS] Sending ubx command: %i!\n", dataSize));
         gpsUbloxSendCommand(src->ptr, dataSize, 0);
         break;
 
@@ -4145,7 +4143,6 @@ mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostPro
     // initialize reply by default
     reply->cmd = cmd->cmd;
 
-    SD(fprintf(stderr, "[MSP] CommandId: 0x%04x bytes: %i!\n", cmdMSP, sbufBytesRemaining(src)));
     if (MSP2_IS_SENSOR_MESSAGE(cmdMSP)) {
         ret = mspProcessSensorCommand(cmdMSP, src);
     } else if (mspFcProcessOutCommand(cmdMSP, dst, mspPostProcessFn)) {

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -173,10 +173,8 @@ static bool mspSerialProcessReceivedData(mspPort_t *mspPort, uint8_t c)
         case MSP_CHECKSUM_V1:
             if (mspPort->checksum1 == c) {
                 mspPort->c_state = MSP_COMMAND_RECEIVED;
-                SD(fprintf(stderr, "[MSPV1] Command received\n"));
             } else {
                 mspPort->c_state = MSP_IDLE;
-                SD(fprintf(stderr, "[MSPV1] Checksum error!\n"));
             }
             break;
 
@@ -229,7 +227,6 @@ static bool mspSerialProcessReceivedData(mspPort_t *mspPort, uint8_t c)
                 // Check for potential buffer overflow
                 if (hdrv2->size > MSP_PORT_INBUF_SIZE) {
                     mspPort->c_state = MSP_IDLE;
-                    SD(fprintf(stderr, "[MSPV2] Potential buffer overflow!\n"));
                 }
                 else {
                     mspPort->dataSize = hdrv2->size;
@@ -253,9 +250,7 @@ static bool mspSerialProcessReceivedData(mspPort_t *mspPort, uint8_t c)
         case MSP_CHECKSUM_V2_NATIVE:
             if (mspPort->checksum2 == c) {
                 mspPort->c_state = MSP_COMMAND_RECEIVED;
-                SD(fprintf(stderr, "[MSPV2] command received!\n"));
             } else {
-                SD(fprintf(stderr, "[MSPV2] Checksum error!\n"));
                 mspPort->c_state = MSP_IDLE;
             }
             break;


### PR DESCRIPTION
Currently, the SITL is unusable for development debugging due to high frequency spamming of the console with MSP received etc. messages. This swamps less frequent dev /debug use of the console.

This PR removes these presumably "left over" debug messages.
