### PR TITLE
Mavlink systemid cli

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2692,6 +2692,16 @@ Rate of the RC channels message for MAVLink telemetry
 
 ---
 
+### mavlink_sysid
+
+MAVLink System ID
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 1 | 1 | 255 |
+
+---
+
 ### mavlink_version
 
 Version of MAVLink to use

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3235,6 +3235,13 @@ groups:
         table: mavlink_radio_type
         default_value: "GENERIC"
         type: uint8_t
+      - name: mavlink_sysid
+        field: mavlink.sysid
+        description: "MAVLink System ID"
+        type: uint8_t
+        min: 1
+        max: 255
+        default_value: 1
 
   - name: PG_OSD_CONFIG
     type: osdConfig_t

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -184,7 +184,7 @@ static mavlink_message_t mavRecvMsg;
 static mavlink_status_t mavRecvStatus;
 
 // Set mavSystemId from telemetryConfig()->mavlink.sysid
-static uint8_t mavSystemId; 
+static uint8_t mavSystemId = 1;
 static uint8_t mavComponentId = MAV_COMP_ID_AUTOPILOT1;
 
 static APM_COPTER_MODE inavToArduCopterMap(flightModeForTelemetry_e flightMode)

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -183,7 +183,8 @@ static mavlink_message_t mavSendMsg;
 static mavlink_message_t mavRecvMsg;
 static mavlink_status_t mavRecvStatus;
 
-static uint8_t mavSystemId = 1;
+// Set mavSystemId from telemetryConfig()->mavlink.sysid
+static uint8_t mavSystemId; 
 static uint8_t mavComponentId = MAV_COMP_ID_AUTOPILOT1;
 
 static APM_COPTER_MODE inavToArduCopterMap(flightModeForTelemetry_e flightMode)
@@ -296,6 +297,7 @@ void configureMAVLinkTelemetryPort(void)
     }
 
     mavlinkPort = openSerialPort(portConfig->identifier, FUNCTION_TELEMETRY_MAVLINK, NULL, NULL, baudRates[baudRateIndex], TELEMETRY_MAVLINK_PORT_MODE, SERIAL_NOT_INVERTED);
+    mavSystemId = telemetryConfig()->mavlink.sysid;
 
     if (!mavlinkPort) {
         return;

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -95,7 +95,8 @@ PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
         .extra3_rate = SETTING_MAVLINK_EXTRA3_RATE_DEFAULT,
         .version = SETTING_MAVLINK_VERSION_DEFAULT,
         .min_txbuff = SETTING_MAVLINK_MIN_TXBUFFER_DEFAULT,
-        .radio_type = SETTING_MAVLINK_RADIO_TYPE_DEFAULT
+        .radio_type = SETTING_MAVLINK_RADIO_TYPE_DEFAULT,
+        .sysid = SETTING_MAVLINK_SYSID_DEFAULT
     }
 );
 

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -81,6 +81,7 @@ typedef struct telemetryConfig_s {
         uint8_t version;
         uint8_t min_txbuff;
         uint8_t radio_type;
+        uint8_t sysid;
     } mavlink;
 } telemetryConfig_t;
 


### PR DESCRIPTION
### **User description**
Adds ability to change mavlink systemid via the CLI


___

### **PR Type**
Enhancement


___

### **Description**
- Added configurable MAVLink System ID via CLI setting

- Introduced `mavlink_sysid` parameter with range 1-255, default value 1

- Updated telemetry configuration structure and initialization logic

- Added documentation for new `mavlink_sysid` setting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["settings.yaml"] -- "defines" --> B["mavlink_sysid parameter"]
  B -- "stored in" --> C["telemetryConfig_t structure"]
  C -- "initialized at" --> D["configureMAVLinkTelemetryPort()"]
  D -- "sets" --> E["mavSystemId variable"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.yaml</strong><dd><code>Define new MAVLink System ID setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/fc/settings.yaml

<ul><li>Added <code>mavlink_sysid</code> configuration parameter with range 1-255<br> <li> Set default value to 1 for MAVLink System ID</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11062/files#diff-4569ee6a30a1d30a1f5aeff4e218a1fbdc14e4373abdcece1af2160926e85f76">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>telemetry.h</strong><dd><code>Extend telemetry config with System ID field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/telemetry.h

- Added `sysid` field to `mavlink` structure in `telemetryConfig_s`


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11062/files#diff-d680bcf7b8b91889f599df6890cb08c880eb6d5cdcbe85b57c23122d3ee40a1c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>telemetry.c</strong><dd><code>Initialize MAVLink System ID in config template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/telemetry.c

<ul><li>Added <code>sysid</code> initialization in <code>telemetryConfig</code> reset template<br> <li> Set default value using <code>SETTING_MAVLINK_SYSID_DEFAULT</code></ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11062/files#diff-2dfb5a648e41aaa74b0550d72543ae99487bb174e04f6f6df3d7ddfdee5a5987">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mavlink.c</strong><dd><code>Use configurable System ID instead of hardcoded value</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/mavlink.c

<ul><li>Changed <code>mavSystemId</code> from hardcoded value 1 to dynamic configuration<br> <li> Set <code>mavSystemId</code> from <code>telemetryConfig()->mavlink.sysid</code> during port <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11062/files#diff-77281cb45441cdeab50dd4c2215dbe6693da397b8633f53566a19d84dbb9c5aa">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Settings.md</strong><dd><code>Document new MAVLink System ID setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Settings.md

<ul><li>Added documentation for <code>mavlink_sysid</code> setting<br> <li> Documented default value 1 and range 1-255</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11062/files#diff-ae20939faff30a268f1d311e9654bb2788d52d5ecdc9a897340914a5ca0c8b44">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

