### PR TITLE
make gimbal trims signed int

### DIFF
--- a/src/main/drivers/gimbal_common.h
+++ b/src/main/drivers/gimbal_common.h
@@ -62,9 +62,9 @@ typedef struct gimbalConfig_s {
     uint8_t tiltChannel;
     uint8_t rollChannel;
     int8_t sensitivity;
-    uint16_t panTrim;
-    uint16_t tiltTrim;
-    uint16_t rollTrim;
+    int16_t panTrim;
+    int16_t tiltTrim;
+    int16_t rollTrim;
 } gimbalConfig_t;
 
 PG_DECLARE(gimbalConfig_t, gimbalConfig);


### PR DESCRIPTION
Gimbal trim allowed range -500 to +500, so it needs to an int16 rather than uint16.