### PR TITLE
Add new target for HGLRCF405V2

### DIFF
--- a/src/main/target/HGLRCF405V2/CMakeLists.txt
+++ b/src/main/target/HGLRCF405V2/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f405xg(HGLRCF405V2)

--- a/src/main/target/HGLRCF405V2/target.c
+++ b/src/main/target/HGLRCF405V2/target.c
@@ -22,7 +22,7 @@
 #include "drivers/timer.h"
 
 timerHardware_t timerHardware[] = {
-    DEF_TIM(TIM5, CH4, PA3,   TIM_USE_PPM        , 0, 0), // PPM IN
+    DEF_TIM(TIM5, CH4, PA3,   TIM_USE_PPM        , 0, 1), // PPM IN
 
     DEF_TIM(TIM8, CH1, PC6,   TIM_USE_OUTPUT_AUTO, 0, 1), // S1
     DEF_TIM(TIM8, CH2, PC7,   TIM_USE_OUTPUT_AUTO, 0, 1), // S2

--- a/src/main/target/HGLRCF405V2/target.c
+++ b/src/main/target/HGLRCF405V2/target.c
@@ -1,0 +1,39 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <platform.h>
+
+#include "drivers/io.h"
+#include "drivers/timer.h"
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM5, CH4, PA3,   TIM_USE_PPM        , 0, 0), // PPM IN
+
+    DEF_TIM(TIM8, CH1, PC6,   TIM_USE_OUTPUT_AUTO, 0, 1), // S1
+    DEF_TIM(TIM8, CH2, PC7,   TIM_USE_OUTPUT_AUTO, 0, 1), // S2
+    DEF_TIM(TIM8, CH3, PC8,   TIM_USE_OUTPUT_AUTO, 0, 1), // S3
+    DEF_TIM(TIM8, CH4, PC9,   TIM_USE_OUTPUT_AUTO, 0, 0), // S4
+    DEF_TIM(TIM2, CH1, PA15,  TIM_USE_OUTPUT_AUTO, 0, 0), // S5
+    DEF_TIM(TIM1, CH1, PA8,   TIM_USE_OUTPUT_AUTO, 0, 1), // S6
+    DEF_TIM(TIM2, CH3, PB10,  TIM_USE_OUTPUT_AUTO, 0, 0), // S7
+    DEF_TIM(TIM2, CH4, PB11,  TIM_USE_OUTPUT_AUTO, 0, 0), // S8
+
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_LED, 0, 0), // LED_STRIP
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/HGLRCF405V2/target.h
+++ b/src/main/target/HGLRCF405V2/target.h
@@ -1,0 +1,158 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "HGF4V2"
+#define USBD_PRODUCT_STRING  "HGLRCF405V2"
+
+#define USE_TARGET_CONFIG
+
+/*** Indicators ***/
+#define LED0                    PC13
+// #define LED1                    PC14
+#define BEEPER                  PB8
+#define BEEPER_INVERTED
+
+/*** SPI/I2C bus ***/
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_NSS_PIN            PA4
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_SPI_DEVICE_2
+#define SPI2_NSS_PIN            PA13
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_SPI_DEVICE_3
+#define SPI3_NSS_PIN            PC0
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6      
+#define I2C1_SDA                PB7 
+
+
+/*** IMU sensors ***/
+
+// MPU6000
+#define USE_IMU_MPU6000
+#define IMU_MPU6000_ALIGN       CW270_DEG
+#define MPU6000_SPI_BUS         BUS_SPI1
+#define MPU6000_CS_PIN          SPI1_NSS_PIN
+
+// ICM42605/ICM42688P
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN       CW270_DEG
+#define ICM42605_SPI_BUS         BUS_SPI1
+#define ICM42605_CS_PIN          SPI1_NSS_PIN
+
+/*** OSD ***/
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          SPI2_NSS_PIN
+
+/*** Onboard flash ***/
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN           SPI3_NSS_PIN
+#define M25P16_SPI_BUS          BUS_SPI3
+
+
+/*** Serial ports ***/
+#define USE_VCP
+// #define USE_UART_INVERTER
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define USE_UART3
+#define UART3_TX_PIN            PC10
+#define UART3_RX_PIN            PC11
+
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1
+
+#define USE_UART5
+#define UART5_TX_PIN            PC12
+#define UART5_RX_PIN            PD2
+
+
+#define SERIAL_PORT_COUNT       6
+
+/*** BARO & MAG ***/
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_SPL06
+#define USE_BARO_DPS310
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+/*** ADC ***/
+#define USE_ADC
+#define ADC_CHANNEL_1_PIN               PC2
+#define ADC_CHANNEL_2_PIN               PC1
+#define ADC_CHANNEL_3_PIN               PC3
+
+#define VBAT_ADC_CHANNEL                ADC_CHN_1 //PC2
+#define CURRENT_METER_ADC_CHANNEL       ADC_CHN_2 //PC1
+#define RSSI_ADC_CHANNEL                ADC_CHN_3 //PC3
+
+#define VBAT_SCALE_DEFAULT              1100
+#define CURRENT_METER_SCALE             206
+
+/*** LED STRIP ***/
+#define USE_LED_STRIP
+#define WS2811_PIN                      PB1
+ 
+/*** Default settings ***/
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#define DEFAULT_RX_TYPE                 RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER               SERIALRX_SBUS
+#define SERIALRX_UART                   SERIAL_PORT_USART2
+
+
+#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_SOFTSERIAL )
+
+/*** Timer/PWM output ***/
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define MAX_PWM_OUTPUT_PORTS            8
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+
+
+/*** Used pins ***/
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))

--- a/src/main/target/HGLRCF405V2/target.h
+++ b/src/main/target/HGLRCF405V2/target.h
@@ -24,7 +24,6 @@
 
 /*** Indicators ***/
 #define LED0                    PC13
-// #define LED1                    PC14
 #define BEEPER                  PB8
 #define BEEPER_INVERTED
 


### PR DESCRIPTION
A new target configuration for HGLRCF405V2 from HGLRC.

The flight controller uses the STM32F405 as the controller.
It features a single gyroscope but is available in versions with different gyroscope models.

Added files: CMakeLists.txt, target.c, target.h

Any and all feedback is appreciated.