### PR TITLE
Fix uninitialised buffers on arming screens

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -5346,11 +5346,13 @@ static void osdShowHDArmScreen(void)
     armScreenRow = drawLogos(false, armScreenRow);
     armScreenRow++;
 
+    memset(buf2, '\0', sizeof(buf2));
     if (!osdConfig()->use_pilot_logo && osdElementEnabled(OSD_PILOT_NAME, false) && strlen(systemConfig()->pilotName) > 0) {
         osdFormatPilotName(buf2);
         showPilotOrCraftName = true;
     }
 
+    memset(craftNameBuf, '\0', sizeof(craftNameBuf));
     if (osdElementEnabled(OSD_CRAFT_NAME, false) && strlen(systemConfig()->craftName) > 0) {
         osdFormatCraftName(craftNameBuf);
         if (strlen(buf2) > 0) {
@@ -5486,11 +5488,13 @@ static void osdShowSDArmScreen(void)
 #endif
 #endif
 
+    memset(buf2, '\0', sizeof(buf2));
     if (osdElementEnabled(OSD_PILOT_NAME, false) && strlen(systemConfig()->pilotName) > 0) {
         osdFormatPilotName(buf2);
         showPilotOrCraftName = true;
     }
 
+    memset(craftNameBuf, '\0', sizeof(craftNameBuf));
     if (osdElementEnabled(OSD_CRAFT_NAME, false) && strlen(systemConfig()->craftName) > 0) {
         osdFormatCraftName(craftNameBuf);
         if (strlen(buf2) > 0) {


### PR DESCRIPTION
Fixes #10506

buf2 and craftNameBuf were not initialised. But, could have been used. Both are now initialised before use. buf2 is used for pilot name. craftNameBuf is used for craft name. Both, pilot but no craft name, and vice versa would have caused the error on the unused name.