### PR TITLE
better default display i2c bus

### DIFF
--- a/src/main/target/common_hardware.c
+++ b/src/main/target/common_hardware.c
@@ -426,7 +426,12 @@
 
 #if defined(USE_OLED_UG2864)
     #if !defined(UG2864_I2C_BUS)
-        #define UG2864_I2C_BUS BUS_I2C1
+        #ifdef MAG_I2C_BUS
+            #define UG2864_I2C_BUS MAG_I2C_BUS
+       #else
+            #define UG2864_I2C_BUS DEFAULT_I2C_BUS
+       #endif
+
     #endif
     BUSDEV_REGISTER_I2C(busdev_ug2864,      DEVHW_UG2864,       UG2864_I2C_BUS,     0x3C,               NONE,           DEVFLAGS_NONE,  0);
 #endif


### PR DESCRIPTION
### **User description**
Uses the external (compass) i2c bus if UG2864_I2C_BUS isn't defined. Otherwise, the default i2c bus.
Rather than i2c1.


___

### **PR Type**
Enhancement


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Improved default I2C bus selection for UG2864 OLED display

- Uses magnetometer I2C bus when available, falls back to default I2C bus

- Replaces hardcoded BUS_I2C1 with more flexible bus selection logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UG2864_I2C_BUS undefined"] --> B["Check MAG_I2C_BUS"]
  B --> C["MAG_I2C_BUS available?"]
  C -->|Yes| D["Use MAG_I2C_BUS"]
  C -->|No| E["Use DEFAULT_I2C_BUS"]
  D --> F["Configure UG2864 display"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common_hardware.c</strong><dd><code>Enhanced I2C bus selection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/common_hardware.c

<ul><li>Replaced hardcoded <code>BUS_I2C1</code> with conditional logic<br> <li> Added fallback hierarchy: <code>MAG_I2C_BUS</code> → <code>DEFAULT_I2C_BUS</code><br> <li> Improved I2C bus selection for UG2864 OLED display configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10984/files#diff-cfaa56dd6217b84f8431fd9d65271a6d06574dcfc312ed8a871788a183e9d470">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

