### PR TITLE
DAKEFPVF722X8: Add UART3

### DIFF
--- a/src/main/target/DAKEFPVF722X8/target.h
+++ b/src/main/target/DAKEFPVF722X8/target.h
@@ -105,6 +105,10 @@
 #define UART1_RX_PIN            PB6
 #define UART1_TX_PIN            PB7
 
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PD8
+
 #define USE_UART4
 #define UART4_RX_PIN            PC11
 #define UART4_TX_PIN            PC10
@@ -117,7 +121,7 @@
 #define UART6_RX_PIN            PC7
 #define UART6_TX_PIN            PC6
 
-#define SERIAL_PORT_COUNT       5
+#define SERIAL_PORT_COUNT       6
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_CRSF

--- a/src/main/target/DAKEFPVF722X8/target.h
+++ b/src/main/target/DAKEFPVF722X8/target.h
@@ -157,14 +157,13 @@
 #define RSSI_ADC_CHANNEL            ADC_CHN_2
 #define CURRENT_METER_ADC_CHANNEL   ADC_CHN_3
 #define ADC1_DMA_STREAM             DMA2_Stream3
+#define VBAT_SCALE_DEFAULT          1600
 
-// unkonw
 #define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_LED_STRIP | FEATURE_GPS)
 
 #define USE_LED_STRIP
 #define WS2811_PIN                  PA0
 
-// unkonw
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
 #define TARGET_IO_PORTA         0xffff


### PR DESCRIPTION
Adds UART3 to this new target.

Also updates VBAT_SCALE_DEFAULT based on the resistors they are using for new boards.