### PR TITLE
fix buffer overflow from deprecated MSP2_INAV_LOGIC_CONDITIONS

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -558,17 +558,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         break;
 #ifdef USE_PROGRAMMING_FRAMEWORK
     case MSP2_INAV_LOGIC_CONDITIONS:
-        for (int i = 0; i < MAX_LOGIC_CONDITIONS; i++) {
-            sbufWriteU8(dst, logicConditions(i)->enabled);
-            sbufWriteU8(dst, logicConditions(i)->activatorId);
-            sbufWriteU8(dst, logicConditions(i)->operation);
-            sbufWriteU8(dst, logicConditions(i)->operandA.type);
-            sbufWriteU32(dst, logicConditions(i)->operandA.value);
-            sbufWriteU8(dst, logicConditions(i)->operandB.type);
-            sbufWriteU32(dst, logicConditions(i)->operandB.value);
-            sbufWriteU8(dst, logicConditions(i)->flags);
-        }
-        break;
+        return false; // Deprecated, causes buffer overflow for 14*64 bytes.
     case MSP2_INAV_LOGIC_CONDITIONS_STATUS:
         for (int i = 0; i < MAX_LOGIC_CONDITIONS; i++) {
             sbufWriteU32(dst, logicConditionGetValue(i));


### PR DESCRIPTION
### **User description**
The deprecated `MSP2_INAV_LOGIC_CONDITIONS` generates a MSP output buffer of 896 bytes, which crashes the SITL and may result in undefined behaviour in the FC.

As there is a usable and safe replacement API, ` MSP2_INAV_LOGIC_CONDITIONS_SINGLE`, this PR neuters `MSP2_INAV_LOGIC_CONDITIONS`  by returning an "invalid" response.

In a future version, we should just remove `MSP2_INAV_LOGIC_CONDITIONS`  completely (which would have the same effect).


___

### **PR Type**
Bug fix


___

### **Description**
- Prevents buffer overflow from deprecated MSP2_INAV_LOGIC_CONDITIONS command

- Returns invalid response instead of writing 896 bytes to buffer

- Directs users to use MSP2_INAV_LOGIC_CONDITIONS_SINGLE alternative


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MSP2_INAV_LOGIC_CONDITIONS<br/>request"] -->|"Previously: write<br/>14*64 bytes"| B["Buffer overflow<br/>crash"]
  A -->|"Now: return false"| C["Invalid response<br/>safe"]
  D["MSP2_INAV_LOGIC_CONDITIONS_SINGLE"] -->|"Recommended<br/>alternative"| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fc_msp.c</strong><dd><code>Disable deprecated MSP2_INAV_LOGIC_CONDITIONS command</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/fc/fc_msp.c

<ul><li>Removed loop that wrote 14 logic condition entries (896 bytes total) <br>to output buffer<br> <li> Replaced with single <code>return false</code> statement to indicate <br>invalid/deprecated command<br> <li> Prevents buffer overflow that caused SITL crashes and undefined <br>behavior<br> <li> Directs users to use MSP2_INAV_LOGIC_CONDITIONS_SINGLE API instead</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11099/files#diff-e67741f944e959c3f68a81189a5fcd8be50f5e4e567c1fc68f50ac5e86d0a233">+1/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

