### PR TITLE
Fix incorrect arming flags reporting on CLI

### DIFF
--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -34,7 +34,7 @@ static EXTENDED_FASTRAM uint32_t enabledSensors = 0;
 #if !defined(CLI_MINIMAL_VERBOSITY)
 const char *armingDisableFlagNames[]= {
     "FS", "ANGLE", "CAL", "OVRLD", "NAV", "COMPASS",
-    "ACC", "ARMSW", "HWFAIL", "BOXFS", "RX",
+    "ACC", "ARMSW", "HWFAIL", "BOXFS", "PLACEHOLDER", "RX",
     "THR", "CLI", "CMS", "OSD", "ROLL/PITCH", "AUTOTRIM", "OOM",
     "SETTINGFAIL", "PWMOUT", "NOPREARM", "DSHOTBEEPER", "LANDED"
 };


### PR DESCRIPTION
CLI was being reported as CMS.

Re-adding the placeholder in the position where we had KILLSW fixes the issue.

![image](https://github.com/user-attachments/assets/9cff0dca-8151-4d6a-94bc-2953dd79db8b)
