### PR TITLE
fix h7 sdcard init

### DIFF
--- a/src/main/drivers/sdcard/sdcard_sdio.c
+++ b/src/main/drivers/sdcard/sdcard_sdio.c
@@ -347,8 +347,20 @@ static bool sdcardSdio_poll(void)
                         break; // Timeout not reached yet so keep waiting
                     }
                     // Timeout has expired, so fall through to convert to a fatal error
+                    FALLTHROUGH;
 
                 case SDCARD_RECEIVE_ERROR:
+                    sdcardSdio_reset();
+
+                    if (sdcard.pendingOperation.callback) {
+                        sdcard.pendingOperation.callback(
+                            SDCARD_BLOCK_OPERATION_READ,
+                            sdcard.pendingOperation.blockIndex,
+                            NULL,
+                            sdcard.pendingOperation.callbackData
+                        );
+                    }
+
                     goto doMore;
                 break;
             }


### PR DESCRIPTION
this PR modifies the H7 sdio init sequence in the following ways:
1. modifies the clock edge to falling. all the stm32 examples i could find use it this way and it seemed to work more reliable with the cards i own
2. disable the sdmmc power saving feature. this drastically reduces time it takes for the sdcard to respond to reads
3. reduce the speed our cards operate at. previously this was maxed, dialing this back a notch is still plenty fast, but should increase compatibility. 
4. modify the SDMMC RCC reset sequence. as i understand the clock is supposed to be enabled when the reset is being triggered.

additionally, code was added to propagate read-timeouts back to their respective callback, this should prevent it from blocking boot in case a incompatible sdcard is encountered. 