### PR TITLE
at32: add uart pinswap

### DIFF
--- a/src/main/drivers/serial_uart.h
+++ b/src/main/drivers/serial_uart.h
@@ -50,7 +50,8 @@ typedef enum {
     UARTDEV_5 = 4,
     UARTDEV_6 = 5,
     UARTDEV_7 = 6,
-    UARTDEV_8 = 7
+    UARTDEV_8 = 7,
+    UARTDEV_MAX
 } UARTDevice_e;
 
 typedef struct {
@@ -69,6 +70,7 @@ typedef struct {
 
 void uartGetPortPins(UARTDevice_e device, serialPortPins_t * pins);
 void uartClearIdleFlag(uartPort_t *s);
+void uartConfigurePinSwap(uartPort_t *uartPort);
 #if defined(AT32F43x) 
 serialPort_t *uartOpen(usart_type *USARTx, serialReceiveCallbackPtr rxCallback, void *rxCallbackData, uint32_t baudRate, portMode_t mode, portOptions_t options);
 #else

--- a/src/main/drivers/serial_uart_at32f43x.c
+++ b/src/main/drivers/serial_uart_at32f43x.c
@@ -45,6 +45,7 @@ typedef struct uartDevice_s {
     uint8_t af;
     uint8_t irq;
     uint32_t irqPriority;
+    bool pinSwap;
 } uartDevice_t;
 
 #ifdef USE_UART1
@@ -59,7 +60,12 @@ static uartDevice_t uart1 =
 #endif
     .rcc_apb2 = RCC_APB2(USART1),
     .irq = USART1_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART
+    .irqPriority = NVIC_PRIO_SERIALUART,
+#ifdef USE_UART1_PIN_SWAP
+    .pinSwap = true,
+#else
+    .pinSwap = false,
+#endif
 };
 #endif
 
@@ -75,7 +81,12 @@ static uartDevice_t uart2 =
 #endif
     .rcc_apb1 = RCC_APB1(USART2),
     .irq = USART2_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART
+    .irqPriority = NVIC_PRIO_SERIALUART,
+#ifdef USE_UART2_PIN_SWAP
+    .pinSwap = true,
+#else
+    .pinSwap = false,
+#endif
 };
 #endif
 
@@ -91,7 +102,12 @@ static uartDevice_t uart3 =
 #endif
     .rcc_apb1 = RCC_APB1(USART3),
     .irq = USART3_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART
+    .irqPriority = NVIC_PRIO_SERIALUART,
+#ifdef USE_UART3_PIN_SWAP
+    .pinSwap = true,
+#else
+    .pinSwap = false,
+#endif
 };
 #endif
 
@@ -107,7 +123,12 @@ static uartDevice_t uart4 =
 #endif
     .rcc_apb1 = RCC_APB1(UART4),
     .irq = UART4_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART
+    .irqPriority = NVIC_PRIO_SERIALUART,
+#ifdef USE_UART4_PIN_SWAP
+    .pinSwap = true,
+#else
+    .pinSwap = false,
+#endif
 };
 #endif
 
@@ -123,7 +144,12 @@ static uartDevice_t uart5 =
 #endif
     .rcc_apb1 = RCC_APB1(UART5),
     .irq = UART5_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART
+    .irqPriority = NVIC_PRIO_SERIALUART,
+#ifdef USE_UART5_PIN_SWAP
+    .pinSwap = true,
+#else
+    .pinSwap = false,
+#endif
 };
 #endif
 
@@ -139,7 +165,12 @@ static uartDevice_t uart6 =
 #endif
     .rcc_apb2 = RCC_APB2(USART6),
     .irq = USART6_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART
+    .irqPriority = NVIC_PRIO_SERIALUART,
+#ifdef USE_UART6_PIN_SWAP
+    .pinSwap = true,
+#else
+    .pinSwap = false,
+#endif
 };
 #endif
 
@@ -152,7 +183,12 @@ static uartDevice_t uart7 =
     .af = GPIO_MUX_8,
     .rcc_apb1 = RCC_APB1(UART7),
     .irq = UART7_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART
+    .irqPriority = NVIC_PRIO_SERIALUART,
+#ifdef USE_UART7_PIN_SWAP
+    .pinSwap = true,
+#else
+    .pinSwap = false,
+#endif
 };
 #endif
 
@@ -165,7 +201,12 @@ static uartDevice_t uart8 =
     .af = GPIO_MUX_8,
     .rcc_apb1 = RCC_APB1(UART8),
     .irq = UART8_IRQn,
-    .irqPriority = NVIC_PRIO_SERIALUART
+    .irqPriority = NVIC_PRIO_SERIALUART,
+#ifdef USE_UART8_PIN_SWAP
+    .pinSwap = true,
+#else
+    .pinSwap = false,
+#endif
 };
 #endif
 
@@ -256,6 +297,30 @@ void uartClearIdleFlag(uartPort_t *s)
 {
     (void) s->USARTx->sts;
     (void) s->USARTx->dt;
+}
+
+static uartDevice_t *uartFindDevice(uartPort_t *uartPort)
+{
+    for (uint32_t i = 0; i < UARTDEV_MAX; i++) {
+        uartDevice_t *pDevice = uartHardwareMap[i];
+
+        if (pDevice->dev == uartPort->USARTx) {
+            return pDevice;
+        }
+    }
+    return NULL;
+}
+
+void uartConfigurePinSwap(uartPort_t *uartPort)
+{
+    uartDevice_t *uartDevice = uartFindDevice(uartPort);
+    if (!uartDevice) {
+        return;
+    }
+
+    if (uartDevice->pinSwap) {
+        usart_transmit_receive_pin_swap(uartPort->USARTx, TRUE);
+    }
 }
 
 uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_t mode, portOptions_t options)

--- a/src/main/drivers/serial_uart_hal_at32f43x.c
+++ b/src/main/drivers/serial_uart_hal_at32f43x.c
@@ -85,6 +85,7 @@ static void uartReconfigure(uartPort_t *uartPort)
           usart_transmitter_enable(uartPort->USARTx, TRUE);
 
     usartConfigurePinInversion(uartPort);
+    uartConfigurePinSwap(uartPort);
 
     if (uartPort->port.options & SERIAL_BIDIR)
         usart_single_line_halfduplex_select(uartPort->USARTx, TRUE);

--- a/src/main/target/NEUTRONRCF435MINI/target.h
+++ b/src/main/target/NEUTRONRCF435MINI/target.h
@@ -144,8 +144,9 @@
 #define UART2_TX_PIN            PA2
 
 #define USE_UART3
-#define UART3_RX_PIN            PB11
-#define UART3_TX_PIN            PB10
+#define USE_UART3_PIN_SWAP
+#define UART3_RX_PIN            PB10
+#define UART3_TX_PIN            PB11
 
 #define USE_UART5
 #define UART5_RX_PIN            PB8


### PR DESCRIPTION
adds support for uart pin swapping on at32.
gated behind a target define in for of `USE_UART*_PIN_SWAP`
replaces #9239 #10065
fixes #10059 #9972