### PR TITLE
Fix PINIO in KAKUTEH7WING

### DIFF
--- a/src/main/target/KAKUTEH7WING/target.h
+++ b/src/main/target/KAKUTEH7WING/target.h
@@ -171,8 +171,8 @@
 // *************** PINIO ***************************
 #define USE_PINIO
 #define USE_PINIOBOX
-#define PINIO1_PIN                  PC13  // VTX power switcher
-#define PINIO2_PIN                  PE3   // 2xCamera switcher
+#define PINIO1_PIN                  PC13  // 2xCamera switcher
+#define PINIO2_PIN                  PE3   // VTX power switcher
 #define PINIO2_FLAGS                PINIO_FLAGS_INVERTED
 #define PINIO3_PIN                  PD4   // User1
 #define PINIO4_PIN                  PE4   // User2

--- a/src/main/target/KAKUTEH7WING/target.h
+++ b/src/main/target/KAKUTEH7WING/target.h
@@ -173,6 +173,7 @@
 #define USE_PINIOBOX
 #define PINIO1_PIN                  PC13  // VTX power switcher
 #define PINIO2_PIN                  PE3   // 2xCamera switcher
+#define PINIO2_FLAGS                PINIO_FLAGS_INVERTED
 #define PINIO3_PIN                  PD4   // User1
 #define PINIO4_PIN                  PE4   // User2
 


### PR DESCRIPTION
PINIO2 should be inverted so the VTX power is on by default, per the Holybro docs
https://docs.holybro.com/autopilot/kakute-h743-wing/camera-and-on-off-pit-switch