### PR TITLE
fix: horizon drift away

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -35,7 +35,9 @@
 #include "common/vector.h"
 #include "common/quaternion.h"
 #include "common/time.h"
+#include "common/utils.h"
 
+#define RAD_TO_DEG (1.0f / RAD)
 
 #include "config/feature.h"
 #include "config/parameter_group.h"
@@ -939,7 +941,7 @@ static void imuCalculateEstimatedAttitude(float dT)
     float pitch_diff = fabsf(acc_pitch - est_pitch);
 
     // Calculate accelerometer trust
-    float accWeight = imuCalculateAccelerometerWeightNearness(&compansatedGravityBF) * imuCalculateAccelerometerWeightRateIgnore(1.0f);
+    accWeight = imuCalculateAccelerometerWeightNearness(&compansatedGravityBF) * imuCalculateAccelerometerWeightRateIgnore(1.0f);
 
     // Get vibration levels
     fpVector3_t accVibeLevels;


### PR DESCRIPTION
### **User description**
Problem:
INAV can lose correct horizon (attitude) after aggressive maneuvers, strong vibrations, or sensor glitches—especially in cold weather. When this happens, the artificial horizon may remain stuck in a wrong position for the rest of the flight, since the Mahony filter cannot recover automatically without external correction.
ArduPilot does not suffer from this issue because it uses more advanced attitude estimation (EKF/DCM) with multiple correction sources (GPS, baro, compass) and robust sanity checks, allowing it to recover the correct horizon even after sensor faults or extreme maneuvers.

Solution (this PR):
This PR adds an automatic attitude (horizon) reset: if roll or pitch diverges from the accelerometer by more than 12° for over 1.5 seconds (with valid GPS), the attitude filter is reset using the current accelerometer vector. This ensures the horizon quickly recovers after real desync events, but does not trigger during normal flight or brief transients.


___

### **PR Type**
Bug fix


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Adds automatic attitude reset for stuck horizon issue

- Compares accelerometer vs filter attitude continuously  

- Resets orientation when 12° divergence persists 1.5s

- Requires GPS trustworthiness for safety validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Accelerometer Data"] --> B["Calculate Roll/Pitch"]
  C["Mahony Filter"] --> D["Current Attitude"]
  B --> E["Compare Attitudes"]
  D --> E
  E --> F["Divergence > 12°?"]
  F --> G["Timer > 1.5s & GPS OK?"]
  G --> H["Reset Orientation"]
  H --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>imu.c</strong><dd><code>Add automatic attitude reset for horizon recovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/flight/imu.c

<ul><li>Adds horizon auto-reset logic after Mahony filter update<br> <li> Calculates roll/pitch from accelerometer and compares with filter <br>output<br> <li> Implements timer-based reset when divergence exceeds 12° for 1.5 <br>seconds<br> <li> Requires GPS trustworthiness check before triggering reset</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10980/files#diff-de6b2b61376cbb30512686ebb362260facb69cf9a4281ebdcd59af61c0306f7a">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

