### PR TITLE
Servo_LPF_Hz default value - update to 150hz

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -5854,11 +5854,11 @@ Servo midpoint
 
 ### servo_lpf_hz
 
-Selects the servo PWM output cutoff frequency. Value is in [Hz]
+Selects the servo PWM output cutoff frequency.  This default setting may be too high for 50hz analog servos and create jitter, if that is identified, try turning the setting down to as low as 20hz at the cost of some additional control latency.  Value is in [Hz]
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 20 | 0 | 400 |
+| 150 | 0 | 400 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1290,7 +1290,7 @@ groups:
         max: 498
       - name: servo_lpf_hz
         description: "Selects the servo PWM output cutoff frequency. Value is in [Hz]"
-        default_value: 20
+        default_value: 150
         field: servo_lowpass_freq
         min: 0
         max: 400


### PR DESCRIPTION
In 2017, #1267 set the servo_lpf_hz value to 20hz.  This LPF is running a biquad filter, and per the calculations I've found should be producing around 16mS of control delay for fixed-wing.  This could be a huge factor in control response when most of the other LPF filters in the stabilization control loop are delivering more like 1-3mS of latency.

I have tested this with the filter turned up to 400mS and (by feel) it felt smoother with less bounciness evident especially in roll.  Discussion on discord brought up that it may make sense to maintain some sensible LPF, which is why I am proposing setting it to 150hz.  This should only produce a delay of around 2.1mS according to estimates I've found, while still providing aliasing protection for a typical 330hz digital servo.

Added notes to the settings page highlighting the possibility of jitteriness (as brought up in #1267 ) and the potential remedy of turning this down to 20hz.

This change is easy to test by changing servo_lpf_hz to 150 in the CLI.