### PR TITLE
flash W25Q128 add chip ID 0xEF6018 for quad SPI mode.

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -92,7 +92,8 @@ struct {
     {0xEF7017, 128, 256}, // W25Q64JV-IM/JM*
     // Winbond W25Q128
     // Datasheet: https://www.winbond.com/resource-files/w25q128fv%20rev.l%2008242015.pdf
-    {0xEF4018, 256, 256},
+    {0xEF4018, 256, 256}, // SPI mode
+    {0xEF6018, 256, 256}, // QPI
     // Zbit ZB25VQ128
     // Datasheet: http://zbitsemi.com/upload/file/20201010/20201010174048_82182.pdf
     {0x5E4018, 256, 256},


### PR DESCRIPTION
The W25Q128 flash chip was already supported in SPI mode, using chip ID 0xEF4018.
Adding chip ID 0xEF6018 for quad SPI mode.

https://www.winbond.com/resource-files/w25q128fv%20rev.l%2008242015.pdf

-- Edit --
May not be needed. It isn't needed on the board I *thought* it was needed on.