### PR TITLE
Fixed althold issue in surface mode for multirotors

### DIFF
--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2461,6 +2461,12 @@ groups:
         field: baro_epv
         min: 0
         max: 9999
+      - name: acc_weight
+        description: "Determines the accelerometer weight. If set to zero, then its value will be automatically set according to vibration levels and clipping (ranging from 0.3 to 1.0)"
+        default_value: 0.0
+        field: acc_weight
+        min: 0
+        max: 10
 
   - name: PG_NAV_CONFIG
     type: navConfig_t

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -260,6 +260,7 @@ typedef struct positionEstimationConfig_s {
     float max_eph_epv;  // Max estimated position error acceptable for estimation (cm)
     float baro_epv;     // Baro position error
 
+    float acc_weight;   // Sets the fixed accelerometer weight. If set to 0, it's value will be determined automatically according to vibrations and clipping
 #ifdef USE_GPS_FIX_ESTIMATION
     uint8_t allow_gps_fix_estimation;
 #endif

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -65,6 +65,7 @@ PG_RESET_TEMPLATE(positionEstimationConfig_t, positionEstimationConfig,
         .reset_home_type = SETTING_INAV_RESET_HOME_DEFAULT,
         .gravity_calibration_tolerance = SETTING_INAV_GRAVITY_CAL_TOLERANCE_DEFAULT,  // 5 cm/s/s calibration error accepted (0.5% of gravity)
         .allow_dead_reckoning = SETTING_INAV_ALLOW_DEAD_RECKONING_DEFAULT,
+        .acc_weight = SETTING_ACC_WEIGHT_DEFAULT,
 
         .max_surface_altitude = SETTING_INAV_MAX_SURFACE_ALTITUDE_DEFAULT,
 
@@ -385,7 +386,11 @@ static void updateIMUTopic(timeUs_t currentTimeUs)
     }
     else {
         /* Update acceleration weight based on vibration levels and clipping */
-        updateIMUEstimationWeight(dt);
+        if (positionEstimationConfig()->acc_weight == 0.0f) {
+            updateIMUEstimationWeight(dt);
+        } else {
+            posEstimator.imu.accWeightFactor = positionEstimationConfig()->acc_weight;
+        }
 
         fpVector3_t accelBF;
 

--- a/src/main/navigation/navigation_pos_estimator_agl.c
+++ b/src/main/navigation/navigation_pos_estimator_agl.c
@@ -150,7 +150,7 @@ void estimationCalculateAGL(estimationContext_t * ctx)
         const float accWeight = navGetAccelerometerWeight();
         posEstimator.est.aglAlt += posEstimator.est.aglVel * ctx->dt;
         posEstimator.est.aglAlt += posEstimator.imu.accelNEU.z * sq(ctx->dt) / 2.0f * accWeight;
-        posEstimator.est.aglVel += posEstimator.imu.accelNEU.z * ctx->dt * sq(accWeight);
+        posEstimator.est.aglVel += posEstimator.imu.accelNEU.z * ctx->dt * accWeight;
 
         // Apply correction
         if (posEstimator.est.aglQual == SURFACE_QUAL_HIGH) {


### PR DESCRIPTION
Some people, including me, were experiencing problems with maintaining altitude in surface mode using mtf-01 sensor.
It seems that the problem was caused by high vibration levels which decreased the accelerometer weight down to 0.3, which is the minimum. But then, this value is squared in `navigation_pos_estimator_agl.c`, which means it goes down to `0.3*0.3=0.09` which is so low that the accelerometer almost becomes unused. Therefore, it was only using the rangefinder measurements but they have so much delay that the drone becomes unable to maintain a good altitude.
https://github.com/iNavFlight/inav/blob/b5e8b2bf6817268e04086d1cf8a190e794ea6d1c/src/main/navigation/navigation_pos_estimator.c#L360
https://github.com/iNavFlight/inav/blob/b5e8b2bf6817268e04086d1cf8a190e794ea6d1c/src/main/navigation/navigation_pos_estimator_agl.c#L153

I fixed this issue primarily by disabling the dynamic accelerometer weight and setting it to fixed 1.0 ( which is the value it should get when there are normal vibration levels )

I added a new setting to do that, `acc_weight`. By default, it is set to zero and that means that its value is determined automatically (as normal). But you can set it to 1.0 and that means the accelerometer weight will always be 1.0.
I particularly tested this version and works well.

Surface mode with 0.3 accelerometer weight:
![image](https://github.com/user-attachments/assets/6fcd27c4-9f71-4275-8399-84f1ab49b7cb)
Surface mode with 1.0 accelerometer weight:
![image](https://github.com/user-attachments/assets/f848b5b6-b130-46e1-80ed-377f864825da)


