### PR TITLE
Fix box ids being truncated in status messages

### DIFF
--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -467,7 +467,7 @@ void packBoxModeFlags(boxBitmask_t * mspBoxModeFlags)
 #endif
 
     memset(mspBoxModeFlags, 0, sizeof(boxBitmask_t));
-    for (uint32_t i = 0; i < activeBoxIdCount; i++) {
+    for (uint32_t i = 0; i < CHECKBOX_ITEM_COUNT; i++) {
         if (activeBoxes[activeBoxIds[i]]) {
             bitArraySet(mspBoxModeFlags->bits, i);
         }


### PR DESCRIPTION
Old code was checking only activeBoxIdCount, instead of total box count.

Array of modes used to setup the bits is using fixed indexes in rc_modes.h.

Any item with index >= activeBoxIdCount would be ignored.