### PR TITLE
battery control profile off by 1

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -248,7 +248,7 @@ void setBatteryProfile(uint8_t profileIndex)
         profileIndex = 0;
     }
     currentBatteryProfile = batteryProfiles(profileIndex);
-    if ((currentBatteryProfile->controlRateProfile > 0) && (currentBatteryProfile->controlRateProfile < MAX_CONTROL_RATE_PROFILE_COUNT)) {
+    if ((currentBatteryProfile->controlRateProfile > 0) && (currentBatteryProfile->controlRateProfile <= MAX_CONTROL_RATE_PROFILE_COUNT)) {
         setConfigProfile(currentBatteryProfile->controlRateProfile - 1);
     }
 }


### PR DESCRIPTION
### **User description**
Because line 252 subtracts one, line 251 should be less than or equal, rather than just less than. It becomes less than after the subtraction.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix off-by-one error in battery control profile validation

- Change comparison operator from `<` to `<=` for correct bounds checking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["controlRateProfile value"] -- "validate bounds" --> B["Old: < MAX_CONTROL_RATE_PROFILE_COUNT"]
  A -- "validate bounds" --> C["New: <= MAX_CONTROL_RATE_PROFILE_COUNT"]
  B -- "excludes valid index" --> D["Bug: misses last profile"]
  C -- "includes all valid indices" --> E["Fixed: correct validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>battery.c</strong><dd><code>Fix battery profile index bounds validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/sensors/battery.c

<ul><li>Fixed off-by-one error in <code>setBatteryProfile()</code> function<br> <li> Changed comparison operator from <code><</code> to <code><=</code> on line 251<br> <li> Ensures <code>controlRateProfile</code> index validation includes the maximum valid <br>profile index<br> <li> Aligns with the subsequent subtraction operation that uses <br><code>controlRateProfile - 1</code></ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11118/files#diff-2e4881de94a1ebb53cabe60c1ffa860fba9ff29651752095cd144ed1db4a3da4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

