### PR TITLE
Add options to adjuest motor RPY when transition mode is activate(vtol)

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -6422,6 +6422,36 @@ Throttle PID attenuation reduces influence of PDFF on ROLL and PITCH of multi-ro
 
 ---
 
+### transition_pid_mmix_multiplier_pitch
+
+pitch axis pid multiplier applied to motor mixer only on mixer trasition mode, 1000(default) is 1.0x, -1000 is 1.0x on opposite
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 1000 | -5000 | 5000 |
+
+---
+
+### transition_pid_mmix_multiplier_roll
+
+roll axis pid multiplier applied to motor mixer only on mixer trasition mode, 1000(default) is 1.0x, -1000 is 1.0x on opposite
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 1000 | -5000 | 5000 |
+
+---
+
+### transition_pid_mmix_multiplier_yaw
+
+yaw axis pid multiplier applied to motor mixer only on mixer trasition mode, 1000(default) is 1.0x, -1000 is 1.0x on opposite
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 1000 | -5000 | 5000 |
+
+---
+
 ### tri_unarmed_servo
 
 On tricopter mix only, if this is set to ON, servo will always be correcting regardless of armed state. to disable this, set it to OFF.

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1267,6 +1267,24 @@ groups:
         default_value: OFF
         field: mixer_config.tailsitterOrientationOffset
         type: bool
+      - name: transition_pid_mmix_multiplier_roll
+        description: "roll axis pid multiplier applied to motor mixer only on mixer trasition mode, 1000(default) is 1.0x, -1000 is 1.0x on opposite"
+        default_value: 1000
+        field: mixer_config.transition_PID_mmix_multiplier_roll
+        min: -5000
+        max: 5000
+      - name: transition_pid_mmix_multiplier_pitch
+        description: "pitch axis pid multiplier applied to motor mixer only on mixer trasition mode, 1000(default) is 1.0x, -1000 is 1.0x on opposite"
+        default_value: 1000
+        field: mixer_config.transition_PID_mmix_multiplier_pitch
+        min: -5000
+        max: 5000
+      - name: transition_pid_mmix_multiplier_yaw
+        description: "yaw axis pid multiplier applied to motor mixer only on mixer trasition mode, 1000(default) is 1.0x, -1000 is 1.0x on opposite"
+        default_value: 1000
+        field: mixer_config.transition_PID_mmix_multiplier_yaw
+        min: -5000
+        max: 5000
 
   - name: PG_REVERSIBLE_MOTORS_CONFIG
     type: reversibleMotorsConfig_t

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -527,6 +527,11 @@ void FAST_CODE mixTable(void)
         input[ROLL] = axisPID[ROLL];
         input[PITCH] = axisPID[PITCH];
         input[YAW] = axisPID[YAW];
+        if(isMixerTransitionMixing){
+            input[ROLL] = input[ROLL] * (currentMixerConfig.transition_PID_mmix_multiplier_roll / 1000.0f);
+            input[PITCH] = input[PITCH] * (currentMixerConfig.transition_PID_mmix_multiplier_pitch / 1000.0f);
+            input[YAW] = input[YAW] * (currentMixerConfig.transition_PID_mmix_multiplier_yaw / 1000.0f);
+        }
     }
 
     // Initial mixer concept by bdoiron74 reused and optimized for Air Mode

--- a/src/main/flight/mixer_profile.c
+++ b/src/main/flight/mixer_profile.c
@@ -54,6 +54,9 @@ void pgResetFn_mixerProfiles(mixerProfile_t *instance)
                          .automated_switch = SETTING_MIXER_AUTOMATED_SWITCH_DEFAULT,
                          .switchTransitionTimer =  SETTING_MIXER_SWITCH_TRANS_TIMER_DEFAULT,
                          .tailsitterOrientationOffset = SETTING_TAILSITTER_ORIENTATION_OFFSET_DEFAULT,
+                         .transition_PID_mmix_multiplier_roll = SETTING_TRANSITION_PID_MMIX_MULTIPLIER_ROLL_DEFAULT,
+                         .transition_PID_mmix_multiplier_pitch = SETTING_TRANSITION_PID_MMIX_MULTIPLIER_PITCH_DEFAULT,
+                         .transition_PID_mmix_multiplier_yaw = SETTING_TRANSITION_PID_MMIX_MULTIPLIER_YAW_DEFAULT
                      });
         for (int j = 0; j < MAX_SUPPORTED_MOTORS; j++)
         {

--- a/src/main/flight/mixer_profile.h
+++ b/src/main/flight/mixer_profile.h
@@ -19,6 +19,9 @@ typedef struct mixerConfig_s {
     bool automated_switch;
     int16_t switchTransitionTimer;
     bool tailsitterOrientationOffset;
+    int16_t transition_PID_mmix_multiplier_roll;
+    int16_t transition_PID_mmix_multiplier_pitch;
+    int16_t transition_PID_mmix_multiplier_yaw;
 } mixerConfig_t;
 typedef struct mixerProfile_s {
     mixerConfig_t mixer_config;


### PR DESCRIPTION
### **User description**
make it able to adjust motor RPY mixing during the transition mode.
intended to solve roll/yaw coupling oscillation in transtion mode on tilting rotor VTOL


___

### **PR Type**
Enhancement


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Add PID multipliers for VTOL transition mode

- Enable independent roll/pitch/yaw axis scaling during transition

- Solve roll/yaw coupling oscillations in tilting rotor VTOL

- Configure multipliers via settings with -5000 to 5000 range


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PID Controller"] --> B["Transition Multipliers"]
  B --> C["Motor Mixer"]
  C --> D["VTOL Motors"]
  E["Settings Config"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mixer.c</strong><dd><code>Apply transition PID multipliers in mixer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/flight/mixer.c

<ul><li>Apply transition PID multipliers to roll/pitch/yaw inputs<br> <li> Scale PID values during mixer transition mode<br> <li> Convert multiplier values from integer to float (divide by 1000)</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10996/files#diff-c98e21d8f3cf216db2a51ba27291626147f6f48724944160963e60565ae349c3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mixer_profile.h</strong><dd><code>Add transition multiplier struct fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/flight/mixer_profile.h

<ul><li>Add three new int16_t fields to mixerConfig_s struct<br> <li> Define transition_PID_mmix_multiplier for roll/pitch/yaw axes</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10996/files#diff-a38358669c51c3e0df1d446f210dcadf730368c0592acfe128048c03b267fa6a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mixer_profile.c</strong><dd><code>Initialize transition multiplier defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/flight/mixer_profile.c

<ul><li>Add default values for transition PID multipliers<br> <li> Initialize roll/pitch/yaw multipliers to 1000 (1.0x)<br> <li> Include new settings in mixer profile reset function</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10996/files#diff-62ba8ed673f88ad9d7823c1a4e87e541e950e450372045ae363d99be056de732">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.yaml</strong><dd><code>Configure transition multiplier settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/fc/settings.yaml

<ul><li>Define settings for transition_pid_mmix_multiplier_roll/pitch/yaw<br> <li> Set default value 1000 with range -5000 to 5000<br> <li> Map settings to mixer_config struct fields</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10996/files#diff-4569ee6a30a1d30a1f5aeff4e218a1fbdc14e4373abdcece1af2160926e85f76">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Settings.md</strong><dd><code>Document transition multiplier settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Settings.md

<ul><li>Document three new transition PID multiplier settings<br> <li> Specify range -5000 to 5000 with default 1000<br> <li> Explain 1000 equals 1.0x scaling factor</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/10996/files#diff-ae20939faff30a268f1d311e9654bb2788d52d5ecdc9a897340914a5ca0c8b44">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

