### PR TITLE
Update external mag I2C driver registration for HUMMINGBIRD_FC305

### DIFF
--- a/src/main/target/HUMMINGBIRD_FC305/target.c
+++ b/src/main/target/HUMMINGBIRD_FC305/target.c
@@ -29,11 +29,15 @@ BUSDEV_REGISTER_SPI(busdev_sdcard_spi,  DEVHW_SDCARD,       SDCARD_SPI_BUS,     
 BUSDEV_REGISTER_SPI(busdev_max7456,    DEVHW_MAX7456,  MAX7456_SPI_BUS,    MAX7456_CS_PIN, NONE, DEVFLAGS_USE_RAW_REGISTERS,  0);
 BUSDEV_REGISTER_I2C(busdev_spl06,      DEVHW_SPL06,        SPL06_I2C_BUS,      SPL06_I2C_ADDR,     NONE,           DEVFLAGS_NONE,      0);
 
+BUSDEV_REGISTER_I2C_TAG(busdev_hmc5883,     DEVHW_HMC5883,      MAG_I2C_BUS,        0x1E,               NONE,                   0,  DEVFLAGS_NONE,    0);
+BUSDEV_REGISTER_I2C_TAG(busdev_qmc5883,     DEVHW_QMC5883,      MAG_I2C_BUS,        0x0D,               NONE,                   0,  DEVFLAGS_NONE,    0);
+BUSDEV_REGISTER_I2C_TAG(busdev_mag3110,     DEVHW_MAG3110,      MAG_I2C_BUS,        0x0E,               NONE,                   0,  DEVFLAGS_NONE,    0);
+
 timerHardware_t timerHardware[] = {
     DEF_TIM(TIM3,  CH3,  PB0, TIM_USE_OUTPUT_AUTO, 0, 0), // S1
-    DEF_TIM(TIM3,  CH2,  PB5, TIM_USE_OUTPUT_AUTO, 0, 0), // S2
-    DEF_TIM(TIM3,  CH1,  PB4, TIM_USE_OUTPUT_AUTO, 0, 0), // S3
-    DEF_TIM(TIM3,  CH4,  PB1, TIM_USE_OUTPUT_AUTO, 0, 0), // S4
+    DEF_TIM(TIM3,  CH4,  PB1, TIM_USE_OUTPUT_AUTO, 0, 0), // S2
+    DEF_TIM(TIM3,  CH2,  PB5, TIM_USE_OUTPUT_AUTO, 0, 0), // S3
+    DEF_TIM(TIM3,  CH1,  PB4, TIM_USE_OUTPUT_AUTO, 0, 0), // S4
 
     DEF_TIM(TIM1,  CH1,  PA8, TIM_USE_LED,                         0, 1),//WS2812B
 };


### PR DESCRIPTION
### **User description**
HUMMINGBIRD FC305: Update MAG driver registration for external I2C pads


___

### **PR Type**
Enhancement, New Target


___

### **Description**
- Add external I2C magnetometer driver registration for three sensor types
  - HMC5883 at address 0x1E
  - QMC5883 at address 0x0D
  - MAG3110 at address 0x0E

- Reorder timer hardware PWM output assignments for correct servo mapping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HUMMINGBIRD_FC305 Target"] --> B["Add MAG I2C Drivers"]
  B --> C["HMC5883, QMC5883, MAG3110"]
  A --> D["Reorder Timer Outputs"]
  D --> E["Correct PWM Servo Mapping"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.c</strong><dd><code>Add magnetometer I2C drivers and fix timer mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/HUMMINGBIRD_FC305/target.c

<ul><li>Register three external I2C magnetometer sensors using <br><code>BUSDEV_REGISTER_I2C_TAG</code> macro<br> <li> Configure HMC5883, QMC5883, and MAG3110 with appropriate I2C addresses <br>on <code>MAG_I2C_BUS</code><br> <li> Reorder timer hardware definitions to correct PWM output channel <br>assignments for servo outputs S2-S4</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11090/files#diff-bb7f060d5874ccecb8fd85bf2297f0f089e9d4a7f853d3353dabf4eee3950afa">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

