### PR TITLE
Update throttle gauge skip

### DIFF
--- a/src/main/io/osd_canvas.c
+++ b/src/main/io/osd_canvas.c
@@ -77,7 +77,7 @@ void osdCanvasDrawThrottleGauge(displayPort_t *display, displayCanvas_t *canvas,
 
     static uint8_t prevThr = 0;
 
-    if (ABS(prevThr - thrPos) < 10) {
+    if (prevThr == (uint8_t)(thrPos / (OSD_THROTTLE_GAUGE_HEIGHT_ROWS * 2))) {
         return;
     }
 
@@ -129,7 +129,7 @@ void osdCanvasDrawThrottleGauge(displayPort_t *display, displayCanvas_t *canvas,
     else
         displayCanvasDrawCharacter(canvas, x, y + (canvas->gridElementHeight * 4), SYM_THR_GAUGE_EMPTY, DISPLAY_CANVAS_BITMAP_OPT_ERASE_TRANSPARENT);
 
-    prevThr = thrPos;
+    prevThr = (uint8_t)(thrPos / (OSD_THROTTLE_GAUGE_HEIGHT_ROWS * 2));
 }
 
 void osdCanvasDrawVario(displayPort_t *display, displayCanvas_t *canvas, const osdDrawPoint_t *p, float zvel)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactors throttle gauge skip logic to use quantized values

- Replaces absolute difference threshold with exact quantization match

- Improves rendering efficiency by reducing unnecessary redraws


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Throttle Position Input"] --> B["Quantize: thrPos / (OSD_THROTTLE_GAUGE_HEIGHT_ROWS * 2)"]
  B --> C["Compare with Previous Quantized Value"]
  C --> D{"Values Match?"}
  D -->|Yes| E["Skip Redraw"]
  D -->|No| F["Redraw Gauge"]
  F --> G["Update Previous Value"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>osd_canvas.c</strong><dd><code>Quantize throttle gauge skip logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/io/osd_canvas.c

<ul><li>Changed skip condition from <code>ABS(prevThr - thrPos) < 10</code> to <code>prevThr == </code><br><code>(uint8_t)(thrPos / (OSD_THROTTLE_GAUGE_HEIGHT_ROWS * 2))</code><br> <li> Updated <code>prevThr</code> assignment to store quantized throttle value instead <br>of raw position<br> <li> Implements quantization-based comparison for more precise redraw <br>control</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11101/files#diff-a1821ad15f49e6f0f3b03d2ff88044686d0008a3e660fdc5d41384bd6399762b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

