### PR TITLE
Update cygwin ci script for the sitl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build firmware
 # Don't enable CI on push, just on PR. If you
 # are working on the main repo and want to trigger
 # a CI build submit a draft PR.
-on: 
+on:
   push:
     branches:
       - '!maintenance-8.x.x'
@@ -231,7 +231,7 @@ jobs:
       - name: Setup Cygwin
         uses: egor-tensin/setup-cygwin@v4
         with:
-          packages: cmake ruby ninja gcc-g++
+          packages: cmake ruby ninja gcc-g++ rubygems
       - name: Setup environment
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -248,9 +248,9 @@ jobs:
           VERSION=$( grep project CMakeLists.txt|awk -F VERSION '{ gsub(/[ \t)]/, "", $2); print $2 }' )
           echo "BUILD_SUFFIX=${BUILD_SUFFIX}" >> $GITHUB_ENV
           echo "BUILD_NAME=inav-${VERSION}-${BUILD_SUFFIX}" >> $GITHUB_ENV
-          
+
       - name: Build SITL
-        run: mkdir -p build_SITL && cd build_SITL && cmake -DSITL=ON -DWARNINGS_AS_ERRORS=ON -G Ninja .. && ninja -j4
+        run: gem install getoptlong && mkdir -p build_SITL && cd build_SITL && cmake -DSITL=ON -DWARNINGS_AS_ERRORS=ON -G Ninja .. && ninja -j4
       - name: Strip version number
         run: |
           for f in ./build_SITL/*_SITL.exe; do


### PR DESCRIPTION
### **User description**
The Cygwin package for ruby no longer appears to automatically install `rubygems` and the `getoptlong` gem, causing CI to fail to build the Windows SITL.

This PR attempts to rectify that by manually installed the required components.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `rubygems` package to Cygwin CI setup

- Install `getoptlong` gem before SITL build

- Fix whitespace formatting in workflow file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cygwin Setup"] -->|Add rubygems package| B["Package Installation"]
  B --> C["Build SITL"]
  C -->|Install getoptlong gem| D["Successful Build"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add Ruby dependencies to Cygwin CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Added <code>rubygems</code> to the Cygwin packages list in setup-cygwin action<br> <li> Added <code>gem install getoptlong</code> command before SITL build step<br> <li> Fixed trailing whitespace on empty lines for code formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11111/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

