### PR TITLE
Update CRSF telemetry modes sensor to better reflect INAV modes

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -352,19 +352,25 @@ static void crsfFrameFlightMode(sbuf_t *dst)
     // use same logic as OSD, so telemetry displays same flight text as OSD when armed
     const char *flightMode = "OK";
     if (ARMING_FLAG(ARMED)) {
-        if (STATE(AIRMODE_ACTIVE)) {
-            flightMode = "AIR";
-        } else {
-            flightMode = "ACRO";
-        }
+        flightMode = "ACRO";
         if (FLIGHT_MODE(FAILSAFE_MODE)) {
             flightMode = "!FS!";
-        } else if (IS_RC_MODE_ACTIVE(BOXHOMERESET) && !FLIGHT_MODE(NAV_RTH_MODE) && !FLIGHT_MODE(NAV_WP_MODE)) {
-            flightMode = "HRST";
+#ifdef USE_FW_AUTOLAND
+        } else if (FLIGHT_MODE(NAV_FW_AUTOLAND)) {
+            flightMode = "LAND";
+#endif
+#ifdef USE_GEOZONE
+        } else if (FLIGHT_MODE(NAV_SEND_TO)) {
+            flightMode = "AUTO";
+#endif            
         } else if (FLIGHT_MODE(MANUAL_MODE)) {
             flightMode = "MANU";
+        } else if (FLIGHT_MODE(TURTLE_MODE)) {
+            flightMode = "TURT";
         } else if (FLIGHT_MODE(NAV_RTH_MODE)) {
-            flightMode = "RTH";
+            flightMode = isWaypointMissionRTHActive() ? "WRTH" : "RTH";
+        } else if (FLIGHT_MODE(NAV_POSHOLD_MODE) && STATE(AIRPLANE)) {
+            flightMode = "LOTR";
         } else if (FLIGHT_MODE(NAV_POSHOLD_MODE)) {
             flightMode = "HOLD";
         } else if (FLIGHT_MODE(NAV_COURSE_HOLD_MODE) && FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
@@ -373,7 +379,7 @@ static void crsfFrameFlightMode(sbuf_t *dst)
             flightMode = "CRSH";
         } else if (FLIGHT_MODE(NAV_WP_MODE)) {
             flightMode = "WP";
-        } else if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
+        } else if (FLIGHT_MODE(NAV_ALTHOLD_MODE) && navigationRequiresAngleMode()) {
             flightMode = "AH";
         } else if (FLIGHT_MODE(ANGLE_MODE)) {
             flightMode = "ANGL";
@@ -381,10 +387,6 @@ static void crsfFrameFlightMode(sbuf_t *dst)
             flightMode = "HOR";
         } else if (FLIGHT_MODE(ANGLEHOLD_MODE)) {
             flightMode = "ANGH";
-#ifdef USE_FW_AUTOLAND
-        } else if (FLIGHT_MODE(NAV_FW_AUTOLAND)) {
-            flightMode = "LAND";
-#endif
         }
 #ifdef USE_GPS
     } else if (feature(FEATURE_GPS) && navConfig()->general.flags.extra_arming_safety && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {


### PR DESCRIPTION
### **User description**
This PR is to better align the flight mode sensor in the CRSF telemetry with the actual modes in INAV. Note at the top of the block it states that the behavior should match the OSD.
- Removed `AIR`. Airmode is a modifier, not a mode. As such it can apply to Acro, Angle, and Horizon. So displaying AIR is inconsistent. The OSD does not display AIR. This could be a hangover from BetaFlight.
- Removed home_reset. It is not a mode at all
- Added the Geozone `AUTO` mode
- Refined position hold to show `LOTR` or `HOLD` depending on the platform
- Added Turtle mode
- Added requirement to be in angle to show `AH`


___

### **PR Type**
Enhancement


___

### **Description**
- Removed AIR mode as airmode is a modifier, not a flight mode

- Removed home_reset mode as it is not a valid flight mode

- Added Geozone AUTO mode and FW autoland LAND mode support

- Added Turtle mode (TURT) display capability

- Refined position hold to show LOTR for airplanes or HOLD for multicopters

- Added angle mode requirement for altitude hold (AH) display

- Enhanced RTH mode to distinguish waypoint mission RTH (WRTH) from standard RTH


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Flight Mode Logic"] -->|Remove| B["AIR mode<br/>home_reset mode"]
  A -->|Add| C["Turtle mode<br/>Geozone AUTO<br/>FW Autoland"]
  A -->|Refine| D["Position Hold<br/>RTH variants<br/>Altitude Hold"]
  B --> E["Match OSD behavior"]
  C --> E
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crsf.c</strong><dd><code>Refactor flight mode detection logic for INAV alignment</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/crsf.c

<ul><li>Removed AIR mode detection and home_reset mode handling<br> <li> Added support for Turtle mode (TURT) display<br> <li> Added Geozone AUTO mode and FW autoland LAND mode with conditional <br>compilation<br> <li> Enhanced position hold to differentiate between airplane (LOTR) and <br>multicopter (HOLD) platforms<br> <li> Enhanced RTH mode to show WRTH for waypoint mission RTH or RTH for <br>standard RTH<br> <li> Added angle mode requirement check for altitude hold (AH) mode display</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11094/files#diff-5b4ded67d6b41332a7188e3100bec940e517ea32550f01e25709b13f86eabc77">+15/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

