### PR TITLE
ublox: include array index to set satellites with no signal as unused

### DIFF
--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -746,8 +746,8 @@ static bool gpsParseFrameUBLOX(void)
                 ubloxNavSat2NavSig(&_buffer.svinfo.channel[i], &satelites[i]);
             }
             for(int i =_buffer.svinfo.numSvs; i < UBLOX_MAX_SIGNALS; ++i) {
-                satelites->gnssId = 0xFF;
-                satelites->svId = 0xFF;
+                satelites[i]->gnssId = 0xFF;
+                satelites[i]->svId = 0xFF;
             }
         }
         break;

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -746,8 +746,8 @@ static bool gpsParseFrameUBLOX(void)
                 ubloxNavSat2NavSig(&_buffer.svinfo.channel[i], &satelites[i]);
             }
             for(int i =_buffer.svinfo.numSvs; i < UBLOX_MAX_SIGNALS; ++i) {
-                satelites[i]->gnssId = 0xFF;
-                satelites[i]->svId = 0xFF;
+                satelites[i].gnssId = 0xFF;
+                satelites[i].svId = 0xFF;
             }
         }
         break;


### PR DESCRIPTION
### **User description**
The code intended to mark satellite slots with no signal as unused.
Due to a missing array index, it instead marked the FIRST satellite as unused, leaving the ones with no signal marked valid.

This change adds the array index so it sets the proper satellites as no signal.

@mmosca  Can you please confirm this is what was intended.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed array indexing bug in satellite signal handling

- Corrected marking of satellites with no signal as unused

- Previously marked first satellite instead of proper indices


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Iterate satellites"] --> B["Mark unused satellites"]
  B --> C["Fixed: Use index [i]"]
  C --> D["Correctly set gnssId/svId to 0xFF"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gps_ublox.c</strong><dd><code>Fix satellite array indexing for unused slots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/io/gps_ublox.c

<ul><li>Added array index <code>[i]</code> to <code>satelites</code> pointer in loop<br> <li> Fixed bug where first satellite was incorrectly marked instead of <br>satellites with no signal<br> <li> Corrected assignment of <code>gnssId</code> and <code>svId</code> to 0xFF for unused satellite <br>slots</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11064/files#diff-a3a83325fab0efdb4fe30266aec13726ac9c0f815d4c2063338f8ce29f722059">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

