### PR TITLE
[Fix] Potential stack smash in gforce OSD statistics

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -4998,7 +4998,7 @@ uint8_t drawStat_ESCTemperature(uint8_t col, uint8_t row, uint8_t statValX)
 uint8_t drawStat_GForce(uint8_t col, uint8_t row, uint8_t statValX)
 {
     char buff[12];
-    char outBuff[12];
+    char outBuff[20];
 
     const float max_gforce = accGetMeasuredMaxG();
     const acc_extremes_t *acc_extremes = accGetMeasuredExtremes();


### PR DESCRIPTION
The out buffer seems to small. 
It can happen (with HD OSD) that writing is done beyond the end of the buffer, 20 bytes should be enough.
