### PR TITLE
made SITL ports configurable

### DIFF
--- a/src/main/drivers/serial_tcp.c
+++ b/src/main/drivers/serial_tcp.c
@@ -47,6 +47,7 @@
 
 static const struct serialPortVTable tcpVTable[];
 static tcpPort_t tcpPorts[SERIAL_PORT_COUNT];
+uint16_t tcpBasePort = TCP_BASE_PORT_DEFAULT;
 
 static void *tcpReceiveThread(void* arg)
 {
@@ -66,7 +67,7 @@ static tcpPort_t *tcpReConfigure(tcpPort_t *port, uint32_t id)
         return NULL;
     }
 
-    uint16_t tcpPort = BASE_IP_ADDRESS + id - 1;
+    uint16_t tcpPort = tcpBasePort + id - 1;
     if (lookupAddress(NULL, tcpPort, SOCK_STREAM, (struct sockaddr*)&port->sockAddress, &sockaddrlen) != 0) {
             return NULL;
     }

--- a/src/main/drivers/serial_tcp.h
+++ b/src/main/drivers/serial_tcp.h
@@ -21,6 +21,8 @@
 #pragma once
 
 #include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -28,7 +30,7 @@
 
 #include "drivers/serial.h"
 
-#define BASE_IP_ADDRESS 5760
+#define TCP_BASE_PORT_DEFAULT 5760
 #define TCP_BUFFER_SIZE 2048
 #define TCP_MAX_PACKET_SIZE 65535
 
@@ -56,3 +58,5 @@ extern void tcpSend(tcpPort_t *port);
 extern int tcpReceive(tcpPort_t *port);
 extern void tcpReceiveBytesEx( int portIndex, const uint8_t* buffer, ssize_t recvSize );
 extern uint32_t tcpRXBytesFree(int portIndex);
+
+extern uint16_t tcpBasePort;

--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -50,6 +50,7 @@
 #include "drivers/pwm_mapping.h"
 #include "drivers/timer.h"
 #include "drivers/serial.h"
+#include "drivers/serial_tcp.h"
 #include "config/config_streamer.h"
 #include "build/version.h"
 
@@ -209,6 +210,7 @@ void printCmdLineOptions(void)
     fprintf(stderr, "--stopbits=[None|One|Two]      Serial receiver stopbits (default: One).\n");
     fprintf(stderr, "--parity=[Even|None|Odd]       Serial receiver parity (default: None).\n");
     fprintf(stderr, "--fcproxy                      Use inav/betaflight FC as a proxy for serial receiver.\n");
+    fprintf(stderr, "--tcpbaseport=[port]           Base TCP port for UART sockets (default: 5760)\n");
     fprintf(stderr, "--chanmap=[mapstring]          Channel mapping. Maps INAVs motor and servo PWM outputs to the virtual receiver output in the simulator.\n");
     fprintf(stderr, "                               The mapstring has the following format: M(otor)|S(servo)<INAV-OUT>-<RECEIVER-OUT>,... All numbers must have two digits\n");
     fprintf(stderr, "                               For example: Map motor 1 to virtal receiver output 1, servo 1 to output 2 and servo 2 to output 3:\n");
@@ -239,6 +241,7 @@ void parseArguments(int argc, char *argv[])
             {"stopbits", required_argument, 0, '3'},
             {"parity", required_argument, 0, '4'},
             {"fcproxy", no_argument, 0, '5'},
+            {"tcpbaseport", required_argument, 0, '6'},
             {NULL, 0, NULL, 0}
         };
 
@@ -324,6 +327,16 @@ void parseArguments(int argc, char *argv[])
             case '5':
                 serialFCProxy = true;
                 break;
+            case '6': {
+                char *endptr = NULL;
+                long basePort = strtol(optarg, &endptr, 10);
+                if ((endptr == NULL) || (*endptr != '\0') || basePort <= 0 || basePort > UINT16_MAX || basePort + SERIAL_PORT_COUNT - 1 > UINT16_MAX) {
+                    fprintf(stderr, "[tcpbaseport] Invalid argument\n.");
+                    exit(0);
+                }
+                tcpBasePort = (uint16_t)basePort;
+                break;
+            }
 
             default:
                 printCmdLineOptions();


### PR DESCRIPTION
### **User description**
Made SITL tcp base port (which adds more ports for every uart) configurable in the SITL executable command line with --tcpbaseport=x, allowing multiple SITL instances to be run at the same time, simulator allowing. Might want to ensure they run with different eeprom.bin files to avoid them overwriting each other, and care with proxied serial devices.
Ran unit tests and tested with the configurator


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable TCP base port for SITL via `--tcpbaseport` command-line argument

- Replace hardcoded `BASE_IP_ADDRESS` constant with dynamic `tcpBasePort` variable

- Enable multiple SITL instances to run simultaneously on different port ranges

- Validate port argument to ensure valid range and prevent port overflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Command-line Argument<br/>--tcpbaseport"] -->|Parse & Validate| B["tcpBasePort Variable"]
  B -->|Used in| C["TCP Port Calculation<br/>tcpBasePort + id - 1"]
  C -->|Enables| D["Multiple SITL Instances<br/>on Different Ports"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serial_tcp.h</strong><dd><code>Export configurable TCP base port variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/serial_tcp.h

<ul><li>Rename <code>BASE_IP_ADDRESS</code> macro to <code>TCP_BASE_PORT_DEFAULT</code> for clarity<br> <li> Add missing includes for <code>stdbool.h</code> and <code>stdint.h</code><br> <li> Declare external <code>tcpBasePort</code> variable to allow runtime configuration<br> <li> Add newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11103/files#diff-f7d6e0a11b7bb6198a6e951e4a874fe0dfa88dc63b96c1c805f6eb2861ebf861">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serial_tcp.c</strong><dd><code>Use configurable base port in TCP initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/serial_tcp.c

<ul><li>Define global <code>tcpBasePort</code> variable initialized to <br><code>TCP_BASE_PORT_DEFAULT</code><br> <li> Replace hardcoded <code>BASE_IP_ADDRESS</code> with <code>tcpBasePort</code> in port calculation <br>logic</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11103/files#diff-4ba9f483d3ae89e691687b65ee03e60bca0956657181038a0189675a8724ecbd">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>target.c</strong><dd><code>Add command-line parsing for TCP base port configuration</code>&nbsp; </dd></summary>
<hr>

src/main/target/SITL/target.c

<ul><li>Add <code>#include "drivers/serial_tcp.h"</code> to access <code>tcpBasePort</code> variable<br> <li> Add <code>--tcpbaseport=[port]</code> option to command-line help documentation<br> <li> Add new command-line argument handler for <code>--tcpbaseport</code> with case <code>'6'</code><br> <li> Implement validation logic to ensure port is positive, within <br><code>UINT16_MAX</code>, and doesn't overflow when adding <code>SERIAL_PORT_COUNT</code><br> <li> Parse and assign validated port value to <code>tcpBasePort</code> global variable</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11103/files#diff-4914f57928db1e3d2ac58e9e5afccc0a7dc8321c98ff5a47d12e3ada098e9be9">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

