### PR TITLE
Change TARGET_BOARD_IDENTIFIER for AET-H743-Basic to avoid confliction

### DIFF
--- a/src/main/target/AETH743Basic/target.h
+++ b/src/main/target/AETH743Basic/target.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#define TARGET_BOARD_IDENTIFIER "H743"
+#define TARGET_BOARD_IDENTIFIER "AE7B"
 
 #define USBD_PRODUCT_STRING     "AETH743Basic"
 


### PR DESCRIPTION
We found the TARGET_BOARD_IDENTIFIER "H743" is conflict with Matek's production. Maybe it will confuse the INAV Configurator's Auto-select target function.