### PR TITLE
Allow servo speed filter carry over on the mixer profile switch

### DIFF
--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -63,6 +63,7 @@ typedef enum {
     INPUT_GVAR_6                    = 36,
     INPUT_GVAR_7                    = 37,
     INPUT_MIXER_TRANSITION          = 38,
+    INPUT_MIXER_SWITCH_HELPER       = 39,
     INPUT_SOURCE_COUNT
 } inputSource_e;
 
@@ -120,6 +121,14 @@ typedef struct servoMixer_s {
 #define SERVO_OUTPUT_MIN 500
 
 PG_DECLARE_ARRAY(servoMixer_t, MAX_SERVO_RULES, customServoMixers);
+
+typedef struct servoMixerSwitch_s {
+    //this is used to keep track of servoSpeedLimitFilter of servo rules during the mixer switch
+    uint8_t targetChannel;                  // servo that receives the output of the rule
+    int16_t rate;                           // range [-1000;+1000] ; can be used to adjust a rate 0-1000% and a direction
+    uint8_t speed;                          // reduces the speed of the rule, 0=unlimited speed
+    float speedLimitFilterState;     // rate limit filter for this rule
+} servoMixerSwitch_t;
 
 typedef struct servoParam_s {
     int16_t min;                            // servo min


### PR DESCRIPTION
### **User description**
A requested feature by many tilting rotor VTOL build. The servo speed limit will not work properly during the mixer profile switch.
It was because the mixer profile switch will reload and reset all servo rules/speed limit filters. And still, there was no straightforward implementation to properly handle the servo speed limit.

This PR addresses the issue by adding new internal servo mixing rules during the mixer profile switch to carry over servoSpeedLimitFilter status and process it after the mixer profile switch


___

### **PR Type**
Enhancement


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Add servo speed filter preservation during mixer profile switches

- Implement helper structure to track filter states across transitions

- Introduce `INPUT_MIXER_SWITCH_HELPER` for internal servo rule management

- Prevent servo speed limit filter reset on profile changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Current Servo Rules"] --> B["Extract Speed Filter States"]
  B --> C["Reset Servo Mixer"]
  C --> D["Load New Profile Rules"]
  D --> E["Add Helper Rules with Preserved Filters"]
  E --> F["Restored Speed Filtering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>servos.c</strong><dd><code>Implement servo speed filter preservation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/flight/servos.c

<ul><li>Add <code>servoMixerSwitchHelper</code> array to preserve speed filter states<br> <li> Extract and store filter states before mixer reset in <br><code>loadCustomServoMixer()</code><br> <li> Create helper servo rules with preserved filter states after loading <br>new profile<br> <li> Add <code>INPUT_MIXER_SWITCH_HELPER</code> input handling with zero value</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10985/files#diff-c90491cca5be9a11d702c750699464d7fbc1cc617e32cd982070552522a70207">+34/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>servos.h</strong><dd><code>Add servo mixer switch helper definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/flight/servos.h

<ul><li>Add <code>INPUT_MIXER_SWITCH_HELPER</code> enum value for internal servo rules<br> <li> Define <code>servoMixerSwitch_t</code> structure to track filter states during <br>switches<br> <li> Include fields for target channel, rate, speed, and filter state</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10985/files#diff-a44957e639868fcd1b23c639952480cb297e666dd5b69e671c6e7d0790a77ecf">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

