### PR TITLE
Option to use position for fixed wing nav altitude control

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3628,7 +3628,7 @@ FF gain of altitude PID controller. Not used if nav_fw_alt_use_position is set O
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 10 | 0 | 255 |
+| 30 | 0 | 255 |
 
 ---
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3132,6 +3132,16 @@ Adjusts the deceleration response of fixed wing altitude control as the target a
 
 ---
 
+### nav_fw_alt_use_position
+
+Use position for fixed wing altitude control rather than velocity (default method).
+
+| Default | Min | Max |
+| --- | --- | --- |
+| OFF | OFF | ON |
+
+---
+
 ### nav_fw_auto_climb_rate
 
 Maximum climb/descent rate that UAV is allowed to reach during navigation modes. [cm/s]
@@ -3614,7 +3624,7 @@ D gain of altitude PID controller (Fixedwing)
 
 ### nav_fw_pos_z_ff
 
-FF gain of altitude PID controller (Fixedwing)
+FF gain of altitude PID controller. Not used if nav_fw_alt_use_position is set ON (Fixedwing)
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2148,7 +2148,7 @@ groups:
         min: 0
         max: 255
       - name: nav_fw_pos_z_ff
-        description: "FF gain of altitude PID controller (Fixedwing)"
+        description: "FF gain of altitude PID controller. Not used if nav_fw_alt_use_position is set ON (Fixedwing)"
         default_value: 10
         field: bank_fw.pid[PID_POS_Z].FF
         min: 0
@@ -2159,6 +2159,11 @@ groups:
         field: fwAltControlResponseFactor
         min: 5
         max: 100
+      - name: nav_fw_alt_use_position
+        description: "Use position for fixed wing altitude control rather than velocity (default method)."
+        default_value: OFF
+        field: fwAltControlUsePos
+        type: bool
       - name: nav_fw_pos_xy_p
         description: "P gain of 2D trajectory PID controller. Play with this to get a straight line between waypoints or a straight RTH"
         default_value: 75

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2149,7 +2149,7 @@ groups:
         max: 255
       - name: nav_fw_pos_z_ff
         description: "FF gain of altitude PID controller. Not used if nav_fw_alt_use_position is set ON (Fixedwing)"
-        default_value: 10
+        default_value: 30
         field: bank_fw.pid[PID_POS_Z].FF
         min: 0
         max: 255

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -179,7 +179,7 @@ static EXTENDED_FASTRAM bool angleHoldIsLevel = false;
 static EXTENDED_FASTRAM float fixedWingLevelTrim;
 static EXTENDED_FASTRAM pidController_t fixedWingLevelTrimController;
 
-PG_REGISTER_PROFILE_WITH_RESET_TEMPLATE(pidProfile_t, pidProfile, PG_PID_PROFILE, 10);
+PG_REGISTER_PROFILE_WITH_RESET_TEMPLATE(pidProfile_t, pidProfile, PG_PID_PROFILE, 11);
 
 PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
         .bank_mc = {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -308,6 +308,7 @@ PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
         .fixedWingLevelTrimGain = SETTING_FW_LEVEL_PITCH_GAIN_DEFAULT,
 
         .fwAltControlResponseFactor = SETTING_NAV_FW_ALT_CONTROL_RESPONSE_DEFAULT,
+        .fwAltControlUsePos = SETTING_NAV_FW_ALT_USE_POSITION_DEFAULT,
 #ifdef USE_SMITH_PREDICTOR
         .smithPredictorStrength = SETTING_SMITH_PREDICTOR_STRENGTH_DEFAULT,
         .smithPredictorDelay = SETTING_SMITH_PREDICTOR_DELAY_DEFAULT,

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -150,6 +150,7 @@ typedef struct pidProfile_s {
     float fixedWingLevelTrimGain;
 
     uint8_t fwAltControlResponseFactor;
+    bool fwAltControlUsePos;
 #ifdef USE_SMITH_PREDICTOR
     float smithPredictorStrength;
     float smithPredictorDelay;

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -4959,13 +4959,23 @@ void navigationUsePIDs(void)
                                         0.0f
     );
 
-    navPidInit(&posControl.pids.fw_alt, (float)pidProfile()->bank_fw.pid[PID_POS_Z].P / 100.0f,
-                                        (float)pidProfile()->bank_fw.pid[PID_POS_Z].I / 100.0f,
-                                        (float)pidProfile()->bank_fw.pid[PID_POS_Z].D / 300.0f,
-                                        (float)pidProfile()->bank_fw.pid[PID_POS_Z].FF / 100.0f,
-                                        NAV_DTERM_CUT_HZ,
-                                        0.0f
-    );
+    if (pidProfile()->fwAltControlUsePos) {
+        navPidInit(&posControl.pids.fw_alt, (float)pidProfile()->bank_fw.pid[PID_POS_Z].P / 100.0f,
+                                            (float)pidProfile()->bank_fw.pid[PID_POS_Z].I / 100.0f,
+                                            (float)pidProfile()->bank_fw.pid[PID_POS_Z].D / 30.0f,
+                                            0.0f,
+                                            NAV_DTERM_CUT_HZ,
+                                            0.0f
+        );
+    } else {
+        navPidInit(&posControl.pids.fw_alt, (float)pidProfile()->bank_fw.pid[PID_POS_Z].P / 100.0f,
+                                            (float)pidProfile()->bank_fw.pid[PID_POS_Z].I / 100.0f,
+                                            (float)pidProfile()->bank_fw.pid[PID_POS_Z].D / 300.0f,
+                                            (float)pidProfile()->bank_fw.pid[PID_POS_Z].FF / 100.0f,
+                                            NAV_DTERM_CUT_HZ,
+                                            0.0f
+        );
+    }
 
     navPidInit(&posControl.pids.fw_heading, (float)pidProfile()->bank_fw.pid[PID_POS_HEADING].P / 10.0f,
                                         (float)pidProfile()->bank_fw.pid[PID_POS_HEADING].I / 10.0f,

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -4962,7 +4962,7 @@ void navigationUsePIDs(void)
     if (pidProfile()->fwAltControlUsePos) {
         navPidInit(&posControl.pids.fw_alt, (float)pidProfile()->bank_fw.pid[PID_POS_Z].P / 100.0f,
                                             (float)pidProfile()->bank_fw.pid[PID_POS_Z].I / 100.0f,
-                                            (float)pidProfile()->bank_fw.pid[PID_POS_Z].D / 30.0f,
+                                            (float)pidProfile()->bank_fw.pid[PID_POS_Z].D / 100.0f,
                                             0.0f,
                                             NAV_DTERM_CUT_HZ,
                                             0.0f

--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -147,7 +147,7 @@ static void updateAltitudeVelocityAndPitchController_FW(timeDelta_t deltaMicros)
     // Default control based on climb rate (velocity)
     float targetValue = desiredClimbRate;
     float measuredValue = navGetCurrentActualPositionAndVelocity()->vel.z;
-    pidControllerFlags_e pidFlags = PID_DTERM_FROM_ERROR;
+    pidControllerFlags_e pidFlags = 0;  // PID_DTERM_FROM_ERROR;
 
     // Optional control based on altitude (position)
     if (pidProfile()->fwAltControlUsePos) {

--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -147,7 +147,6 @@ static void updateAltitudeVelocityAndPitchController_FW(timeDelta_t deltaMicros)
     // Default control based on climb rate (velocity)
     float targetValue = desiredClimbRate;
     float measuredValue = navGetCurrentActualPositionAndVelocity()->vel.z;
-    pidControllerFlags_e pidFlags = 0;  // PID_DTERM_FROM_ERROR;
 
     // Optional control based on altitude (position)
     if (pidProfile()->fwAltControlUsePos) {
@@ -193,11 +192,10 @@ static void updateAltitudeVelocityAndPitchController_FW(timeDelta_t deltaMicros)
 
         targetValue = desiredAltitude;
         measuredValue = currentAltitude;
-        pidFlags = 0;  // use measurement for D term
     }
 
     // PID controller to translate desired target error (velocity or position) into pitch angle [decideg]
-    float targetPitchAngle = navPidApply2(&posControl.pids.fw_alt, targetValue, measuredValue, US2S(deltaMicros), minDiveDeciDeg, maxClimbDeciDeg, pidFlags);
+    float targetPitchAngle = navPidApply2(&posControl.pids.fw_alt, targetValue, measuredValue, US2S(deltaMicros), minDiveDeciDeg, maxClimbDeciDeg, 0);
 
     // Apply low-pass filter to prevent rapid correction
     targetPitchAngle = pt1FilterApply4(&pitchFilterState, targetPitchAngle, getSmoothnessCutoffFreq(NAV_FW_BASE_PITCH_CUTOFF_FREQUENCY_HZ), US2S(deltaMicros));


### PR DESCRIPTION
Adds an option to use position based nav altitude control on fixed wing instead of velocity based control which doesn't appear to work reliably on some plane types. Option enabled with new setting `nav_fw_alt_use_position ` (OFF by default).

`nav_fw_alt_control_response `still works with the position based control in the same way as for velocity based control.

Only tested on HITL so far where it seems to work well. The new method of controlling altitude rate appears to be a big improvement on the old position based altitude control method with rates being held more accurately with limited pitching oscillations compared to previously. PID values may need further fine tuning.