### PR TITLE
Add missing gyro defines to TMOTORF7

### DIFF
--- a/src/main/target/TMOTORF7/target.h
+++ b/src/main/target/TMOTORF7/target.h
@@ -44,6 +44,16 @@
 #define MPU6000_CS_PIN          PA4
 #define MPU6000_SPI_BUS         BUS_SPI1
 
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW0_DEG
+#define ICM42605_CS_PIN         PA4
+#define ICM42605_SPI_BUS        BUS_SPI1
+
+#define USE_IMU_BMI270
+#define IMU_BMI270_ALIGN        CW0_DEG
+#define BMI270_CS_PIN           PA4
+#define BMI270_SPI_BUS          BUS_SPI1
+
 // *************** I2C Mag *********************
 #define USE_I2C
 #define USE_I2C_DEVICE_2


### PR DESCRIPTION
T-MOTOR has released different versions of this FC with new gyros due to the MPU6000 going EOL. Adds defines for the BMI270 and ICM42688p.