### PR TITLE
at32: add abilty to specify uart af

### DIFF
--- a/src/main/drivers/serial_uart_at32f43x.c
+++ b/src/main/drivers/serial_uart_at32f43x.c
@@ -54,7 +54,11 @@ static uartDevice_t uart1 =
     .dev = USART1,
     .rx = IO_TAG(UART1_RX_PIN),
     .tx = IO_TAG(UART1_TX_PIN),
+#ifdef UART1_AF
+    .af = CONCAT(GPIO_MUX_, UART1_AF),
+#else
     .af = GPIO_MUX_7,
+#endif
 #ifdef UART1_AHB1_PERIPHERALS
     .rcc_ahb1 = UART1_AHB1_PERIPHERALS,
 #endif
@@ -75,7 +79,11 @@ static uartDevice_t uart2 =
     .dev = USART2,
     .rx = IO_TAG(UART2_RX_PIN),
     .tx = IO_TAG(UART2_TX_PIN),
+#ifdef UART2_AF
+    .af = CONCAT(GPIO_MUX_, UART2_AF),
+#else
     .af = GPIO_MUX_7,
+#endif
 #ifdef UART2_AHB1_PERIPHERALS
     .rcc_ahb1 = UART2_AHB1_PERIPHERALS,
 #endif
@@ -96,7 +104,11 @@ static uartDevice_t uart3 =
     .dev = USART3,
     .rx = IO_TAG(UART3_RX_PIN),
     .tx = IO_TAG(UART3_TX_PIN),
+#ifdef UART3_AF
+    .af = CONCAT(GPIO_MUX_, UART3_AF),
+#else
     .af = GPIO_MUX_7,
+#endif
 #ifdef UART3_AHB1_PERIPHERALS
     .rcc_ahb1 = UART3_AHB1_PERIPHERALS,
 #endif
@@ -117,7 +129,11 @@ static uartDevice_t uart4 =
     .dev = UART4,
     .rx = IO_TAG(UART4_RX_PIN),
     .tx = IO_TAG(UART4_TX_PIN),
+#ifdef UART4_AF
+    .af = CONCAT(GPIO_MUX_, UART4_AF),
+#else
     .af = GPIO_MUX_8,
+#endif
 #ifdef UART4_AHB1_PERIPHERALS
     .rcc_ahb1 = UART4_AHB1_PERIPHERALS,
 #endif
@@ -138,7 +154,11 @@ static uartDevice_t uart5 =
     .dev = UART5,
     .rx = IO_TAG(UART5_RX_PIN),
     .tx = IO_TAG(UART5_TX_PIN),
+#ifdef UART5_AF
+    .af = CONCAT(GPIO_MUX_, UART5_AF),
+#else
     .af = GPIO_MUX_8,
+#endif
 #ifdef UART5_AHB1_PERIPHERALS
     .rcc_ahb1 = UART5_AHB1_PERIPHERALS,
 #endif
@@ -159,7 +179,11 @@ static uartDevice_t uart6 =
     .dev = USART6,
     .rx = IO_TAG(UART6_RX_PIN),
     .tx = IO_TAG(UART6_TX_PIN),
+#ifdef UART6_AF
+    .af = CONCAT(GPIO_MUX_, UART6_AF),
+#else
     .af = GPIO_MUX_8,
+#endif
 #ifdef UART6_AHB1_PERIPHERALS
     .rcc_ahb1 = UART6_AHB1_PERIPHERALS,
 #endif
@@ -180,7 +204,11 @@ static uartDevice_t uart7 =
     .dev = UART7,
     .rx = IO_TAG(UART7_RX_PIN),
     .tx = IO_TAG(UART7_TX_PIN),
+#ifdef UART7_AF
+    .af = CONCAT(GPIO_MUX_, UART7_AF),
+#else
     .af = GPIO_MUX_8,
+#endif
     .rcc_apb1 = RCC_APB1(UART7),
     .irq = UART7_IRQn,
     .irqPriority = NVIC_PRIO_SERIALUART,
@@ -198,7 +226,11 @@ static uartDevice_t uart8 =
     .dev = UART8,
     .rx = IO_TAG(UART8_RX_PIN),
     .tx = IO_TAG(UART8_TX_PIN),
+#ifdef UART8_AF
+    .af = CONCAT(GPIO_MUX_, UART8_AF),
+#else
     .af = GPIO_MUX_8,
+#endif
     .rcc_apb1 = RCC_APB1(UART8),
     .irq = UART8_IRQn,
     .irqPriority = NVIC_PRIO_SERIALUART,

--- a/src/main/target/TBS_LUCID_FC/target.h
+++ b/src/main/target/TBS_LUCID_FC/target.h
@@ -41,6 +41,7 @@
 #define UART1_RX_PIN              PA10
 
 #define USE_UART2
+#define UART2_AF                  6
 #define UART2_TX_PIN              NONE
 #define UART2_RX_PIN              PB0
 


### PR DESCRIPTION
in line with how its handled on stm32 platforms, i dont know how many other boards are affected. 