### PR TITLE
Replace "exposition" with "exponential" in Settings.md

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2604,7 +2604,7 @@ Servo travel multiplier for the PITCH axis in `MANUAL` flight mode [0-100]%
 
 ### manual_rc_expo
 
-Exposition value used for the PITCH/ROLL axes by the `MANUAL` flight mode [0-100]
+Exponential value used for the PITCH/ROLL axes by the `MANUAL` flight mode [0-100]
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -2614,7 +2614,7 @@ Exposition value used for the PITCH/ROLL axes by the `MANUAL` flight mode [0-100
 
 ### manual_rc_yaw_expo
 
-Exposition value used for the YAW axis by the `MANUAL` flight mode [0-100]
+Exponential value used for the YAW axis by the `MANUAL` flight mode [0-100]
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -5764,7 +5764,7 @@ The end  stick weight for Rate Dynamics
 
 ### rc_expo
 
-Exposition value used for the PITCH/ROLL axes by all the stabilized flights modes (all but `MANUAL`)
+Exponential value used for the PITCH/ROLL axes by all the stabilized flights modes (all but `MANUAL`)
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -5804,7 +5804,7 @@ The RC filter smoothing factor. The higher the value, the more smoothing but als
 
 ### rc_yaw_expo
 
-Exposition value used for the YAW axis by all the stabilized flights modes (all but `MANUAL`)
+Exponential value used for the YAW axis by all the stabilized flights modes (all but `MANUAL`)
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -6374,7 +6374,7 @@ Weight used for the throttle compensation based on battery voltage. See the [bat
 
 ### thr_expo
 
-Throttle exposition value
+Throttle exponential value
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1353,7 +1353,7 @@ groups:
         min: 0
         max: 100
       - name: thr_expo
-        description: "Throttle exposition value"
+        description: "Throttle exponential value"
         default_value: 0
         field: throttle.rcExpo8
         min: 0
@@ -1382,13 +1382,13 @@ groups:
         min: 0
         max: 5000
       - name: rc_expo
-        description: "Exposition value used for the PITCH/ROLL axes by all the stabilized flights modes (all but `MANUAL`)"
+        description: "Exponential value used for the PITCH/ROLL axes by all the stabilized flights modes (all but `MANUAL`)"
         default_value: 70
         field: stabilized.rcExpo8
         min: 0
         max: 100
       - name: rc_yaw_expo
-        description: "Exposition value used for the YAW axis by all the stabilized flights modes (all but `MANUAL`)"
+        description: "Exponential value used for the YAW axis by all the stabilized flights modes (all but `MANUAL`)"
         default_value: 20
         field: stabilized.rcYawExpo8
         min: 0
@@ -1414,13 +1414,13 @@ groups:
         min: 1
         max: 180
       - name: manual_rc_expo
-        description: "Exposition value used for the PITCH/ROLL axes by the `MANUAL` flight mode [0-100]"
+        description: "Exponential value used for the PITCH/ROLL axes by the `MANUAL` flight mode [0-100]"
         default_value: 35
         field: manual.rcExpo8
         min: 0
         max: 100
       - name: manual_rc_yaw_expo
-        description: "Exposition value used for the YAW axis by the `MANUAL` flight mode [0-100]"
+        description: "Exponential value used for the YAW axis by the `MANUAL` flight mode [0-100]"
         default_value: 20
         field: manual.rcYawExpo8
         min: 0


### PR DESCRIPTION
### **User description**
"expo" really means exponential, not "exposition".


___

### **PR Type**
Documentation


___

### **Description**
- Replace "exposition" with "exponential" in Settings.md

- Corrects terminology in 5 parameter descriptions

- Affects manual_rc_expo, manual_rc_yaw_expo, rc_expo, rc_yaw_expo, thr_expo


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Settings.md documentation"] -- "terminology correction" --> B["Replace exposition with exponential"]
  B --> C["5 parameter descriptions updated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Settings.md</strong><dd><code>Correct exposition to exponential terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Settings.md

<ul><li>Replaced "Exposition" with "Exponential" in 5 parameter descriptions<br> <li> Updated manual_rc_expo parameter documentation<br> <li> Updated manual_rc_yaw_expo parameter documentation<br> <li> Updated rc_expo parameter documentation<br> <li> Updated rc_yaw_expo parameter documentation<br> <li> Updated thr_expo parameter documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11084/files#diff-ae20939faff30a268f1d311e9654bb2788d52d5ecdc9a897340914a5ca0c8b44">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

