### PR TITLE
GEPRC_F722_AIO add target with UART3 instead of i2c

### DIFF
--- a/src/main/target/GEPRC_F722_AIO/CMakeLists.txt
+++ b/src/main/target/GEPRC_F722_AIO/CMakeLists.txt
@@ -1,1 +1,2 @@
 target_stm32f722xe(GEPRC_F722_AIO)
+target_stm32f722xe(GEPRC_F722_AIO_UART3)

--- a/src/main/target/GEPRC_F722_AIO/target.h
+++ b/src/main/target/GEPRC_F722_AIO/target.h
@@ -56,9 +56,8 @@
 #define ICM42605_SPI_BUS        BUS_SPI1
 
 // *************** I2C/Baro/Mag *********************
-#define USE_I2C
-
 #ifndef GEPRC_F722_AIO_UART3
+#define USE_I2C
 #define USE_I2C_DEVICE_2
 #define I2C2_SCL                PB10
 #define I2C2_SDA                PB11

--- a/src/main/target/GEPRC_F722_AIO/target.h
+++ b/src/main/target/GEPRC_F722_AIO/target.h
@@ -17,7 +17,11 @@
 
 #pragma once
 
+#ifdef GEPRC_F722_AIO_UART3
+#define TARGET_BOARD_IDENTIFIER "GEP3"
+#else
 #define TARGET_BOARD_IDENTIFIER "GEPR"
+#endif
 
 #define USBD_PRODUCT_STRING     "GEPRC_F722_AIO"
 
@@ -53,6 +57,8 @@
 
 // *************** I2C/Baro/Mag *********************
 #define USE_I2C
+
+#ifndef GEPRC_F722_AIO_UART3
 #define USE_I2C_DEVICE_2
 #define I2C2_SCL                PB10
 #define I2C2_SDA                PB11
@@ -74,6 +80,7 @@
 #define USE_RANGEFINDER
 #define RANGEFINDER_I2C_BUS     BUS_I2C2
 #define BNO055_I2C_BUS          BUS_I2C2
+#endif
 
 // *************** FLASH **************************
 #define M25P16_CS_PIN           PB9
@@ -108,9 +115,11 @@
 #define UART2_RX_PIN            PA3
 #define UART2_TX_PIN            PA2
 
+#ifdef GEPRC_F722_AIO_UART3
 #define USE_UART3
 #define UART3_RX_PIN            PB11
 #define UART3_TX_PIN            PB10
+#endif
 
 #define USE_UART4
 #define UART4_RX_PIN            PC11
@@ -120,7 +129,11 @@
 #define UART5_RX_PIN            PD2
 #define UART5_TX_PIN            PC12
 
+#ifdef GEPRC_F722_AIO_UART3
 #define SERIAL_PORT_COUNT       6
+#else
+#define SERIAL_PORT_COUNT       5
+#endif
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_SBUS


### PR DESCRIPTION


The board shares the same pins between UART3 and external i2c.
This PR allows the user to choose UART3 rather than external i2c.

This is based on the co mment from @YI-BOYANG on https://github.com/iNavFlight/inav/pull/10233

@YI-BOYANG does this look okay to you?