### PR TITLE
 Add spa06 and spl07 baro for Kakutef4/f7 FC

### DIFF
--- a/src/main/target/KAKUTEF4/target.h
+++ b/src/main/target/KAKUTEF4/target.h
@@ -78,6 +78,8 @@
 #   define BARO_I2C_BUS            BUS_I2C1
 #   define USE_BARO_MS5611
 #   define USE_BARO_BMP280
+#   define USE_BARO_DPS310
+#   define USE_BARO_SPL06
 #else // V1 does not have I2C exposed, common_post.h will pull in USE_*_MSP
 #   define USE_BARO
 #   define USE_MAG

--- a/src/main/target/KAKUTEF7/target.h
+++ b/src/main/target/KAKUTEF7/target.h
@@ -131,6 +131,8 @@
 #define USE_BARO
 #define USE_BARO_BMP280
 #define USE_BARO_MS5611
+#define USE_BARO_DPS310
+#define USE_BARO_SPL06
 #define BARO_I2C_BUS            BUS_I2C1
 
 #define USE_MAG

--- a/src/main/target/KAKUTEF7MINIV3/target.h
+++ b/src/main/target/KAKUTEF7MINIV3/target.h
@@ -117,6 +117,8 @@
 #define BARO_I2C_BUS            BUS_I2C1
 #define USE_BARO_BMP280
 #define USE_BARO_MS5611
+#define USE_BARO_DPS310
+#define USE_BARO_SPL06
 
 /*
  * Mag


### PR DESCRIPTION
The BARO used in the KakuteF4/F7 series flight controllers is BMP280. BMP280 is now discontinued. Need to replace BMP280 to SPA06/SPL07.