### PR TITLE
DAKEFPVF722 SPL06 support

### DIFF
--- a/src/main/target/DAKEFPVF722/target.h
+++ b/src/main/target/DAKEFPVF722/target.h
@@ -78,6 +78,11 @@
 #define BMP280_SPI_BUS          BUS_SPI2
 #define BMP280_CS_PIN           PA13
 
+#define USE_BARO_SPL06
+#define SPL06_SPI_BUS          BUS_SPI2
+#define SPL06_CS_PIN           PA13
+
+
 // M25P256 flash
 #define USE_FLASHFS
 #define USE_FLASH_M25P16


### PR DESCRIPTION
### **User description**
Some DAKEFPVF722  seem to have the SPL06 .
Tested and confirmed by a user.


___

### **PR Type**
Enhancement


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Add SPL06 barometer support for DAKEFPVF722 target

- Configure SPL06 on SPI2 bus with PA13 chip select


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DAKEFPVF722["DAKEFPVF722 Target"] --> BMP280["BMP280 Barometer"]
  DAKEFPVF722 --> SPL06["SPL06 Barometer"]
  BMP280 --> SPI2["SPI2 Bus (PA13)"]
  SPL06 --> SPI2
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Add SPL06 barometer configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/DAKEFPVF722/target.h

<ul><li>Add <code>USE_BARO_SPL06</code> definition to enable SPL06 barometer<br> <li> Configure SPL06 to use SPI2 bus with PA13 chip select pin<br> <li> Maintain existing BMP280 barometer configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11022/files#diff-356c8755bdc2153351e048bdd3ad790de557554c27ac5f2292b15251fcb32dbe">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

