### PR TITLE
Change gimbal sensitivity from programming framework

### DIFF
--- a/docs/Programming Framework.md
+++ b/docs/Programming Framework.md
@@ -101,6 +101,7 @@ IPF can be edited using INAV Configurator user interface, or via CLI. To use COn
 | 52            | LED Pin PWM                   | Value `Operand A` from [`0` : `100`] starts PWM generation on LED Pin. See [LED pin PWM](LED%20pin%20PWM.md). Any other value stops PWM generation (stop to allow ws2812 LEDs updates in shared modes). |
 | 53            | Disable GPS Sensor Fix        | Disables the GNSS sensor fix. For testing GNSS failure. |
 | 54            | Mag calibration               | Trigger a magnetometer calibration. |
+| 55            | Set Gimbal Sensitivity        | Scales `Operand A` from [`-16` : `15`]
 
 ### Operands
 

--- a/src/main/drivers/gimbal_common.c
+++ b/src/main/drivers/gimbal_common.c
@@ -89,6 +89,11 @@ bool gimbalCommonIsReady(gimbalDevice_t *gimbalDevice)
     return false;
 }
 
+void setGimbalSensitivity(int16_t sensitivity)
+{
+    gimbalConfigMutable()->sensitivity = sensitivity;
+}
+
 #ifdef GIMBAL_UNIT_TEST
 void taskUpdateGimbal(timeUs_t currentTimeUs)
 {

--- a/src/main/drivers/gimbal_common.h
+++ b/src/main/drivers/gimbal_common.h
@@ -62,9 +62,9 @@ typedef struct gimbalConfig_s {
     uint8_t tiltChannel;
     uint8_t rollChannel;
     int8_t sensitivity;
-    uint16_t panTrim;
-    uint16_t tiltTrim;
-    uint16_t rollTrim;
+    int16_t panTrim;
+    int16_t tiltTrim;
+    int16_t rollTrim;
 } gimbalConfig_t;
 
 PG_DECLARE(gimbalConfig_t, gimbalConfig);
@@ -96,6 +96,7 @@ bool gimbalCommonIsEnabled(void);
 bool gimbalCommonHtrkIsEnabled(void);
 
 int16_t gimbalCommonGetPanPwm(const gimbalDevice_t *gimbalDevice);
+void setGimbalSensitivity(int16_t sensitivity);
 
 #ifdef __cplusplus
 }

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -4307,18 +4307,21 @@ groups:
         field: sensitivity
         min: -16
         max: 15
+        type: int8_t
       - name: gimbal_pan_trim
         field: panTrim
         description: "Trim gimbal pan center position."
         default_value: 0
         min: -500
         max: 500
+        type: int16_t
       - name: gimbal_tilt_trim
         field: tiltTrim
         description: "Trim gimbal tilt center position."
         default_value: 0
         min: -500
         max: 500
+        type: int16_t
       - name: gimbal_roll_trim
         field: rollTrim
         description: "Trim gimbal roll center position."

--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -48,6 +48,7 @@
 #include "flight/pid.h"
 #include "flight/mixer_profile.h"
 #include "drivers/io_port_expander.h"
+#include "drivers/gimbal_common.h"
 #include "io/osd_common.h"
 #include "sensors/diagnostics.h"
 
@@ -342,6 +343,16 @@ static int logicConditionCompute(
             break;
         }
 #endif
+
+        case LOGIC_CONDITION_SET_GIMBAL_SENSITIVITY:
+#ifdef USE_SERIAL_GIMBAL
+            setGimbalSensitivity(constrain(operandA, SETTING_GIMBAL_SENSITIVITY_MIN, SETTING_GIMBAL_SENSITIVITY_MAX));
+            return true;
+            break;
+#else
+            return false;
+#endif
+
         case LOGIC_CONDITION_INVERT_ROLL:
             LOGIC_CONDITION_GLOBAL_FLAG_ENABLE(LOGIC_CONDITION_GLOBAL_FLAG_OVERRIDE_INVERT_ROLL);
             return true;

--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -84,7 +84,8 @@ typedef enum {
     LOGIC_CONDITION_LED_PIN_PWM                 = 52,
     LOGIC_CONDITION_DISABLE_GPS_FIX             = 53,
     LOGIC_CONDITION_RESET_MAG_CALIBRATION       = 54,
-    LOGIC_CONDITION_LAST                        = 55,
+    LOGIC_CONDITION_SET_GIMBAL_SENSITIVITY      = 55,
+    LOGIC_CONDITION_LAST                        = 56,
 } logicOperation_e;
 
 typedef enum logicOperandType_s {


### PR DESCRIPTION
Would be nice to change gimbal sensitivity during flight, the easiest way how to achieve it by programming framework.

In settings.yaml is mentioned min max values as -16 to 15, but variable in configuration is not marked as int16, default value is uint8. 
https://github.com/iNavFlight/inav/blob/master/src/main/fc/settings.yaml#L4284

This PR assume that source of true is min max -16 to 15, so I changed type for all related variables in code from uint8 to int16. 

https://github.com/iNavFlight/inav-configurator/pull/2204

