### PR TITLE
dmesg: log init messages to RAM until serial init

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -73,10 +73,9 @@ While connected to the CLI, all Logical Switches are temporarily disabled (5.1.0
 | `beeper` | Show/set beeper (buzzer) [usage](Buzzer.md) |
 | `bind_rx` | Initiate binding for SRXL2 or CRSF receivers |
 | `blackbox` | Configure blackbox fields |
-| `bootlog` | Show boot events |
+| `bootlog` | Show init logs from [serial_printf_debugging](./development/serial_printf_debugging.md) |
 | `color` | Configure colors |
 | `defaults` | Reset to defaults and reboot |
-| `dmesg` | Show init logs from [serial_printf_debugging](./development/serial_printf_debugging.md) |
 | `dfu` | DFU mode on reboot |
 | `diff` | List configuration changes from default |
 | `dump` | Dump configuration |

--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -76,6 +76,7 @@ While connected to the CLI, all Logical Switches are temporarily disabled (5.1.0
 | `bootlog` | Show boot events |
 | `color` | Configure colors |
 | `defaults` | Reset to defaults and reboot |
+| `dmesg` | Show init logs from [serial_printf_debugging](./development/serial_printf_debugging.md) |
 | `dfu` | DFU mode on reboot |
 | `diff` | List configuration changes from default |
 | `dump` | Dump configuration |

--- a/docs/development/serial_printf_debugging.md
+++ b/docs/development/serial_printf_debugging.md
@@ -4,7 +4,9 @@
 
 INAV offers a function to use serial `printf` style debugging.
 
-This provides a simple and intuitive debugging facility. This facility is only available after the serial sub-system has been initialised, which should be adequate for all but the most hard-core debugging requirements.
+This provides a simple and intuitive debugging facility.
+This facility is only available after the serial sub-system has been initialised, but logs generated prior to serial
+initialization can be obtained via the `dmesg` functionality.
 
 In order to use this feature, the source file must include `common/log.h`.
 
@@ -137,3 +139,12 @@ The output will be formatted as follows:
 For the Configurator, debug messages are shown in the developer console log.
 
 Note: The numeric value in square brackets is the FC uptime in seconds.
+
+To see printf-style log messages generated prior serial initialization, reserve about 2KB-4KB RAM to buffer the
+log) by defining DMESG_SIZE:
+#define DMESG_SIZE 2048
+
+Then `make clean` and `make`.
+
+Then in the CLI you can run `dmesg` to see the buffered log.
+Note dmesg also requires that a serial port be defined for serial debugging.

--- a/docs/development/serial_printf_debugging.md
+++ b/docs/development/serial_printf_debugging.md
@@ -6,7 +6,7 @@ INAV offers a function to use serial `printf` style debugging.
 
 This provides a simple and intuitive debugging facility.
 This facility is only available after the serial sub-system has been initialised, but logs generated prior to serial
-initialization can be obtained via the `dmesg` functionality.
+initialization can be obtained via the `bootlog` functionality.
 
 In order to use this feature, the source file must include `common/log.h`.
 
@@ -140,11 +140,11 @@ For the Configurator, debug messages are shown in the developer console log.
 
 Note: The numeric value in square brackets is the FC uptime in seconds.
 
-To see printf-style log messages generated prior serial initialization, reserve about 2KB-4KB RAM to buffer the
-log) by defining DMESG_SIZE:
-#define DMESG_SIZE 2048
+To see printf-style log messages generated prior serial initialization, reserve about 2KB RAM to buffer the
+log) by defining USE_BOOTLOG:
+#define USE_BOOTLOG 2048
 
 Then `make clean` and `make`.
 
-Then in the CLI you can run `dmesg` to see the buffered log.
+Then in the CLI you can run `bootlog` to see the buffered log.
 Note dmesg also requires that a serial port be defined for serial debugging.

--- a/src/main/common/log.c
+++ b/src/main/common/log.c
@@ -61,8 +61,8 @@ PG_RESET_TEMPLATE(logConfig_t, logConfig,
     .topics = SETTING_LOG_TOPICS_DEFAULT
 );
 
-#if defined(DMESG_SIZE)
-char dmesg_buffer[DMESG_SIZE];
+#if defined(USE_BOOTLOG)
+char dmesg_buffer[USE_BOOTLOG];
 char *dmesg_head = dmesg_buffer;
 #endif
 
@@ -141,8 +141,8 @@ static void logPrint(const char *buf, size_t size)
         mspSerialPushPort(MSP_DEBUGMSG, (uint8_t*)buf, size, mspLogPort, MSP_V2_NATIVE);
     }
 
-#ifdef DMESG_SIZE
-    if ( (dmesg_head + size + 2) < (dmesg_buffer + DMESG_SIZE) ) {
+#ifdef USE_BOOTLOG
+    if ( (dmesg_head + size + 2) < (dmesg_buffer + USE_BOOTLOG) ) {
         for (unsigned int ii = 0; ii < size; ii++) {
 		    *dmesg_head = buf[ii];
 			dmesg_head++;

--- a/src/main/common/log.c
+++ b/src/main/common/log.c
@@ -62,8 +62,8 @@ PG_RESET_TEMPLATE(logConfig_t, logConfig,
 );
 
 #if defined(USE_BOOTLOG)
-char dmesg_buffer[USE_BOOTLOG];
-char *dmesg_head = dmesg_buffer;
+char bootlog_buffer[USE_BOOTLOG];
+char *bootlog_head = bootlog_buffer;
 #endif
 
 void logInit(void)
@@ -142,14 +142,14 @@ static void logPrint(const char *buf, size_t size)
     }
 
 #ifdef USE_BOOTLOG
-    if ( (dmesg_head + size + 2) < (dmesg_buffer + USE_BOOTLOG) ) {
+    if ( (bootlog_head + size + 2) < (bootlog_buffer + USE_BOOTLOG) ) {
         for (unsigned int ii = 0; ii < size; ii++) {
-		    *dmesg_head = buf[ii];
-			dmesg_head++;
+		    *bootlog_head = buf[ii];
+			bootlog_head++;
         }
-		dmesg_head[0] = '\r';
-		dmesg_head[1] = '\n';
-		dmesg_head =  dmesg_head + 2;
+		bootlog_head[0] = '\r';
+		bootlog_head[1] = '\n';
+		bootlog_head =  bootlog_head + 2;
 	}
 #endif
 }

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -131,8 +131,8 @@ extern timeDelta_t cycleTime; // FIXME dependency on mw.c
 extern uint8_t detectedSensors[SENSOR_INDEX_COUNT];
 
 #ifdef USE_BOOTLOG
-extern char dmesg_buffer[USE_BOOTLOG];
-extern char *dmesg_head;
+extern char bootlog_buffer[USE_BOOTLOG];
+extern char *bootlog_head;
 #endif
 
 static serialPort_t *cliPort;
@@ -4804,11 +4804,11 @@ static void cliUbloxPrintSatelites(char *arg)
 #endif
 
 #ifdef USE_BOOTLOG
-static void printDmesg(char *cmdline __attribute__((unused))) {
-    int size = dmesg_head - dmesg_buffer;
+static void printBootLog(char *cmdline __attribute__((unused))) {
+    int size = bootlog_head - bootlog_buffer;
 	cliPrintLinef("log size written: %i of %i bytes reserved", size, USE_BOOTLOG);
     for (int ii = 0; ii < size; ii++) {
-        cliWrite(dmesg_buffer[ii]);
+        cliWrite(bootlog_buffer[ii]);
     }
 }
 #endif
@@ -4833,7 +4833,7 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("bind_rx", "initiate binding for RX SPI or SRXL2", NULL, cliRxBind),
 #endif
 #if defined(USE_BOOTLOG)
-    CLI_COMMAND_DEF("bootlog", "show boot log", NULL, printDmesg),
+    CLI_COMMAND_DEF("bootlog", "show boot log", NULL, printBootLog),
 #endif
 #ifdef USE_LED_STRIP
     CLI_COMMAND_DEF("color", "configure colors", NULL, cliColor),

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -130,8 +130,8 @@ bool cliMode = false;
 extern timeDelta_t cycleTime; // FIXME dependency on mw.c
 extern uint8_t detectedSensors[SENSOR_INDEX_COUNT];
 
-#ifdef DMESG_SIZE
-extern char dmesg_buffer[DMESG_SIZE];
+#ifdef USE_BOOTLOG
+extern char dmesg_buffer[USE_BOOTLOG];
 extern char *dmesg_head;
 #endif
 
@@ -4803,10 +4803,10 @@ static void cliUbloxPrintSatelites(char *arg)
 }
 #endif
 
-#ifdef DMESG_SIZE
+#ifdef USE_BOOTLOG
 static void printDmesg(char *cmdline __attribute__((unused))) {
     int size = dmesg_head - dmesg_buffer;
-	cliPrintLinef("log size written: %i", size);
+	cliPrintLinef("log size written: %i of %i bytes reserved", size, USE_BOOTLOG);
     for (int ii = 0; ii < size; ii++) {
         cliWrite(dmesg_buffer[ii]);
     }
@@ -4833,7 +4833,7 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("bind_rx", "initiate binding for RX SPI or SRXL2", NULL, cliRxBind),
 #endif
 #if defined(USE_BOOTLOG)
-    CLI_COMMAND_DEF("bootlog", "show boot events", NULL, cliBootlog),
+    CLI_COMMAND_DEF("bootlog", "show boot log", NULL, printDmesg),
 #endif
 #ifdef USE_LED_STRIP
     CLI_COMMAND_DEF("color", "configure colors", NULL, cliColor),
@@ -4844,9 +4844,6 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("dfu", "DFU mode on reboot", NULL, cliDfu),
     CLI_COMMAND_DEF("diff", "list configuration changes from default",
         "[master|battery_profile|control_profile|mixer_profile|rates|all] {showdefaults}", cliDiff),
-#ifdef DMESG_SIZE
-    CLI_COMMAND_DEF("dmesg", "init log (DMESG_SIZE)", NULL, printDmesg),
-#endif
     CLI_COMMAND_DEF("dump", "dump configuration",
         "[master|battery_profile|control_profile|mixer_profile|rates|all] {showdefaults}", cliDump),
 #ifdef USE_RX_ELERES

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -130,6 +130,11 @@ bool cliMode = false;
 extern timeDelta_t cycleTime; // FIXME dependency on mw.c
 extern uint8_t detectedSensors[SENSOR_INDEX_COUNT];
 
+#ifdef DMESG_SIZE
+extern char dmesg_buffer[DMESG_SIZE];
+extern char *dmesg_head;
+#endif
+
 static serialPort_t *cliPort;
 
 static bufWriter_t *cliWriter;
@@ -4798,6 +4803,16 @@ static void cliUbloxPrintSatelites(char *arg)
 }
 #endif
 
+#ifdef DMESG_SIZE
+static void printDmesg(char *cmdline __attribute__((unused))) {
+    int size = dmesg_head - dmesg_buffer;
+	cliPrintLinef("log size written: %i", size);
+    for (int ii = 0; ii < size; ii++) {
+        cliWrite(dmesg_buffer[ii]);
+    }
+}
+#endif
+
 static void cliHelp(char *cmdline);
 
 // should be sorted a..z for bsearch()
@@ -4829,6 +4844,9 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("dfu", "DFU mode on reboot", NULL, cliDfu),
     CLI_COMMAND_DEF("diff", "list configuration changes from default",
         "[master|battery_profile|control_profile|mixer_profile|rates|all] {showdefaults}", cliDiff),
+#ifdef DMESG_SIZE
+    CLI_COMMAND_DEF("dmesg", "init log (DMESG_SIZE)", NULL, printDmesg),
+#endif
     CLI_COMMAND_DEF("dump", "dump configuration",
         "[master|battery_profile|control_profile|mixer_profile|rates|all] {showdefaults}", cliDump),
 #ifdef USE_RX_ELERES


### PR DESCRIPTION
This will allow the use of printf-style log messages prior serial initialization.

To use, reserve about 2KB-4KB RAM to buffer the log by defining DMESG_SIZE (changed to USE_BOOTLOG for historical compatibility)
#define DMESG_SIZE 2048
 
 Then `make clean` and `make`.
 
 Then in the CLI you can run `dmesg` to see the buffered log, similar to how dmesg works on Linux.
 
 
![ksnip_20250429-003924](https://github.com/user-attachments/assets/4306fac4-44a6-4699-a61c-aba2d3e99667)
