### PR TITLE
NEXUSX: USE_DSHOT_DMAR, use TIM2 instead of TIM5

### DIFF
--- a/src/main/target/NEXUSX/config.c
+++ b/src/main/target/NEXUSX/config.c
@@ -36,4 +36,7 @@
 void targetConfiguration(void)
 {
   pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+
+  // default "ESC" pin to be a motor
+  timerOverridesMutable(timer2id(TIM1))->outputMode = OUTPUT_MODE_MOTORS;
 }

--- a/src/main/target/NEXUSX/target.c
+++ b/src/main/target/NEXUSX/target.c
@@ -33,8 +33,8 @@ timerHardware_t timerHardware[] = {
 
     DEF_TIM(TIM1, CH2, PA9,   TIM_USE_OUTPUT_AUTO, 0, 0),   // labelled "ESC"
 
-    DEF_TIM(TIM5, CH3, PA2,   TIM_USE_OUTPUT_AUTO, 0, 0),   // labelled "RPM", clashes with UART2 TX
-    DEF_TIM(TIM5, CH4, PA3,   TIM_USE_OUTPUT_AUTO, 0, 0),   // labelled "TLM", clashes with UART2 RX
+    DEF_TIM(TIM2, CH3, PA2,   TIM_USE_OUTPUT_AUTO, 0, 0),   // labelled "RPM", clashes with UART2 TX
+    DEF_TIM(TIM2, CH4, PA3,   TIM_USE_OUTPUT_AUTO, 0, 0),   // labelled "TLM", clashes with UART2 RX
 
     DEF_TIM(TIM4, CH1, PB6,   TIM_USE_OUTPUT_AUTO, 0, 0),   // labelled "AUX", clashes with UART1 TX and I2C1 SCL
     DEF_TIM(TIM4, CH2, PB7,   TIM_USE_OUTPUT_AUTO, 0, 0),   // labelled "SBUS", clashes with UART1 RX and I2C1 SDA

--- a/src/main/target/NEXUSX/target.h
+++ b/src/main/target/NEXUSX/target.h
@@ -151,3 +151,5 @@
 #define USE_SERIALSHOT
 #define USE_ESC_SENSOR
 #define USE_SMARTPORT_MASTER // no internal current sensor, enable SMARTPORT_MASTER so external ones can be used
+
+#define USE_DSHOT_DMAR


### PR DESCRIPTION
### **User description**
Activate `USE_DSHOT_DMAR` for target NEXUSX.

Also move pins labelled "RPM" and "TLM" (PA2 and PA3) to timer2 instead of timer5.
This lifts the previous limitation of 7 motor outputs. Apparently, DSHOT_DMAR can only handle 4 timers for motors.

The move causes the pin labelled "TAIL" to be on the same timer as "RPM" and "TLM", removing a small amount of flexibility.
However, it is still possible to have 0, 1, 2, 3, 4, 5, 6, 7, 8 and 9 motors without wasting a pin to timer limitations if the user selects clever timer assignments in the mixer tab.

Furthermore, this PR sets TIM1 as MOTOR by default, which is mapped to the "ESC" pin.
This creates sane defaults for platforms with 1 and 4 motors without user intervention.

This PR is the result of investigation of changes proposed in https://github.com/iNavFlight/inav/pull/11120

I have tested:
- MULTISHOT with 7, 8 and 9 motor outputs using oscilloscope
- DSHOT600 with 7, 8 and 9 motor outputs using oscilloscope
- Servo outputs on remaining pins
- Default mixer assignments for quadcopter and plane with tail


___

### **PR Type**
Enhancement


___

### **Description**
- Enable DSHOT_DMAR support for NEXUSX target

- Reassign RPM and TLM pins from TIM5 to TIM2

- Increases motor output limit from 7 to 9

- Set TIM1 as default motor output for sane defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DSHOT_DMAR enabled"] --> B["Max 4 timers supported"]
  B --> C["Reassign TIM5 to TIM2"]
  C --> D["Motor limit: 7 → 9"]
  E["TIM1 default motor"] --> F["Sane defaults for 1/4 motors"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Enable DSHOT_DMAR feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/NEXUSX/target.h

<ul><li>Added <code>USE_DSHOT_DMAR</code> define to enable DSHOT DMA support<br> <li> Activates hardware DMA capability for improved DSHOT performance</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11129/files#diff-68db77ab2521a8e5f5a4b3aed5a8c2a94e9520310fb496af593a9b343caf5135">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.c</strong><dd><code>Reassign RPM and TLM pins to TIM2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/NEXUSX/target.c

<ul><li>Migrated RPM pin (PA2) from TIM5 CH3 to TIM2 CH3<br> <li> Migrated TLM pin (PA3) from TIM5 CH4 to TIM2 CH4<br> <li> Consolidates timer usage to support DSHOT_DMAR limitation of 4 timers <br>max</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11129/files#diff-3fac237af9a044802dc89eaef541282a1740b17a4bbd677fe95f0d58271ada0a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.c</strong><dd><code>Configure TIM1 as default motor output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/NEXUSX/config.c

<ul><li>Set TIM1 (ESC pin) as default motor output mode<br> <li> Provides sensible defaults for single and quadcopter configurations<br> <li> Eliminates need for manual timer assignment in common use cases</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11129/files#diff-2c3fa351d8a76b8587d115c7c7c0d01663ce297c699edbe0c636403a50b5f460">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

