### PR TITLE
Add forwardslash to efficiency metre and enable imperial units for some OSD elements.

### DIFF
--- a/src/main/io/displayport_msp_dji_compat.c
+++ b/src/main/io/displayport_msp_dji_compat.c
@@ -136,31 +136,37 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_DECORATION + 7: // NW pointing arrow
             return DJI_SYM_ARROW_11;
-
+/*
+        case SYM_VTX_POWER:
+            return DJI_SYM_VTX_POWER;
+*/
         case SYM_VOLT:
             return DJI_SYM_VOLT;
 
         case SYM_MAH:
             return DJI_SYM_MAH;
 
+        case SYM_AH_MI:
+            return DJI_SYM_MI;
+
+        case SYM_AH_NM:
+            return DJI_SYM_MI;
+
         case SYM_AH_KM:
             return DJI_SYM_KM;
 
-        case SYM_AH_MI:
-            return DJI_SYM_MI;
-/*
-        case SYM_VTX_POWER:
-            return DJI_SYM_VTX_POWER;
+        case SYM_MAH_MI_0:
+            return DJI_SYM_MAH;
 
-        case SYM_AH_NM:
-            return DJI_SYM_AH_NM;
+        case SYM_MAH_MI_1:
+            return DJI_SYM_MI;
 
         case SYM_MAH_NM_0:
-            return DJI_SYM_MAH_NM_0;
+            return DJI_SYM_MAH;
 
         case SYM_MAH_NM_1:
-            return DJI_SYM_MAH_NM_1;
-*/
+            return DJI_SYM_MI;
+
         case SYM_MAH_KM_0:
             return DJI_SYM_MAH;
 
@@ -193,7 +199,16 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_AMP:
             return DJI_SYM_AMP;
+
+        case SYM_WATT:
+            return DJI_SYM_WATT;
 /*
+        case SYM_MW:
+            return DJI_SYM_MW;
+
+        case SYM_KILOWATT:
+            return DJI_SYM_KILOWATT;
+
         case SYM_WH:
             return DJI_SYM_WH;
 
@@ -205,15 +220,6 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_WH_NM:
             return DJI_SYM_WH_NM;
-*/
-        case SYM_WATT:
-            return DJI_SYM_WATT;
-/*
-        case SYM_MW:
-            return DJI_SYM_MW;
-
-        case SYM_KILOWATT:
-            return DJI_SYM_KILOWATT;
 */
         case SYM_FT:
             return DJI_SYM_FT;
@@ -298,12 +304,6 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 /*
         case SYM_KT:
             return DJI_SYM_KT
-
-        case SYM_MAH_MI_0:
-            return DJI_SYM_MAH_MI_0;
-
-        case SYM_MAH_MI_1:
-            return DJI_SYM_MAH_MI_1;
 */
         case SYM_THR:
             return DJI_SYM_THR;

--- a/src/main/io/displayport_msp_dji_compat.c
+++ b/src/main/io/displayport_msp_dji_compat.c
@@ -27,10 +27,10 @@
 #include <string.h>
 
 //                       0123456789
-static char *dji_logo = " DJI, FIX "
-                        " THE OSD  "
-                        "  FOR O3  "
-                        "  AND O4  ";
+static char *dji_logo = " ---O O---"
+                        "  -- X -- "
+                        "   -O O-  "
+                        " INAV8-DJI";
 
 uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 {
@@ -57,7 +57,10 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
             return DJI_SYM_RSSI;
 
         case SYM_LQ:
-            return 'Q';
+            return DJI_SYM_LQ;
+
+        case SYM_AZIMUTH:
+            return 'A';
 
         case SYM_LAT:
             return DJI_SYM_LAT;
@@ -75,12 +78,11 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
             return DJI_SYM_HOMEFLAG;
 
         case SYM_DEGREES:
-            return DJI_SYM_GPS_DEGREE;
+            return DJI_SYM_HEADING_DEGREE;
 
-/*
         case SYM_HEADING:
             return DJI_SYM_HEADING;
-
+/*
         case SYM_SCALE:
             return DJI_SYM_SCALE;
 
@@ -91,30 +93,28 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
             return DJI_SYM_HDP_R;
 */
         case SYM_HOME:
-            return DJI_SYM_HOMEFLAG;
+            return DJI_SYM_HOME;
 
         case SYM_2RSS:
             return DJI_SYM_RSSI;
 
-/*
         case SYM_DB:
-            return DJI_SYM_DB
+            return 'D';
 
         case SYM_DBM:
-            return DJI_SYM_DBM;
+            return 'D';
 
         case SYM_SNR:
-            return DJI_SYM_SNR;
-*/
+            return 'S';
 
         case SYM_AH_DECORATION_UP:
-            return DJI_SYM_ARROW_SMALL_UP;
+            return DJI_SYM_AH_DECORATION_UP;
 
         case SYM_AH_DECORATION_DOWN:
-            return DJI_SYM_ARROW_SMALL_DOWN;
+            return DJI_SYM_AH_DECORATION_DOWN;
 
         case SYM_DECORATION:
-            return DJI_SYM_ARROW_SMALL_UP;
+            return DJI_SYM_ARROW_NORTH; // N pointing arrow
         
         case SYM_DECORATION + 1: // NE pointing arrow
             return DJI_SYM_ARROW_7;
@@ -144,10 +144,10 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
             return DJI_SYM_MAH;
 
         case SYM_AH_KM:
-            return 'K';
+            return DJI_SYM_KM;
 
         case SYM_AH_MI:
-            return 'M';
+            return DJI_SYM_MI;
 /*
         case SYM_VTX_POWER:
             return DJI_SYM_VTX_POWER;
@@ -160,13 +160,13 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_MAH_NM_1:
             return DJI_SYM_MAH_NM_1;
-
+*/
         case SYM_MAH_KM_0:
-            return DJI_SYM_MAH_KM_0;
+            return DJI_SYM_MAH;
 
         case SYM_MAH_KM_1:
-            return DJI_SYM_MAH_KM_1;
-
+            return DJI_SYM_KM;
+/*
         case SYM_MILLIOHM:
             return DJI_SYM_MILLIOHM;
 */
@@ -224,28 +224,27 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
         case SYM_ALT_M:
             return DJI_SYM_M;
 
-        case SYM_TOTAL:
-            return DJI_SYM_FLY_H;
-/*
-
         case SYM_ALT_KM:
-            return DJI_SYM_ALT_KM;
+            return DJI_SYM_KM;
 
+        case SYM_TOTAL:
+            return DJI_SYM_TOTAL;
+/*
         case SYM_ALT_KFT:
             return DJI_SYM_ALT_KFT;
-
+*/
         case SYM_DIST_M:
-            return DJI_SYM_DIST_M;
+            return DJI_SYM_M;
 
         case SYM_DIST_KM:
-            return DJI_SYM_DIST_KM;
+            return DJI_SYM_KM;
 
         case SYM_DIST_FT:
-            return DJI_SYM_DIST_FT;
+            return DJI_SYM_FT;
 
         case SYM_DIST_MI:
-            return DJI_SYM_DIST_MI;
-
+            return DJI_SYM_MI;
+/*
         case SYM_DIST_NM:
             return DJI_SYM_DIST_NM;
 */
@@ -253,10 +252,10 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
             return DJI_SYM_M;
 
         case SYM_KM:
-            return 'K';
+            return DJI_SYM_KM;
 
         case SYM_MI:
-            return 'M';
+            return DJI_SYM_MI;
 /*
         case SYM_NM:
             return DJI_SYM_NM;
@@ -264,10 +263,9 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
         case SYM_WIND_HORIZONTAL:
             return 'W';     // W for wind
 
-/*
         case SYM_WIND_VERTICAL:
-            return DJI_SYM_WIND_VERTICAL;
-
+            return 'W';     // W for wind
+/*
         case SYM_3D_KT:
             return DJI_SYM_3D_KT;
 */
@@ -275,7 +273,7 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
             return 'A';     // A for airspeed
 
         case SYM_3D_KMH:
-            return DJI_SYM_KPH;
+            return DJI_SYM_KMH;
 
         case SYM_3D_MPH:
             return DJI_SYM_MPH;
@@ -290,10 +288,10 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
             return DJI_SYM_100FTM;
 */
         case SYM_MS:
-            return DJI_SYM_MPS;
+            return DJI_SYM_MS;
 
         case SYM_KMH:
-            return DJI_SYM_KPH;
+            return DJI_SYM_KMH;
 
         case SYM_MPH:
             return DJI_SYM_MPH;
@@ -330,13 +328,19 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_FLY_M:
             return DJI_SYM_FLY_M;
-/*
+
         case SYM_GLIDESLOPE:
             return DJI_SYM_GLIDESLOPE;
 
+        case SYM_GLIDE_DIST:
+            return DJI_SYM_GLIDE_DIST;
+
+        case SYM_GLIDE_MINS:
+            return DJI_SYM_GLIDE_MINS;
+
         case SYM_WAYPOINT:
             return DJI_SYM_WAYPOINT;
-
+/*
         case SYM_CLOCK:
             return DJI_SYM_CLOCK;
 
@@ -346,9 +350,8 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
         case SYM_ZERO_HALF_LEADING_DOT:
             return DJI_SYM_ZERO_HALF_LEADING_DOT;
 */
-
         case SYM_AUTO_THR0:
-            return 'A';
+            return DJI_SYM_AMP;
 
         case SYM_AUTO_THR1:
             return DJI_SYM_THR;
@@ -371,27 +374,26 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
         case SYM_GFORCE:
             return 'G';
 
-/*
         case SYM_GFORCE_X:
-            return DJI_SYM_GFORCE_X;
+            return 'G';
 
         case SYM_GFORCE_Y:
-            return DJI_SYM_GFORCE_Y;
+            return 'G';
 
         case SYM_GFORCE_Z:
-            return DJI_SYM_GFORCE_Z;
-*/
-        case SYM_BARO_TEMP:
-            return DJI_SYM_TEMPERATURE;
-
-        case SYM_IMU_TEMP:
-            return DJI_SYM_TEMPERATURE;
+            return 'G';
 
         case SYM_TEMP:
-            return DJI_SYM_TEMPERATURE;
+            return DJI_SYM_TEMP;
+
+        case SYM_BARO_TEMP:
+            return DJI_SYM_TEMP;
+
+        case SYM_IMU_TEMP:
+            return DJI_SYM_TEMP;
 
         case SYM_ESC_TEMP:
-            return DJI_SYM_TEMPERATURE;
+            return DJI_SYM_TEMP;
 /*
         case SYM_TEMP_SENSOR_FIRST:
             return DJI_SYM_TEMP_SENSOR_FIRST;
@@ -422,27 +424,21 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_MAX:
             return DJI_SYM_MAX;
-/*
+
         case SYM_PROFILE:
-            return DJI_SYM_PROFILE;
-*/
+            return 'P';
+
         case SYM_SWITCH_INDICATOR_LOW:
-            return DJI_SYM_STICK_OVERLAY_SPRITE_LOW;
+            return DJI_SYM_SWITCH_INDICATOR_LOW;
 
         case SYM_SWITCH_INDICATOR_MID:
-            return DJI_SYM_STICK_OVERLAY_SPRITE_MID;
+            return DJI_SYM_SWITCH_INDICATOR_MID;
 
         case SYM_SWITCH_INDICATOR_HIGH:
-            return DJI_SYM_STICK_OVERLAY_SPRITE_HIGH;
+            return DJI_SYM_SWITCH_INDICATOR_HIGH;
 /*
         case SYM_AH:
             return DJI_SYM_AH;
-
-        case SYM_GLIDE_DIST:
-            return DJI_SYM_GLIDE_DIST;
-
-        case SYM_GLIDE_MINS:
-            return DJI_SYM_GLIDE_MINS;
 
         case SYM_AH_V_FT_0:
             return DJI_SYM_AH_V_FT_0;
@@ -455,20 +451,28 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_AH_V_M_1:
             return DJI_SYM_AH_V_M_1;
-
+*/
         case SYM_FLIGHT_MINS_REMAINING:
-            return DJI_SYM_FLIGHT_MINS_REMAINING;
+            return DJI_SYM_FLY_M;
 
         case SYM_FLIGHT_HOURS_REMAINING:
-            return DJI_SYM_FLIGHT_HOURS_REMAINING;
-
+            return DJI_SYM_FLY_H;
+/*
         case SYM_GROUND_COURSE:
             return DJI_SYM_GROUND_COURSE;
 
         case SYM_CROSS_TRACK_ERROR:
             return DJI_SYM_CROSS_TRACK_ERROR;
-*/
 
+        case SYM_LOGO_START:
+            return DJI_SYM_LOGO_START;
+
+        case SYM_LOGO_WIDTH:
+            return DJI_SYM_LOGO_WIDTH;
+
+        case SYM_LOGO_HEIGHT:
+            return DJI_SYM_LOGO_HEIGHT;
+*/
         case SYM_AH_LEFT:
             return DJI_SYM_AH_LEFT;
 
@@ -480,59 +484,58 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 */
         case SYM_AH_CH_LEFT:
         case SYM_AH_CH_AIRCRAFT1:
-            return DJI_SYM_CROSSHAIR_LEFT;
+            return DJI_SYM_AH_CENTER_LINE_LEFT;
+
+        case SYM_AH_CH_TYPE3:
+            return DJI_SYM_AH_CH_TYPE3;
+        case SYM_AH_CH_TYPE4:
+            return DJI_SYM_AH_CH_TYPE4;
+        case SYM_AH_CH_TYPE5:
+            return DJI_SYM_AH_CH_TYPE5;
+        case SYM_AH_CH_TYPE6:
+            return DJI_SYM_AH_CH_TYPE6;
+        case SYM_AH_CH_TYPE7:
+            return DJI_SYM_AH_CH_TYPE7;
+        case SYM_AH_CH_TYPE8:
+            return DJI_SYM_AH_CH_TYPE8;
+
         case SYM_AH_CH_CENTER:
         case SYM_AH_CH_AIRCRAFT2:
-            return DJI_SYM_CROSSHAIR_CENTRE;
+            return DJI_SYM_AH_CENTER;
+
+        case (SYM_AH_CH_TYPE3+1):
+            return DJI_SYM_AH_CH_TYPE3_1;
+        case (SYM_AH_CH_TYPE4+1):
+            return DJI_SYM_AH_CH_TYPE4_1;
+        case (SYM_AH_CH_TYPE5+1):
+            return DJI_SYM_AH_CH_TYPE5_1;
+        case (SYM_AH_CH_TYPE6+1):
+            return DJI_SYM_AH_CH_TYPE6_1;
+        case (SYM_AH_CH_TYPE7+1):
+            return DJI_SYM_AH_CH_TYPE7_1;
+        case (SYM_AH_CH_TYPE8+1):
+            return DJI_SYM_AH_CH_TYPE8_1;
+
         case SYM_AH_CH_RIGHT:
         case SYM_AH_CH_AIRCRAFT3:
-            return DJI_SYM_CROSSHAIR_RIGHT;
+            return DJI_SYM_AH_CENTER_LINE_RIGHT;
+
+        case (SYM_AH_CH_TYPE3+2):
+            return DJI_SYM_AH_CH_TYPE3_2;
+        case (SYM_AH_CH_TYPE4+2):
+            return DJI_SYM_AH_CH_TYPE4_2;
+        case (SYM_AH_CH_TYPE5+2):
+            return DJI_SYM_AH_CH_TYPE5_2;
+        case (SYM_AH_CH_TYPE6+2):
+            return DJI_SYM_AH_CH_TYPE6_2;
+        case (SYM_AH_CH_TYPE7+2):
+            return DJI_SYM_AH_CH_TYPE7_2;
+        case (SYM_AH_CH_TYPE8+2):
+            return DJI_SYM_AH_CH_TYPE8_2;
         
         case SYM_AH_CH_AIRCRAFT0:
         case SYM_AH_CH_AIRCRAFT4:
-            return DJI_SYM_BLANK;
-
-        case SYM_AH_CH_TYPE3:
-            return DJI_SYM_NONE;
-        case (SYM_AH_CH_TYPE3+1):
-            return DJI_SYM_SMALL_CROSSHAIR;
-        case (SYM_AH_CH_TYPE3+2):
-            return DJI_SYM_NONE;
-        
-        case SYM_AH_CH_TYPE4:
-            return DJI_SYM_HYPHEN;
-        case (SYM_AH_CH_TYPE4+1):
-            return DJI_SYM_SMALL_CROSSHAIR;
-        case (SYM_AH_CH_TYPE4+2):
-            return DJI_SYM_HYPHEN;
-        
-        case SYM_AH_CH_TYPE5:
-            return DJI_SYM_STICK_OVERLAY_HORIZONTAL;
-        case (SYM_AH_CH_TYPE5+1):
-            return DJI_SYM_SMALL_CROSSHAIR;
-        case (SYM_AH_CH_TYPE5+2):
-            return DJI_SYM_STICK_OVERLAY_HORIZONTAL;
-        
-        case SYM_AH_CH_TYPE6:
-            return DJI_SYM_NONE;
-        case (SYM_AH_CH_TYPE6+1):
-            return DJI_SYM_STICK_OVERLAY_SPRITE_MID;
-        case (SYM_AH_CH_TYPE6+2):
-            return DJI_SYM_NONE;
-        
-        case SYM_AH_CH_TYPE7:
-            return DJI_SYM_ARROW_SMALL_LEFT;
-        case (SYM_AH_CH_TYPE7+1):
-            return DJI_SYM_SMALL_CROSSHAIR;
-        case (SYM_AH_CH_TYPE7+2):
-            return DJI_SYM_ARROW_SMALL_RIGHT;
-        
-        case SYM_AH_CH_TYPE8:
-            return DJI_SYM_AH_LEFT;
-        case (SYM_AH_CH_TYPE8+1):
-            return DJI_SYM_SMALL_CROSSHAIR;
-        case (SYM_AH_CH_TYPE8+2):
-            return DJI_SYM_AH_RIGHT;
+            return ' ';
 
         case SYM_ARROW_UP:
             return DJI_SYM_ARROW_NORTH;
@@ -668,7 +671,7 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
             return DJI_SYM_ARROW_SMALL_DOWN;
 
         case SYM_ALT:
-            return DJI_SYM_ALTITUDE;
+            return DJI_SYM_ALT;
 /*
         case SYM_HUD_SIGNAL_0:
             return DJI_SYM_HUD_SIGNAL_0;

--- a/src/main/io/dji_osd_symbols.h
+++ b/src/main/io/dji_osd_symbols.h
@@ -22,37 +22,49 @@
 #pragma once
 
 //Misc
-#define DJI_SYM_NONE                    0x00
-#define DJI_SYM_END_OF_FONT             0xFF
-#define DJI_SYM_BLANK                   0x20
-#define DJI_SYM_HYPHEN                  0x2D
-#define DJI_SYM_BBLOG                   0x10
-#define DJI_SYM_HOMEFLAG                0x11
-#define DJI_SYM_RPM                     0x12
-#define DJI_SYM_ROLL                    0x14
-#define DJI_SYM_PITCH                   0x15
-#define DJI_SYM_TEMPERATURE             0x7A
-#define DJI_SYM_MAX                     0x24
+#define DJI_SYM_NONE                    0x00 // NONE
+#define DJI_SYM_END_OF_FONT             0xFF // End of font
+#define DJI_SYM_BLANK                   0x20 // Blank space
+#define DJI_SYM_HYPHEN                  0x2D // Hyphen symbol
+#define DJI_SYM_BBLOG                   0x10 // Black Box Log symbol
+#define DJI_SYM_RPM                     0x12 // RPM symbol
+#define DJI_SYM_ROLL                    0x14 // ROLL symbol
+#define DJI_SYM_PITCH                   0x15 // PITCH symbol
+#define DJI_SYM_TEMP                    0x7A // TEMP symbol
+#define DJI_SYM_MAX                     0x24 // MAX symbol
+
+// Glide calculations
+#define DJI_SYM_GLIDESLOPE              0x2F // Forward slash symbol looks like slope
+#define DJI_SYM_GLIDE_DIST              0x24 // MAX Symbol for max glide distance
+#define DJI_SYM_GLIDE_MINS              0x9C // Fly Time Symbol
 
 // GPS and navigation
-#define DJI_SYM_LAT                     0x89
-#define DJI_SYM_LON                     0x98
-#define DJI_SYM_ALTITUDE                0x7F
-#define DJI_SYM_OVER_HOME               0x05
+#define DJI_SYM_HOME                    0x05 // Home house symbol
+#define DJI_SYM_HOMEFLAG                0x11 // Home pin symbol
+#define DJI_SYM_LAT                     0x89 // LAT symbol
+#define DJI_SYM_LON                     0x98 // LON symbol
+#define DJI_SYM_ALT                     0x7F // ALT symbol
+#define DJI_SYM_TOTAL                   0x71 // Circle with arrow
+#define DJI_SYM_WAYPOINT                0x40 // @ Symbol
+#define DJI_SYM_HEADING                 0x70 // Betaflight speed symbol (looks like compass symbol)
+#define DJI_SYM_HEADING_DEGREE          0x08 // High circle looks like degrees icon
 
 // RSSI
-#define DJI_SYM_RSSI                    0x01
+#define DJI_SYM_RSSI                    0x01 // RSSI bars
+#define DJI_SYM_LQ                      0x7B // RSSI bars with LQ on top
 
 // Throttle Position (%)
-#define DJI_SYM_THR                     0x04
+#define DJI_SYM_THR                     0x04 // Throttle symbol
 
 // Unit Icons (Metric)
-#define DJI_SYM_M                       0x0C
-#define DJI_SYM_C                       0x0E
+#define DJI_SYM_M                       0x0C // Meters
+#define DJI_SYM_KM                      0x7D // Kilometers
+#define DJI_SYM_C                       0x0E // Celsius
 
 // Unit Icons (Imperial)
-#define DJI_SYM_F                       0x0D
-#define DJI_SYM_FT                      0x0F
+#define DJI_SYM_FT                      0x0F // Feet
+#define DJI_SYM_MI                      0x7E // Miles
+#define DJI_SYM_F                       0x0D // Farenheit
 
 // Heading Graphics
 #define DJI_SYM_HEADING_N               0x18
@@ -69,7 +81,38 @@
 #define DJI_SYM_AH_RIGHT                0x02
 #define DJI_SYM_AH_LEFT                 0x03
 #define DJI_SYM_AH_DECORATION           0x13
-#define DJI_SYM_SMALL_CROSSHAIR         0x7E
+#define DJI_SYM_AH_DECORATION_UP        0x75
+#define DJI_SYM_AH_DECORATION_DOWN      0x76
+#define DJI_SYM_SMALL_CROSSHAIR         0x73
+
+// Crosshair Styles
+#define DJI_SYM_AH_CENTER_LINE_LEFT     0x72
+#define DJI_SYM_AH_CENTER               0x73
+#define DJI_SYM_AH_CENTER_LINE_RIGHT    0x74
+
+#define DJI_SYM_AH_CH_TYPE3	            0x00
+#define DJI_SYM_AH_CH_TYPE3_1	        0x73
+#define DJI_SYM_AH_CH_TYPE3_2	        0x00
+
+#define DJI_SYM_AH_CH_TYPE4	            0x2D
+#define DJI_SYM_AH_CH_TYPE4_1	        0x73
+#define DJI_SYM_AH_CH_TYPE4_2	        0x2D
+
+#define DJI_SYM_AH_CH_TYPE5	            0x17
+#define DJI_SYM_AH_CH_TYPE5_1	        0x73
+#define DJI_SYM_AH_CH_TYPE5_2	        0x17
+
+#define DJI_SYM_AH_CH_TYPE6	            0x00
+#define DJI_SYM_AH_CH_TYPE6_1	        0x09
+#define DJI_SYM_AH_CH_TYPE6_2	        0x00
+
+#define DJI_SYM_AH_CH_TYPE7	            0x78
+#define DJI_SYM_AH_CH_TYPE7_1	        0x73
+#define DJI_SYM_AH_CH_TYPE7_2	        0x77
+
+#define DJI_SYM_AH_CH_TYPE8	            0x02
+#define DJI_SYM_AH_CH_TYPE8_1	        0x73
+#define DJI_SYM_AH_CH_TYPE8_2	        0x03
 
 // Satellite Graphics
 #define DJI_SYM_SAT_L                   0x1E
@@ -97,6 +140,11 @@
 #define DJI_SYM_ARROW_SMALL_DOWN        0x76
 #define DJI_SYM_ARROW_SMALL_RIGHT       0x77
 #define DJI_SYM_ARROW_SMALL_LEFT        0x78
+
+//Switch indicators
+#define DJI_SYM_SWITCH_INDICATOR_HIGH   0x75 // DJI_SYM_ARROW_SMALL_UP
+#define DJI_SYM_SWITCH_INDICATOR_MID    0x2D // Hyphon
+#define DJI_SYM_SWITCH_INDICATOR_LOW    0x76 // DJI_SYM_ARROW_SMALL_DOWN
 
 // AH Bars
 #define DJI_SYM_AH_BAR9_0               0x80
@@ -133,19 +181,22 @@
 #define DJI_SYM_VOLT                    0x06
 #define DJI_SYM_AMP                     0x9A
 #define DJI_SYM_MAH                     0x07
-#define DJI_SYM_WATT                    0x57  // 0x57 is 'W'
+#define DJI_SYM_WATT                    0x57  // 'W'
 
 // Time
-#define DJI_SYM_ON_H                    0x70
-#define DJI_SYM_FLY_H                   0x71
+#define DJI_SYM_ON_H                    0x9B
+#define DJI_SYM_FLY_H                   0x9C
 #define DJI_SYM_ON_M                    0x9B
 #define DJI_SYM_FLY_M                   0x9C
 
 // Speed
-#define DJI_SYM_KPH                     0x9E
-#define DJI_SYM_MPH                     0x9D
-#define DJI_SYM_MPS                     0x9F
-#define DJI_SYM_FTPS                    0x99
+#define DJI_SYM_MS                      0x9F // m/s
+#define DJI_SYM_KMH                     0x9E // km/h
+#define DJI_SYM_MPH                     0x9D // mi/h
+#define DJI_SYM_FTPS                    0x99 // ft/s
+
+// Menu cursor
+#define DJI_SYM_CURSOR                  0x3E
 
 // Stick overlays
 #define DJI_SYM_STICK_OVERLAY_SPRITE_HIGH 0x08
@@ -156,6 +207,6 @@
 #define DJI_SYM_STICK_OVERLAY_HORIZONTAL  0x17
 
 // GPS degree/minute/second symbols
-#define DJI_SYM_GPS_DEGREE              DJI_SYM_STICK_OVERLAY_SPRITE_HIGH  // kind of looks like the degree symbol
+#define DJI_SYM_GPS_DEGREE              0x08 // kind of looks like the degree symbol (DJI_SYM_STICK_OVERLAY_SPRITE_HIGH)
 #define DJI_SYM_GPS_MINUTE              0x27 // '
 #define DJI_SYM_GPS_SECOND              0x22 // "

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1724,10 +1724,10 @@ static bool osdDrawSingleElement(uint8_t item)
             uint8_t osdRssi = osdConvertRSSI();
             buff[0] = SYM_RSSI;
             if (osdRssi < 100)
-                tfp_sprintf(buff + 1, "%2d", osdRssi);
+                tfp_sprintf(buff + 1, " %2d", osdRssi);
             else
-                tfp_sprintf(buff + 1, "%c ", SYM_MAX);
-
+                tfp_sprintf(buff + 1, "100");
+            
             if (osdRssi < osdConfig()->rssi_alarm) {
                 TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
             }
@@ -2589,7 +2589,7 @@ static bool osdDrawSingleElement(uint8_t item)
             if (!failsafeIsReceivingRxData())
                 tfp_sprintf(buff, "%s%c", "    ", SYM_MW);
             else
-                tfp_sprintf(buff, "%4d%c", rxLinkStatistics.uplinkTXPower, SYM_MW);
+                tfp_sprintf(buff, "%4d", rxLinkStatistics.uplinkTXPower);
             break;
         }
 
@@ -2601,6 +2601,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 tfp_sprintf(buff, "%4d%c%c", rxLinkStatistics.downlinkTXPower, SYM_MW, SYM_AH_DECORATION_DOWN);
             break;
         }
+
     case OSD_RX_BAND:
         displayWriteChar(osdDisplayPort, elemPosX++, elemPosY, SYM_RX_BAND);
         strcat(buff, rxLinkStatistics.band);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3401,29 +3401,31 @@ static bool osdDrawSingleElement(uint8_t item)
                 case OSD_UNIT_IMPERIAL:
                     moreThanAh = osdFormatCentiNumber(buff, value * METERS_PER_MILE / 10, 1000, 0, 2, digits, false);
                     if (!moreThanAh) {
-                        tfp_sprintf(buff + strlen(buff), "%c%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
+                        tfp_sprintf(buff + strlen(buff), "%c/%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
                     } else {
                         tfp_sprintf(buff + strlen(buff), "%c", SYM_AH_MI);
                     }
                     if (!efficiencyValid) {
                         buff[0] = buff[1] = buff[2] = buff[3] = '-';
                         buff[digits] = SYM_MAH_MI_0;        // This will overwrite the "-" at buff[3] if not in DJICOMPAT mode
-                        buff[digits + 1] = SYM_MAH_MI_1;
-                        buff[digits + 2] = '\0';
+                        buff[digits + 1] = '/'
+                        buff[digits + 2] = SYM_MAH_MI_1;
+                        buff[digits + 3] = '\0';
                     }
                     break;
                 case OSD_UNIT_GA:
                      moreThanAh = osdFormatCentiNumber(buff, value * METERS_PER_NAUTICALMILE / 10, 1000, 0, 2, digits, false);
                     if (!moreThanAh) {
-                        tfp_sprintf(buff + strlen(buff), "%c%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
+                        tfp_sprintf(buff + strlen(buff), "%c/%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
                     } else {
                         tfp_sprintf(buff + strlen(buff), "%c", SYM_AH_NM);
                     }
                     if (!efficiencyValid) {
                         buff[0] = buff[1] = buff[2] = buff[3] = '-';
                         buff[digits] = SYM_MAH_NM_0;
-                        buff[digits + 1] = SYM_MAH_NM_1;
-                        buff[digits + 2] = '\0';
+                        buff[digits + 1] = '/';
+                        buff[digits + 2] = SYM_MAH_NM_1;
+                        buff[digits + 3] = '\0';
                     }
                     break;
                 case OSD_UNIT_METRIC_MPH:
@@ -3431,15 +3433,16 @@ static bool osdDrawSingleElement(uint8_t item)
                 case OSD_UNIT_METRIC:
                     moreThanAh = osdFormatCentiNumber(buff, value * 100, 1000, 0, 2, digits, false);
                     if (!moreThanAh) {
-                        tfp_sprintf(buff + strlen(buff), "%c%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
+                        tfp_sprintf(buff + strlen(buff), "%c/%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
                     } else {
                         tfp_sprintf(buff + strlen(buff), "%c", SYM_AH_KM);
                     }
                     if (!efficiencyValid) {
                         buff[0] = buff[1] = buff[2] = buff[3] = '-';
                         buff[digits] = SYM_MAH_KM_0;
-                        buff[digits + 1] = SYM_MAH_KM_1;
-                        buff[digits + 2] = '\0';
+                        buff[digits + 1] = '/';
+                        buff[digits + 2] = SYM_MAH_KM_1;
+                        buff[digits + 3] = '\0';
                     }
                     break;
             }
@@ -4960,7 +4963,7 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                         strcat(outBuff, osdFormatTrimWhiteSpace(buff));
                         if (osdDisplayIsHD()) {
                             if (!moreThanAh)
-                                tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
+                                tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
                             else
                                 tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_MI);
 
@@ -4972,11 +4975,11 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                         strcat(outBuff, osdFormatTrimWhiteSpace(buff));
 
                         if (!moreThanAh)
-                            tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
+                            tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
                         else
                             tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_MI);
                     } else {
-                        tfp_sprintf(outBuff + strlen(outBuff), "---/---%c%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
+                        tfp_sprintf(outBuff + strlen(outBuff), "---/---%c/%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
                     }
                 } else {
                     if (efficiencyValid) {
@@ -4998,7 +5001,7 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                         strcat(outBuff, osdFormatTrimWhiteSpace(buff));
                          if (osdDisplayIsHD()) {
                             if (!moreThanAh)
-                                tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
+                                tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
                             else
                                 tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_NM);
 
@@ -5009,12 +5012,12 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                         moreThanAh = moreThanAh || osdFormatCentiNumber(buff, (int32_t)(getMAhDrawn() * 10000.0f * METERS_PER_NAUTICALMILE / totalDistance), 1000, 0, 2, digits, false);
                         strcat(outBuff, osdFormatTrimWhiteSpace(buff));
                         if (!moreThanAh) {
-                            tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
+                            tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
                         } else {
                             tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_NM);
                         }
                     } else {
-                        tfp_sprintf(outBuff + strlen(outBuff), "---/---%c%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
+                        tfp_sprintf(outBuff + strlen(outBuff), "---/---%c/%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
                     }
                 } else {
                     if (efficiencyValid) {
@@ -5043,7 +5046,7 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                 strcat(outBuff, osdFormatTrimWhiteSpace(buff));
                 if (osdDisplayIsHD()) {
                     if (!moreThanAh)
-                        tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
+                        tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
                     else
                         tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_KM);
 
@@ -5054,12 +5057,12 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                 moreThanAh = moreThanAh || osdFormatCentiNumber(buff, (int32_t)(getMAhDrawn() * 10000000.0f / totalDistance), 1000, 0, 2, digits, false);
                 strcat(outBuff, osdFormatTrimWhiteSpace(buff));
                 if (!moreThanAh) {
-                    tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
+                    tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
                 } else {
                     tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_KM);
                 }
             } else {
-                tfp_sprintf(outBuff + strlen(outBuff), "---/---%c%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
+                tfp_sprintf(outBuff + strlen(outBuff), "---/---%c/%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
             }
         } else {
             if (efficiencyValid) {


### PR DESCRIPTION
In the regular version of the firmware, the efficiency symbol is made of two parts where the division is made with a horizontal line, 

A good example of this is the `mAh/km` symbol. 

Betaflight does not support those newer symbols and so I adapted to code to add a `/` between the `mAh` and the `km` symbol the same way that it is in Betaflight. 

The same was done for imperial units. 

Important to note that if Nautical Miles are selected, the symbol still remains as `mi` and the user has to know that nautical miles and not regular miles are used. 