### PR TITLE
Updates to wind in the IPF

### DIFF
--- a/docs/Programming Framework.md
+++ b/docs/Programming Framework.md
@@ -170,6 +170,7 @@ IPF can be edited using INAV Configurator user interface, or via CLI. To use COn
 | 46            | Minimum Ground Speed [m/s]            | The current minimum ground speed allowed in navigation flight modes |
 | 47            | Horizontal Wind Speed [cm/s]          | Estimated wind speed. If the wind estimator is unavailble or the wind estimation is invalid, -1 is returned |
 | 48            | Wind Direction [deg]                  | Estimated wind direction. If the wind estimator is unavailble or the wind estimation is invalid, -1 is returned |
+| 49            | Relative Wind Offset [deg]            | The relative offset between the heading of the aircraft and the heading of the wind. 0 indicates flying directly into a headwing. Negative numbers are a left offset. For example, if -20° is shown, turning right will correct towards 0. If the wind estimator is unavailble or the wind estimation is invalid, 0 is returned |
 
 #### FLIGHT_MODE
 

--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -766,11 +766,11 @@ static int logicConditionGetFlightOperandValue(int operand) {
             if (isEstimatedWindSpeedValid()) {
                 uint16_t windAngle;
                 getEstimatedHorizontalWindSpeed(&windAngle);
-                int32_t windHeading = (int32_t)windHeading + 18000; // Correct heading to display correctly.
+                int32_t windHeading = (int32_t)windAngle + 18000; // Correct heading to display correctly.
         
                 while (windHeading < 0) windHeading += 36000;
                 while (windHeading >= 36000) windHeading -= 36000;
-                
+
                 return (int32_t)CENTIDEGREES_TO_DEGREES(windHeading);
             } else
                 return -1;

--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -766,11 +766,12 @@ static int logicConditionGetFlightOperandValue(int operand) {
             if (isEstimatedWindSpeedValid()) {
                 uint16_t windAngle;
                 getEstimatedHorizontalWindSpeed(&windAngle);
-                int32_t windHeading = (int32_t)CENTIDEGREES_TO_DEGREES((int32_t)windHeading + 18000); // Correct heading to display correctly.
+                int32_t windHeading = (int32_t)windHeading + 18000; // Correct heading to display correctly.
         
-                while (windHeading < 0) windHeading += 360;
-                while (windHeading >= 360) windHeading -= 360;
-                return windHeading;
+                while (windHeading < 0) windHeading += 36000;
+                while (windHeading >= 36000) windHeading -= 36000;
+                
+                return (int32_t)CENTIDEGREES_TO_DEGREES(windHeading);
             } else
                 return -1;
         }
@@ -785,16 +786,16 @@ static int logicConditionGetFlightOperandValue(int operand) {
             if (isEstimatedWindSpeedValid()) {
                 uint16_t windAngle;
                 getEstimatedHorizontalWindSpeed(&windAngle);
-                int32_t relativeWindHeading = (int32_t)CENTIDEGREES_TO_DEGREES((int32_t)windAngle + 18000 - DECIDEGREES_TO_CENTIDEGREES(attitude.values.yaw));
+                int32_t relativeWindHeading = (int32_t)windAngle + 18000 - DECIDEGREES_TO_CENTIDEGREES(attitude.values.yaw);
         
-                while (relativeWindHeading < 0) relativeWindHeading += 360;
-                while (relativeWindHeading >= 360) relativeWindHeading -= 360;
+                while (relativeWindHeading < 0) relativeWindHeading += 36000;
+                while (relativeWindHeading >= 36000) relativeWindHeading -= 36000;
                 
                 relativeWindHeading = -relativeWindHeading;
-                if (relativeWindHeading <= -180)
-                    relativeWindHeading = 180 + (relativeWindHeading + 180);
+                if (relativeWindHeading <= -18000)
+                    relativeWindHeading = 18000 + (relativeWindHeading + 18000);
 
-                return relativeWindHeading;
+                return (int32_t)CENTIDEGREES_TO_DEGREES(relativeWindHeading);
             } else
                 return 0;
         }

--- a/src/main/programming/logic_condition.c
+++ b/src/main/programming/logic_condition.c
@@ -760,60 +760,48 @@ static int logicConditionGetFlightOperandValue(int operand) {
 #endif
             break;
 
-        case LOGIC_CONDITION_OPERAND_FLIGHT_WIND_DIRECTION: // deg
+        case LOGIC_CONDITION_OPERAND_FLIGHT_WIND_DIRECTION: // deg 0 - 360; -1 if not valid
 #ifdef USE_WIND_ESTIMATOR
         {
             if (isEstimatedWindSpeedValid()) {
                 uint16_t windAngle;
                 getEstimatedHorizontalWindSpeed(&windAngle);
-                int32_t windHeading = windAngle + 18000; // Correct heading to display correctly.
+                int32_t windHeading = (int32_t)CENTIDEGREES_TO_DEGREES((int32_t)windHeading + 18000); // Correct heading to display correctly.
         
-                windHeading = (CENTIDEGREES_TO_DEGREES((int)windHeading));
-                while (windHeading < 0) {
-                    windHeading += 360;
-                }
-                while (windHeading >= 360) {
-                    windHeading -= 360;
-                }
+                while (windHeading < 0) windHeading += 360;
+                while (windHeading >= 360) windHeading -= 360;
                 return windHeading;
             } else
                 return -1;
         }
 #else
-            return -1;
+        return -1;
 #endif
-            break;
+        break;
 
-        case LOGIC_CONDITION_OPERAND_FLIGHT_RELATIVE_WIND_OFFSET: // deg
+        case LOGIC_CONDITION_OPERAND_FLIGHT_RELATIVE_WIND_OFFSET: // deg -180 to 180; 0 if not valid
 #ifdef USE_WIND_ESTIMATOR
         {
             if (isEstimatedWindSpeedValid()) {
                 uint16_t windAngle;
                 getEstimatedHorizontalWindSpeed(&windAngle);
-                gvSet(3, DECIDEGREES_TO_DEGREES(attitude.values.yaw));
-                int32_t relativeWindHeading = windAngle + 18000 - DECIDEGREES_TO_CENTIDEGREES(attitude.values.yaw);
+                int32_t relativeWindHeading = (int32_t)CENTIDEGREES_TO_DEGREES((int32_t)windAngle + 18000 - DECIDEGREES_TO_CENTIDEGREES(attitude.values.yaw));
         
-                relativeWindHeading = (CENTIDEGREES_TO_DEGREES((int)relativeWindHeading));
-                while (relativeWindHeading < 0) {
-                    relativeWindHeading += 360;
-                }
-                while (relativeWindHeading >= 360) {
-                    relativeWindHeading -= 360;
-                }
+                while (relativeWindHeading < 0) relativeWindHeading += 360;
+                while (relativeWindHeading >= 360) relativeWindHeading -= 360;
                 
                 relativeWindHeading = -relativeWindHeading;
-                if (relativeWindHeading <= -180) {
+                if (relativeWindHeading <= -180)
                     relativeWindHeading = 180 + (relativeWindHeading + 180);
-                }
 
                 return relativeWindHeading;
             } else
                 return 0;
         }
 #else
-            return 0;
+        return 0;
 #endif
-            break;        
+        break;        
 
         case LOGIC_CONDITION_OPERAND_FLIGHT_ALTITUDE: // cm
             return constrain(getEstimatedActualPosition(Z), INT32_MIN, INT32_MAX);

--- a/src/main/programming/logic_condition.h
+++ b/src/main/programming/logic_condition.h
@@ -151,6 +151,7 @@ typedef enum {
     LOGIC_CONDITION_OPERAND_FLIGHT_MIN_GROUND_SPEED, // m/s                 // 46
     LOGIC_CONDITION_OPERAND_FLIGHT_HORIZONTAL_WIND_SPEED, // cm/s           // 47
     LOGIC_CONDITION_OPERAND_FLIGHT_WIND_DIRECTION, // deg                   // 48
+    LOGIC_CONDITION_OPERAND_FLIGHT_RELATIVE_WIND_OFFSET, // deg             // 49
 } logicFlightOperands_e;
 
 typedef enum {


### PR DESCRIPTION
### **User description**
- Correct the wind heading value. It was 180 degrees off and another 22 degrees clockwise.
- Added `Relative wind offset` which gives the relative difference in degrees between the wind heading and aircraft heading. 0 degrees is flying directly in to the headwind. -180 to 1 degree(s) signifies a counter-clockwise offset.

<img width="1796" height="950" alt="image" src="https://github.com/user-attachments/assets/180fd465-c741-4d12-9d3e-3110453728d2" />
For this test I had a 13.5knots (approx. 25km/h) wind speed at 550ft AMSL with a 225&deg; heading (south westerly). The altitude reads 0 due to many reboots of the FC during the flight. After each reboot, I loitered until the wind speed was estimated around 25km/h. I realise that the wind direction arrow from my IPF is 180 degrees out.

<br> <br>
Requires Configurator https://github.com/iNavFlight/inav-configurator/pull/2426

___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Corrected wind heading calculation by adding 18000 centidegrees offset

- Removed incorrect 22-degree clockwise adjustment from wind heading

- Added new Relative Wind Offset operand for aircraft-to-wind heading comparison

- Updated documentation with new operand definition and behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Wind Heading Calculation"] -->|"Add 18000 centidegrees"| B["Corrected Wind Heading"]
  B -->|"Remove 22° adjustment"| C["Accurate Wind Direction"]
  D["Aircraft Heading"] -->|"Compare with Wind"| E["Relative Wind Offset"]
  C -->|"0° = headwind"| E
  E -->|"Negative = left offset"| F["Navigation Logic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logic_condition.c</strong><dd><code>Wind heading fix and relative wind offset implementation</code>&nbsp; </dd></summary>
<hr>

src/main/programming/logic_condition.c

<ul><li>Fixed wind heading calculation by adding 18000 centidegrees offset <br>instead of using incorrect 22-degree adjustment<br> <li> Renamed variable from <code>windAngle</code> to <code>windHeading</code> for clarity<br> <li> Implemented new <code>LOGIC_CONDITION_OPERAND_FLIGHT_RELATIVE_WIND_OFFSET</code> <br>case with relative wind offset calculation<br> <li> Relative wind offset compares aircraft heading to wind heading with <br>proper angle normalization</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11109/files#diff-47a2668ce75470ac664bc0f0f7490fd3d314c73a30f83fd226f08aaccb934245">+41/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logic_condition.h</strong><dd><code>Add relative wind offset operand enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/programming/logic_condition.h

<ul><li>Added new enum value <br><code>LOGIC_CONDITION_OPERAND_FLIGHT_RELATIVE_WIND_OFFSET</code> with operand ID 49<br> <li> Maintains sequential operand numbering for logic condition framework</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11109/files#diff-eab7383dd5c6d629517e2d328ff572eb52a109effdf690142f3178aa5bc2f43a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Programming Framework.md</strong><dd><code>Document relative wind offset operand</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Programming Framework.md

<ul><li>Added documentation for operand 49 (Relative Wind Offset) with <br>detailed description<br> <li> Clarified behavior: 0° indicates flying directly into headwind, <br>negative values indicate left offset<br> <li> Documented fallback behavior when wind estimator is unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11109/files#diff-7b69fa6d46e9d8f3d59e6de2ce28fb7421dc947b6e5c495bebee5f8e5d7f70ce">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

