### PR TITLE
Jh fix gcc15 warnings

### DIFF
--- a/src/main/io/vtx_string.c
+++ b/src/main/io/vtx_string.c
@@ -51,7 +51,7 @@ const char * const vtx58BandNames[VTX_STRING_5G8_BAND_COUNT + 1] = {
     "R",
 };
 
-const char vtx58BandLetter[VTX_STRING_5G8_BAND_COUNT + 1] = "-ABEFR";
+const char vtx58BandLetter[VTX_STRING_5G8_BAND_COUNT + 1] __attribute__ ((nonstring)) = "-ABEFR";
 
 const char * const vtx58ChannelNames[VTX_STRING_5G8_CHAN_COUNT + 1] = {
     "-", "1", "2", "3", "4", "5", "6", "7", "8",
@@ -73,7 +73,7 @@ const char * const vtx1G3BandNames[VTX_STRING_1G3_BAND_COUNT + 1] = {
     "B",
 };
 
-const char vtx1G3BandLetter[VTX_STRING_1G3_BAND_COUNT + 1] = "-AB";
+const char vtx1G3BandLetter[VTX_STRING_1G3_BAND_COUNT + 1] __attribute__ ((nonstring)) = "-AB";
 
 const char * const vtx1G3ChannelNames[VTX_STRING_1G3_CHAN_COUNT + 1] = {
     "-", "1", "2", "3", "4", "5", "6", "7", "8",

--- a/src/main/io/vtx_string.c
+++ b/src/main/io/vtx_string.c
@@ -51,7 +51,7 @@ const char * const vtx58BandNames[VTX_STRING_5G8_BAND_COUNT + 1] = {
     "R",
 };
 
-const char vtx58BandLetter[VTX_STRING_5G8_BAND_COUNT + 1] __attribute__ ((nonstring)) = "-ABEFR";
+const char vtx58BandLetter[VTX_STRING_5G8_BAND_COUNT + 1] = {'-', 'A', 'B', 'E', 'F', 'R'};
 
 const char * const vtx58ChannelNames[VTX_STRING_5G8_CHAN_COUNT + 1] = {
     "-", "1", "2", "3", "4", "5", "6", "7", "8",
@@ -73,7 +73,7 @@ const char * const vtx1G3BandNames[VTX_STRING_1G3_BAND_COUNT + 1] = {
     "B",
 };
 
-const char vtx1G3BandLetter[VTX_STRING_1G3_BAND_COUNT + 1] __attribute__ ((nonstring)) = "-AB";
+const char vtx1G3BandLetter[VTX_STRING_1G3_BAND_COUNT + 1] = {'-', 'A', 'B'};
 
 const char * const vtx1G3ChannelNames[VTX_STRING_1G3_CHAN_COUNT + 1] = {
     "-", "1", "2", "3", "4", "5", "6", "7", "8",


### PR DESCRIPTION
### **User description**
gcc 15 generated warnings in osd.c:
```
[267/311] Building C object src/main/t...s/SITL.elf.dir/__/__/io/vtx_string.c.o
/home/jrh/Projects/inav/src/main/io/vtx_string.c:54:61: warning: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (7 chars into 6 available) [-Wunterminated-string-initialization]
   54 | const char vtx58BandLetter[VTX_STRING_5G8_BAND_COUNT + 1] = "-ABEFR";
      |                                                             ^~~~~~~~
/home/jrh/Projects/inav/src/main/io/vtx_string.c:76:62: warning: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (4 chars into 3 available) [-Wunterminated-string-initialization]
   76 | const char vtx1G3BandLetter[VTX_STRING_1G3_BAND_COUNT + 1] = "-AB";
```

Fix these warnings by using array of characters rather than strings.


___

### **PR Type**
Bug fix


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Fix GCC 15 warnings for character array initialization

- Replace string literals with character array initializers

- Prevent NUL terminator truncation warnings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["String literal initialization"] --> B["Character array initialization"]
  B --> C["GCC 15 warnings resolved"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vtx_string.c</strong><dd><code>Fix character array initialization warnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/io/vtx_string.c

<li>Replace string literal initialization with character array syntax for <br><code>vtx58BandLetter</code><br> <li> Replace string literal initialization with character array syntax for <br><code>vtx1G3BandLetter</code><br> <li> Fix GCC 15 warnings about NUL terminator truncation


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10972/files#diff-cb3594f05c2e3bb51648916a77336e7c62f7f815ce0a6819e1e0d58b70066dee">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

