### PR TITLE
Add flyspark target

### DIFF
--- a/src/main/target/FLYSPARKF4V4/CMakeLists.txt
+++ b/src/main/target/FLYSPARKF4V4/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f405xg(FlySparkF4v1)

--- a/src/main/target/FLYSPARKF4V4/config.c
+++ b/src/main/target/FLYSPARKF4V4/config.c
@@ -1,0 +1,39 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include <stdint.h>
+#include "platform.h"
+#include "fc/fc_msp_box.h"
+#include "io/piniobox.h"
+#include "io/serial.h"
+
+void targetConfiguration(void)
+{
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].functionMask = FUNCTION_MSP;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].msp_baudrateIndex = BAUD_115200;
+
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART5)].functionMask = FUNCTION_ESCSERIAL;
+    
+    pinioBoxConfigMutable()->permanentId[0] = BOXARM;
+}

--- a/src/main/target/FLYSPARKF4V4/target.c
+++ b/src/main/target/FLYSPARKF4V4/target.c
@@ -1,0 +1,53 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/pinio.h"
+#include "drivers/sensor.h"
+
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688,  DEVHW_ICM42605, ICM42605_SPI_BUS,  ICM42605_CS_PIN,  NONE,  0,  DEVFLAGS_NONE,  IMU_ICM42605_ALIGN);
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM4,   CH1, PB6,  TIM_USE_OUTPUT_AUTO, 1, 0), // S1
+    DEF_TIM(TIM4,   CH2, PB7,  TIM_USE_OUTPUT_AUTO, 1, 0), // S2
+    DEF_TIM(TIM3,   CH3, PB0,  TIM_USE_OUTPUT_AUTO, 1, 0), // S3
+    DEF_TIM(TIM3,   CH4, PB1,  TIM_USE_OUTPUT_AUTO, 1, 0), // S4
+    DEF_TIM(TIM8,   CH3, PC8,  TIM_USE_OUTPUT_AUTO, 1, 0), // S5
+    DEF_TIM(TIM8,   CH4, PC9,  TIM_USE_OUTPUT_AUTO, 1, 0), // S6
+    DEF_TIM(TIM2,   CH3, PB10, TIM_USE_OUTPUT_AUTO, 1, 0), // S7
+    DEF_TIM(TIM2,   CH1, PA15, TIM_USE_OUTPUT_AUTO, 1, 0), // S8
+
+    DEF_TIM(TIM12,   CH2, PB15, TIM_USE_OUTPUT_AUTO,    1, 0), // S9
+    DEF_TIM(TIM12,   CH1, PB14, TIM_USE_OUTPUT_AUTO,    1, 0), // S10
+
+    DEF_TIM(TIM1,   CH1, PA8,  TIM_USE_LED,   0, 0), //2812LED  D(1,5,3)
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/FLYSPARKF4V4/target.h
+++ b/src/main/target/FLYSPARKF4V4/target.h
@@ -1,0 +1,168 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "FSF4"		
+#define USBD_PRODUCT_STRING  "FlySparkF4v1"	
+
+/*** Indicators ***/
+#define LED0                    PC13  //Blue  
+
+#define BEEPER                  PC15
+#define BEEPER_INVERTED
+
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                  PB11
+#define PINIO1_FLAGS                PINIO_FLAGS_INVERTED
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define USE_UART3
+#define UART3_TX_PIN            PC10
+#define UART3_RX_PIN            PC11
+
+// Internally routed to Bluetooth
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1 
+
+#define USE_UART5
+#define UART5_TX_PIN            PC12    // Not broken out
+#define UART5_RX_PIN            PD2     //ESC TLM
+
+#define USE_UART6
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+#define USE_SOFTSERIAL1
+#define SOFTSERIAL_1_TX_PIN      PA2
+#define SOFTSERIAL_1_RX_PIN      PA2
+
+#define SERIAL_PORT_COUNT       8
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+// *************** Gyro & ACC **********************
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW90_DEG
+#define ICM42605_CS_PIN         PA4
+#define ICM42605_SPI_BUS        BUS_SPI1
+
+// *************** I2C(Baro & I2C) **************************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_BMP085
+#define USE_BARO_DPS310
+#define USE_BARO_SPL06
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+#define USE_RANGEFINDER
+#define TEMPERATURE_I2C_BUS     BUS_I2C1
+#define PITOT_I2C_BUS           BUS_I2C1
+#define RANGEFINDER_I2C_BUS     BUS_I2C1
+
+// *************** Internal SD card **************************
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+#define SDCARD_SPI_BUS          BUS_SPI3
+#define SDCARD_CS_PIN           PC14
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+// *************** OSD *****************************
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PC2
+#define SPI2_MOSI_PIN           PC3
+
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          PB12
+
+// *************** ADC *****************************
+
+#define USE_ADC
+#define ADC_CHANNEL_1_PIN           PC0
+#define ADC_CHANNEL_2_PIN           PC1
+#define ADC_CHANNEL_3_PIN           PC5
+
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_3
+
+// *************** LED *****************************
+#define USE_LED_STRIP
+#define WS2811_PIN PA8
+
+#define DEFAULT_FEATURES                (FEATURE_TX_PROF_SEL  | FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT  | FEATURE_BLACKBOX | FEATURE_TELEMETRY)
+#define CURRENT_METER_SCALE     400
+
+#define USE_DSHOT
+#define USE_SERIALSHOT
+#define USE_ESC_SENSOR
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define MAX_PWM_OUTPUT_PORTS        10
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD (BIT(2))


### PR DESCRIPTION
Created the target.c file for handling FlySpark hardware target setup. 
This file includes essential timer and device configurations required for initialization.
