### PR TITLE
Lower ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           path: targets.txt
 
   build-SITL-Linux-arm64:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies


### PR DESCRIPTION
ubuntu 24.04 creates a binary that does not run on raspberypi, downgrading to to use ubuntu 22.04 for better compatibility.