### PR TITLE
fix LTM attitude (mis-cast)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
 endif()
 
 
-project(INAV VERSION 8.1.0)
+project(INAV VERSION 9.0.0)
 
 enable_language(ASM)
 

--- a/docs/OSD.md
+++ b/docs/OSD.md
@@ -23,7 +23,7 @@ Not all OSDs are created equally. This table shows the differences between the d
 | DJI WTFOS     | 60 x 22        | X         |        | X               | YES                     |
 | HDZero        | 50 x 18        | X         |        | X               | YES                     |
 | Avatar        | 53 x 20        | X         |        | X               | YES                     |
-| DJI O3        | 53 x 20 (HD)   | X         |        | X	(partial)     | NO - BF Characters only |
+| DJI O3        | 53 x 20 (HD)   | X         |        | X (partial)     | NO - BF Characters only |
 
 ## OSD Elements
 Here are the OSD Elements provided by INAV.

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 > INAV no longer accepts targets based on STM32 F411 MCU.
 
-> INAV 7 was the last INAV official release available for F411 based flight controllers. INAV 8 is not officially available for F411 boards.
+> INAV 7 was the last INAV official release available for F411 based flight controllers. INAV 8 is not officially available for F411 boards and the team has not tested either. Issues that can't be reproduced on other MCUs may not be fixed and the targets for F411 targets may eventually be removed from future releases.
 
 # ICM426xx IMUs PSA
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 > INAV no longer accepts targets based on STM32 F411 MCU.
 
-> INAV 7 was the last INAV official release available for F411 based flight controllers. INAV 8 is not officially available for F411 boards and the team has not tested either. Issues that can't be reproduced on other MCUs may not be fixed and the targets for F411 targets may eventually be removed from future releases.
+> INAV 7 was the last INAV official release available for F411 based flight controllers. INAV 8 is not officially available for F411 boards and the team has not tested either. Issues that can't be reproduced on other MCUs may not be fixed and the targets for F411 targets may eventually be completelly removed from future releases.
 
 # ICM426xx IMUs PSA
 

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -212,9 +212,9 @@ void ltm_sframe(sbuf_t *dst)
 void ltm_aframe(sbuf_t *dst)
 {
     sbufWriteU8(dst, 'A');
-    sbufWriteU16(dst, DECIDEGREES_TO_DEGREES(attitude.values.pitch));
-    sbufWriteU16(dst, DECIDEGREES_TO_DEGREES(attitude.values.roll));
-    sbufWriteU16(dst, DECIDEGREES_TO_DEGREES(attitude.values.yaw));
+    sbufWriteU16(dst, (int16_t)DECIDEGREES_TO_DEGREES(attitude.values.pitch));
+    sbufWriteU16(dst, (int16_t)DECIDEGREES_TO_DEGREES(attitude.values.roll));
+    sbufWriteU16(dst, (int16_t)DECIDEGREES_TO_DEGREES(attitude.values.yaw));
 }
 
 #if defined(USE_GPS)


### PR DESCRIPTION
The LTM A frame is currently broken always returns ("randomly small") +ve values, presumable as a result the float promotion  (`/10.0f`)  prior to being fed into `sbufWriteU16`.

This PR adds appropriate casts.
