### PR TITLE
Add target for SpeedyBee F405 V5

### DIFF
--- a/src/main/target/SPEEDYBEEF405V5/CMakeLists.txt
+++ b/src/main/target/SPEEDYBEEF405V5/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f405xg(SPEEDYBEEF405V5)

--- a/src/main/target/SPEEDYBEEF405V5/config.c
+++ b/src/main/target/SPEEDYBEEF405V5/config.c
@@ -1,0 +1,39 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include <stdint.h>
+#include "platform.h"
+#include "fc/fc_msp_box.h"
+#include "io/piniobox.h"
+#include "io/serial.h"
+
+void targetConfiguration(void)
+{
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].functionMask = FUNCTION_MSP;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].msp_baudrateIndex = BAUD_115200;
+
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART5)].functionMask = FUNCTION_ESCSERIAL;
+    
+    pinioBoxConfigMutable()->permanentId[0] = BOXARM;
+}

--- a/src/main/target/SPEEDYBEEF405V5/config.c
+++ b/src/main/target/SPEEDYBEEF405V5/config.c
@@ -30,10 +30,7 @@
 
 void targetConfiguration(void)
 {
-    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].functionMask = FUNCTION_MSP;
-    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART4)].msp_baudrateIndex = BAUD_115200;
-
     serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART5)].functionMask = FUNCTION_ESCSERIAL;
-    
+
     pinioBoxConfigMutable()->permanentId[0] = BOXARM;
 }

--- a/src/main/target/SPEEDYBEEF405V5/target.c
+++ b/src/main/target/SPEEDYBEEF405V5/target.c
@@ -1,0 +1,48 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/pinio.h"
+#include "drivers/sensor.h"
+
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688,  DEVHW_ICM42605, ICM42605_SPI_BUS,  ICM42605_CS_PIN,  NONE,  0,  DEVFLAGS_NONE,  IMU_ICM42605_ALIGN);
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM3,   CH4, PB1,  TIM_USE_MOTOR, 1, 0), // S1 (PB1/TIM3_CH4)
+    DEF_TIM(TIM3,   CH3, PB0,  TIM_USE_MOTOR, 1, 0), // S2 (PB0/TIM3_CH3)
+    DEF_TIM(TIM2,   CH3, PB10, TIM_USE_MOTOR, 1, 0), // S3 (PB10/TIM2_CH3)
+    DEF_TIM(TIM2,   CH4, PB11, TIM_USE_MOTOR, 1, 0), // S4 (PB11/TIM2_CH4)
+    DEF_TIM(TIM8,   CH4, PC9,  TIM_USE_SERVO, 1, 0), // S5 (PC9/TIM8_CH4)
+    DEF_TIM(TIM8,   CH3, PC8,  TIM_USE_SERVO, 1, 0), // S6 (PC8/TIM8_CH3)
+
+    DEF_TIM(TIM1,   CH1, PA8,  TIM_USE_LED,   0, 0), //2812LED  D(1,5,3)
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/SPEEDYBEEF405V5/target.h
+++ b/src/main/target/SPEEDYBEEF405V5/target.h
@@ -1,0 +1,167 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "SB45"
+#define USBD_PRODUCT_STRING  "SpeedyBeeF405V5"
+
+/*** Indicators ***/
+#define LED0                    PA15  //Blue
+
+#define BEEPER                  PB9
+#define BEEPER_INVERTED
+
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                  PC13
+#define PINIO1_FLAGS                PINIO_FLAGS_INVERTED
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define USE_UART3
+#define UART3_TX_PIN            PC10
+#define UART3_RX_PIN            PC11
+
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1
+
+#define USE_UART5
+#define UART5_TX_PIN            NONE
+#define UART5_RX_PIN            PD2     //ESC TLM
+
+#define USE_UART6
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+#define USE_SOFTSERIAL1
+#define SOFTSERIAL_1_TX_PIN      PA2
+#define SOFTSERIAL_1_RX_PIN      PA2
+
+#define SERIAL_PORT_COUNT       8
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART6
+
+// *************** Gyro & ACC **********************
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_IMU_ICM42605 // ICM42688P
+#define IMU_ICM42605_ALIGN      CW270_DEG
+#define ICM42605_CS_PIN         PA4
+#define ICM42605_SPI_BUS        BUS_SPI1
+
+// *************** I2C(Baro & I2C) **************************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_BMP085
+#define USE_BARO_DPS310
+#define USE_BARO_SPL06
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+#define USE_RANGEFINDER
+#define TEMPERATURE_I2C_BUS     BUS_I2C1
+#define PITOT_I2C_BUS           BUS_I2C1
+#define RANGEFINDER_I2C_BUS     BUS_I2C1
+
+// *************** Internal SD card **************************
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_SPI_BUS          BUS_SPI3
+#define M25P16_CS_PIN           PC12
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+// *************** OSD *****************************
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PC2
+#define SPI2_MOSI_PIN           PC3
+
+#define USE_OSD
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          PB12
+
+// *************** ADC *****************************
+
+#define USE_ADC
+#define ADC_CHANNEL_1_PIN           PC0
+#define ADC_CHANNEL_2_PIN           PC1
+#define ADC_CHANNEL_3_PIN           PC5
+
+#define RSSI_ADC_CHANNEL            ADC_CHN_1
+#define VBAT_ADC_CHANNEL            ADC_CHN_2
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_3
+
+
+// *************** LED *****************************
+#define USE_LED_STRIP
+#define WS2811_PIN PA8
+
+#define DEFAULT_FEATURES                (FEATURE_TX_PROF_SEL  | FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT  | FEATURE_BLACKBOX | FEATURE_TELEMETRY)
+#define CURRENT_METER_SCALE     36
+
+#define USE_DSHOT
+#define USE_SERIALSHOT
+#define USE_ESC_SENSOR
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define MAX_PWM_OUTPUT_PORTS        10
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD (BIT(2))

--- a/src/main/target/SPEEDYBEEF405V5/target.h
+++ b/src/main/target/SPEEDYBEEF405V5/target.h
@@ -36,7 +36,6 @@
 #define USE_PINIO
 #define USE_PINIOBOX
 #define PINIO1_PIN                  PC13
-#define PINIO1_FLAGS                PINIO_FLAGS_INVERTED
 
 // *************** UART *****************************
 #define USE_VCP


### PR DESCRIPTION
### **User description**
So I bought a SpeedyBee F405 V5 stack back in September. According to the specifications it should have INAV support but doesn't. SpeedyBee support wasn't very helpful so I decided to write my own target code for it.

This code is heavily based upon the [F405 V4 target](https://github.com/iNavFlight/inav/tree/master/src/main/target/SPEEDYBEEF405V4) and the configuration from [Betaflight](https://github.com/betaflight/config/blob/master/configs/SPEEDYBEEF405V5/config.h). It has not been flown yet, but the following functions have been tested:

- SpeedyBee bluetooth app
- GPS/Mag (UART4/I2C)
- Board LEDs
- Barometer
- Serial RX
- Blackbox flash
- Motor outputs (S1/S2/S3/S4)
- Servo outputs (S5/S6)
- IMU
- USB
- VTX communication and power supply (tested using DJI O3)
- Beeper

This PR solves https://github.com/iNavFlight/inav/discussions/11044


___

### **PR Type**
Enhancement


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Adds complete target support for SpeedyBee F405 V5 flight controller

- Configures ICM42605 IMU, MAX7456 OSD, and M25P16 flash storage

- Defines 6 motor/servo outputs and LED strip support

- Sets up 6 UARTs with CRSF receiver on UART6


___

### Diagram Walkthrough


```mermaid
flowchart LR
  target["SpeedyBee F405 V5 Target"] --> hardware["Hardware Configuration"]
  hardware --> imu["ICM42605 IMU on SPI1"]
  hardware --> osd["MAX7456 OSD on SPI2"]
  hardware --> flash["M25P16 Flash on SPI3"]
  hardware --> uart["6 UART Ports"]
  hardware --> io["Motor/Servo/LED Outputs"]
  target --> config["Default Configuration"]
  config --> escserial["ESC Serial on UART5"]
  config --> pinio["PINIO ARM Control"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>New target</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Complete hardware pin and peripheral definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/SPEEDYBEEF405V5/target.h

<ul><li>Defines board identifier, USB product string, and LED/beeper pins<br> <li> Configures 6 UART ports with CRSF receiver on UART6<br> <li> Sets up SPI devices for IMU (ICM42605), OSD (MAX7456), and flash <br>(M25P16)<br> <li> Defines I2C bus for barometer, magnetometer, and sensors<br> <li> Configures ADC channels for RSSI, VBAT, and current sensing</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11059/files#diff-b57c70c7e79e64bf3b27ccb0eb79d23cf737b13ab057799b307ed710e6e45e8c">+167/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>target.c</strong><dd><code>Timer hardware and IMU device registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/SPEEDYBEEF405V5/target.c

<ul><li>Registers ICM42605 IMU on SPI1 with CW270 alignment<br> <li> Defines 6 timer channels for 4 motors and 2 servos<br> <li> Configures LED strip output on PA8</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11059/files#diff-385d479372aaecb4e671be0cca559ad8129ddb8f4e6f1de55621a69c76b1ab62">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.c</strong><dd><code>Default serial and PINIO configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/SPEEDYBEEF405V5/config.c

<ul><li>Sets UART5 to ESC serial function by default<br> <li> Configures PINIO box 0 for ARM control</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11059/files#diff-7b8a009693d2b1f47cdb53f371c62bb670f6ca868d9a968d1fe0c1558de33e52">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Build system integration for new target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/SPEEDYBEEF405V5/CMakeLists.txt

- Adds CMake build target for STM32F405 MCU


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11059/files#diff-25e2d91a652d7de411ebebd8fa3a22cbeae0d56509f6bffc7e7cd0be452de06e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

