### PR TITLE
allow servo speed filter carry over on the mixer profile switch

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -59,7 +59,6 @@
 #include "rx/rx.h"
 
 #include "sensors/gyro.h"
-#include "common/log.h"
 
 PG_REGISTER_WITH_RESET_TEMPLATE(servoConfig_t, servoConfig, PG_SERVO_CONFIG, 3);
 
@@ -209,15 +208,15 @@ void loadCustomServoMixer(void)
 {
     
     //move the rate filter to new servo rules
-    int maxMoveFilters = MAX_SERVO_RULES/2;
     int movefilterCount = 0;
-    servoMixerSwitch_t servoMixerSwitchHelper[maxMoveFilters]; // helper to keep track of servoSpeedLimitFilter of servo rules
+    static servoMixerSwitch_t servoMixerSwitchHelper[MAX_SERVO_RULES_SWITCH_CARRY]; // helper to keep track of servoSpeedLimitFilter of servo rules
     memset(servoMixerSwitchHelper, 0, sizeof(servoMixerSwitchHelper));
     for (int i = 0; i < servoRuleCount; i++) {
-        if(currentServoMixer[i].inputSource == INPUT_MIXER_SWITCH_HELPER || movefilterCount >= maxMoveFilters) {
+        if(currentServoMixer[i].inputSource == INPUT_MIXER_SWITCH_HELPER || movefilterCount >= MAX_SERVO_RULES_SWITCH_CARRY) {
+            //will not carry over INPUT_MIXER_SWITCH_HELPER rules
             break;
         }
-        if(currentServoMixer[i].speed != 0 && servoSpeedLimitFilter[i].state !=0) {
+        if(currentServoMixer[i].speed != 0 && fabsf(servoSpeedLimitFilter[i].state) < 0.01f) {
             servoMixerSwitchHelper[movefilterCount].targetChannel = currentServoMixer[i].targetChannel;
             servoMixerSwitchHelper[movefilterCount].speed = currentServoMixer[i].speed;
             servoMixerSwitchHelper[movefilterCount].rate = currentServoMixer[i].rate;

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -216,7 +216,7 @@ void loadCustomServoMixer(void)
             //will not carry over INPUT_MIXER_SWITCH_HELPER rules
             break;
         }
-        if(currentServoMixer[i].speed != 0 && fabsf(servoSpeedLimitFilter[i].state) < 0.01f) {
+        if(currentServoMixer[i].speed != 0 && fabsf(servoSpeedLimitFilter[i].state) > 0.01f) {
             servoMixerSwitchHelper[movefilterCount].targetChannel = currentServoMixer[i].targetChannel;
             servoMixerSwitchHelper[movefilterCount].speed = currentServoMixer[i].speed;
             servoMixerSwitchHelper[movefilterCount].rate = currentServoMixer[i].rate;

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -59,6 +59,7 @@
 #include "rx/rx.h"
 
 #include "sensors/gyro.h"
+#include "common/log.h"
 
 PG_REGISTER_WITH_RESET_TEMPLATE(servoConfig_t, servoConfig, PG_SERVO_CONFIG, 3);
 
@@ -106,7 +107,6 @@ int16_t servo[MAX_SUPPORTED_SERVOS];
 
 static uint8_t servoRuleCount = 0;
 static servoMixer_t currentServoMixer[MAX_SERVO_RULES];
-
 /*
 //Was used to keep track of servo rules in all mixer_profile, In order to Apply mixer speed limit when rules turn off
 static servoMixer_t currentServoMixer[MAX_SERVO_RULES*MAX_MIXER_PROFILE_COUNT];
@@ -207,6 +207,25 @@ int getServoCount(void)
 
 void loadCustomServoMixer(void)
 {
+    
+    //move the rate filter to new servo rules
+    int maxMoveFilters = MAX_SERVO_RULES/2;
+    int movefilterCount = 0;
+    servoMixerSwitch_t servoMixerSwitchHelper[maxMoveFilters]; // helper to keep track of servoSpeedLimitFilter of servo rules
+    memset(servoMixerSwitchHelper, 0, sizeof(servoMixerSwitchHelper));
+    for (int i = 0; i < servoRuleCount; i++) {
+        if(currentServoMixer[i].inputSource == INPUT_MIXER_SWITCH_HELPER || movefilterCount >= maxMoveFilters) {
+            break;
+        }
+        if(currentServoMixer[i].speed != 0 && servoSpeedLimitFilter[i].state !=0) {
+            servoMixerSwitchHelper[movefilterCount].targetChannel = currentServoMixer[i].targetChannel;
+            servoMixerSwitchHelper[movefilterCount].speed = currentServoMixer[i].speed;
+            servoMixerSwitchHelper[movefilterCount].rate = currentServoMixer[i].rate;
+            servoMixerSwitchHelper[movefilterCount].speedLimitFilterState = servoSpeedLimitFilter[i].state;
+            movefilterCount++;
+        }
+    }
+
     servoRuleCount = 0;
     memset(currentServoMixer, 0, sizeof(currentServoMixer));
 
@@ -218,6 +237,19 @@ void loadCustomServoMixer(void)
         }
         currentServoMixer[servoRuleCount] = *customServoMixers(i);
         servoSpeedLimitFilter[servoRuleCount].state = 0;
+        servoRuleCount++;
+    }
+
+    // add servo rules to handle the rate limit filter
+    for (int i = 0; i < movefilterCount; i++) {
+        if (servoRuleCount >= MAX_SERVO_RULES) {
+            break; // prevent overflow
+        }
+        currentServoMixer[servoRuleCount].targetChannel = servoMixerSwitchHelper[i].targetChannel;
+        currentServoMixer[servoRuleCount].speed = servoMixerSwitchHelper[i].speed;
+        currentServoMixer[servoRuleCount].rate = servoMixerSwitchHelper[i].rate;
+        currentServoMixer[servoRuleCount].inputSource = INPUT_MIXER_SWITCH_HELPER; // no input
+        servoSpeedLimitFilter[servoRuleCount].state = servoMixerSwitchHelper[i].speedLimitFilterState;
         servoRuleCount++;
     }
 }
@@ -323,6 +355,7 @@ void servoMixer(float dT)
     input[INPUT_STABILIZED_THROTTLE] = mixerThrottleCommand - 1000 - 500;  // Since it derives from rcCommand or mincommand and must be [-500:+500]
 
     input[INPUT_MIXER_TRANSITION] = isMixerTransitionMixing * 500; //fixed value
+    input[INPUT_MIXER_SWITCH_HELPER] = 0; // no input, used to apply speed limit filter from previous servo rules
 
     // center the RC input value around the RC middle value
     // by subtracting the RC middle value from the RC input value, we get:

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -150,6 +150,7 @@ typedef struct servoMixerSwitch_s {
     uint8_t speed;                          // reduces the speed of the rule, 0=unlimited speed
     float speedLimitFilterState;     // rate limit filter for this rule
 } servoMixerSwitch_t;
+#define MAX_SERVO_RULES_SWITCH_CARRY (MAX_SERVO_RULES / 2)
 
 typedef struct servoParam_s {
     int16_t min;                            // servo min

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -84,6 +84,7 @@ typedef enum {
     INPUT_RC_CH32                   = 57,
     INPUT_RC_CH33                   = 58,
     INPUT_RC_CH34                   = 59,
+    INPUT_MIXER_SWITCH_HELPER       = 60,
     INPUT_SOURCE_COUNT
 } inputSource_e;
 
@@ -141,6 +142,14 @@ typedef struct servoMixer_s {
 #define SERVO_OUTPUT_MIN 500
 
 PG_DECLARE_ARRAY(servoMixer_t, MAX_SERVO_RULES, customServoMixers);
+
+typedef struct servoMixerSwitch_s {
+    //this is used to keep track of servoSpeedLimitFilter of servo rules during the mixer switch
+    uint8_t targetChannel;                  // servo that receives the output of the rule
+    int16_t rate;                           // range [-1000;+1000] ; can be used to adjust a rate 0-1000% and a direction
+    uint8_t speed;                          // reduces the speed of the rule, 0=unlimited speed
+    float speedLimitFilterState;     // rate limit filter for this rule
+} servoMixerSwitch_t;
 
 typedef struct servoParam_s {
     int16_t min;                            // servo min


### PR DESCRIPTION
### **User description**
A requested feature by many tilting rotor VTOL build. The servo speed limit will not work properly during the mixer profile switch.
It was because the mixer profile switch will reload and reset all servo rules/speed limit filters. And still, there was no straightforward implementation to properly handle the servo speed limit.

This PR addresses the issue by adding new internal servo mixing rules during the mixer profile switch to carry over servoSpeedLimitFilter status and process it after the mixer profile switch

Bench test ok

___

### **PR Type**
Enhancement


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Add servo speed filter carry-over during mixer profile switches

- Implement helper structure to preserve filter states

- Prevent servo speed limit reset on profile changes

- Support tilting rotor VTOL builds with smooth transitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Current Servo Rules"] --> B["Extract Speed Filters"]
  B --> C["Store in Helper Array"]
  C --> D["Reset Servo Mixer"]
  D --> E["Load New Profile"]
  E --> F["Add Helper Rules"]
  F --> G["Restore Filter States"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>servos.c</strong><dd><code>Implement servo speed filter carry-over mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/flight/servos.c

<ul><li>Add servo speed filter preservation logic during mixer profile <br>switches<br> <li> Implement <code>servoMixerSwitchHelper</code> array to store filter states<br> <li> Create helper servo rules with <code>INPUT_MIXER_SWITCH_HELPER</code> input source<br> <li> Restore speed limit filter states after profile reload</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10986/files#diff-c90491cca5be9a11d702c750699464d7fbc1cc617e32cd982070552522a70207">+34/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>servos.h</strong><dd><code>Add helper structures for servo filter preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/flight/servos.h

<ul><li>Add <code>INPUT_MIXER_SWITCH_HELPER</code> enum value for helper servo rules<br> <li> Define <code>servoMixerSwitch_t</code> structure to track filter states<br> <li> Include fields for target channel, rate, speed, and filter state</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10986/files#diff-a44957e639868fcd1b23c639952480cb297e666dd5b69e671c6e7d0790a77ecf">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

