### PR TITLE
Fix barometer I2C address redefine issues

### DIFF
--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -34,7 +34,9 @@
 
 #if defined(USE_BARO_BMP085)
 
+#if !defined(BMP085_I2C_ADDR)
 #define BMP085_I2C_ADDR         0x77
+#endif
 #define BMP085_CHIP_ID          0x55
 
 typedef struct {

--- a/src/main/drivers/barometer/barometer_bmp388.c
+++ b/src/main/drivers/barometer/barometer_bmp388.c
@@ -39,7 +39,9 @@
 
 #if defined(USE_BARO) && (defined(USE_BARO_BMP388) || defined(USE_BARO_SPI_BMP388) || defined(USE_BARO_BMP390) || defined(USE_BARO_SPI_BMP390))
 
+#if !defined(BMP388_I2C_ADDR)
 #define BMP388_I2C_ADDR                                 (0x76) // same as BMP280/BMP180
+#endif
 #define BMP388_DEFAULT_CHIP_ID                          (0x50) // from https://github.com/BoschSensortec/BMP3-Sensor-API/blob/master/bmp3_defs.h#L130
 #define BMP390_DEFAULT_CHIP_ID                          (0x60) // from https://github.com/BoschSensortec/BMP3-Sensor-API/blob/master/bmp3_defs.h#L133
 

--- a/src/main/drivers/barometer/barometer_spl06.h
+++ b/src/main/drivers/barometer/barometer_spl06.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#if !defined(SPL06_I2C_ADDR)
 #define SPL06_I2C_ADDR                         0x76
+#endif
 #define SPL06_DEFAULT_CHIP_ID                  0x10
 
 #define SPL06_PRESSURE_START_REG               0x00


### PR DESCRIPTION
Dear INAV developers,

PR #9902 adds configuration symbol for barometer I2C address. When defining the address in target.h with the same symbol as barometer driver files, it causes a redefined error. And this PR is to fix the issues.

Best Regard!
Minderring