### PR TITLE
Fix Mac SITL CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          brew install cmake ninja ruby
+          brew install ruby
 
       - name: Setup environment
         env:


### PR DESCRIPTION
### **User description**
Mac SITL CI should work again.


___

### **PR Type**
Bug fix


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Remove cmake and ninja from Mac SITL CI dependencies

- Fix Mac SITL CI build issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mac SITL CI"] -- "remove dependencies" --> B["cmake, ninja removed"]
  B --> C["CI fixed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Remove cmake ninja dependencies from Mac CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Remove <code>cmake</code> and <code>ninja</code> from brew install command<br> <li> Keep only <code>ruby</code> as dependency for Mac SITL build</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11017/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

