### PR TITLE
Add new target ORBITH743

### DIFF
--- a/src/main/drivers/flash_w25n01g.c
+++ b/src/main/drivers/flash_w25n01g.c
@@ -124,6 +124,7 @@
 
 // JEDEC ID
 #define JEDEC_ID_WINBOND_W25N01GV 0xEFAA21
+#define JEDEC_ID_WINBOND_W25N02KV 0xEFAA22
 
 static busDevice_t *busDev = NULL;
 static flashGeometry_t geometry;
@@ -235,6 +236,11 @@ bool w25n01g_detect(uint32_t chipID)
     switch (chipID) {
     case JEDEC_ID_WINBOND_W25N01GV:
         geometry.sectors = 1024;      // Blocks
+        geometry.pagesPerSector = 64; // Pages/Blocks
+        geometry.pageSize = 2048;
+        break;
+    case JEDEC_ID_WINBOND_W25N02KV:
+        geometry.sectors = 2048;      // Blocks
         geometry.pagesPerSector = 64; // Pages/Blocks
         geometry.pageSize = 2048;
         break;

--- a/src/main/target/ORBITH743/CMakeLists.txt
+++ b/src/main/target/ORBITH743/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32h743xi(ORBITH743)

--- a/src/main/target/ORBITH743/config.c
+++ b/src/main/target/ORBITH743/config.c
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <platform.h>
+#include "fc/fc_msp_box.h"
+#include "io/piniobox.h"
+#include "io/serial.h"
+#include "common/axis.h"
+#include "config/config_master.h"
+#include "config/feature.h"
+#include "drivers/sensor.h"
+#include "drivers/pwm_esc_detect.h"
+#include "drivers/pwm_output.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/serial.h"
+#include "fc/rc_controls.h"
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+#include "rx/rx.h"
+#include "io/serial.h"
+#include "sensors/battery.h"
+#include "sensors/sensors.h"
+#include "telemetry/telemetry.h"
+
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART1)].functionMask = FUNCTION_ESCSERIAL;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART6)].functionMask = FUNCTION_GPS;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART5)].functionMask = FUNCTION_RX_SERIAL;
+}

--- a/src/main/target/ORBITH743/target.c
+++ b/src/main/target/ORBITH743/target.c
@@ -1,0 +1,54 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/pinio.h"
+#include "drivers/sensor.h"
+
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688_1, DEVHW_ICM42605, ICM42688_SPI_BUS_1,  ICM42688_CS_PIN_1,  NONE,  0,  DEVFLAGS_NONE,  IMU_ICM42688_ALIGN_1);
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688_2, DEVHW_ICM42605, ICM42688_SPI_BUS_2,  ICM42688_CS_PIN_2,  NONE,  0,  DEVFLAGS_NONE,  IMU_ICM42688_ALIGN_2);
+
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM5, CH1, PA0, TIM_USE_OUTPUT_AUTO, 0, 0),   // S1
+    DEF_TIM(TIM5, CH2, PA1, TIM_USE_OUTPUT_AUTO, 0, 1),   // S2
+    DEF_TIM(TIM5, CH3, PA2, TIM_USE_OUTPUT_AUTO, 0, 2),   // S3  
+    DEF_TIM(TIM5, CH4, PA3, TIM_USE_OUTPUT_AUTO, 0, 3),   // S4
+
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_OUTPUT_AUTO, 0, 4),   // S5
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_OUTPUT_AUTO, 0, 5),   // S6
+    DEF_TIM(TIM3, CH1, PB4,  TIM_USE_OUTPUT_AUTO, 0, 6),   // S7
+    DEF_TIM(TIM3, CH2, PB5,  TIM_USE_OUTPUT_AUTO, 0, 7),   // S8
+    
+    DEF_TIM(TIM2, CH1, PA15, TIM_USE_OUTPUT_AUTO, 0, 0),   // S9
+    DEF_TIM(TIM2, CH2, PB3, TIM_USE_OUTPUT_AUTO, 0, 0),   // S10 DMA_NONE
+    DEF_TIM(TIM4, CH1, PD12, TIM_USE_OUTPUT_AUTO, 0, 0),   // S11
+    DEF_TIM(TIM4, CH2, PD13, TIM_USE_OUTPUT_AUTO, 0, 0),   // S12 DMA_NONE
+
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_LED, 0, 14),    // LED_2812
+    DEF_TIM(TIM12,  CH2, PB15, TIM_USE_PPM, 0, 0),  // BEEPER PWM
+  
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/ORBITH743/target.h
+++ b/src/main/target/ORBITH743/target.h
@@ -1,0 +1,200 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "ORB7"
+#define USBD_PRODUCT_STRING     "ORBITH743"
+
+#define USE_TARGET_CONFIG
+
+#define LED0                    PE3
+#define LED1                    PE4
+
+#define BEEPER                  PB7
+#define BEEPER_INVERTED
+
+
+// *************** SPI *****************************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define USE_SPI_DEVICE_2
+#define USE_SPI_DEVICE_3
+#define USE_SPI_DEVICE_4
+
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define SPI2_SCK_PIN            PB10
+#define SPI2_MISO_PIN           PC2
+#define SPI2_MOSI_PIN           PC3
+
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PC12
+
+#define SPI4_SCK_PIN            PE12
+#define SPI4_MISO_PIN           PE13
+#define SPI4_MOSI_PIN           PE14
+
+// *************** I2C **************************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+
+#define I2C1_SCL PB8
+#define I2C1_SDA PB9
+
+// *************** UART *****************************
+#define USE_VCP
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_UART4
+#define USE_UART5
+#define USE_UART6
+#define USE_UART7
+#define USE_UART8
+
+#define UART1_TX_PIN PB14
+#define UART1_RX_PIN PA10
+
+#define UART2_TX_PIN PD5
+#define UART2_RX_PIN PD6
+
+#define UART3_TX_PIN PD8
+#define UART3_RX_PIN PD9
+
+#define UART4_TX_PIN PD1
+#define UART4_RX_PIN PD0
+
+#define UART5_TX_PIN PB13
+#define UART5_RX_PIN PB12
+
+#define UART6_TX_PIN PC6
+#define UART6_RX_PIN PC7
+
+#define UART7_TX_PIN PE8
+#define UART7_RX_PIN PE7
+
+#define UART8_TX_PIN PE1
+#define UART8_RX_PIN PE0
+
+#define SERIAL_PORT_COUNT 9 //VCP, UART1, UART2, UART3, UART4, UART5, UART6, UART7, UART8
+
+#define DEFAULT_RX_TYPE     RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER   SERIALRX_CRSF
+#define SERIALRX_UART       SERIAL_PORT_USART5
+
+
+// *************** Gyro & ACC **********************
+#define USE_DUAL_GYRO
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS
+
+#define USE_IMU_ICM42605
+
+#define IMU_ICM42688_ALIGN_1      CW270_DEG
+#define ICM42688_CS_PIN_1         PE11
+#define ICM42688_SPI_BUS_1        BUS_SPI1
+#define ICM42688_EXTI_PIN_1       PE10
+
+#define IMU_ICM42688_ALIGN_2      CW270_DEG
+#define ICM42688_CS_PIN_2         PE9
+#define ICM42688_SPI_BUS_2        BUS_SPI4
+#define ICM42688_EXTI_PIN_2       PB2
+
+
+// *************** OSD *****************************
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          PE6
+
+// *************** FLASH ***************************
+#define W25N01G_SPI_BUS BUS_SPI3
+#define W25N01G_CS_PIN  PD3
+
+#define USE_BLACKBOX
+#define USE_FLASHFS
+#define USE_FLASH_W25N01G
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+// *************** Baro/Mag *********************
+
+#define USE_BARO
+#define BARO_I2C_BUS BUS_I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_DPS310
+#define USE_BARO_SPL06
+
+//#define DPS310_I2C_ADDR 0x77 // 0x77 is for test board
+#define DPS310_I2C_ADDR 0x76
+
+#define USE_MAG
+#define MAG_I2C_BUS BUS_I2C1
+#define USE_MAG_ALL
+
+#define TEMPERATURE_I2C_BUS     BUS_I2C1
+#define PITOT_I2C_BUS           BUS_I2C1
+
+#define USE_RANGEFINDER
+#define RANGEFINDER_I2C_BUS BUS_I2C1
+
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+
+#define ADC_CHANNEL_1_PIN           PC0  //ADC123 VBAT1
+#define ADC_CHANNEL_2_PIN           PC1  //ADC123 CURR1
+#define ADC_CHANNEL_3_PIN           PC5  //ADC12  RSSI
+#define ADC_CHANNEL_4_PIN           PC4  //ADC12  VBAT2
+#define ADC_CHANNEL_5_PIN           PA4  //ADC12  CURR2
+
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_3
+
+// *************** PINIO ***************************
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                  PE2  // VTX power switcher
+#define PINIO2_PIN                  PD2  // 2xCamera switcher
+#define PINIO1_FLAGS				PINIO_FLAGS_INVERTED
+#define PINIO2_FLAGS				PINIO_FLAGS_INVERTED
+
+// *************** LEDSTRIP ************************
+#define USE_LED_STRIP
+#define WS2811_PIN                  PA8
+
+#define DEFAULT_FEATURES            (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX)
+#define CURRENT_METER_SCALE         125
+#define VBAT_SCALE_DEFAULT          1010
+
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0xffff
+#define TARGET_IO_PORTE 0xffff
+
+#define MAX_PWM_OUTPUT_PORTS        15
+#define USE_DSHOT
+#define USE_ESC_SENSOR


### PR DESCRIPTION
## Add Support for New Target: ORBITH743 Flight Controller

We are submitting support for a new flight controller board: **ORBITH743**, based on the STM32H743VIH6 MCU.

This board has been designed, manufactured, and tested by our team and has been verified to work correctly with iNav firmware. Below are the key specifications and features:

## Specifications

### Processor
- STM32H743VIH6 (480MHz)
- 256MB Flash for datalogging

### Sensors
- 2x ICM42688 (accelerometer + gyroscope)
- DPS368 barometer
- Voltage & Current monitoring

### Power
- 2–6S LiPo input
- 5V 2.5A BEC (for peripherals)
- 10V 3A BEC (for video systems)

### Interfaces
- 8x UARTs
- USB Type-C
- 12x PWM outputs
- I2C port (for external compass, airspeed sensor, etc.)
- DJI Air Unit support
- Built-in OSD (MAX7456)
- 2x power monitor inputs
- Buzzer and LED strip support

### RC Input
- SBUS, PPM, Serial RX, and MSP receivers supported
- Default RC input is on UART5 (SERIAL5)

### Dimensions & Mounting
- Size: 38.3 mm x 39.8 mm
- Weight: 8.4 g
- Mounting: 30.5 mm x 30.5 mm standard holes

## Special Features
- VTX power control via `PINIO1`
- Camera input switching via `PINIO2`
- Full DShot and Bi-Directional DShot support on M1–M8
- Dedicated PWM-only outputs for servos (S1–S4)

## Firmware Target
This board is added under the target name: `ORBITH743`

Let us know if any changes or improvements are needed. We would greatly appreciate your feedback and review.

Thanks in advance!
![ORBITH743 Top](https://github.com/user-attachments/assets/78fa174c-725a-4b4c-929a-9184a1a1099a)
![ORBITH743 Bottom](https://github.com/user-attachments/assets/b461ba55-d078-455d-ac26-d0db4e9835ab)
![ORBITH743 Wiring Diagram](https://github.com/user-attachments/assets/57d3f123-2287-4d3a-8093-c51195399d40)

