### PR TITLE
Switch parameters with battery capacity unit

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -3716,7 +3716,7 @@ static void cliSet(char *cmdline)
                 if (changeValue) {
                     // If changing the battery capacity unit, update the osd stats energy unit to match
                     if (strcmp(name, "battery_capacity_unit") == 0) {
-                        if (batteryMetersConfig()->capacity_unit != tmp.int_value) {
+                        if (batteryMetersConfig()->capacity_unit != (uint8_t)tmp.int_value) {
                             if (tmp.int_value == BAT_CAPACITY_UNIT_MAH) {
                                 osdConfigMutable()->stats_energy_unit = OSD_STATS_ENERGY_UNIT_MAH;
                             } else {

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -3714,6 +3714,17 @@ static void cliSet(char *cmdline)
                 }
 
                 if (changeValue) {
+                    // If changing the battery capacity unit, update the osd stats energy unit to match
+                    if (strcmp(name, "battery_capacity_unit") == 0) {
+                        if (batteryMetersConfig()->capacity_unit != tmp.int_value) {
+                            if (tmp.int_value == BAT_CAPACITY_UNIT_MAH) {
+                                osdConfigMutable()->stats_energy_unit = OSD_STATS_ENERGY_UNIT_MAH;
+                            } else {
+                                osdConfigMutable()->stats_energy_unit = OSD_STATS_ENERGY_UNIT_WH;
+                            }
+                        }
+                    }
+
                     cliSetIntFloatVar(val, tmp);
 
                     cliPrintf("%s set to ", name);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2082,6 +2082,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             currentBatteryProfileMutable->capacity.value = sbufReadU32(src);
             currentBatteryProfileMutable->capacity.warning = sbufReadU32(src);
             currentBatteryProfileMutable->capacity.critical = sbufReadU32(src);
+            uint8_t currentCapacityUnit = batteryMetersConfigMutable()->capacity_unit;
             batteryMetersConfigMutable()->capacity_unit = sbufReadU8(src);
             if ((batteryMetersConfig()->voltageSource != BAT_VOLTAGE_RAW) && (batteryMetersConfig()->voltageSource != BAT_VOLTAGE_SAG_COMP)) {
                 batteryMetersConfigMutable()->voltageSource = BAT_VOLTAGE_RAW;
@@ -2090,6 +2091,12 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             if ((batteryMetersConfig()->capacity_unit != BAT_CAPACITY_UNIT_MAH) && (batteryMetersConfig()->capacity_unit != BAT_CAPACITY_UNIT_MWH)) {
                 batteryMetersConfigMutable()->capacity_unit = BAT_CAPACITY_UNIT_MAH;
                 return MSP_RESULT_ERROR;
+            } else if (currentCapacityUnit != batteryMetersConfig()->capacity_unit) {
+                if (batteryMetersConfig()->capacity_unit == BAT_CAPACITY_UNIT_MAH) {
+                    osdConfigMutable()->stats_energy_unit = OSD_STATS_ENERGY_UNIT_MAH;
+                } else {
+                    osdConfigMutable()->stats_energy_unit = OSD_STATS_ENERGY_UNIT_WH;
+                }
             }
         } else
             return MSP_RESULT_ERROR;
@@ -2121,6 +2128,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             currentBatteryProfileMutable->capacity.value = sbufReadU32(src);
             currentBatteryProfileMutable->capacity.warning = sbufReadU32(src);
             currentBatteryProfileMutable->capacity.critical = sbufReadU32(src);
+            uint8_t currentCapacityUnit = batteryMetersConfigMutable()->capacity_unit;
             batteryMetersConfigMutable()->capacity_unit = sbufReadU8(src);
             if ((batteryMetersConfig()->voltageSource != BAT_VOLTAGE_RAW) && (batteryMetersConfig()->voltageSource != BAT_VOLTAGE_SAG_COMP)) {
                 batteryMetersConfigMutable()->voltageSource = BAT_VOLTAGE_RAW;
@@ -2129,6 +2137,12 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             if ((batteryMetersConfig()->capacity_unit != BAT_CAPACITY_UNIT_MAH) && (batteryMetersConfig()->capacity_unit != BAT_CAPACITY_UNIT_MWH)) {
                 batteryMetersConfigMutable()->capacity_unit = BAT_CAPACITY_UNIT_MAH;
                 return MSP_RESULT_ERROR;
+            } else if (currentCapacityUnit != batteryMetersConfig()->capacity_unit) {
+                if (batteryMetersConfig()->capacity_unit == BAT_CAPACITY_UNIT_MAH) {
+                    osdConfigMutable()->stats_energy_unit = OSD_STATS_ENERGY_UNIT_MAH;
+                } else {
+                    osdConfigMutable()->stats_energy_unit = OSD_STATS_ENERGY_UNIT_WH;
+                }
             }
         } else
             return MSP_RESULT_ERROR;


### PR DESCRIPTION
There is a parameter for the OSD called `osd_stats_energy_unit`. This selects whether mAh or Wh are displayed on the end of flight stats screen. People are confused the when the switch the battery capacity unit to Wh from Ah, this value doesn't change.

This PR will change `osd_stats_energy_unit` to match the battery capacity unit if it changes. This will be more an expected behavior. Plus it gives pilots the option to change to the other units for the stats if they want.