### PR TITLE
RSSI to display 100 instead of SYM_MAX

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1723,9 +1723,9 @@ static bool osdDrawSingleElement(uint8_t item)
             uint8_t osdRssi = osdConvertRSSI();
             buff[0] = SYM_RSSI;
             if (osdRssi < 100)
-                tfp_sprintf(buff + 1, "%2d", osdRssi);
+                tfp_sprintf(buff + 1, " %2d", osdRssi);
             else
-                tfp_sprintf(buff + 1, "%c ", SYM_MAX);
+                tfp_sprintf(buff + 1, "100");
             
             if (osdRssi < osdConfig()->rssi_alarm) {
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);


### PR DESCRIPTION
### CURRENT BEHAVIOUR

The current way the RSSI is displayed is such that the RSSI takes up two characters. Whilst this is OK for most OSD systems which have a dedicated icon for RSSI and LQ, it causes alignement issues with regards to the values when used with the O3 system for example. As the LQ hovers around 100 most of the time and the RSSI is usually lower than 100, there is logic behind the value taking up 2 spaces and being replaced by the MAX symbol when it is 100. 

But this is not ideal when you would like to align those values to the symbol as well as the number

### DESIRED BEHAVIOUS
I think that the MAX symbol should not be used. Istead, the value should be shown as 100 when it is 100, same as the LQ. This way both the LQ and the RSSI, which are most frequently used together will both be showing with the same total number of characters, i.e. 4 in total, 1 for the signal bars icon and 3 for the value. This way users can correclty align the two signal icons one under the other and the values can be aligned to the right. 

### EXAMPLE

In other words, like this:

![Screenshot_2024-12-23_at_22 06 36](https://github.com/user-attachments/assets/4667162a-23da-4f20-99b7-f9e268674155)

Specifically, for users of the O3 system, which lacks separate icons for RSSI and LQ can use the custom fields to display what they would like as plain text next to the respective line. 


### OTHER COMMENTS

Other systems would benefit from this as well, as the value will be correclty alligned when placed one under the other.

In my case the LQ is the top and the the RSSI is at the bottom and I added those lables as text next to the value

### ADDITIONAL WORK

The only thing that would need to be done would be to adjust the lenght in the configurator as well.


Feel free to let me know if you think I've made a mistake, but this just my way of thinking about this.