### PR TITLE
NEXUSX use dmar

### DIFF
--- a/src/main/target/NEXUSX/target.h
+++ b/src/main/target/NEXUSX/target.h
@@ -88,11 +88,6 @@
 #define UART2_TX_PIN            PA2 // pin labelled as "RPM"
 #define UART2_RX_PIN            PA3 // pin labelled as "TLM"
 
-#define USE_UART3
-// port labelled "C"
-#define UART3_TX_PIN            PB10
-#define UART3_RX_PIN            PB11
-
 #define USE_UART4
 // port labelled "A"
 #define UART4_TX_PIN            PA0
@@ -108,7 +103,7 @@
 #define UART6_TX_PIN            PC6
 #define UART6_RX_PIN            PC7
 
-#define SERIAL_PORT_COUNT       7
+#define SERIAL_PORT_COUNT       6
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_CRSF
@@ -152,3 +147,7 @@
 #define USE_SERIALSHOT
 #define USE_ESC_SENSOR
 #define USE_SMARTPORT_MASTER // no internal current sensor, enable SMARTPORT_MASTER so external ones can be used
+
+#define USE_DSHOT_DMAR
+#define TARGET_MOTOR_COUNT      7
+

--- a/src/main/target/NEXUSX/target.h
+++ b/src/main/target/NEXUSX/target.h
@@ -88,6 +88,11 @@
 #define UART2_TX_PIN            PA2 // pin labelled as "RPM"
 #define UART2_RX_PIN            PA3 // pin labelled as "TLM"
 
+-#define USE_UART3
+-// port labelled "C"
+-#define UART3_TX_PIN            PB10
+-#define UART3_RX_PIN            PB11
+
 #define USE_UART4
 // port labelled "A"
 #define UART4_TX_PIN            PA0
@@ -103,7 +108,7 @@
 #define UART6_TX_PIN            PC6
 #define UART6_RX_PIN            PC7
 
-#define SERIAL_PORT_COUNT       6
+#define SERIAL_PORT_COUNT       7
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_CRSF

--- a/src/main/target/NEXUSX/target.h
+++ b/src/main/target/NEXUSX/target.h
@@ -88,10 +88,10 @@
 #define UART2_TX_PIN            PA2 // pin labelled as "RPM"
 #define UART2_RX_PIN            PA3 // pin labelled as "TLM"
 
--#define USE_UART3
--// port labelled "C"
--#define UART3_TX_PIN            PB10
--#define UART3_RX_PIN            PB11
+#define USE_UART3
+// port labelled "C"
+#define UART3_TX_PIN            PB10
+#define UART3_RX_PIN            PB11
 
 #define USE_UART4
 // port labelled "A"


### PR DESCRIPTION
### **User description**
A couple minor changes to the NEXUS target based on my testing.

In https://github.com/iNavFlight/inav/pull/11082#issuecomment-3476445405
@functionpointer  pointed out that UART3 would only work for a receiver due to the initialization order. One of the two variants already has an onboard receiver on UART5.  Defining uart3 may therefore cause confusion more often than its helpful.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove UART3 configuration to prevent receiver confusion

- Update serial port count from 7 to 6

- Enable DMA support for DShot ESC protocol

- Set motor count to 7 for proper PWM configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UART3 Config"] -->|removed| B["6 Serial Ports"]
  C["DShot Protocol"] -->|enable DMA| D["USE_DSHOT_DMAR"]
  E["Motor Config"] -->|set count| F["TARGET_MOTOR_COUNT 7"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Remove UART3, enable DShot DMA, configure motors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/NEXUSX/target.h

<ul><li>Removed UART3 definition and pin configuration (PB10/PB11)<br> <li> Decreased SERIAL_PORT_COUNT from 7 to 6<br> <li> Added USE_DSHOT_DMAR flag for DMA-accelerated DShot<br> <li> Added TARGET_MOTOR_COUNT set to 7</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11120/files#diff-68db77ab2521a8e5f5a4b3aed5a8c2a94e9520310fb496af593a9b343caf5135">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

