### PR TITLE
fix ADSB cardinal for broken mag direction

### DIFF
--- a/docs/ADSB.md
+++ b/docs/ADSB.md
@@ -7,7 +7,13 @@ is an air traffic surveillance technology that enables aircraft to be accurately
 
 OSD can be configured to shows the closest aircraft.
 
-## OSD element
+## OSD ADSB Info element
+* "-" no ADSB device detected
+* "H" IMU heading is not valid 
+* "G" no GPS fix or less than 4 stats
+* "[Number]" count of ADSB aircrafts
+
+## OSD ADSB Warning element
 OSD can be configured to simple view (one line) or to extended view (two lines) by \
 `set osd_adsb_warning_style=EXTENDED`
 

--- a/src/main/io/adsb.c
+++ b/src/main/io/adsb.c
@@ -98,6 +98,26 @@ adsbVehicle_t *findVehicleClosest(void) {
  * @return
  */
 adsbVehicle_t *findVehicleClosestLimit(int32_t maxVerticalDistance) {
+
+    ////////////////////////////////////////////////////////////
+    //debug vehicle
+    /*adsbVehicleValues_t* vehicle = getVehicleForFill();
+    if(vehicle != NULL){
+        char name[9] = "DUMMY    ";
+        vehicle->icao = 666;
+        vehicle->gps.lat = 492383514;
+        vehicle->gps.lon = 165148681;
+        vehicle->alt = 100000;
+        vehicle->heading = 66;
+        vehicle->flags = ADSB_FLAGS_VALID_ALTITUDE | ADSB_FLAGS_VALID_COORDS;
+        vehicle->altitudeType = 0;
+        memcpy(&(vehicle->callsign), name, sizeof(vehicle->callsign));
+        vehicle->emitterType = 6;
+        vehicle->tslc = 0;
+        adsbNewVehicle(vehicle);
+    }*/
+    ////////////////////////////////////////////////////////////
+
     adsbVehicle_t *adsbLocal = NULL;
     for (uint8_t i = 0; i < MAX_ADSB_VEHICLES; i++) {
         if(adsbVehiclesList[i].ttl > 0 && adsbVehiclesList[i].calculatedVehicleValues.valid){
@@ -178,7 +198,7 @@ void adsbNewVehicle(adsbVehicleValues_t* vehicleValuesLocal) {
     }
 
     // non GPS mode, GPS is not fix, just find free space in list or by icao and save vehicle without calculated values
-    if (!enviromentOkForCalculatingDistaceBearing()) {
+    if (!isEnvironmentOkForCalculatingADSBDistanceBearing()) {
         if(vehicle == NULL){
             vehicle = findFreeSpaceInList();
         }
@@ -264,8 +284,16 @@ void adsbTtlClean(timeUs_t currentTimeUs) {
     }
 };
 
-bool enviromentOkForCalculatingDistaceBearing(void){
-    return (STATE(GPS_FIX) && gpsSol.numSat > 4);
+bool isEnvironmentOkForCalculatingADSBDistanceBearing(void){
+    return
+    (gpsSol.numSat > 4 &&
+    (
+        STATE(GPS_FIX)
+        #ifdef USE_GPS_FIX_ESTIMATION
+            || STATE(GPS_ESTIMATED_FIX)
+        #endif
+        )
+    );
 }
 
 #endif

--- a/src/main/io/adsb.h
+++ b/src/main/io/adsb.h
@@ -64,5 +64,5 @@ uint8_t getActiveVehiclesCount(void);
 void adsbTtlClean(timeUs_t currentTimeUs);
 adsbVehicleStatus_t* getAdsbStatus(void);
 adsbVehicleValues_t* getVehicleForFill(void);
-bool enviromentOkForCalculatingDistaceBearing(void);
+bool isEnvironmentOkForCalculatingADSBDistanceBearing(void);
 void recalculateVehicle(adsbVehicle_t* vehicle);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -317,6 +317,14 @@ static void osdFormatDistanceSymbol(char *buff, int32_t dist, uint8_t decimals, 
 }
 
 /**
+ * return flight direction on degrees
+ */
+static int16_t osdGetFlightDirection(void)
+{
+    return STATE(AIRPLANE) ? CENTIDEGREES_TO_DEGREES(posControl.actualState.cog) : DECIDEGREES_TO_DEGREES(osdGetHeading());
+}
+
+/**
  * Converts distance into a string based on the current unit system.
  * @param dist Distance in centimeters
  */
@@ -1979,8 +1987,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     if (!(osdConfig()->pan_servo_pwm2centideg == 0)){
                         panHomeDirOffset = osdGetPanServoOffset();
                     }
-                    int16_t flightDirection = STATE(AIRPLANE) ? CENTIDEGREES_TO_DEGREES(posControl.actualState.cog) : DECIDEGREES_TO_DEGREES(osdGetHeading());
-                    int homeDirection = GPS_directionToHome - flightDirection + panHomeDirOffset;
+                    int homeDirection = GPS_directionToHome - osdGetFlightDirection() + panHomeDirOffset;
                     osdDrawDirArrow(osdDisplayPort, osdGetDisplayPortCanvas(), OSD_DRAW_POINT_GRID(elemPosX, elemPosY), homeDirection);
                 }
             } else {
@@ -2176,16 +2183,17 @@ static bool osdDrawSingleElement(uint8_t item)
             uint8_t buffIndexFirstLine = 0;
             uint8_t arrowIndexIndex = 0;
             adsbVehicle_t *vehicle = findVehicleClosestLimit(METERS_TO_CENTIMETERS(osdConfig()->adsb_ignore_plane_above_me_limit));
-            if(vehicle != NULL)
-            {
+            if (vehicle != NULL) {
                 recalculateVehicle(vehicle);
             }
 
             if (
-                    vehicle != NULL &&
-                    (vehicle->calculatedVehicleValues.dist > 0 &&
-                    vehicle->calculatedVehicleValues.dist < METERS_TO_CENTIMETERS(osdConfig()->adsb_distance_warning))
-            ){
+                    vehicle != NULL
+                    && (vehicle->calculatedVehicleValues.dist > 0
+                    && vehicle->calculatedVehicleValues.dist < METERS_TO_CENTIMETERS(osdConfig()->adsb_distance_warning))
+                    && isEnvironmentOkForCalculatingADSBDistanceBearing()
+
+            ) {
                 adsbLengthForClearFirstLine = 11;
 
                 buff[buffIndexFirstLine++] = SYM_ADSB;
@@ -2219,21 +2227,20 @@ static bool osdDrawSingleElement(uint8_t item)
                 //////////////////////////////////////////////////////
                 // ALT diff to ADSB vehicle draw
                 int16_t panServoDirOffset = 0;
-                if (osdConfig()->pan_servo_pwm2centideg != 0){
+                if (osdConfig()->pan_servo_pwm2centideg != 0) {
                     panServoDirOffset = osdGetPanServoOffset();
                 }
 
-                if(arrowIndexIndex > 0)
-                {
+                if (arrowIndexIndex > 0 && isImuHeadingValid()) {
                     //[direction to vehicle]
-                    int directionToPeerError = osdGetHeadingAngle(CENTIDEGREES_TO_DEGREES(vehicle->calculatedVehicleValues.dir)) + panServoDirOffset - (int)DECIDEGREES_TO_DEGREES(osdGetHeading());
+                    int directionToPeerError = osdGetHeadingAngle(CENTIDEGREES_TO_DEGREES(vehicle->calculatedVehicleValues.dir)) + panServoDirOffset - osdGetFlightDirection();
                     osdDrawDirCardinal(osdDisplayPort, elemPosX + arrowIndexIndex, elemPosY, directionToPeerError, elemAttr);
                 }
                 //////////////////////////////////////////////////////
 
                 //////////////////////////////////////////////////////
                 // Second line, extra info
-                if(osdConfig()->adsb_warning_style == OSD_ADSB_WARNING_STYLE_EXTENDED){
+                if (osdConfig()->adsb_warning_style == OSD_ADSB_WARNING_STYLE_EXTENDED) {
                     // Vehicle type
                     tfp_sprintf(buff, "%s", getAdsbEmitterTypeString(vehicle->vehicleValues.emitterType));
 
@@ -2245,41 +2252,43 @@ static bool osdDrawSingleElement(uint8_t item)
                     displayWriteWithAttr(osdDisplayPort, elemPosX, elemPosY + 1, buff, elemAttr);
 
                     // Vehicle direction
-                    int16_t flightDirection = STATE(AIRPLANE) ? CENTIDEGREES_TO_DEGREES(posControl.actualState.cog) : DECIDEGREES_TO_DEGREES(osdGetHeading());
-                    osdDrawDirArrow(osdDisplayPort, osdGetDisplayPortCanvas(), OSD_DRAW_POINT_GRID(elemPosX + 6, elemPosY + 1), (float)(CENTIDEGREES_TO_DEGREES(vehicle->vehicleValues.heading) - flightDirection + panServoDirOffset));
+                    if(isImuHeadingValid())
+                    {
+                        osdDrawDirArrow(osdDisplayPort, osdGetDisplayPortCanvas(), OSD_DRAW_POINT_GRID(elemPosX + 6, elemPosY + 1), (float)(CENTIDEGREES_TO_DEGREES(vehicle->vehicleValues.heading) - osdGetFlightDirection() + panServoDirOffset));
+                    }
 
                     adsbLengthForClearSecondLine += 7;
                 }
                 ///////////////////////////////////////////////////
-            }
-            else
-            {
+            } else {
                 //clear first line
-                if(adsbLengthForClearFirstLine > 0){
+                if(adsbLengthForClearFirstLine > 0) {
                     memset(buff, SYM_BLANK, constrain(adsbLengthForClearFirstLine, 0, 20));
                     displayWrite(osdDisplayPort, elemPosX, elemPosY, buff);
                     adsbLengthForClearFirstLine = 0;
                 }
 
                 //clear second line
-                if(adsbLengthForClearSecondLine > 0){
+                if(adsbLengthForClearSecondLine > 0) {
                     memset(buff, SYM_BLANK, constrain(adsbLengthForClearSecondLine, 0, 20));
                     displayWrite(osdDisplayPort, elemPosX, elemPosY + 1, buff);
                     adsbLengthForClearSecondLine = 0;
                 }
             }
-
             return true;
         }
         case OSD_ADSB_INFO:
         {
             buff[0] = SYM_ADSB;
-            if(getAdsbStatus()->vehiclesMessagesTotal > 0 || getAdsbStatus()->heartbeatMessagesTotal > 0){
-                tfp_sprintf(buff + 1, "%1d", getActiveVehiclesCount());
-            }else{
+            if (getAdsbStatus()->vehiclesMessagesTotal == 0 && getAdsbStatus()->heartbeatMessagesTotal == 0) {
                 buff[1] = '-';
+            } else if (!isEnvironmentOkForCalculatingADSBDistanceBearing()) {
+                buff[1] = 'G';
+            } else if (!isImuHeadingValid()) {
+                buff[1] = 'H';
+            } else {
+                tfp_sprintf(buff + 1, "%1d", getActiveVehiclesCount());
             }
-
             break;
         }
 
@@ -3996,8 +4005,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 if (!(osdConfig()->pan_servo_pwm2centideg == 0)){
                     panHomeDirOffset = osdGetPanServoOffset();
                 }
-                int16_t flightDirection = STATE(AIRPLANE) ? CENTIDEGREES_TO_DEGREES(posControl.actualState.cog) : DECIDEGREES_TO_DEGREES(osdGetHeading());
-                int direction = CENTIDEGREES_TO_DEGREES(geozone.directionToNearestZone) - flightDirection + panHomeDirOffset;
+                int direction = CENTIDEGREES_TO_DEGREES(geozone.directionToNearestZone) - osdGetFlightDirection() + panHomeDirOffset;
                 osdDrawDirArrow(osdDisplayPort, osdGetDisplayPortCanvas(), OSD_DRAW_POINT_GRID(elemPosX, elemPosY), direction);
             } else {
                 if (isGeozoneActive()) {


### PR DESCRIPTION
### **User description**
Use same calculation for fixed wings as "direction to home". For fixed wing is used _posControl.actualState.cog_  instead of _osdGetHeading()_, I have no idea why. 

But some people reported that direction to ADSB aircraft is wrong, I have no able to reproduce the issue.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix ADSB cardinal direction calculation for broken magnetic heading
  - Refactored flight direction calculation into reusable `osdGetFlightDirection()` function
  - Applied consistent direction calculation across home arrow and ADSB features

- Improved GPS environment validation for ADSB distance/bearing calculations
  - Enhanced `isEnvironmentOkForCalculatingADSBDistanceBearing()` to support GPS fix estimation
  - Added IMU heading validity checks before drawing direction indicators

- Enhanced ADSB info element to display status indicators
  - Shows 'G' for GPS issues, 'H' for IMU heading problems, '-' for no device

- Code quality improvements and formatting consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ADSB Direction Calculation"] --> B["osdGetFlightDirection()"]
  B --> C["Fixed Wing: COG"]
  B --> D["Multirotor: Heading"]
  E["GPS Environment Check"] --> F["isEnvironmentOkForCalculatingADSBDistanceBearing()"]
  F --> G["GPS Fix or Estimation"]
  F --> H["Satellite Count > 4"]
  I["ADSB Info Display"] --> J["Status Indicators"]
  J --> K["G: GPS Issue"]
  J --> L["H: IMU Invalid"]
  J --> M["Number: Aircraft Count"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>adsb.c</strong><dd><code>Enhance GPS validation and rename environment check function</code></dd></summary>
<hr>

src/main/io/adsb.c

<ul><li>Renamed <code>enviromentOkForCalculatingDistaceBearing()</code> to <br><code>isEnvironmentOkForCalculatingADSBDistanceBearing()</code> with improved logic<br> <li> Enhanced GPS validation to support GPS fix estimation mode via <br><code>USE_GPS_FIX_ESTIMATION</code> ifdef<br> <li> Added debug vehicle code block (commented out) for testing purposes<br> <li> Improved code formatting and consistency in function implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11076/files#diff-7a4a3c8df2b77ad83f0c9802a47de4c9864a6fed7fbfddeb091533a438435dab">+31/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>adsb.h</strong><dd><code>Update function declaration for GPS validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/io/adsb.h

<ul><li>Updated function declaration to match renamed <br><code>isEnvironmentOkForCalculatingADSBDistanceBearing()</code><br> <li> Maintains API consistency across header and implementation files</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11076/files#diff-e549d67b9879212715d8495c46efdcc51672ec98d2c59c016f1efe56f028b770">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>osd.c</strong><dd><code>Refactor direction calculation and add validation checks</code>&nbsp; </dd></summary>
<hr>

src/main/io/osd.c

<ul><li>Created new <code>osdGetFlightDirection()</code> helper function for consistent <br>direction calculation<br> <li> Refactored home arrow direction calculation to use new helper function<br> <li> Added IMU heading validity checks before drawing ADSB direction <br>indicators<br> <li> Enhanced ADSB info element to display status codes: 'G' for GPS <br>issues, 'H' for IMU heading problems<br> <li> Added environment validation check in ADSB warning display logic<br> <li> Improved code formatting and conditional statement consistency <br>throughout ADSB sections<br> <li> Applied same direction calculation pattern to geozone fence direction <br>feature</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11076/files#diff-a680ca1e23901579e9214c055509004e8b5c05e3f7281ed74ac1edfc38caabae">+35/-27</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ADSB.md</strong><dd><code>Document ADSB info element status indicators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/ADSB.md

<ul><li>Added documentation for OSD ADSB Info element status indicators<br> <li> Documented meaning of display characters: '-' for no device, 'H' for <br>IMU issues, 'G' for GPS issues, number for aircraft count<br> <li> Separated documentation into distinct sections for Info and Warning <br>elements</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11076/files#diff-a080490acf540fed96bbb898face0800903b0a831f20c956c741e55649f1c4b2">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

