### PR TITLE
Update Geofence `AUTO` mode to `GEO`

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2561,7 +2561,7 @@ static bool osdDrawSingleElement(uint8_t item)
 #endif
 #ifdef USE_GEOZONE
             if (FLIGHT_MODE(NAV_SEND_TO))
-                p = "AUTO";
+                p = "GEO";
             else
 #endif
             if (FLIGHT_MODE(FAILSAFE_MODE))

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -361,7 +361,7 @@ static void crsfFrameFlightMode(sbuf_t *dst)
 #endif
 #ifdef USE_GEOZONE
         } else if (FLIGHT_MODE(NAV_SEND_TO)) {
-            flightMode = "AUTO";
+            flightMode = "GEO";
 #endif            
         } else if (FLIGHT_MODE(MANUAL_MODE)) {
             flightMode = "MANU";


### PR DESCRIPTION
### **User description**
When the Geofence automated flight is active, it currently says `AUTO` in the OSD. It would be nicer if it were a bit more specific as to what is happening. So now will say `GEO`. This is also reflected in the CRSF telemetry and will be reflected in S.Port telemetry too,


___

### **PR Type**
Enhancement


___

### **Description**
- Replace generic "AUTO" mode label with "GEO" for geofence flights

- Updates OSD display to show specific geofence mode identifier

- Updates CRSF telemetry to reflect geofence mode change


___

### Diagram Walkthrough


```mermaid
flowchart LR
  OSD["OSD Display"]
  CRSF["CRSF Telemetry"]
  GEO["GEO Mode Label"]
  OSD -- "AUTO → GEO" --> GEO
  CRSF -- "AUTO → GEO" --> GEO
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>osd.c</strong><dd><code>Update OSD geofence mode label to GEO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/io/osd.c

<ul><li>Changed geofence flight mode display from "AUTO" to "GEO" in OSD<br> <li> Updates NAV_SEND_TO flight mode string representation<br> <li> Improves clarity of geofence automated flight status on screen</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11096/files#diff-a680ca1e23901579e9214c055509004e8b5c05e3f7281ed74ac1edfc38caabae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crsf.c</strong><dd><code>Update CRSF telemetry geofence mode label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/crsf.c

<ul><li>Changed geofence flight mode from "AUTO" to "GEO" in CRSF telemetry<br> <li> Updates NAV_SEND_TO flight mode string in telemetry frame<br> <li> Ensures consistent geofence mode labeling across telemetry systems</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11096/files#diff-5b4ded67d6b41332a7188e3100bec940e517ea32550f01e25709b13f86eabc77">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

