### PR TITLE
Update status flag check for QMC5883

### DIFF
--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -103,7 +103,7 @@ static bool qmc5883Read(magDev_t * mag)
     mag->magADCRaw[Z] = 0;
 
     bool ack = busRead(mag->busDev, QMC5883L_REG_STATUS, &status);
-    if (!ack || (status & 0x04) == 0) {
+    if (!ack || (status & 0x01) == 0) {
         return false;
     }
 


### PR DESCRIPTION
### **User description**
As discussed in https://github.com/iNavFlight/inav/pull/9967 , but I'm pulling in just the change without the code refactoring.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect status flag check in QMC5883L compass driver

- Changed status register bitmask from 0x04 to 0x01

- Resolves data ready detection issues in compass initialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["QMC5883L Driver"] -- "Status Check" --> B["Old: status & 0x04"]
  B -- "Bug" --> C["Incorrect Data Ready Detection"]
  A -- "Status Check" --> D["New: status & 0x01"]
  D -- "Fix" --> E["Correct Data Ready Detection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compass_qmc5883l.c</strong><dd><code>Fix QMC5883L status register bitmask</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/compass/compass_qmc5883l.c

<ul><li>Changed status register bitmask from 0x04 to 0x01 in qmc5883Read <br>function<br> <li> Fixes incorrect data ready flag detection in QMC5883L compass driver<br> <li> Resolves issues #9091 and #9101 related to compass initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11105/files#diff-ba6032b50db32bedc9e7e5e917e40f2c1eb2a0dc4357433c8b6b1e554b4fb928">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

