### PR TITLE
Solved my skyrocket issue by adding 2 new features

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2461,6 +2461,24 @@ groups:
         field: baro_epv
         min: 0
         max: 9999
+      - name: dynamic_acc_weight
+        description: "You can disable or enable the dynamic accelerometer weight ( calculated based on accelerometer vibrations and clipping)"
+        default_value: ON
+        field: dynamic_acc_weight
+        type: bool
+      - name: temp_correction_a
+        description: "Some accelerometers may experience drifting caused by changing temperatures, you can use this parameter and temp_correction_b to establish the linear relationship between the accelerometer drifting and the temperature (the baro needs to be in the FC, where the accelerometer is located) the formula is f(x) = ax + b where f(x) is the calculated offset for x temperature in degrees"
+        default_value: 0
+        field: temp_correction_a
+        min: -900
+        max: 900
+      - name: temp_correction_b
+        description: "See temp_correction_a"
+        default_value: 0
+        field: temp_correction_b
+        min: -900
+        max: 900
+
 
   - name: PG_NAV_CONFIG
     type: navConfig_t

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -259,6 +259,10 @@ typedef struct positionEstimationConfig_s {
 
     float max_eph_epv;  // Max estimated position error acceptable for estimation (cm)
     float baro_epv;     // Baro position error
+    
+    bool dynamic_acc_weight;                // To enable/disable the dynamic accelerometer weighting (relative to vibrations and clipping)
+    float temp_correction_a;          
+    float temp_correction_b;
 
 #ifdef USE_GPS_FIX_ESTIMATION
     uint8_t allow_gps_fix_estimation;


### PR DESCRIPTION
I'm using the following setup:
 - 1S 18650 battery
 - FLYWOO F405 ERVT 1-2S 5-in-1 FC ( with overheating issues )
 - 1202.5 11500KV motors

I basically solved a skyrocket behavior by applying temperature corrections to the accelerometer measurements. I don't know if this will be helpful for anyone but I'd like to share my story.
Here's the full story:

My drone couldn't maintain a good AltHold (it had a skyrocket behavior) and I tried almost everything to get it to work. After analyzing several times all the data from the Blackbox with the INAV Blackbox Explorer I found the following things:
![image](https://github.com/user-attachments/assets/d48bb39e-23a9-4f5d-9565-8f90724bfc28)
As you can see in the above image, the navAccel[2] variable which is used to calculate navVel[2] (estimated vertical speed) was just drifted downwards just as if it were badly calibrated (but it was properly calibrated) and therefore the estimated speed was always at a negative value. This caused the drone to think it was always falling down.


![image](https://github.com/user-attachments/assets/af11fcc8-94da-48fe-95c2-2175d17b554e)
Later then I found there was a relationship between that accelerometer drifting and the temperature ( using the integrated temperature sensor of the barometer which is in the FC, where the accelerometer is located ). The thing is that my all-in-one board overheats a lot and it's temperature oscillates more than 30ºC (from 45ºC to 75ºC) and instead of just buying another one I tried to fix this someway

![image](https://github.com/user-attachments/assets/76d2d9d6-2291-43ac-8617-ae41cef2a56d)
So I performed a test flight hovering stable in the air, took the values of the drifting and the temperature, and put them in a spreadsheet. Therefore I found that the relationship between the accelerometer drifting and the temperature was linear and very precise.
Once I got the values for the relationship I got into programming that compensation and after struggling with the code and debugging for a while (my first time touching INAV source code) I finally made it work and the results were incredible.

![image](https://github.com/user-attachments/assets/4ee6316e-aaa9-43b6-ae58-0f1d47c4a1cd)
As you can see the drone now achives accurate vertical position estimation ( just 10-20cm away from baro readings without adding more baro weight) and there's no accelerometer drifting apparently.

I changed the least lines of code I could and programmed it so that no corrections are made unless you set those settings in the CLI.


![image](https://github.com/user-attachments/assets/fe666767-c346-4020-95ab-857502394b63)
Apart from that I also found that the dynamic accelerometer weighting just wasn't pretty helpful as my quad also has severe vibrations and its weight is always at the lowest value except when the drone is falling (the motors are spinning slower). Therefore, the accel weight is only increased when the drone descends and that doesn't help in estimating the vertical position. In the above image the blue line represents the accelerometer weight.

With these changes I created 3 new settings and now you can:
 - Disable the dynamic accelerometer weight to set it to constant 0.3 ( `dynamic_acc_weight` --> ON/OFF)
 - Add temperature compensation for the accelerometer using the baro temperature sensor. ( `temp_correction_a` and `temp_correction_b` as for the *f(x) = ax +b* formula )