### PR TITLE
Update mavlink.c

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -673,7 +673,7 @@ void mavlinkSendAttitude(void)
         // roll Roll angle (rad)
         RADIANS_TO_MAVLINK_RANGE(DECIDEGREES_TO_RADIANS(attitude.values.roll)),
         // pitch Pitch angle (rad)
-        RADIANS_TO_MAVLINK_RANGE(DECIDEGREES_TO_RADIANS(-attitude.values.pitch)),
+        RADIANS_TO_MAVLINK_RANGE(DECIDEGREES_TO_RADIANS(attitude.values.pitch)),
         // yaw Yaw angle (rad)
         RADIANS_TO_MAVLINK_RANGE(DECIDEGREES_TO_RADIANS(attitude.values.yaw)),
         // rollspeed Roll angular speed (rad/s)


### PR DESCRIPTION
debug了mavlink遥测回传中pitch的正负性使其和实际方向一致
![5d338dc5405ad2b698a4af318aa1e2a](https://github.com/user-attachments/assets/c7420e21-861d-4dac-855c-840436862ff0)
![796e067e0b6351ab8e94b945770af96](https://github.com/user-attachments/assets/b1f9ea08-598f-46fc-afab-7e6bec7a1345)
