### PR TITLE
fix MATEKF405 variants BBL logging

### DIFF
--- a/src/main/target/MATEKF405/CMakeLists.txt
+++ b/src/main/target/MATEKF405/CMakeLists.txt
@@ -1,2 +1,3 @@
 target_stm32f405xg(MATEKF405)
 target_stm32f405xg(MATEKF405OSD)
+target_stm32f405xg(MATEKF405SPI)

--- a/src/main/target/MATEKF405/CMakeLists.txt
+++ b/src/main/target/MATEKF405/CMakeLists.txt
@@ -1,3 +1,3 @@
 target_stm32f405xg(MATEKF405)
 target_stm32f405xg(MATEKF405OSD)
-target_stm32f405xg(MATEKF405SPI)
+target_stm32f405xg(MATEKF405MINI)

--- a/src/main/target/MATEKF405/target.h
+++ b/src/main/target/MATEKF405/target.h
@@ -47,7 +47,13 @@
 #define USE_IMU_MPU6000
 #define IMU_MPU6000_ALIGN       CW270_DEG
 
-#ifdef MATEKF405SPI
+// *************** SPI3 ********************
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN   	    PB4
+#define SPI3_MOSI_PIN   	    PB5
+
+#ifdef MATEKF405MINI
 // *************** M25P256 flash ********************
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
@@ -61,11 +67,6 @@
 #define USE_SDCARD_SPI
 #define SDCARD_SPI_BUS          BUS_SPI3
 #define SDCARD_CS_PIN           PC1
-
-#define USE_SPI_DEVICE_3
-#define SPI3_SCK_PIN            PB3
-#define SPI3_MISO_PIN   	    PB4
-#define SPI3_MOSI_PIN   	    PB5
 
 #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
 #endif
@@ -172,7 +173,7 @@
 #define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
 #define RSSI_ADC_CHANNEL            ADC_CHN_3
 
-#define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY )
+#define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_BLACKBOX )
 #define CURRENT_METER_SCALE   179
 
 #define USE_LED_STRIP

--- a/src/main/target/MATEKF405/target.h
+++ b/src/main/target/MATEKF405/target.h
@@ -47,21 +47,7 @@
 #define USE_IMU_MPU6000
 #define IMU_MPU6000_ALIGN       CW270_DEG
 
-// *************** SPI3 ********************
-#define USE_SPI_DEVICE_3
-#define SPI3_SCK_PIN            PB3
-#define SPI3_MISO_PIN   	    PB4
-#define SPI3_MOSI_PIN   	    PB5
-
-#ifdef MATEKF405OSD
-// *************** SD Card **************************
-#define USE_SDCARD
-#define USE_SDCARD_SPI
-#define SDCARD_SPI_BUS          BUS_SPI3
-#define SDCARD_CS_PIN           PC1
-
-#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
-#else
+#ifdef MATEKF405SPI
 // *************** M25P256 flash ********************
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
@@ -69,6 +55,19 @@
 #define M25P16_CS_PIN           PC0
 
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+#else
+// *************** SD Card **************************
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+#define SDCARD_SPI_BUS          BUS_SPI3
+#define SDCARD_CS_PIN           PC1
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN   	    PB4
+#define SPI3_MOSI_PIN   	    PB5
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
 #endif
 
 // *************** OSD *****************************
@@ -173,11 +172,7 @@
 #define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
 #define RSSI_ADC_CHANNEL            ADC_CHN_3
 
-#ifdef MATEKF405
-#define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_BLACKBOX )
-#else
 #define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY )
-#endif
 #define CURRENT_METER_SCALE   179
 
 #define USE_LED_STRIP


### PR DESCRIPTION
#10630 breaks all `MATEKF405` targets with SD Cards (   AIO / CTR / STD).
The suggestion to use `MATEKF405OSD` is not helpful, as it removes I2C.

This PR addresses all MATEKF405 variants by adding a `MATEKF405SPI` target for the (less common) baords with SPI flash logging.

Tested on MATEKF405 STD and OSD.
