### PR TITLE
Change bus for built-in compass for MICOAIR743 target

### DIFF
--- a/src/main/target/MICOAIR743/target.h
+++ b/src/main/target/MICOAIR743/target.h
@@ -100,7 +100,7 @@
 #define BARO_I2C_BUS            BUS_I2C2
 
 #define USE_MAG
-#define MAG_I2C_BUS             BUS_I2C1
+#define MAG_I2C_BUS             BUS_I2C2
 #define USE_MAG_ALL
 
 // *************** ENABLE OPTICAL FLOW & RANGEFINDER *****************************


### PR DESCRIPTION
As discussed with @mmosca in discord, changed i2c bus for built-in compass from i2c1 to i2c2

![image](https://github.com/user-attachments/assets/7edc56c3-338b-4850-b7a6-ea5d371f26a9)
https://micoair.com/flightcontroller_micoair743/