### PR TITLE
Dakefpvf435

### DIFF
--- a/src/main/target/DAKEFPVF435/target.c
+++ b/src/main/target/DAKEFPVF435/target.c
@@ -57,9 +57,8 @@ timerHardware_t timerHardware[] = {
 	DEF_TIM(TMR5, CH2, PH3,  TIM_USE_OUTPUT_AUTO, 0,9), // S1
 	DEF_TIM(TMR5, CH1, PH2,  TIM_USE_OUTPUT_AUTO, 0,10),// S2
     
-    // DEF_TIM(TMR3, CH3, PC8,   TIM_USE_ANY, 0, 0), 
-	DEF_TIM(TMR3, CH3, PC8,   TIM_USE_LED, 0, 0),  // LED_STRIP
+	DEF_TIM(TMR3, CH3, PC8,   TIM_USE_LED | TIM_USE_ANY, 0, 11),  // LED_STRIP
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);
-  
+

--- a/src/main/target/DAKEFPVF435/target.c
+++ b/src/main/target/DAKEFPVF435/target.c
@@ -57,8 +57,8 @@ timerHardware_t timerHardware[] = {
 	DEF_TIM(TMR5, CH2, PH3,  TIM_USE_OUTPUT_AUTO, 0,9), // S1
 	DEF_TIM(TMR5, CH1, PH2,  TIM_USE_OUTPUT_AUTO, 0,10),// S2
     
-    DEF_TIM(TMR3, CH3, PC8,   TIM_USE_ANY, 0, 11),  //
-    // DEF_TIM(TMR9, CH2, PC5,   TIM_USE_LED, 0, 0),  // LED STRIP
+    // DEF_TIM(TMR3, CH3, PC8,   TIM_USE_ANY, 0, 0), 
+	DEF_TIM(TMR3, CH3, PC8,   TIM_USE_LED, 0, 0),  // LED_STRIP
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/DAKEFPVF435/target.h
+++ b/src/main/target/DAKEFPVF435/target.h
@@ -162,7 +162,7 @@
 
 #define USE_DSHOT
 #define USE_ESC_SENSOR
-#define MAX_PWM_OUTPUT_PORTS    10
+#define MAX_PWM_OUTPUT_PORTS    11
 
 // PINIO
 #define USE_PINIO
@@ -171,4 +171,4 @@
 #define PINIO2_PIN           PB10
 
 // VBAT 10K/160K
-#define VBAT_SCALE_DEFAULT 1600
+#define VBAT_SCALE_DEFAULT 1094


### PR DESCRIPTION
### **User description**
Fixing up issues with the original target.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed LED strip configuration by enabling `TIM_USE_LED` flag on timer TMR3 CH3

- Corrected `MAX_PWM_OUTPUT_PORTS` from 10 to 11 to match actual motor/servo outputs

- Updated `VBAT_SCALE_DEFAULT` from 1600 to 1094 for accurate voltage readings

- Cleaned up commented code and improved formatting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Timer Configuration"] -- "Enable LED support" --> B["TMR3 CH3 PC8"]
  C["PWM Configuration"] -- "Increase count" --> D["MAX_PWM_OUTPUT_PORTS: 11"]
  E["Voltage Scaling"] -- "Correct calibration" --> F["VBAT_SCALE: 1094"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.c</strong><dd><code>Enable LED strip timer with proper flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/DAKEFPVF435/target.c

<ul><li>Enabled <code>TIM_USE_LED</code> flag for TMR3 CH3 on PC8 pin<br> <li> Removed commented-out LED strip timer definition<br> <li> Fixed whitespace and formatting issues</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11066/files#diff-5bd23652f4d6a7f399c0fae2231d0a56e838d4e36458f03a14e460fe92b153ec">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Correct PWM port count and voltage scaling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/DAKEFPVF435/target.h

<ul><li>Increased <code>MAX_PWM_OUTPUT_PORTS</code> from 10 to 11<br> <li> Updated <code>VBAT_SCALE_DEFAULT</code> from 1600 to 1094 for correct voltage <br>measurement</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11066/files#diff-8d354b5c67e5c03efa2da3a018ab2a4a52500f9bb360151c074391e9de581a4f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

