### PR TITLE
Default motor stop to `ON`

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3018,7 +3018,7 @@ If enabled, motor will stop when throttle is low on this mixer_profile
 
 | Default | Min | Max |
 | --- | --- | --- |
-| OFF | OFF | ON |
+| ON | OFF | ON |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1231,7 +1231,7 @@ groups:
         max: INT16_MAX
       - name: motorstop_on_low
         description: "If enabled, motor will stop when throttle is low on this mixer_profile"
-        default_value: OFF
+        default_value: ON
         field: mixer_config.motorstopOnLow
         type: bool
       - name: mixer_pid_profile_linking


### PR DESCRIPTION
In older versions of INAV. `FEATURE MOTOR_STOP` was enabled by default. This is for safety, so motors will not spin unexpectedly. When the feature was changed to a parameter. The default was set to `OFF`, meaning motors will spin with no throttle. This PR re-establishes the past safety president of having motor stop enabled by default.