### PR TITLE
Nav position estimator baro air cushion compensation fix

### DIFF
--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -834,14 +834,12 @@ bool isMulticopterLandingDetected(void)
     }
 #endif
 
-    bool throttleIsBelowMidHover = rcCommand[THROTTLE] < (0.5 * (currentBatteryProfile->nav.mc.hover_throttle + getThrottleIdleValue()));
-
     /* Basic condition to start looking for landing
      * Detection active during Failsafe only if throttle below mid hover throttle
      * and WP mission not active (except landing states).
      * Also active in non autonomous flight modes but only when thottle low */
     bool startCondition = (navGetCurrentStateFlags() & (NAV_CTL_LAND | NAV_CTL_EMERG))
-                          || (FLIGHT_MODE(FAILSAFE_MODE) && !FLIGHT_MODE(NAV_WP_MODE) && throttleIsBelowMidHover)
+                          || (FLIGHT_MODE(FAILSAFE_MODE) && !FLIGHT_MODE(NAV_WP_MODE) && !isMulticopterThrottleAboveMidHover())
                           || (!navigationIsFlyingAutonomousMode() && throttleStickIsLow());
 
     static timeMs_t landingDetectorStartedAt;
@@ -921,6 +919,11 @@ bool isMulticopterLandingDetected(void)
         landingDetectorStartedAt = currentTimeMs;
         return false;
     }
+}
+
+bool isMulticopterThrottleAboveMidHover(void)
+{
+    return rcCommand[THROTTLE] > 0.5 * (currentBatteryProfile->nav.mc.hover_throttle + getThrottleIdleValue());
 }
 
 /*-----------------------------------------------------------

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -596,6 +596,7 @@ static bool estimationCalculateCorrection_Z(estimationContext_t * ctx)
             else if (isBaroGroundValid) {
                 // We might be experiencing air cushion effect during takeoff - use sonar or baro ground altitude to detect it
                 if (isMulticopterThrottleAboveMidHover()) {
+                    // Disable ground effect detection at lift off when est alt and baro alt converge. Always disable if baro alt > 1m.
                     isBaroGroundValid = fabsf(posEstimator.est.pos.z - posEstimator.baro.alt) > 20.0f && posEstimator.baro.alt < 100.0f;
                 }
 
@@ -605,6 +606,8 @@ static bool estimationCalculateCorrection_Z(estimationContext_t * ctx)
 
         // Altitude
         float baroAltResidual = wBaro * ((isAirCushionEffectDetected ? baroGroundAlt : posEstimator.baro.alt) - posEstimator.est.pos.z);
+
+        // Disable alt pos correction at point of lift off if ground effect active
         if (isAirCushionEffectDetected && isMulticopterThrottleAboveMidHover()) {
             baroAltResidual = 0.0f;
         }

--- a/src/main/navigation/navigation_pos_estimator_private.h
+++ b/src/main/navigation/navigation_pos_estimator_private.h
@@ -154,13 +154,6 @@ typedef enum {
 } navDefaultAltitudeSensor_e;
 
 typedef struct {
-    timeUs_t    baroGroundTimeout;
-    float       baroGroundAlt;
-    bool        isBaroGroundValid;
-} navPositionEstimatorSTATE_t;
-
-
-typedef struct {
     uint32_t                    flags;
 
     // Data sources
@@ -175,9 +168,6 @@ typedef struct {
 
     // Estimate
     navPositionEstimatorESTIMATE_t  est;
-
-    // Extra state variables
-    navPositionEstimatorSTATE_t state;
 } navigationPosEstimator_t;
 
 typedef struct {

--- a/src/main/navigation/navigation_private.h
+++ b/src/main/navigation/navigation_private.h
@@ -582,6 +582,8 @@ bool isMulticopterLandingDetected(void);
 void calculateMulticopterInitialHoldPosition(fpVector3_t * pos);
 float getSqrtControllerVelocity(float targetAltitude, timeDelta_t deltaMicros);
 
+bool isMulticopterThrottleAboveMidHover(void);
+
 /* Fixed-wing specific functions */
 void setupFixedWingAltitudeController(void);
 


### PR DESCRIPTION
Prevents baro air cushion effect compensation remaining active when it shouldn't be and also limits its use to multirotor only. Should close https://github.com/iNavFlight/inav/issues/10917.

Needs testing.