### PR TITLE
f435 correct uart->tx_af

### DIFF
--- a/src/main/drivers/serial_uart_at32f43x.c
+++ b/src/main/drivers/serial_uart_at32f43x.c
@@ -471,7 +471,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_t mode, 
     else {
         if (mode & MODE_TX) {
             IOInit(tx, OWNER_SERIAL, RESOURCE_UART_TX, RESOURCE_INDEX(device));
-            IOConfigGPIOAF(tx, IOCFG_AF_PP, uart->rx_af);
+            IOConfigGPIOAF(tx, IOCFG_AF_PP, uart->tx_af);
         }
 
         if (mode & MODE_RX) {


### PR DESCRIPTION
serial_uart_at32f43x.c  contained:


        if (mode & MODE_TX) {
            IOConfigGPIOAF(tx, IOCFG_AF_PP, uart->      **rx_af**    );
        }

        if (mode & MODE_RX) {
            IOConfigGPIOAF(rx, IOCFG_AF_PP, uart->rx_af);
        }



Which seemed to be setting the alternate function of the TX pin based on the RX define.
Testing with the JHEMCU F435 indicates the TX define should be used for the TX pin:


        if (mode & MODE_TX) {
            IOConfigGPIOAF(tx, IOCFG_AF_PP, uart->      **tx_af**   );
        }

        if (mode & MODE_RX) {
            IOConfigGPIOAF(rx, IOCFG_AF_PP, uart->rx_af);
        }


Requesting review by @bkleiner because they have some knowledge in this area.

