### PR TITLE
fixed crash: Firmware crash when OSD is disabled but MSP Display UART is allocated

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -677,7 +677,9 @@ void init(void)
 #endif
 
 #ifdef USE_VTX_MSP
-    vtxMspInit();
+    if (feature(FEATURE_OSD)) {
+       vtxMspInit();
+    }
 #endif
 
 #endif // USE_VTX_CONTROL


### PR DESCRIPTION
**Issue:**
The firmware crashes at startup in the following scenarios:
- MSP Display UART is allocated while OSD feature is disabled.
- OSD feature is disabled while MSP Display UART remains allocated.

**Affected versions:**
master, 8.0.0, 8.0.1

**Crash location:**
https://github.com/iNavFlight/inav/blob/be52fe6adc180eb22c5398e6823946264ce40c91/src/main/io/vtx_msp.c#L162

**Cause:**
```mspPort``` is ```NULL``` when accessed at the above line, due to the missing initialization of ```mspdisplayport``` caused by the disabled OSD feature.