### PR TITLE
vtol.md: s/pid_profile/control_profile/

### DIFF
--- a/docs/VTOL.md
+++ b/docs/VTOL.md
@@ -22,7 +22,7 @@ We highly value your feedback as it plays a crucial role in the development and 
 
 # VTOL Configuration Steps
 
-### The VTOL functionality is achieved by switching/transitioning between two configurations stored in the FC. VTOL specific configurations are Mixer Profiles with associated PID profiles. One profile set is for fixed-wing(FW) mode, One is for multi-copter(MC) mode. Configuration/Settings other than Mixer/PID profiles are shared among two modes 
+### The VTOL functionality is achieved by switching/transitioning between two configurations stored in the FC. VTOL specific configurations are Mixer Profiles with associated control profiles. One profile set is for fixed-wing(FW) mode, One is for multi-copter(MC) mode. Configuration/Settings other than Mixer/control profiles are shared among two modes
 ![Alt text](Screenshots/mixerprofile_flow.png)
 
 0. **Find a DIFF ALL file for your model and start from there if possible**
@@ -78,7 +78,7 @@ set platform_type = TRICOPTER
 set model_preview_type = 1
 set mixer_pid_profile_linking = ON
 
-profile 1 #pid profile
+profile 1 #control profile
 set dterm_lpf_hz = 10
 set d_boost_min =  1.000
 set d_boost_max =  1.000
@@ -115,11 +115,12 @@ save
 
 # STEP 1: Configuring as a normal fixed-wing in Profile 1
 
-1. **Select the fisrt Mixer Profile and PID Profile:**
-   - In the CLI, switch to the mixer_profile and pid_profile you wish to set first. You can also switch mixer_profile/pid_profile through gui with aforementioned presets loaded.
+1. **Select the first Mixer Profile and Control Profile:**
+   - In the CLI, switch to the mixer_profile and control_profile you wish to set first. You can also switch
+     mixer_profile/control_profile through gui with aforementioned presets loaded.
      ```
      mixer_profile 1 #in this example, we set profile 1 first
-     set mixer_pid_profile_linking = ON  # Let the mixer_profile handle the pid_profile switch on this mixer_profile
+     set mixer_pid_profile_linking = ON  # Let the mixer_profile handle the control profile (formerly pid_profile) switch on this mixer_profile
      set platform_type = AIRPLANE
      save
      ```
@@ -136,8 +137,9 @@ You must also assign the tilting servos values using the MAX values.  If you don
 
 # STEP 2: Configuring as a Multi-Copter in Profile 2
 
-1. **Switch to Another Mixer Profile with PID Profile:**
-   - In the CLI, switch to another mixer_profile along with the appropriate pid_profile. You can also switch mixer_profile/pid_profile through gui with aforementioned presets loaded.
+1. **Switch to Another Mixer Profile with Control Profile:**
+   - In the CLI, switch to another mixer_profile along with the appropriate control profile. You can also switch
+     mixer_profile/control_profile through gui with aforementioned presets loaded.
      ```
      mixer_profile 2
      set mixer_pid_profile_linking = ON
@@ -146,7 +148,7 @@ You must also assign the tilting servos values using the MAX values.  If you don
      ```
 
 2. **Configure the Multicopter/tricopter:**
-   - Set up your multi-copter/fixed-wing as usual, this time for mixer_profile 2 and pid_profile 2.
+   - Set up your multi-copter/fixed-wing as usual, this time for mixer_profile 2 and control_profile 2.
    - Utilize the 'MAX' input in the servo mixer to tilt the motors without altering the servo midpoint.
    - At this stage, focus on configuring profile-specific settings. You can streamline this process by copying and pasting the default PID settings.
    - you can set -1 in motor mixer throttle as a place holder: this will disable that motor but will load following the motor rules
@@ -200,7 +202,7 @@ The steps below describe how you can fine-tune the tilting servos to obtian the 
    - Also, ensure that your MAX values in the Mixer tab are at 100 and -100, so that your servo will move to the maximum position, as shown in the screenshots in STEP1 and STEP2.
 
 3. **Adjust the maximum throws for the Multicopter/Tricopter mode:**
-   - While in tricopter mode, go to the Outputs tab and adjust the endpoints MIN and MAX values so your motors are pointed slightly backwards.
+   - While in tricopter mode, go to the Outputs tab and adjust the endpoints MIN and MAX values such that your motors are pointed slightly backwards.
    - Rotate the prop such that it is pointed backwards towards the wing/motor mount and ensure that the gap is the same on both sides by adjusting the MIN and MAX values for the tilt servo channels.
    - NOTE: You can check the distance with calipers or gauge blocks. Alternatively, you can adjust the MIN and MAX for your tilting servos such that the props are just touching the top of the wing or motor mount, and then you can increase/decrease the MIN and MAX values for each channel by the same ammount for both servos. This should ensure that you have the same gap between the tip of the prop and the wing or motor mount for both sides.
 

--- a/docs/VTOL.md
+++ b/docs/VTOL.md
@@ -202,7 +202,7 @@ The steps below describe how you can fine-tune the tilting servos to obtian the 
    - Also, ensure that your MAX values in the Mixer tab are at 100 and -100, so that your servo will move to the maximum position, as shown in the screenshots in STEP1 and STEP2.
 
 3. **Adjust the maximum throws for the Multicopter/Tricopter mode:**
-   - While in tricopter mode, go to the Outputs tab and adjust the endpoints MIN and MAX values such that your motors are pointed slightly backwards.
+   - While in tricopter mode, navigate to the Outputs tab and adjust the MIN and MAX endpoint values to position the motors slightly backward.
    - Rotate the prop such that it is pointed backwards towards the wing/motor mount and ensure that the gap is the same on both sides by adjusting the MIN and MAX values for the tilt servo channels.
    - NOTE: You can check the distance with calipers or gauge blocks. Alternatively, you can adjust the MIN and MAX for your tilting servos such that the props are just touching the top of the wing or motor mount, and then you can increase/decrease the MIN and MAX values for each channel by the same ammount for both servos. This should ensure that you have the same gap between the tip of the prop and the wing or motor mount for both sides.
 


### PR DESCRIPTION
### **User description**
Update PID profile to control profile.


___

### **PR Type**
Documentation


___

### **Description**
- Replace terminology "PID profile" with "control profile"

- Update documentation to reflect API naming changes

- Fix typo "fisrt" to "first"

- Minor grammar improvement "so" to "such that"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PID profile<br/>terminology"] -- "replace with" --> B["control profile<br/>terminology"]
  C["Documentation<br/>accuracy"] -- "improved by" --> D["Consistent naming<br/>throughout VTOL.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VTOL.md</strong><dd><code>Terminology update from PID to control profiles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/VTOL.md

<ul><li>Replaced all instances of "PID profile" with "control profile" <br>throughout the document<br> <li> Updated configuration examples and CLI commands to use new terminology<br> <li> Fixed typo "fisrt" to "first" in step 1 heading<br> <li> Improved grammar in step 3 description ("so" to "such that")<br> <li> Added clarification comment about control profile formerly being <br>pid_profile<br> <li> Reformatted line wrapping for better readability in step 1 and step 2 <br>descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11108/files#diff-0af75bf11973aba0f05be425ef6d064d7133cbeba55ae5e3694a53cc32d9f80f">+11/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

