### PR TITLE
DO NOT MERGE -prevent dshot 0048 on forward after reverse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
 endif()
 
 
-project(INAV VERSION 9.0.0)
+project(INAV VERSION 8.1.0)
 
 enable_language(ASM)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
 endif()
 
 
-project(INAV VERSION 8.1.0)
+project(INAV VERSION 9.0.0)
 
 enable_language(ASM)
 

--- a/docs/OSD.md
+++ b/docs/OSD.md
@@ -23,7 +23,7 @@ Not all OSDs are created equally. This table shows the differences between the d
 | DJI WTFOS     | 60 x 22        | X         |        | X               | YES                     |
 | HDZero        | 50 x 18        | X         |        | X               | YES                     |
 | Avatar        | 53 x 20        | X         |        | X               | YES                     |
-| DJI O3        | 53 x 20 (HD)   | X         |        | X	(partial)     | NO - BF Characters only |
+| DJI O3        | 53 x 20 (HD)   | X         |        | X (partial)     | NO - BF Characters only |
 
 ## OSD Elements
 Here are the OSD Elements provided by INAV.

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -574,6 +574,8 @@ void FAST_CODE mixTable(void)
             reversibleMotorsThrottleState = MOTOR_DIRECTION_BACKWARD;
             throttleRangeMax = throttleDeadbandLow;
             throttleRangeMin = motorConfig()->mincommand;
+        } else if (isMotorProtocolDigital()) {
+            reversibleMotorsThrottleState = MOTOR_DIRECTION_FORWARD; // prevent dshot 0048 on forward after reverse
         }
 
 


### PR DESCRIPTION
This fix is a working fix for #10648.

However, I can imagine some code/use cases may find it desirable to add reversibleMotorsThrottleState = MOTOR_DIRECTION_NEUTRAL  or MOTOR_DIRECTION_DEADBAND state so that the vehicle is not erroneously indicating motor direction FORWARD state while it may still be coasting BACKWARD.