### PR TITLE
add stick_center note to vtol/mixer profile docs for 4+1 motor vtol configurations.

### DIFF
--- a/docs/MixerProfile.md
+++ b/docs/MixerProfile.md
@@ -41,6 +41,8 @@ The default `mmix` throttle value is 0.0, It will not show in `diff` command whe
 - -1.0<throttle<=0.0 : motor stop, default value 0, set to -1 to use a place holder for subsequent motor rules
 - -2.0<throttle<-1.0 : spin regardless of throttle position at speed `abs(throttle)-1` when Mixer Transition is activated.
 
+Airmode type should be set to "STICK_CENTER". Airmode type must NOT be set to "THROTTLE_THRESHOLD". If set to throttle threshold the (-) motor will spin till throttle threshold is passed. 
+
 Example: This will spin motor number 5 (counting from 1) at 20%, in transition mode only, to gain speed for a "4 rotor 1 pusher" setup:
 
 ```

--- a/docs/VTOL.md
+++ b/docs/VTOL.md
@@ -186,7 +186,8 @@ Add new servo mixer rules, and select 'Mixer Transition' in input. Set the weigh
 ## Motor 'Transition Mixing': Dedicated forward motor configuration
 In motor mixer set:
 - -2.0 < throttle < -1.0: The motor will spin regardless of the radio's throttle position at a speed of `abs(throttle) - 1` multiplied by throttle range only when Mixer Transition is activated.
-
+- Airmode type should be set to "STICK_CENTER". Airmode type must NOT be set to "THROTTLE_THRESHOLD". If set to throttle threshold the (-) motor will spin till throttle threshold is passed.
+  
 ![Alt text](Screenshots/mixerprofile_4puls1_mix.png)
 
 ## TailSitter 'Transition Mixing': 


### PR DESCRIPTION
adding note to save some confusion in the future.