### PR TITLE
Update SmartPort telemetry to reflect latest flight modes

### DIFF
--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -102,12 +102,14 @@ The following sensors are transmitted
 * **VSpd** : vertical speed, unit is cm/s.
 * **Hdg** : heading, North is 0°, South is 180°.
 * **AccX,Y,Z** : accelerometer values (not sent if `frsky_pitch_roll = ON`).
-* **470** : flight mode, sent as 5 digits. Number is sent as **ABCDE** detailed below. The numbers are additives (for example: if digit C is 6, it means both position hold and altitude hold are active) :
-  * **A** : 1 = flaperon mode, 2 = auto tune mode, 4 = failsafe mode
-  * **B** : 1 = return to home, 2 = waypoint mode, 4 = headfree mode
-  * **C** : 1 = heading hold, 2 = altitude hold, 4 = position hold
-  * **D** : 1 = angle mode, 2 = horizon mode, 4 = passthru mode
-  * **E** : 1 = ok to arm, 2 = arming is prevented, 4 = armed
+* **470** : flight mode, sent as 7 digits. Number is sent as **ABCDEFG** detailed below. The numbers are additives (for example: if digit C is 6, it means both position hold and altitude hold are active) :
+  * **A** : 1 = WRTH mode, 2 = Angle hold mode
+  * **B** : 1 = Fixed Wing Auto-land, 2 = Turtle mode, 4 = Geofence action mode, 8 = Loiter mode
+  * **C** : 1 = flaperon mode, 2 = auto tune mode, 4 = failsafe mode
+  * **D** : 1 = return to home, 2 = waypoint mode, 4 = headfree mode, 8 = Course Hold
+  * **E** : 1 = heading hold, 2 = altitude hold, 4 = position hold
+  * **F** : 1 = angle mode, 2 = horizon mode, 4 = passthru mode
+  * **G** : 1 = ok to arm, 2 = arming is prevented, 4 = armed
   
   _NOTE_ This sensor used to be **Tmp1**. The ID has been reassigned in INAV 8.0. The old ID of **Tmp1** can still be used, by using `set frsky_use_legacy_gps_mode_sensor_ids = ON`. This is deprecated and will be removed in INAV 10.0. All tools and scripts using the old IDs should be updated to use the new ID.
 * **480** : GPS lock status, accuracy, home reset trigger, and number of satellites. Number is sent as **ABCD** detailed below. Typical minimum GPS 3D lock value is 3906 (GPS locked and home fixed, HDOP highest accuracy, 6 satellites).

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2565,7 +2565,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 p = "MANU";
 #ifdef USE_GEOZONE
             else if (FLIGHT_MODE(NAV_SEND_TO) && !FLIGHT_MODE(NAV_WP_MODE))
-                p = "GEO";
+                p = "GEO ";
 #endif
             else if (FLIGHT_MODE(TURTLE_MODE))
                 p = "TURT";

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -162,9 +162,9 @@ static smartPortWriteFrameFn *smartPortWriteFrame;
 static bool smartPortMspReplyPending = false;
 #endif
 
-static uint16_t frskyGetFlightMode(void)
+static uint32_t frskyGetFlightMode(void)
 {
-    uint16_t tmpi = 0;
+    uint32_t tmpi = 0;
 
     // ones column
     if (!isArmingDisabled())
@@ -187,11 +187,11 @@ static uint16_t frskyGetFlightMode(void)
         tmpi += 100;
     if (FLIGHT_MODE(NAV_ALTHOLD_MODE))
         tmpi += 200;
-    if (FLIGHT_MODE(NAV_POSHOLD_MODE))
+    if (FLIGHT_MODE(NAV_POSHOLD_MODE) && !STATE(AIRPLANE))
         tmpi += 400;
 
     // thousands column
-    if (FLIGHT_MODE(NAV_RTH_MODE))
+    if (FLIGHT_MODE(NAV_RTH_MODE) && !isWaypointMissionRTHActive())
         tmpi += 1000;
     if (FLIGHT_MODE(NAV_COURSE_HOLD_MODE)) // intentionally out of order and 'else-ifs' to prevent column overflow
         tmpi += 8000;
@@ -207,6 +207,22 @@ static uint16_t frskyGetFlightMode(void)
         tmpi += 40000;
     else if (FLIGHT_MODE(AUTO_TUNE)) // intentionally reverse order and 'else-if' to prevent 16-bit overflow
         tmpi += 20000;
+
+    // hundred thousands column
+    if (FLIGHT_MODE(NAV_FW_AUTOLAND))
+        tmpi += 100000;
+    if (FLIGHT_MODE(TURTLE_MODE))
+        tmpi += 200000;
+    else if (FLIGHT_MODE(NAV_POSHOLD_MODE) && STATE(AIRPLANE))
+        tmpi += 800000;
+    if (FLIGHT_MODE(NAV_SEND_TO))
+        tmpi += 400000;
+
+    // million column
+    if (FLIGHT_MODE(NAV_RTH_MODE) && isWaypointMissionRTHActive())
+        tmpi += 1000000;
+    if (FLIGHT_MODE(ANGLEHOLD_MODE))
+        tmpi += 2000000;
 
     return tmpi;
 }

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -166,7 +166,7 @@ static uint32_t frskyGetFlightMode(void)
 {
     uint32_t tmpi = 0;
 
-    // ones column
+    // ones column (G)
     if (!isArmingDisabled())
         tmpi += 1;
     else
@@ -174,7 +174,7 @@ static uint32_t frskyGetFlightMode(void)
     if (ARMING_FLAG(ARMED))
         tmpi += 4;
 
-    // tens column
+    // tens column (F)
     if (FLIGHT_MODE(ANGLE_MODE))
         tmpi += 10;
     if (FLIGHT_MODE(HORIZON_MODE))
@@ -182,7 +182,7 @@ static uint32_t frskyGetFlightMode(void)
     if (FLIGHT_MODE(MANUAL_MODE))
         tmpi += 40;
 
-    // hundreds column
+    // hundreds column (E)
     if (FLIGHT_MODE(HEADING_MODE))
         tmpi += 100;
     if (FLIGHT_MODE(NAV_ALTHOLD_MODE))
@@ -190,7 +190,7 @@ static uint32_t frskyGetFlightMode(void)
     if (FLIGHT_MODE(NAV_POSHOLD_MODE) && !STATE(AIRPLANE))
         tmpi += 400;
 
-    // thousands column
+    // thousands column (D)
     if (FLIGHT_MODE(NAV_RTH_MODE) && !isWaypointMissionRTHActive())
         tmpi += 1000;
     if (FLIGHT_MODE(NAV_COURSE_HOLD_MODE)) // intentionally out of order and 'else-ifs' to prevent column overflow
@@ -200,7 +200,7 @@ static uint32_t frskyGetFlightMode(void)
     else if (FLIGHT_MODE(HEADFREE_MODE))
         tmpi += 4000;
 
-    // ten thousands column
+    // ten thousands column (C)
     if (FLIGHT_MODE(FLAPERON))
         tmpi += 10000;
     if (FLIGHT_MODE(FAILSAFE_MODE))
@@ -208,7 +208,7 @@ static uint32_t frskyGetFlightMode(void)
     else if (FLIGHT_MODE(AUTO_TUNE)) // intentionally reverse order and 'else-if' to prevent 16-bit overflow
         tmpi += 20000;
 
-    // hundred thousands column
+    // hundred thousands column (B)
     if (FLIGHT_MODE(NAV_FW_AUTOLAND))
         tmpi += 100000;
     if (FLIGHT_MODE(TURTLE_MODE))
@@ -218,7 +218,7 @@ static uint32_t frskyGetFlightMode(void)
     if (FLIGHT_MODE(NAV_SEND_TO))
         tmpi += 400000;
 
-    // million column
+    // million column (A)
     if (FLIGHT_MODE(NAV_RTH_MODE) && isWaypointMissionRTHActive())
         tmpi += 1000000;
     if (FLIGHT_MODE(ANGLEHOLD_MODE))


### PR DESCRIPTION
### **User description**
This brings the SmartPort flight modes in line with what is shown on the OSD and CRSF telemetry.

I am working on updating the OpenTX Telemetry Widget. All new modes have been tested, except Turtle, using SmartPort. I just need to test with CRSF and create the voice files. https://github.com/iNavFlight/OpenTX-Telemetry-Widget/pull/193

I've also added a small correction to the OSD display of the `GEO` mode.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Expand SmartPort telemetry flight mode support to 32-bit range

- Add new flight modes: Turtle, FW Autoland, Angle Hold, Waypoint RTH

- Refine existing mode conditions with airplane state checks

- Fix GEO mode display padding in OSD


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SmartPort Flight Mode<br/>Detection"] -->|"Expand to 32-bit"| B["Support Additional<br/>Flight Modes"]
  B -->|"Add Modes"| C["Turtle, FW Autoland,<br/>Angle Hold, WP RTH"]
  B -->|"Refine Conditions"| D["Airplane State Checks<br/>for PosHold & RTH"]
  E["OSD Display"] -->|"Fix Padding"| F["GEO Mode<br/>Alignment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>smartport.c</strong><dd><code>Expand SmartPort flight mode detection to 32-bit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/telemetry/smartport.c

<ul><li>Changed <code>frskyGetFlightMode()</code> return type from <code>uint16_t</code> to <code>uint32_t</code> to <br>support expanded flight mode range<br> <li> Added hundred thousands column for new modes: NAV_FW_AUTOLAND <br>(100000), TURTLE_MODE (200000), NAV_SEND_TO (400000), and <br>airplane-specific NAV_POSHOLD_MODE (800000)<br> <li> Added million column for Waypoint Mission RTH (1000000) and <br>ANGLEHOLD_MODE (2000000)<br> <li> Refined NAV_POSHOLD_MODE condition to exclude airplane mode and <br>NAV_RTH_MODE to exclude waypoint missions</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11104/files#diff-a8c06bacdf002c8f2d1ea3d9d66ab89494d0810480f58140d6575e5759bc3f30">+20/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>osd.c</strong><dd><code>Fix GEO mode display padding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/io/osd.c

<ul><li>Added trailing space to GEO mode display string for consistent <br>alignment with other 4-character mode labels</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11104/files#diff-a680ca1e23901579e9214c055509004e8b5c05e3f7281ed74ac1edfc38caabae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

