### PR TITLE
NEXUSX: fix UART3/I2C2 resource conflict

### DIFF
--- a/src/main/target/NEXUSX/target.h
+++ b/src/main/target/NEXUSX/target.h
@@ -79,11 +79,9 @@
 // *************** UART *****************************
 #define USE_VCP
 
-#ifdef NEXUSX
 #define USE_UART1 // clashes with I2C1
 #define UART1_TX_PIN            PB6 // pin labelled "AUX"
 #define UART1_RX_PIN            PB7 // pin labelled "SBUS"
-#endif
 
 #define USE_UART2
 #define UART2_TX_PIN            PA2 // pin labelled as "RPM"

--- a/src/main/target/NEXUSX/target.h
+++ b/src/main/target/NEXUSX/target.h
@@ -50,6 +50,7 @@
 #define USE_I2C_DEVICE_2 // clashes with UART3
 #define I2C2_SCL                PB10
 #define I2C2_SDA                PB11
+#define I2C_DEVICE_2_SHARES_UART3
 #define DEFAULT_I2C BUS_I2C2
 
 #define USE_BARO


### PR DESCRIPTION
### **User description**
Fixes resource conflict discussed in https://github.com/iNavFlight/inav/pull/11120 and https://github.com/iNavFlight/inav/pull/11082#issuecomment-3476445405

The "C" port exposes pins PB10 and PB11, which can be used for UART3 and I2C2. Previously, an initialization order quirk caused UART3 to only be usable for serial rx. For other functions such as GPS the pins would be initialized as I2C2.

This PR adds the `#define I2C_DEVICE_2_SHARES_UART3` directive to `target.h`, which enables deconflicting logic in `fc_init.c`.

Using the resource command, i have tested:
- When UART3 is unused in ports tab, PB10 and PB11 are initialized as I2C2
- When UART3 is set as serial rx, PB10 and PB11 are set to UART3
- When UART3 is set as GPS, PB10 and PB11 are set to UART3

I have also attached a physical GPS module to UART3 and it works.

With this PR, UART3 can now be used without any limitations


___

### **PR Type**
Bug fix


___

### **Description**
- Add `I2C_DEVICE_2_SHARES_UART3` directive to enable resource conflict resolution

- Remove redundant `NEXUSX` preprocessor check around UART1 definition

- Allows UART3 to be fully functional for GPS and other applications


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["I2C2 and UART3<br/>share PB10/PB11"] -->|"Add I2C_DEVICE_2_SHARES_UART3"| B["Deconflicting logic<br/>in fc_init.c"]
  B -->|"Resolves conflict"| C["UART3 fully functional<br/>for GPS/Serial"]
  D["Redundant NEXUSX<br/>preprocessor check"] -->|"Remove"| E["Cleaner target.h<br/>configuration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Add I2C/UART3 conflict resolution and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/NEXUSX/target.h

<ul><li>Added <code>I2C_DEVICE_2_SHARES_UART3</code> define to enable resource conflict <br>resolution logic<br> <li> Removed redundant <code>#ifdef NEXUSX</code> and <code>#endif</code> preprocessor directives <br>around UART1 definition<br> <li> Maintains I2C2 configuration on pins PB10/PB11 with proper conflict <br>handling</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11127/files#diff-68db77ab2521a8e5f5a4b3aed5a8c2a94e9520310fb496af593a9b343caf5135">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

