### PR TITLE
fix changing msp receiver crash

### DIFF
--- a/src/main/rx/msp_override.c
+++ b/src/main/rx/msp_override.c
@@ -131,6 +131,12 @@ bool mspOverrideUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime
         }
     }
 
+    // Changing receiver_type from MSP to anything can cause a race with
+    // the function pointer as NULL. This will not end well, so bail out early.
+    if(rxRuntimeConfigMSP.rcFrameStatusFn == NULL) {
+	return false;
+    }
+
     const uint8_t frameStatus = rxRuntimeConfigMSP.rcFrameStatusFn(&rxRuntimeConfigMSP);
     if (frameStatus & RX_FRAME_COMPLETE) {
         rxDataProcessingRequired = true;


### PR DESCRIPTION
### **User description**
With `USE_MSP_OVERRIDE`, changing the `receiver_type` from `MSP` to anything else can cause a soft or hard lockup of the FC.
This is due to a race condition where the new  `rxRuntimeConfigMSP.rcFrameStatusFn` has not been set up, but is called unconditionally.
Fix this by checking for NULL and bailing out if so.


___

### **PR Type**
Bug fix


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Fix race condition crash when changing receiver type from MSP

- Add NULL check for `rcFrameStatusFn` before function call

- Prevent soft/hard lockup during receiver reconfiguration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MSP Receiver Active"] --> B["Receiver Type Changed"]
  B --> C["Race Condition Check"]
  C --> D["rcFrameStatusFn NULL?"]
  D -->|Yes| E["Return false (Safe Exit)"]
  D -->|No| F["Continue Normal Operation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>msp_override.c</strong><dd><code>Add NULL check for MSP receiver function pointer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/rx/msp_override.c

<li>Add NULL check for <code>rxRuntimeConfigMSP.rcFrameStatusFn</code> pointer<br> <li> Return false early if function pointer is NULL<br> <li> Add explanatory comment about race condition during receiver type <br>changes


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10971/files#diff-e9e7679b72175a326029c1cc88989288814ed6f3ccd666762b2dbfc396f19996">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

