### PR TITLE
Change Autotune default max servo range

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1178,7 +1178,7 @@ The target percentage of maximum mixer output used for determining the rates in 
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 80 | 50 | 100 |
+| 90 | 50 | 100 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2342,7 +2342,7 @@ groups:
         type: uint8_t
       - name: fw_autotune_max_rate_deflection
         description: "The target percentage of maximum mixer output used for determining the rates in `AUTO` and `LIMIT`."
-        default_value: 80
+        default_value: 90
         field: fw_max_rate_deflection
         min: 50
         max: 100


### PR DESCRIPTION
Since https://github.com/iNavFlight/inav/pull/9905 disables all PID controls at high rate input, we don't need that headroom anymore when autotuning, as we have no assisting PID controls. 
Keeping it at 90% though, to stay slightly below manual rates on borderline setups with near stall authority. 

Reverts https://github.com/iNavFlight/inav/pull/7180