### PR TITLE
lucid_h7: add pc13 for 9v en

### DIFF
--- a/src/main/target/TBS_LUCID_H7/config.c
+++ b/src/main/target/TBS_LUCID_H7/config.c
@@ -26,14 +26,23 @@
 
 #include "platform.h"
 
-#include "fc/fc_msp_box.h"
 #include "fc/config.h"
+#include "fc/fc_msp_box.h"
+#include "fc/rc_modes.h"
 
 #include "io/piniobox.h"
+
+#include "drivers/pwm_mapping.h"
 
 void targetConfiguration(void)
 {
     pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
     pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+    pinioBoxConfigMutable()->permanentId[2] = BOX_PERMANENT_ID_USER3;
     beeperConfigMutable()->pwmMode = true;
+
+    modeActivationConditionsMutable(0)->auxChannelIndex = 0;
+    modeActivationConditionsMutable(0)->modeId = BOXUSER1;
+    modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MIN);
+    modeActivationConditionsMutable(0)->range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
 }

--- a/src/main/target/TBS_LUCID_H7/target.h
+++ b/src/main/target/TBS_LUCID_H7/target.h
@@ -160,6 +160,8 @@
 #define USE_PINIOBOX
 #define PINIO1_PIN                  PD10 
 #define PINIO2_PIN                  PD11
+#define PINIO3_PIN                  PC13
+#define PINIO3_FLAGS                PINIO_FLAGS_INVERTED
 
 #define USE_LED_STRIP
 #define WS2811_PIN                  PA8

--- a/src/main/target/TBS_LUCID_H7_WING/config.c
+++ b/src/main/target/TBS_LUCID_H7_WING/config.c
@@ -22,16 +22,30 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-#include "fc/config.h"
-
 #include <stdint.h>
 
-#include "fc/fc_msp_box.h"
-#include "io/piniobox.h"
 #include "platform.h"
+
+#include "fc/config.h"
+#include "fc/fc_msp_box.h"
+#include "fc/rc_modes.h"
+
+#include "io/piniobox.h"
+
+#include "drivers/pwm_mapping.h"
 
 void targetConfiguration(void)
 {
     pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
     pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+    
+    modeActivationConditionsMutable(0)->auxChannelIndex = 0;
+    modeActivationConditionsMutable(0)->modeId = BOXUSER1;
+    modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MIN);
+    modeActivationConditionsMutable(0)->range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
+
+    modeActivationConditionsMutable(1)->auxChannelIndex = 0;
+    modeActivationConditionsMutable(1)->modeId = BOXUSER2;
+    modeActivationConditionsMutable(1)->range.startStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MIN);
+    modeActivationConditionsMutable(1)->range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
 }

--- a/src/main/target/TBS_LUCID_H7_WING_MINI/config.c
+++ b/src/main/target/TBS_LUCID_H7_WING_MINI/config.c
@@ -21,16 +21,27 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
-#include "fc/config.h"
-
 #include <stdint.h>
 
-#include "fc/fc_msp_box.h"
-#include "io/piniobox.h"
 #include "platform.h"
+
+#include "fc/config.h"
+#include "fc/fc_msp_box.h"
+#include "fc/rc_modes.h"
+
+#include "io/piniobox.h"
+
+#include "drivers/pwm_mapping.h"
 
 void targetConfiguration(void)
 {
     pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+
+    modeActivationConditionsMutable(0)->auxChannelIndex = 0;
+    modeActivationConditionsMutable(0)->modeId = BOXUSER1;
+    modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MIN);
+    modeActivationConditionsMutable(0)->range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
+
+    timerOverridesMutable(timer2id(TIM3))->outputMode = OUTPUT_MODE_SERVOS;
+    timerOverridesMutable(timer2id(TIM4))->outputMode = OUTPUT_MODE_MOTORS;
 }


### PR DESCRIPTION
the 9v on the H7 was missed during initial target creation, externally pulled high.
adds defaults for the USR aux switches on the all lucid h7 fcs.
adds timer assigments for the mini, as the esc is hard soldered. 
