### PR TITLE
Have RSSI go from 0-100%, rather than 0-99%

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -181,7 +181,7 @@ typedef struct statistic_s {
     uint16_t min_voltage; // /100
     int16_t max_current;
     int32_t max_power;
-    int8_t min_rssi;
+    uint8_t min_rssi;
     int16_t min_lq; // for CRSF
     int16_t min_rssi_dbm; // for CRSF
     int32_t max_altitude;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1717,7 +1717,7 @@ static bool osdDrawSingleElement(uint8_t item)
             if (osdRssi < 100)
                 tfp_sprintf(buff + 1, "%2d", osdRssi);
             else
-                tfp_sprintf(buff + 1, " %c", SYM_MAX);
+                tfp_sprintf(buff + 1, "%c ", SYM_MAX);
             
             if (osdRssi < osdConfig()->rssi_alarm) {
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -616,11 +616,11 @@ char *osdFormatTrimWhiteSpace(char *buff)
 
 /**
  * Converts RSSI into a % value used by the OSD.
+ * Range is [0, 100]
  */
-static uint16_t osdConvertRSSI(void)
+static uint8_t osdConvertRSSI(void)
 {
-    // change range to [0, 99]
-    return constrain(getRSSI() * 100 / RSSI_MAX_VALUE, 0, 99);
+    return constrain(getRSSI() * 100 / RSSI_MAX_VALUE, 0, 100);
 }
 
 static uint16_t osdGetCrsfLQ(void)
@@ -1712,9 +1712,13 @@ static bool osdDrawSingleElement(uint8_t item)
     }
     case OSD_RSSI_VALUE:
         {
-            uint16_t osdRssi = osdConvertRSSI();
+            uint8_t osdRssi = osdConvertRSSI();
             buff[0] = SYM_RSSI;
-            tfp_sprintf(buff + 1, "%2d", osdRssi);
+            if (osdRssi < 100)
+                tfp_sprintf(buff + 1, "%2d", osdRssi);
+            else
+                tfp_sprintf(buff + 1, " %c", SYM_MAX);
+            
             if (osdRssi < osdConfig()->rssi_alarm) {
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -181,7 +181,7 @@ typedef struct statistic_s {
     uint16_t min_voltage; // /100
     int16_t max_current;
     int32_t max_power;
-    int16_t min_rssi;
+    int8_t min_rssi;
     int16_t min_lq; // for CRSF
     int16_t min_rssi_dbm; // for CRSF
     int32_t max_altitude;
@@ -4586,7 +4586,7 @@ static void osdResetStats(void)
     stats.max_3D_speed = 0;
     stats.max_air_speed = 0;
     stats.min_voltage = 12000;
-    stats.min_rssi = 99;
+    stats.min_rssi = 100;
     stats.min_lq = 300;
     stats.min_rssi_dbm = 0;
     stats.max_altitude = 0;


### PR DESCRIPTION
Rather than constraining the RSSI to a max of 99. It now constrains to 100 (which should be the maximum after the scaling anyway. As this is a 2 digit OSD element. Rather than expanding it to use 100 as digits. The SYM_MAX symbol is used when the RSSI is at 100%.

The `osdConvertRSSI()` function now returns uint8_t rather than uint16_t. As this function returns a value between 0 and 100. There is no need for this it be uint16_t.