### PR TITLE
Fix cardinal OSD icon for DJI

### DIFF
--- a/src/main/io/osd_hud.c
+++ b/src/main/io/osd_hud.c
@@ -187,6 +187,11 @@ void osdHudDrawPoi(uint32_t poiDistance, int16_t poiDirection, int32_t poiAltitu
                 d = 0; // Directly behind
             }
 
+            //for native DJI is 0 direction forward
+            if(osdConfig()->video_system == VIDEO_SYSTEM_DJI_NATIVE) {
+                d = (d + 6) % 12;
+            }
+
             d = SYM_HUD_CARDINAL + d;
             osdHudWrite(poi_x + 2, poi_y, d, 1);
         } else {


### PR DESCRIPTION
New DJI O4 did not implemented cardinal "radar" icon properly. Index 0 "first cardinal icon" for walksnail/hdzero is for 180 degrees, ponting backwards. In DJI O4 first index for cardinal is 0 degrees, pointing forward. 

It's wrong in inav radar. 