### PR TITLE
MSP2 via CSFR/SmartPort telemetry

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -41,7 +41,7 @@
 #include "rx/crsf.h"
 
 #include "telemetry/crsf.h"
-#define CRSF_TIME_NEEDED_PER_FRAME_US   1100 // 700 ms + 400 ms for potential ad-hoc request
+#define CRSF_TIME_NEEDED_PER_FRAME_US   1750 // 700 ms + 400 ms for potential ad-hoc request
 #define CRSF_TIME_BETWEEN_FRAMES_US     6667 // At fastest, frames are sent by the transmitter every 6.667 milliseconds, 150 Hz
 
 #define CRSF_DIGITAL_CHANNEL_MIN 172
@@ -55,7 +55,7 @@ STATIC_UNIT_TESTED crsfFrame_t crsfFrame;
 STATIC_UNIT_TESTED uint32_t crsfChannelData[CRSF_MAX_CHANNEL];
 
 static serialPort_t *serialPort;
-static timeUs_t crsfFrameStartAt = 0;
+static timeUs_t crsfFrameStartAtUs = 0;
 static uint8_t telemetryBuf[CRSF_FRAME_SIZE_MAX];
 static uint8_t telemetryBufLen = 0;
 
@@ -141,20 +141,20 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *rxCallbackData)
     UNUSED(rxCallbackData);
 
     static uint8_t crsfFramePosition = 0;
-    const timeUs_t now = micros();
+    const timeUs_t currentTimeUs = microsISR();
 
 #ifdef DEBUG_CRSF_PACKETS
     debug[2] = now - crsfFrameStartAt;
 #endif
 
-    if (now > crsfFrameStartAt + CRSF_TIME_NEEDED_PER_FRAME_US) {
+    if (cmpTimeUs(currentTimeUs, crsfFrameStartAtUs) > CRSF_TIME_NEEDED_PER_FRAME_US) {
         // We've received a character after max time needed to complete a frame,
         // so this must be the start of a new frame.
         crsfFramePosition = 0;
     }
 
     if (crsfFramePosition == 0) {
-        crsfFrameStartAt = now;
+        crsfFrameStartAtUs = currentTimeUs;
     }
     // assume frame is 5 bytes long until we have received the frame length
     // full frame length includes the length of the address and framelength fields
@@ -174,8 +174,8 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *rxCallbackData)
                         case CRSF_FRAMETYPE_MSP_REQ:
                         case CRSF_FRAMETYPE_MSP_WRITE: {
                             uint8_t *frameStart = (uint8_t *)&crsfFrame.frame.payload + CRSF_FRAME_ORIGIN_DEST_SIZE;
-                            if (bufferCrsfMspFrame(frameStart, CRSF_FRAME_RX_MSP_FRAME_SIZE)) {
-                                crsfScheduleMspResponse();
+                            if (bufferCrsfMspFrame(frameStart, crsfFrame.frame.frameLength - 4)) {
+                                crsfScheduleMspResponse(crsfFrame.frame.payload[1]);
                             }
                             break;
                         }
@@ -289,7 +289,7 @@ void crsfRxSendTelemetryData(void)
         // check that we are not in bi dir mode or that we are not currently receiving data (ie in the middle of an RX frame)
         // and that there is time to send the telemetry frame before the next RX frame arrives
         if (CRSF_PORT_OPTIONS & SERIAL_BIDIR) {
-            const timeDelta_t timeSinceStartOfFrame = cmpTimeUs(micros(), crsfFrameStartAt);
+            const timeDelta_t timeSinceStartOfFrame = cmpTimeUs(micros(), crsfFrameStartAtUs);
             if ((timeSinceStartOfFrame < CRSF_TIME_NEEDED_PER_FRAME_US) ||
                 (timeSinceStartOfFrame > CRSF_TIME_BETWEEN_FRAMES_US - CRSF_TIME_NEEDED_PER_FRAME_US)) {
                 return;
@@ -298,6 +298,11 @@ void crsfRxSendTelemetryData(void)
         serialWriteBuf(serialPort, telemetryBuf, telemetryBufLen);
         telemetryBufLen = 0; // reset telemetry buffer
     }
+}
+
+bool crsfRxIsTelemetryBufEmpty(void)
+{
+    return telemetryBufLen == 0;
 }
 
 bool crsfRxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)

--- a/src/main/rx/crsf.h
+++ b/src/main/rx/crsf.h
@@ -130,6 +130,7 @@ typedef union crsfFrame_u {
 
 void crsfRxWriteTelemetryData(const void *data, int len);
 void crsfRxSendTelemetryData(void);
+bool crsfRxIsTelemetryBufEmpty(void);
 
 struct rxConfig_s;
 struct rxRuntimeConfig_s;

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -107,7 +107,14 @@ bool bufferCrsfMspFrame(uint8_t *frameStart, int frameLength)
 
 bool handleCrsfMspFrameBuffer(uint8_t payloadSize, mspResponseFnPtr responseFn)
 {
-    bool requestHandled = false;
+    static bool replyPending = false;
+    if (replyPending) {
+        if (crsfRxIsTelemetryBufEmpty()) {
+            replyPending = sendMspReply(payloadSize, responseFn);
+        }
+        return replyPending;
+    }
+
     if (!mspRxBuffer.len) {
         return false;
     }
@@ -115,17 +122,21 @@ bool handleCrsfMspFrameBuffer(uint8_t payloadSize, mspResponseFnPtr responseFn)
     while (true) {
         const int mspFrameLength = mspRxBuffer.bytes[pos];
         if (handleMspFrame(&mspRxBuffer.bytes[CRSF_MSP_LENGTH_OFFSET + pos], mspFrameLength)) {
-            requestHandled |= sendMspReply(payloadSize, responseFn);
+            if (crsfRxIsTelemetryBufEmpty()) {
+                replyPending = sendMspReply(payloadSize, responseFn);
+            } else {
+                replyPending = true;
+            }
         }
         pos += CRSF_MSP_LENGTH_OFFSET + mspFrameLength;
         ATOMIC_BLOCK(NVIC_PRIO_SERIALUART) {
             if (pos >= mspRxBuffer.len) {
                 mspRxBuffer.len = 0;
-                return requestHandled;
+                return replyPending ;
             }
         }
     }
-    return requestHandled;
+    return replyPending;
 }
 #endif
 
@@ -453,28 +464,36 @@ static uint8_t crsfSchedule[CRSF_SCHEDULE_COUNT_MAX];
 
 static bool mspReplyPending;
 
-void crsfScheduleMspResponse(void)
+//Id of the last receiver MSP frame over CRSF. Needed to send response with correct frame ID
+static uint8_t mspRequestOriginID = 0;
+
+void crsfScheduleMspResponse(uint8_t requestOriginID)
 {
     mspReplyPending = true;
+    mspRequestOriginID = requestOriginID;
 }
 
-void crsfSendMspResponse(uint8_t *payload)
+void crsfSendMspResponse(uint8_t *payload, const uint8_t payloadSize)
 {
     sbuf_t crsfPayloadBuf;
     sbuf_t *dst = &crsfPayloadBuf;
 
     crsfInitializeFrame(dst);
-    sbufWriteU8(dst, CRSF_FRAME_TX_MSP_FRAME_SIZE + CRSF_FRAME_LENGTH_EXT_TYPE_CRC);
+    sbufWriteU8(dst, payloadSize + CRSF_FRAME_LENGTH_EXT_TYPE_CRC);
     crsfSerialize8(dst, CRSF_FRAMETYPE_MSP_RESP);
-    crsfSerialize8(dst, CRSF_ADDRESS_RADIO_TRANSMITTER);
+    crsfSerialize8(dst, mspRequestOriginID);
     crsfSerialize8(dst, CRSF_ADDRESS_FLIGHT_CONTROLLER);
-    crsfSerializeData(dst, (const uint8_t*)payload, CRSF_FRAME_TX_MSP_FRAME_SIZE);
+    crsfSerializeData(dst, (const uint8_t*)payload, payloadSize);
     crsfFinalize(dst);
 }
 #endif
 
 static void processCrsf(void)
 {
+    if (!crsfRxIsTelemetryBufEmpty()) {
+        return; // do nothing if telemetry ouptut buffer is not empty yet.
+    }
+
     static uint8_t crsfScheduleIndex = 0;
     const uint8_t currentSchedule = crsfSchedule[crsfScheduleIndex];
 

--- a/src/main/telemetry/crsf.h
+++ b/src/main/telemetry/crsf.h
@@ -27,7 +27,7 @@ void initCrsfTelemetry(void);
 bool checkCrsfTelemetryState(void);
 void handleCrsfTelemetry(timeUs_t currentTimeUs);
 void crsfScheduleDeviceInfoResponse(void);
-void crsfScheduleMspResponse(void);
+void crsfScheduleMspResponse(uint8_t requestOriginID);
 int getCrsfFrame(uint8_t *frame, crsfFrameType_e frameType);
 #if defined(USE_MSP_OVER_TELEMETRY)
 void initCrsfMspBuffer(void);

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -14,25 +14,49 @@
 
 #include "msp/msp.h"
 
-#include "telemetry/crsf.h"
 #include "telemetry/msp_shared.h"
-#include "telemetry/smartport.h"
 
-#define TELEMETRY_MSP_VERSION    1
-#define TELEMETRY_MSP_VER_SHIFT  5
-#define TELEMETRY_MSP_VER_MASK   (0x7 << TELEMETRY_MSP_VER_SHIFT)
-#define TELEMETRY_MSP_ERROR_FLAG (1 << 5)
-#define TELEMETRY_MSP_START_FLAG (1 << 4)
-#define TELEMETRY_MSP_SEQ_MASK   0x0F
+#define TELEMETRY_MSP_VERSION    2
 #define TELEMETRY_MSP_RES_ERROR (-10)
+
+enum { // constants for status of msp-over-telemetry frame
+    TELEMETRY_MSP_SEQ_MASK      = 0x0f, // 0b00001111,   // sequence number mask
+    TELEMETRY_MSP_VER_MASK      = 0x60, // 0b01100000,   // MSP version mask
+    TELEMETRY_MSP_START_MASK    = 0x10, // 0b00010000,   // bit of starting frame (if 1, the frame is a first/single chunk of msp-frame)
+    TELEMETRY_MSP_ERROR_MASK    = 0x80, // 0b10000000,   // Error bit (1 if error)
+    TELEMETRY_MSP_VER_SHIFT     = 5,    // MSP version shift
+};
 
 enum {
     TELEMETRY_MSP_VER_MISMATCH=0,
     TELEMETRY_MSP_CRC_ERROR=1,
-    TELEMETRY_MSP_ERROR=2
+    TELEMETRY_MSP_ERROR=2,
+    TELEMETRY_MSP_REQUEST_IS_TOO_BIG = 3,
 };
 
-STATIC_UNIT_TESTED uint8_t checksum = 0;
+enum { // minimum length for a frame.
+    MIN_LENGTH_CHUNK         = 2, // status + at_least_one_byte
+    MIN_LENGTH_REQUEST_V1    = 3, // status + length + ID
+    MIN_LENGTH_REQUEST_V2    = 6, // status + flag + ID_lo + ID_hi + size_lo + size_hi
+};
+
+enum { // byte position(index) in msp-over-telemetry request payload
+    // MSPv1
+    MSP_INDEX_STATUS        = 0,                           // status byte
+    MSP_INDEX_SIZE_V1       = MSP_INDEX_STATUS        + 1, // MSPv1 payload size
+    MSP_INDEX_ID_V1         = MSP_INDEX_SIZE_V1       + 1, // MSPv1 ID/command/function byte
+    MSP_INDEX_PAYLOAD_V1    = MSP_INDEX_ID_V1         + 1, // MSPv1 Payload start / CRC for zero payload
+
+    // MSPv2
+    MSP_INDEX_FLAG_V2       = MSP_INDEX_SIZE_V1,           // MSPv2 flags byte
+    MSP_INDEX_ID_LO         = MSP_INDEX_ID_V1,             // MSPv2 Lo byte of ID/command/function
+    MSP_INDEX_ID_HI         = MSP_INDEX_ID_LO         + 1, // MSPv2 Hi byte of ID/command/function
+    MSP_INDEX_SIZE_V2_LO    = MSP_INDEX_ID_HI         + 1, // MSPv2 Lo byte of payload size
+    MSP_INDEX_SIZE_V2_HI    = MSP_INDEX_SIZE_V2_LO    + 1, // MSPv2 Hi byte of payload size
+    MSP_INDEX_PAYLOAD_V2    = MSP_INDEX_SIZE_V2_HI    + 1, // MSPv2 first byte of payload itself
+};
+
+static uint8_t lastRequestVersion; // MSP version of last request. Temporary solution. It's better to keep it in requestPacket.
 STATIC_UNIT_TESTED mspPackage_t mspPackage;
 static mspRxBuffer_t mspRxBuffer;
 static mspTxBuffer_t mspTxBuffer;
@@ -80,7 +104,7 @@ void sendMspErrorResponse(uint8_t error, int16_t cmd)
     sbufSwitchToReader(&mspPackage.responsePacket->buf, mspPackage.responseBuffer);
 }
 
-bool handleMspFrame(uint8_t *frameStart, int frameLength)
+bool handleMspFrame(uint8_t *const frameStart, const int payloadLength)
 {
     static uint8_t mspStarted = 0;
     static uint8_t lastSeq = 0;
@@ -93,75 +117,90 @@ bool handleMspFrame(uint8_t *frameStart, int frameLength)
         initSharedMsp();
     }
 
-    mspPacket_t *packet = mspPackage.requestPacket;
-    sbuf_t *frameBuf = sbufInit(&mspPackage.requestFrame, frameStart, frameStart + (uint8_t)frameLength);
-    sbuf_t *rxBuf = &mspPackage.requestPacket->buf;
-    const uint8_t header = sbufReadU8(frameBuf);
-    const uint8_t seqNumber = header & TELEMETRY_MSP_SEQ_MASK;
-    const uint8_t version = (header & TELEMETRY_MSP_VER_MASK) >> TELEMETRY_MSP_VER_SHIFT;
+    if (payloadLength < MIN_LENGTH_CHUNK) {
+        return false;   // prevent analyzing garbage data
+    }
 
-    if (version != TELEMETRY_MSP_VERSION) {
+    mspPacket_t *requestPacket = mspPackage.requestPacket;
+
+    const uint8_t status = frameStart[MSP_INDEX_STATUS];
+    const uint8_t seqNumber = status & TELEMETRY_MSP_SEQ_MASK;
+    lastRequestVersion = (status & TELEMETRY_MSP_VER_MASK) >> TELEMETRY_MSP_VER_SHIFT;
+
+    if (lastRequestVersion > TELEMETRY_MSP_VERSION) {
         sendMspErrorResponse(TELEMETRY_MSP_VER_MISMATCH, 0);
         return true;
     }
 
-    if (header & TELEMETRY_MSP_START_FLAG) {
-        // first packet in sequence
-        uint8_t mspPayloadSize = sbufReadU8(frameBuf);
+    if (status & TELEMETRY_MSP_START_MASK) { // first packet in sequence
+        uint16_t mspPayloadSize;
 
-        packet->cmd = sbufReadU8(frameBuf);
-        packet->result = 0;
-        packet->buf.ptr = mspPackage.requestBuffer;
-        packet->buf.end = mspPackage.requestBuffer + mspPayloadSize;
+        if (lastRequestVersion == 1) { // MSPv1
 
-        checksum = mspPayloadSize ^ packet->cmd;
+            mspPayloadSize = frameStart[MSP_INDEX_SIZE_V1];
+            requestPacket->cmd = frameStart[MSP_INDEX_ID_V1];
+            sbufInit(&mspPackage.requestFrame, frameStart + MSP_INDEX_PAYLOAD_V1, frameStart + payloadLength);
+
+        } else { // MSPv2
+            if (payloadLength < MIN_LENGTH_REQUEST_V2) {
+                return false;   // prevent analyzing garbage data
+            }
+            requestPacket->flags = frameStart[MSP_INDEX_FLAG_V2];
+            requestPacket->cmd = *(uint16_t *) &frameStart[MSP_INDEX_ID_LO];
+            mspPayloadSize = *(uint16_t *) &frameStart[MSP_INDEX_SIZE_V2_LO];
+            sbufInit(&mspPackage.requestFrame, frameStart + MSP_INDEX_PAYLOAD_V2, frameStart + payloadLength);
+        }
+
+        if (mspPayloadSize <= sizeof(mspRxBuffer)) { // prevent buffer overrun
+            requestPacket->result = 0;
+            requestPacket->buf.ptr = mspPackage.requestBuffer;
+            requestPacket->buf.end = mspPackage.requestBuffer + mspPayloadSize;
+            mspStarted = 1;
+        } else { // this MSP packet is too big to fit in the buffer.
+            sendMspErrorResponse(TELEMETRY_MSP_REQUEST_IS_TOO_BIG, mspPackage.requestPacket->cmd);
+            return true;
+        }
         mspStarted = 1;
-    } else if (!mspStarted) {
-        // no start packet yet, throw this one away
-        return false;
-    } else if (((lastSeq + 1) & TELEMETRY_MSP_SEQ_MASK) != seqNumber) {
-        // packet loss detected!
-        mspStarted = 0;
-        return false;
+    } else { // second onward chunk
+        if (!mspStarted) { // no start packet yet, throw this one away
+            return false;
+        } else {
+            if (((lastSeq + 1) & TELEMETRY_MSP_SEQ_MASK) != seqNumber) {
+                // packet loss detected!
+                mspStarted = 0;
+                return false;
+            }
+        }
+        sbufInit(&mspPackage.requestFrame, frameStart + 1, frameStart + payloadLength);
     }
 
-    const uint8_t bufferBytesRemaining = sbufBytesRemaining(rxBuf);
-    const uint8_t frameBytesRemaining = sbufBytesRemaining(frameBuf);
-    uint8_t payload[frameBytesRemaining];
+    const uint8_t payloadExpecting = sbufBytesRemaining(&requestPacket->buf);
+    const uint8_t payloadIncoming = sbufBytesRemaining(&mspPackage.requestFrame);
+    uint8_t payload[payloadIncoming];
 
-    if (bufferBytesRemaining >= frameBytesRemaining) {
-        sbufReadData(frameBuf, payload, frameBytesRemaining);
-        sbufAdvance(frameBuf, frameBytesRemaining);
-        sbufWriteData(rxBuf, payload, frameBytesRemaining);
+    if (payloadExpecting > payloadIncoming) {
+        sbufReadData(&mspPackage.requestFrame, payload, payloadIncoming);
+        sbufAdvance(&mspPackage.requestFrame, payloadIncoming);
+        sbufWriteData(&requestPacket->buf, payload, payloadIncoming);
         lastSeq = seqNumber;
 
         return false;
-    } else {
-        sbufReadData(frameBuf, payload, bufferBytesRemaining);
-        sbufAdvance(frameBuf, bufferBytesRemaining);
-        sbufWriteData(rxBuf, payload, bufferBytesRemaining);
-        sbufSwitchToReader(rxBuf, mspPackage.requestBuffer);
-        while (sbufBytesRemaining(rxBuf)) {
-            checksum ^= sbufReadU8(rxBuf);
-        }
-
-        if (checksum != *frameBuf->ptr) {
-            mspStarted = 0;
-            sendMspErrorResponse(TELEMETRY_MSP_CRC_ERROR, packet->cmd);
-            return true;
-        }
     }
 
     mspStarted = 0;
-    sbufSwitchToReader(rxBuf, mspPackage.requestBuffer);
+
+    sbufReadData(&mspPackage.requestFrame, payload, payloadExpecting);
+    sbufAdvance(&mspPackage.requestFrame, payloadExpecting);
+    sbufWriteData(&requestPacket->buf, payload, payloadExpecting);
+    sbufSwitchToReader(&requestPacket->buf, mspPackage.requestBuffer);
     processMspPacket();
     return true;
 }
 
 bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)
 {
-    static uint8_t checksum = 0;
     static uint8_t seq = 0;
+    static bool headerSent = false;
 
     uint8_t payloadOut[payloadSize];
     sbuf_t payload;
@@ -169,20 +208,27 @@ bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)
     sbuf_t *txBuf = &mspPackage.responsePacket->buf;
 
     // detect first reply packet
-    if (txBuf->ptr == mspPackage.responseBuffer) {
+    if (!headerSent) {
 
         // header
-        uint8_t head = TELEMETRY_MSP_START_FLAG | (seq++ & TELEMETRY_MSP_SEQ_MASK);
+        uint8_t status = TELEMETRY_MSP_START_MASK | (seq++ & TELEMETRY_MSP_SEQ_MASK) | (lastRequestVersion << TELEMETRY_MSP_VER_SHIFT);;
         if (mspPackage.responsePacket->result < 0) {
-            head |= TELEMETRY_MSP_ERROR_FLAG;
+            status |= TELEMETRY_MSP_ERROR_MASK;
         }
-        sbufWriteU8(payloadBuf, head);
+        sbufWriteU8(payloadBuf, status);
 
-        uint8_t size = sbufBytesRemaining(txBuf);
-        sbufWriteU8(payloadBuf, size);
+        const uint8_t size = sbufBytesRemaining(txBuf);
+        if (lastRequestVersion == 1) { // MSPv1
+            sbufWriteU8(payloadBuf, size);
+            sbufWriteU8(payloadBuf, mspPackage.responsePacket->cmd);
+        } else { // MSPv2
+            sbufWriteU8(payloadBuf, mspPackage.responsePacket->flags);  // MSPv2 flags
+            sbufWriteU16(payloadBuf, mspPackage.responsePacket->cmd);    // command is 16 bit in MSPv2
+            sbufWriteU16(payloadBuf, (uint16_t) size);        // size is 16 bit in MSPv2
+        }
+        headerSent = true;
     } else {
-        // header
-        sbufWriteU8(payloadBuf, (seq++ & TELEMETRY_MSP_SEQ_MASK));
+        sbufWriteU8(payloadBuf, (seq++ & TELEMETRY_MSP_SEQ_MASK) | (lastRequestVersion << TELEMETRY_MSP_VER_SHIFT)); // header without 'start' flag
     }
 
     const uint8_t bufferBytesRemaining = sbufBytesRemaining(txBuf);
@@ -194,31 +240,19 @@ bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)
         sbufReadData(txBuf, frame, payloadBytesRemaining);
         sbufAdvance(txBuf, payloadBytesRemaining);
         sbufWriteData(payloadBuf, frame, payloadBytesRemaining);
-        responseFn(payloadOut);
+        responseFn(payloadOut, payloadSize);
 
         return true;
-
-    } else {
-
-        sbufReadData(txBuf, frame, bufferBytesRemaining);
-        sbufAdvance(txBuf, bufferBytesRemaining);
-        sbufWriteData(payloadBuf, frame, bufferBytesRemaining);
-        sbufSwitchToReader(txBuf, mspPackage.responseBuffer);
-
-        checksum = sbufBytesRemaining(txBuf) ^ mspPackage.responsePacket->cmd;
-
-        while (sbufBytesRemaining(txBuf)) {
-            checksum ^= sbufReadU8(txBuf);
-        }
-        sbufWriteU8(payloadBuf, checksum);
-
-        while (sbufBytesRemaining(payloadBuf)>1) {
-            sbufWriteU8(payloadBuf, 0);
-        }
-
     }
 
-    responseFn(payloadOut);
+    // last/only chunk
+    sbufReadData(txBuf, frame, bufferBytesRemaining);
+    sbufAdvance(txBuf, bufferBytesRemaining);
+    sbufWriteData(payloadBuf, frame, bufferBytesRemaining);
+    sbufSwitchToReader(txBuf, mspPackage.responseBuffer);
+
+    responseFn(payloadOut, payloadBuf->ptr - payloadOut);
+    headerSent = false; // <-- added: reset for the next response
     return false;
 }
 

--- a/src/main/telemetry/msp_shared.h
+++ b/src/main/telemetry/msp_shared.h
@@ -4,7 +4,7 @@
 #include "telemetry/crsf.h"
 #include "telemetry/smartport.h"
 
-typedef void (*mspResponseFnPtr)(uint8_t *payload);
+typedef void (*mspResponseFnPtr)(uint8_t *payload, const uint8_t payloadSize);
 
 struct mspPacket_s;
 typedef struct mspPackage_s {
@@ -26,5 +26,5 @@ typedef union mspTxBuffer_u {
 } mspTxBuffer_t;
 
 void initSharedMsp(void);
-bool handleMspFrame(uint8_t *frameStart, int frameLength);
+bool handleMspFrame(uint8_t *frameStart, int payloadLength);
 bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn);

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -401,10 +401,10 @@ void checkSmartPortTelemetryState(void)
 }
 
 #if defined(USE_MSP_OVER_TELEMETRY)
-static void smartPortSendMspResponse(uint8_t *data) {
+static void smartPortSendMspResponse(uint8_t *data, const uint8_t dataSize) {
     smartPortPayload_t payload;
     payload.frameId = FSSP_MSPS_FRAME;
-    memcpy(&payload.valueId, data, SMARTPORT_MSP_PAYLOAD_SIZE);
+    memcpy(&payload.valueId, data, MIN(dataSize,SMARTPORT_MSP_PAYLOAD_SIZE));
 
     smartPortWriteFrame(&payload);
 }


### PR DESCRIPTION
### **User description**
PR adds support for MSP2 inspired by implementation from betaflight. PR does not change manupulation with buffers and keep INAV style. In PR is fix for [mspRequestOriginID ](https://github.com/iNavFlight/inav/pull/10671/commits/82ea67e9f15d428ef38c3d79163a29b0cecf846c)originally made Pawel 

1) from MSP and MSP2 via CSFR has been removed MSP CRC, because CRSF contains itself CRC, so no need to duplicate
2) CRSF MSP frame `<receiver address 8b><sender address 8b><csfr flags 8b><length 8b><cmd 8b><payload ....>`
3) CRSF MSP2 frame 
` <receiver address 8b><sender address 8b><csfr flags 8b><MSP flags 8b><cmd 16b LE><length 16b LE><payload ... >`
4) JUMBO frames **are not** supported
5) simple test LUA files for MSP and MSP2 are attached, scripts has no any GUI, only send data over VSP from transmitter
example: 
```
RF2: Sending MSP cmd 1
RF2: TX (6 B)
RF2:   [1]:  0xC8
RF2:   [2]:  0xEA
RF2:   [3]:  0x30
RF2:   [4]:  0x0
RF2:   [5]:  0x1
RF2:   [6]:  0x1
RF2: -----
RF2: cmd:0x7B
RF2:   data length: 60
RF2:   [1]:  0xEA
RF2:   [2]:  0xC8
RF2:   [3]:  0x32
RF2:   [4]:  0x3
RF2:   [5]:  0x1
RF2:   [6]:  0x8
RF2:   [7]:  0x9
RF2:   [8]:  0x9
```

### Tasks:
- [x]  CRSF MSP1
- [x]  CRSF MSP2
- [x]  CRSF MSP1 >60B
- [x]  CRSF MSP2 >60B
- [x] Smartport MSP1
- [x] Smartport MSP2
- [ ] create unit test (optional)
- [x] [ apply fix ](https://github.com/betaflight/betaflight/commit/7c12405fb89d9f3f5b7254cf96625f87bd987d75), I don't know what the fix fixed and if it's needed (optional)
-----
-----
### Testing:

#### CRSF (ready for test):

- [x] test MSP1 simple frame REQUEST
- [x] test MSP1 simple frame RESPONSE
- [x] test MSP1 frame <60B REQUEST
- [x] test MSP1 frame <60B RESPONSE
- [x] test MSP2 simple frame REQUEST
- [x] test MSP2 simple frame RESPONSE
- [x] test MSP2 frame <60B REQUEST
- [x] test MSP2 frame <60B RESPONSE

-----

#### SmartPort:
- [x] test MSP1 simple frame REQUEST
- [x] test MSP1 simple frame RESPONSE
- [x] test MSP1 frame <60B REQUEST
- [x] test MSP1 frame <60B RESPONSE
- [x] test MSP2 simple frame REQUEST
- [x] test MSP2 simple frame RESPONSE
- [x] test MSP2 frame <60B REQUEST
- [x] test MSP2 frame <60B RESPONSE

-----

[MSP-test-lua.zip](https://github.com/user-attachments/files/23267156/MSP-test.zip)


___

### **PR Type**
Enhancement, New Feature


___

### **Description**
- Add MSP2 protocol support over CRSF and SmartPort telemetry

- Implement chunked frame handling for payloads exceeding 60 bytes

- Fix MSP request origin ID tracking for proper response routing

- Refactor MSP frame parsing with improved version detection and error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MSP Request<br/>CRSF/SmartPort"] --> B["Parse MSP Frame<br/>v1 or v2"]
  B --> C["Handle Chunked<br/>Payloads"]
  C --> D["Process MSP<br/>Command"]
  D --> E["Generate MSP<br/>Response"]
  E --> F["Send Response<br/>with Origin ID"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crsf.c</strong><dd><code>Improve CRSF timing and MSP frame handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/rx/crsf.c

<ul><li>Increased CRSF frame timing from 1100µs to 1750µs for ad-hoc requests<br> <li> Renamed <code>crsfFrameStartAt</code> to <code>crsfFrameStartAtUs</code> for clarity<br> <li> Changed time measurement from <code>micros()</code> to <code>microsISR()</code> for ISR context<br> <li> Updated MSP frame buffering to use actual frame length instead of <br>fixed size<br> <li> Added <code>crsfScheduleMspResponse()</code> parameter for request origin ID <br>tracking<br> <li> Added <code>crsfRxIsTelemetryBufEmpty()</code> function to check telemetry buffer <br>state</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11093/files#diff-d82859eb24a725305958143d71c15f877b0fe70dbbacc198c254974f20181fb1">+13/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crsf.h</strong><dd><code>Add telemetry buffer status check function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/rx/crsf.h

- Added `crsfRxIsTelemetryBufEmpty()` function declaration


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11093/files#diff-ca3ce34b669ab8b0bc2448ebf2ec338c481a36e09de03828d2d29fdcf8603812">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crsf.c</strong><dd><code>Implement MSP response chunking and origin ID tracking</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/crsf.c

<ul><li>Implement reply pending state machine to handle chunked MSP responses<br> <li> Wait for telemetry buffer to empty before sending MSP reply<br> <li> Track MSP request origin ID for correct response addressing<br> <li> Update <code>crsfScheduleMspResponse()</code> to accept and store request origin ID<br> <li> Modify <code>crsfSendMspResponse()</code> to accept dynamic payload size parameter<br> <li> Add telemetry buffer check in <code>processCrsf()</code> to prevent frame collision</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11093/files#diff-5b4ded67d6b41332a7188e3100bec940e517ea32550f01e25709b13f86eabc77">+28/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crsf.h</strong><dd><code>Update MSP response scheduling signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/crsf.h

<ul><li>Update <code>crsfScheduleMspResponse()</code> signature to include <code>requestOriginID</code> <br>parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11093/files#diff-62a95b5be471a83af7822dab6e8cd680c80b213a37e1a3893192c5023a6845cb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>msp_shared.h</strong><dd><code>Update MSP callback and function signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/msp_shared.h

<ul><li>Update <code>mspResponseFnPtr</code> callback signature to include payload size <br>parameter<br> <li> Update <code>handleMspFrame()</code> parameter naming for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11093/files#diff-a3e1c39efc3dd7824bf93743c1af2d025b801fff15b947d07e0d8deae74b3c64">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>smartport.c</strong><dd><code>Add payload size handling to SmartPort MSP response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/smartport.c

<ul><li>Update <code>smartPortSendMspResponse()</code> to accept payload size parameter<br> <li> Use <code>MIN()</code> macro to safely copy data within SmartPort payload bounds</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11093/files#diff-a8c06bacdf002c8f2d1ea3d9d66ab89494d0810480f58140d6575e5759bc3f30">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>New feature</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>msp_shared.c</strong><dd><code>Add MSPv2 protocol support and chunked frame handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/msp_shared.c

<ul><li>Add MSPv2 protocol support with 16-bit command and size fields<br> <li> Refactor frame parsing to handle both MSPv1 and MSPv2 formats<br> <li> Implement proper version detection and validation<br> <li> Add buffer overflow protection with size validation<br> <li> Remove CRC calculation (handled by CRSF/SmartPort layer)<br> <li> Implement chunked response handling with header sent tracking<br> <li> Add detailed byte position constants for frame structure<br> <li> Update error handling with new error types for version mismatch and <br>oversized requests</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11093/files#diff-e9fac829a2b023959791d065f732c99c5e95e7afd4bde5ca934a1136bec5ca67">+121/-87</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

