### PR TITLE
Attempt to build MacOS STIL Intel binary via CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           name: ${{ env.BUILD_NAME }}_SITL-Linux
           path: ./build_SITL/*_SITL
 
-  build-SITL-Mac:
+  build-SITL-Mac-ARM64:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -218,7 +218,48 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.BUILD_NAME }}_SITL-MacOS
+          name: ${{ env.BUILD_NAME }}_SITL-MacOS-Arm64
+          path: ./build_SITL/*_SITL
+
+    build-SITL-Mac-Intel:
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          brew install ruby
+
+      - name: Setup environment
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+        run: |
+          # This is the hash of the commit for the PR
+          # when the action is triggered by PR, empty otherwise
+          COMMIT_ID=${{ github.event.pull_request.head.sha }}
+          # This is the hash of the commit when triggered by push
+          # but the hash of refs/pull/<n>/merge, which is different
+          # from the hash of the latest commit in the PR, that's
+          # why we try github.event.pull_request.head.sha first
+          COMMIT_ID=${COMMIT_ID:-${{ github.sha }}}
+          BUILD_SUFFIX=ci-$(date '+%Y%m%d')-$(git rev-parse --short ${COMMIT_ID})
+          VERSION=$(grep project CMakeLists.txt|awk -F VERSION '{ gsub(/[ \t)]/, "", $2); print $2 }')
+          echo "BUILD_SUFFIX=${BUILD_SUFFIX}" >> $GITHUB_ENV
+          echo "BUILD_NAME=inav-${VERSION}-${BUILD_SUFFIX}" >> $GITHUB_ENV
+          echo "NUM_CORES=$(grep processor /proc/cpuinfo  | wc -l)" >> $GITHUB_ENV
+      - name: Build SITL
+        run: |
+          mkdir -p build_SITL && cd build_SITL
+          cmake -DSITL=ON -DWARNINGS_AS_ERRORS=ON -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -G Ninja ..
+          ninja -j4
+      - name: Strip version number
+        run: |
+          for f in build_SITL/*_SITL; do
+            mv -v $f $(echo $f | sed -Ee 's/_[0-9]+\.[0-9]+\.[0-9]+//')
+          done
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_NAME }}_SITL-MacOS-Intel
           path: ./build_SITL/*_SITL
 
   build-SITL-Windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           name: ${{ env.BUILD_NAME }}_SITL-MacOS-Arm64
           path: ./build_SITL/*_SITL
 
-    build-SITL-Mac-Intel:
+  build-SITL-Mac-Intel:
     runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -59,11 +59,17 @@ jobs:
           path: resources/sitl/windows
           pattern: inav-*SITL-WIN
           merge-multiple: true
-      - name: download sitl mac
+      - name: download sitl mac arm64
         uses: actions/download-artifact@v4
         with:
-          path: resources/sitl/macos
-          pattern: inav-*SITL-MacOS
+          path: resources/sitl/macos/arm64
+          pattern: inav-*SITL-MacOS-Arm64
+          merge-multiple: true
+      - name: download sitl mac intel
+        uses: actions/download-artifact@v4
+        with:
+          path: resources/sitl/macos/intel
+          pattern: inav-*SITL-MacOS-Intel
           merge-multiple: true
       - name: Consolidate sitl files
         run: |


### PR DESCRIPTION
### **PR Type**
Enhancement

We ship and build the Configurator for Intel Macs, but no SITL binary.

___

### **Description**
- Add Intel Mac SITL build job to CI workflow

- Rename existing ARM64 Mac job for clarity

- Update nightly build to handle separate ARM64 and Intel artifacts

- Organize macOS SITL binaries by architecture in resources


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CI["CI Workflow"] -->|build-SITL-Mac-ARM64| ARM64["ARM64 Binary"]
  CI -->|build-SITL-Mac-Intel| Intel["Intel Binary"]
  ARM64 -->|upload| ARM64_Artifact["SITL-MacOS-Arm64"]
  Intel -->|upload| Intel_Artifact["SITL-MacOS-Intel"]
  ARM64_Artifact -->|nightly| ARM64_Path["resources/sitl/macos/arm64"]
  Intel_Artifact -->|nightly| Intel_Path["resources/sitl/macos/intel"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add Intel Mac SITL build job to CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Rename <code>build-SITL-Mac</code> job to <code>build-SITL-Mac-ARM64</code> for clarity<br> <li> Add new <code>build-SITL-Mac-Intel</code> job running on <code>macos-15-intel</code> runner<br> <li> Update artifact names to distinguish between ARM64 and Intel builds<br> <li> Intel job builds universal binary with both architectures via CMake</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11125/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+43/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nightly-build.yml</strong><dd><code>Separate macOS artifact handling by architecture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/nightly-build.yml

<ul><li>Rename macOS artifact download step to specify ARM64 architecture<br> <li> Add separate download step for Intel macOS artifacts<br> <li> Update download paths to organize binaries by architecture <br>subdirectories<br> <li> Update artifact patterns to match new naming convention</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11125/files#diff-2ee59052448a421cff47b6ee98f786b57f3012d9f9132d37b9bde685a6266166">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

