### PR TITLE
Corrected mode display ordering

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2559,15 +2559,14 @@ static bool osdDrawSingleElement(uint8_t item)
                 p = "LAND";
             else
 #endif
-#ifdef USE_GEOZONE
-            if (FLIGHT_MODE(NAV_SEND_TO))
-                p = "GEO";
-            else
-#endif
             if (FLIGHT_MODE(FAILSAFE_MODE))
                 p = "!FS!";
             else if (FLIGHT_MODE(MANUAL_MODE))
                 p = "MANU";
+#ifdef USE_GEOZONE
+            else if (FLIGHT_MODE(NAV_SEND_TO) && !FLIGHT_MODE(NAV_WP_MODE))
+                p = "GEO";
+#endif
             else if (FLIGHT_MODE(TURTLE_MODE))
                 p = "TURT";
             else if (FLIGHT_MODE(NAV_RTH_MODE))

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -353,14 +353,15 @@ static void crsfFrameFlightMode(sbuf_t *dst)
     const char *flightMode = "OK";
     if (ARMING_FLAG(ARMED)) {
         flightMode = "ACRO";
+#ifdef USE_FW_AUTOLAND
+        if (FLIGHT_MODE(NAV_FW_AUTOLAND)) {
+            flightMode = "LAND";
+        } else
+#endif
         if (FLIGHT_MODE(FAILSAFE_MODE)) {
             flightMode = "!FS!";
-#ifdef USE_FW_AUTOLAND
-        } else if (FLIGHT_MODE(NAV_FW_AUTOLAND)) {
-            flightMode = "LAND";
-#endif
 #ifdef USE_GEOZONE
-        } else if (FLIGHT_MODE(NAV_SEND_TO)) {
+        } else if (FLIGHT_MODE(NAV_SEND_TO) && !FLIGHT_MODE(NAV_WP_MODE)) {
             flightMode = "GEO";
 #endif            
         } else if (FLIGHT_MODE(MANUAL_MODE)) {

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -359,13 +359,13 @@ static void crsfFrameFlightMode(sbuf_t *dst)
         } else
 #endif
         if (FLIGHT_MODE(FAILSAFE_MODE)) {
-            flightMode = "!FS!";
+            flightMode = "!FS!";          
+        } else if (FLIGHT_MODE(MANUAL_MODE)) {
+            flightMode = "MANU";
 #ifdef USE_GEOZONE
         } else if (FLIGHT_MODE(NAV_SEND_TO) && !FLIGHT_MODE(NAV_WP_MODE)) {
             flightMode = "GEO";
-#endif            
-        } else if (FLIGHT_MODE(MANUAL_MODE)) {
-            flightMode = "MANU";
+#endif  
         } else if (FLIGHT_MODE(TURTLE_MODE)) {
             flightMode = "TURT";
         } else if (FLIGHT_MODE(NAV_RTH_MODE)) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected flight mode display priority ordering in OSD and telemetry

- Moved GEOZONE mode check after FAILSAFE and MANUAL modes

- Added condition to exclude GEOZONE when in waypoint mode

- Aligned flight mode logic between OSD and CRSF telemetry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Flight Mode Check"] --> B["FW_AUTOLAND?"]
  B -->|Yes| C["Display LAND"]
  B -->|No| D["FAILSAFE?"]
  D -->|Yes| E["Display !FS!"]
  D -->|No| F["MANUAL?"]
  F -->|Yes| G["Display MANU"]
  F -->|No| H["GEOZONE & !WP?"]
  H -->|Yes| I["Display GEO"]
  H -->|No| J["Other Modes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>osd.c</strong><dd><code>Reordered OSD flight mode display priority</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/io/osd.c

<ul><li>Reorganized flight mode priority checks for correct display ordering<br> <li> Moved GEOZONE mode check after FAILSAFE and MANUAL mode checks<br> <li> Added condition to prevent GEOZONE display when in waypoint mode<br> <li> Ensured GEOZONE check uses <code>else if</code> for proper priority handling</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11097/files#diff-a680ca1e23901579e9214c055509004e8b5c05e3f7281ed74ac1edfc38caabae">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crsf.c</strong><dd><code>Aligned CRSF telemetry flight mode ordering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/crsf.c

<ul><li>Restructured flight mode priority logic to match OSD implementation<br> <li> Moved FAILSAFE check before GEOZONE check<br> <li> Added condition to exclude GEOZONE when in waypoint mode<br> <li> Aligned telemetry flight mode display with OSD behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11097/files#diff-5b4ded67d6b41332a7188e3100bec940e517ea32550f01e25709b13f86eabc77">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

