### PR TITLE
Fix typo in Control Profiles documentation

### DIFF
--- a/docs/Control Profiles.md
+++ b/docs/Control Profiles.md
@@ -4,7 +4,7 @@ A profile is a set of configuration settings.
 
 Currently, INAV gives you three control profiles. The default control profile is `1`.
 
-## Changing contorl profiles
+## Changing control profiles
 ### Stick Commands
 Control profiles can be selected using a GUI or the following stick combinations:
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Fix typo in Control Profiles documentation header

- Corrected "contorl" to "control" in section title


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Documentation File"] -- "Fix typo: contorl → control" --> B["Updated Header"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Control Profiles.md</strong><dd><code>Fix typo in section header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Control Profiles.md

<ul><li>Fixed typo in section header from "Changing contorl profiles" to <br>"Changing control profiles"</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11086/files#diff-945dad847575ea94edbd30a61f4b2e8b8bf1869810a015dd86b8e387fec75d5b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

