### PR TITLE
Blind attempt at random Jeti issues

### DIFF
--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -189,7 +189,7 @@ static void jetiExBusDataReceive(uint16_t c, void *data)
         }
     }
 
-    if (jetiExBusFramePosition == jetiExBusFrameMaxSize) {
+    if (jetiExBusFramePosition >= jetiExBusFrameMaxSize) {
         // frame overrun
         jetiExBusFrameReset();
         jetiExBusFrameState = EXBUS_STATE_ZERO;


### PR DESCRIPTION
Blind attempt at fixing #10646

Quick lock at code, only suspicious thing it the == comparison for frame length or some operator precedence for type castings.

Impossible to debug/diagnose without hardware though.

Please test: https://github.com/iNavFlight/inav/actions/runs/13010083214/artifacts/2497055310
