### PR TITLE
Fixed wing flight detection fix

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -3543,6 +3543,7 @@ void updateLandingStatus(timeMs_t currentTimeMs)
             landingDetectorIsActive = false;
         }
         resetLandingDetector();
+        getTakeoffAltitude();
 
         return;
     }
@@ -5276,6 +5277,16 @@ int8_t navCheckActiveAngleHoldAxis(void)
 uint8_t getActiveWpNumber(void)
 {
     return NAV_Status.activeWpNumber;
+}
+
+float getTakeoffAltitude(void)
+{
+    static float refTakeoffAltitude = 0.0f;
+    if (!ARMING_FLAG(ARMED) && !landingDetectorIsActive) {
+        refTakeoffAltitude = posControl.actualState.abs.pos.z;
+    }
+
+    return refTakeoffAltitude;
 }
 
 #ifdef USE_FW_AUTOLAND

--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -712,10 +712,11 @@ bool isFixedWingFlying(void)
     }
 #endif
     bool throttleCondition = getMotorCount() == 0 || rcCommand[THROTTLE] > currentBatteryProfile->nav.fw.cruise_throttle;
-    bool velCondition = posControl.actualState.velXY > 250.0f || airspeed > 250.0f;
+    bool velCondition = posControl.actualState.velXY > 350.0f || airspeed > 350.0f;
+    bool altCondition = fabsf(posControl.actualState.abs.pos.z - getTakeoffAltitude()) > 500.0f;
     bool launchCondition = isNavLaunchEnabled() && fixedWingLaunchStatus() == FW_LAUNCH_FLYING;
 
-    return (isGPSHeadingValid() && throttleCondition && velCondition) || launchCondition;
+    return (isGPSHeadingValid() && throttleCondition && velCondition && altCondition) || launchCondition;
 }
 
 /*-----------------------------------------------------------

--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -299,7 +299,7 @@ static bool hasIdleWakeWiggleSucceeded(timeUs_t currentTimeUs) {
 
 static inline bool isLaunchMaxAltitudeReached(void)
 {
-    return (navConfig()->fw.launch_max_altitude > 0) && (getEstimatedActualPosition(Z) >= navConfig()->fw.launch_max_altitude);
+    return (navConfig()->fw.launch_max_altitude > 0) && ((getEstimatedActualPosition(Z) - getTakeoffAltitude()) >= navConfig()->fw.launch_max_altitude);
 }
 
 static inline bool areSticksMoved(timeMs_t initialTime, timeUs_t currentTimeUs)

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -423,7 +423,7 @@ typedef enum {
 #ifdef USE_GEOZONE
 typedef struct navSendTo_s {
     fpVector3_t targetPos;
-    uint16_t altitudeTargetRange;   // 0 for only "2D" 
+    uint16_t altitudeTargetRange;   // 0 for only "2D"
     uint32_t targetRange;
     bool lockSticks;
     uint32_t lockStickTime;
@@ -554,6 +554,7 @@ bool isNavHoldPositionActive(void);
 bool isLastMissionWaypoint(void);
 float getActiveSpeed(void);
 bool isWaypointNavTrackingActive(void);
+float getTakeoffAltitude(void);
 
 void updateActualHeading(bool headingValid, int32_t newHeading, int32_t newGroundCourse);
 void updateActualHorizontalPositionAndVelocity(bool estPosValid, bool estVelValid, float newX, float newY, float newVelX, float newVelY);


### PR DESCRIPTION
Closes https://github.com/iNavFlight/inav/issues/10595 by adding an altitude change check for fixed wing flight detection. Flight is only detected if the altitude changes by 5m in addition to the other existing checks. The 5m is relative to a reference takeoff altitude that is constantly updated whilst disarmed only being fixed on arming as the reference takeoff altitude to be used during flight.

The takeoff reference altitude mentioned above is also used to fix a general issue related to the use of `inav_reset_altitude `set to `FIRST_ARM` (default). If you change takeoff elevation after first arming/disarming the reference altitudes for launch mode max altitude, RTH altitudes and other altitude related settings potentially end up using the wrong reference takeoff altitude. This PR fixes the Launch mode issue which can cause the plane to disarm by landing shortly after arming for a new flight if the takeoff altitude exceeds the launch finish altitude or alternatively it might cause the launch to end too early. The best solution if you fly from varying takeoff altitudes is to set `inav_reset_altitude `to `EACH_ARM` so the change for Launch mode is really just fool proofing.

Other related issues such as RTH altitudes are beyond the scope of this changes for now,

HITL testing shows this change to work as expected.