### PR TITLE
MAMBAF722_2022B: use DMAR for motor 7

### DIFF
--- a/src/main/target/MAMBAF722_2022A/target.h
+++ b/src/main/target/MAMBAF722_2022A/target.h
@@ -23,6 +23,7 @@
 
 #define TARGET_BOARD_IDENTIFIER         "M72B"
 #define USBD_PRODUCT_STRING             "MAMBAF722_2022B"
+#define USE_DSHOT_DMAR
 
 #else
 


### PR DESCRIPTION
Use DMAR to allow motor 7 to work on MAMBAF722_2022B

https://github.com/iNavFlight/inav/issues/10296