### PR TITLE
Change SPEEDYBEEF405AIO S4 and LED dmavar

### DIFF
--- a/src/main/target/SPEEDYBEEF405AIO/target.c
+++ b/src/main/target/SPEEDYBEEF405AIO/target.c
@@ -31,9 +31,9 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM2,  CH2, PA1,  TIM_USE_OUTPUT_AUTO,  0, 0 ), // S1
     DEF_TIM(TIM2,  CH1, PA0,  TIM_USE_OUTPUT_AUTO,  0, 0 ), // S2
     DEF_TIM(TIM5,  CH3, PA2,  TIM_USE_OUTPUT_AUTO,  0, 0 ), // S3
-    DEF_TIM(TIM5,  CH4, PA3,  TIM_USE_OUTPUT_AUTO,  0, 1 ), // S4
+    DEF_TIM(TIM5,  CH4, PA3,  TIM_USE_OUTPUT_AUTO,  0, 0 ), // S4
 
-    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_LED,          0, 0), // LED
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_LED,          0, 1), // LED
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);


### PR DESCRIPTION
The test showed that the LED strip is not working. 
Refer to [BF SPEEDYBEEF405AIO config](https://github.com/betaflight/config/blob/master/configs/SPEEDYBEEF405AIO/config.h):

- S4 is assigned to DMA1
- LED strip is assigned to DMA2
