### PR TITLE
CADDXF4_AIO_ELRS baro uses i2c2

### DIFF
--- a/src/main/target/CADDXF4_AIO_ELRS/target.h
+++ b/src/main/target/CADDXF4_AIO_ELRS/target.h
@@ -40,8 +40,7 @@
 #define USE_BARO
 #define USE_BARO_ALL
 
-#define BMP280_SPI_BUS		BUS_SPI2
-#define BMP280_CS_PIN           PB3
+#define BARO_I2C_BUS            BUS_I2C2
 
 //#define USE_MAX7456
 //#define MAX7456_SPI_BUS		BUS_SPI2
@@ -72,18 +71,15 @@
 // PC13 used as inverter select GPIO for UART2
 #define INVERTER_PIN_UART2_RX   PC13
 
-#define USE_UART3
-#define UART3_RX_PIN            PB11
-#define UART3_TX_PIN            PB10
+//#define USE_UART3 // used by onboard baro i2c
+//#define UART3_RX_PIN            PB11
+//#define UART3_TX_PIN            PB10
 
 #define USE_UART6
 #define UART6_RX_PIN            PC7
 #define UART6_TX_PIN            PC6
 
-//#define USE_SOFTSERIAL1
-//#define USE_SOFTSERIAL2
-
-#define SERIAL_PORT_COUNT       5 //VCP, USART1, USART2, USART3, USART6, SOFTSERIAL1, SOFTSERIAL2
+#define SERIAL_PORT_COUNT       4 //VCP, USART1, USART2, USART6
 
 //#define USE_ESCSERIAL // XXX
 //#define ESCSERIAL_TIMER_TX_PIN  PB8 // (Hardware=0, PPM)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Switch barometer from SPI to I2C interface

- Disable UART3 to free pins for I2C2

- Update serial port count configuration


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Barometer"] -- "changed from" --> B["SPI2 + CS pin"]
  A -- "changed to" --> C["I2C2 bus"]
  D["UART3"] -- "disabled to free" --> E["I2C2 pins"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Switch barometer interface from SPI to I2C</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/CADDXF4_AIO_ELRS/target.h

<li>Replaced BMP280 SPI configuration with I2C2 bus definition<br> <li> Commented out UART3 configuration to free pins for I2C2<br> <li> Updated serial port count from 5 to 4<br> <li> Removed unused softserial configuration lines


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10951/files#diff-62bf5b9b2a5e71309c7acbb7bb40db7b215aa3f9fb490420449c27e5e07a10b8">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>