### PR TITLE
Refactor CRSF and SmartPort telemetry

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -592,6 +592,36 @@ Blackbox logging rate numerator. Use num/denom settings to decide if a frame sho
 
 ---
 
+### crsf_telemetry_link_rate
+
+CRSF telemetry link rate
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 250 | 0 | 50000 |
+
+---
+
+### crsf_telemetry_link_ratio
+
+CRSF telemetry link ratio
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 8 | 0 | 50000 |
+
+---
+
+### crsf_telemetry_mode
+
+Use extended custom or native telemetry sensors for CRSF
+
+| Default | Min | Max |
+| --- | --- | --- |
+| NATIVE |  |  |
+
+---
+
 ### cruise_power
 
 Power draw at cruise throttle used for remaining flight time/distance estimation in 0.01W unit
@@ -1195,16 +1225,6 @@ The tilt angle of the FPV camera in degrees, used by the FPV ANGLE MIX mode
 ### frsky_pitch_roll
 
 S.Port telemetry: Send pitch and roll degrees*10 instead of raw accelerometer data
-
-| Default | Min | Max |
-| --- | --- | --- |
-| OFF | OFF | ON |
-
----
-
-### frsky_use_legacy_gps_mode_sensor_ids
-
-S.Port telemetry: If `ON`, send the legacy telemetry IDs for modes (Tmp1) and GNSS (Tmp2). These are old IDs, deprecated, and will be removed in INAV 10.0. Tools and scripts using these IDs should be updated to use the new IDs of **470** for Modes and **480** for GNSS. Default: 'OFF'
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -6209,6 +6229,16 @@ _// TODO_
 | Default | Min | Max |
 | --- | --- | --- |
 | OFF | OFF | ON |
+
+---
+
+### smartport_telemetry_mode
+
+Use legacy or standard telemetry sensors for SmartPort
+
+| Default | Min | Max |
+| --- | --- | --- |
+| LEGACY |  |  |
 
 ---
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -612,16 +612,6 @@ CRSF telemetry link ratio
 
 ---
 
-### crsf_telemetry_mode
-
-Use extended custom or native telemetry sensors for CRSF
-
-| Default | Min | Max |
-| --- | --- | --- |
-| NATIVE |  |  |
-
----
-
 ### cruise_power
 
 Power draw at cruise throttle used for remaining flight time/distance estimation in 0.01W unit
@@ -6232,16 +6222,6 @@ _// TODO_
 
 ---
 
-### smartport_telemetry_mode
-
-Use legacy or standard telemetry sensors for SmartPort
-
-| Default | Min | Max |
-| --- | --- | --- |
-| LEGACY |  |  |
-
----
-
 ### smith_predictor_delay
 
 Expected delay of the gyro signal. In milliseconds
@@ -6389,6 +6369,16 @@ Determines if the telemetry protocol default signal inversion is reversed. This 
 | Default | Min | Max |
 | --- | --- | --- |
 | OFF | OFF | ON |
+
+---
+
+### telemetry_mode
+
+Use extended custom or native telemetry sensors for CRSF or SmartPort
+
+| Default | Min | Max |
+| --- | --- | --- |
+| LEGACY |  |  |
 
 ---
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -626,6 +626,10 @@ main_sources(COMMON_SRC
     telemetry/sim.h
     telemetry/telemetry.c
     telemetry/telemetry.h
+    telemetry/sensors.c
+    telemetry/sensors.h
+    telemetry/smartport_legacy.c
+    telemetry/smartport_legacy.h
 )
 
 add_subdirectory(target)

--- a/src/main/common/crc.c
+++ b/src/main/common/crc.c
@@ -143,3 +143,17 @@ uint8_t crc8_sum_update(uint8_t crc, const void *data, uint32_t length)
     }
     return crc;
 }
+
+// Fowler–Noll–Vo hash function; see https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function
+uint32_t fnv_update(uint32_t hash, const void *data, uint32_t length)
+{
+    const uint8_t *ptr = data;
+    const uint8_t *pend = ptr + length;
+
+    while (ptr != pend) {
+        hash *= FNV_PRIME;
+        hash ^= *ptr++;
+    }
+
+    return hash;
+}

--- a/src/main/common/crc.h
+++ b/src/main/common/crc.h
@@ -19,6 +19,8 @@
 
 #include <stdint.h>
 
+#define FNV_PRIME           16777619
+
 struct sbuf_s;
 
 uint16_t crc16_ccitt(uint16_t crc, unsigned char a);
@@ -36,3 +38,6 @@ uint8_t crc8(uint8_t crc, uint8_t a);
 uint8_t crc8_update(uint8_t crc, const void *data, uint32_t length);
 
 uint8_t crc8_sum_update(uint8_t crc, const void *data, uint32_t length);
+
+uint32_t fnv_update(uint32_t hash, const void *data, uint32_t length);
+

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -203,6 +203,13 @@ static void updateArmingStatus(void)
     if (ARMING_FLAG(ARMED)) {
         LED0_ON;
     } else {
+
+        // Check if the power on arming grace time has elapsed
+        if ((isArmingDisabledReason() & ARMING_DISABLED_BOOT_GRACE_TIME)  && (millis() >= 3000)) {
+            // If so, unset the grace time arming disable flag
+            DISABLE_ARMING_FLAG(ARMING_DISABLED_BOOT_GRACE_TIME);
+        }
+
         /* CHECK: Run-time calibration */
         static bool calibratingFinishedBeep = false;
         if (areSensorsCalibrating()) {

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -611,6 +611,8 @@ void init(void)
     }
 #endif
 
+    ENABLE_ARMING_FLAG(ARMING_DISABLED_BOOT_GRACE_TIME);
+
 #ifdef USE_BLACKBOX
 
     //Do not allow blackbox to be run faster that 1kHz. It can cause UAV to drop dead when digital ESC protocol is used

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -58,7 +58,8 @@ const armingFlag_e armDisableReasonsChecklist[] = {
     ARMING_DISABLED_SERVO_AUTOTRIM,
     ARMING_DISABLED_OOM,
     ARMING_DISABLED_NO_PREARM,
-    ARMING_DISABLED_DSHOT_BEEPER
+    ARMING_DISABLED_DSHOT_BEEPER,
+    ARMING_DISABLED_BOOT_GRACE_TIME
 };
 
 armingFlag_e isArmingDisabledReason(void)

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -48,6 +48,7 @@ typedef enum {
     ARMING_DISABLED_NO_PREARM                       = (1 << 28),
     ARMING_DISABLED_DSHOT_BEEPER                    = (1 << 29),
     ARMING_DISABLED_LANDING_DETECTED                = (1 << 30),
+    ARMING_DISABLED_BOOT_GRACE_TIME                 = (1 << 31),
 
     ARMING_DISABLED_ALL_FLAGS                       = (ARMING_DISABLED_GEOZONE | ARMING_DISABLED_FAILSAFE_SYSTEM | ARMING_DISABLED_NOT_LEVEL | 
                                                        ARMING_DISABLED_SENSORS_CALIBRATING | ARMING_DISABLED_SYSTEM_OVERLOADED | ARMING_DISABLED_NAVIGATION_UNSAFE |
@@ -57,7 +58,7 @@ typedef enum {
                                                        ARMING_DISABLED_CMS_MENU | ARMING_DISABLED_OSD_MENU | ARMING_DISABLED_ROLLPITCH_NOT_CENTERED |
                                                        ARMING_DISABLED_SERVO_AUTOTRIM | ARMING_DISABLED_OOM | ARMING_DISABLED_INVALID_SETTING |
                                                        ARMING_DISABLED_PWM_OUTPUT_ERROR | ARMING_DISABLED_NO_PREARM | ARMING_DISABLED_DSHOT_BEEPER |
-                                                       ARMING_DISABLED_LANDING_DETECTED),
+                                                       ARMING_DISABLED_LANDING_DETECTED | ARMING_DISABLED_BOOT_GRACE_TIME),
 } armingFlag_e;
 
 // Arming blockers that can be overriden by emergency arming.
@@ -71,7 +72,9 @@ typedef enum {
                                             | ARMING_DISABLED_COMPASS_NOT_CALIBRATED \
                                             | ARMING_DISABLED_ACCELEROMETER_NOT_CALIBRATED \
                                             | ARMING_DISABLED_ARM_SWITCH \
-                                            | ARMING_DISABLED_HARDWARE_FAILURE)
+                                            | ARMING_DISABLED_HARDWARE_FAILURE  \
+                                            | ARMING_DISABLED_BOOT_GRACE_TIME  \
+                                            )
 
 
 extern uint32_t armingFlags;

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -103,12 +103,9 @@ tables:
   - name: bat_voltage_source
     values: ["RAW", "SAG_COMP"]
     enum: batVoltageSource_e
-  - name: crsf_telemetry_modes
-    values: [ "OFF", "NATIVE", "CUSTOM" ]
-    enum: crsfTelemetryMode_e
-  - name: smartport_telemetry_modes
-    values: [ "LEGACY", "STANDARD" ]
-    enum: smartportTelemetryMode_e
+  - name: telemetry_modes
+    values: [ "LEGACY", "CUSTOM" ]
+    enum: telemetryMode_e
   - name: smartport_fuel_unit
     values: ["PERCENT", "MAH", "MWH"]
     enum: smartportFuelUnit_e
@@ -3136,17 +3133,11 @@ groups:
         description: "S.Port telemetry: Send pitch and roll degrees*10 instead of raw accelerometer data"
         default_value: OFF
         type: bool
-      - name: crsf_telemetry_mode
-        description: "Use extended custom or native telemetry sensors for CRSF"
-        default_value: NATIVE
-        condition: USE_CUSTOM_TELEMETRY
-        table: crsf_telemetry_modes
-        type: uint8_t
-      - name: smartport_telemetry_mode
-        description: "Use legacy or standard telemetry sensors for SmartPort"
+      - name: telemetry_mode
+        description: "Use extended custom or native telemetry sensors for CRSF or SmartPort"
         default_value: LEGACY
         condition: USE_CUSTOM_TELEMETRY
-        table: smartport_telemetry_modes
+        table: telemetry_modes
         type: uint8_t
       - name: crsf_telemetry_link_rate
         description: "CRSF telemetry link rate"

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -103,6 +103,12 @@ tables:
   - name: bat_voltage_source
     values: ["RAW", "SAG_COMP"]
     enum: batVoltageSource_e
+  - name: crsf_telemetry_modes
+    values: [ "OFF", "NATIVE", "CUSTOM" ]
+    enum: crsfTelemetryMode_e
+  - name: smartport_telemetry_modes
+    values: [ "LEGACY", "STANDARD" ]
+    enum: smartportTelemetryMode_e
   - name: smartport_fuel_unit
     values: ["PERCENT", "MAH", "MWH"]
     enum: smartportFuelUnit_e
@@ -3130,10 +3136,32 @@ groups:
         description: "S.Port telemetry: Send pitch and roll degrees*10 instead of raw accelerometer data"
         default_value: OFF
         type: bool
-      - name: frsky_use_legacy_gps_mode_sensor_ids
-        description: "S.Port telemetry: If `ON`, send the legacy telemetry IDs for modes (Tmp1) and GNSS (Tmp2). These are old IDs, deprecated, and will be removed in INAV 10.0. Tools and scripts using these IDs should be updated to use the new IDs of **470** for Modes and **480** for GNSS. Default: 'OFF'"
-        default_value: OFF
-        type: bool
+      - name: crsf_telemetry_mode
+        description: "Use extended custom or native telemetry sensors for CRSF"
+        default_value: NATIVE
+        condition: USE_CUSTOM_TELEMETRY
+        table: crsf_telemetry_modes
+        type: uint8_t
+      - name: smartport_telemetry_mode
+        description: "Use legacy or standard telemetry sensors for SmartPort"
+        default_value: LEGACY
+        condition: USE_CUSTOM_TELEMETRY
+        table: smartport_telemetry_modes
+        type: uint8_t
+      - name: crsf_telemetry_link_rate
+        description: "CRSF telemetry link rate"
+        condition: USE_TELEMETRY_CRSF
+        default_value: 250
+        type: uint16_t
+        min: 0
+        max: 50000
+      - name: crsf_telemetry_link_ratio
+        description: "CRSF telemetry link ratio"
+        default_value: 8
+        condition: USE_TELEMETRY_CRSF
+        type: uint16_t
+        min: 0
+        max: 50000
       - name: report_cell_voltage
         description: "S.Port and IBUS telemetry: Send the average cell voltage if set to ON"
         default_value: OFF

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -966,6 +966,8 @@ static const char * osdArmingDisabledReasonMessage(void)
             // Cases without message
         case ARMING_DISABLED_LANDING_DETECTED:
             FALLTHROUGH;
+        case ARMING_DISABLED_BOOT_GRACE_TIME:
+            FALLTHROUGH;
         case ARMING_DISABLED_CMS_MENU:
             FALLTHROUGH;
         case ARMING_DISABLED_OSD_MENU:

--- a/src/main/io/osd_dji_hd.c
+++ b/src/main/io/osd_dji_hd.c
@@ -520,6 +520,8 @@ static char * osdArmingDisabledReasonMessage(void)
             // Cases without message
         case ARMING_DISABLED_GEOZONE:
             return OSD_MESSAGE_STR("NO FLY ZONE");
+        case ARMING_DISABLED_BOOT_GRACE_TIME:
+            FALLTHROUGH;
         case ARMING_DISABLED_LANDING_DETECTED:
             FALLTHROUGH;
         case ARMING_DISABLED_CMS_MENU:

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -59,7 +59,7 @@
 #define MSP_PROTOCOL_VERSION                0   // Same version over MSPv1 & MSPv2 - message format didn't change and it backward compatible
 
 #define API_VERSION_MAJOR                   2   // increment when major changes are made
-#define API_VERSION_MINOR                   5   // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   6   // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 

--- a/src/main/msp/msp_protocol_v2_inav.h
+++ b/src/main/msp/msp_protocol_v2_inav.h
@@ -126,3 +126,8 @@
 #define MSP2_INAV_SET_GVAR                      0x2214
 
 #define MSP2_INAV_FULL_LOCAL_POSE               0x2220
+
+
+#define MSP2_INAV_TELEMETRY_SENSORS             0x222A
+#define MSP2_INAV_SET_TELEMETRY_SENSORS         0x222B
+#define MSP2_INAV_SET_TELEMETRY_SENSOR          0x222C

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -32,7 +32,6 @@
 
 #include "drivers/time.h"
 #include "drivers/serial.h"
-#include "drivers/serial_uart.h"
 
 #include "io/serial.h"
 #include "io/osd.h"
@@ -184,6 +183,10 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *rxCallbackData)
                             }
                             break;
                         }
+
+                        case CRSF_FRAMETYPE_DEVICE_PING:
+                            crsfScheduleDeviceInfoResponse();
+                            break;
 #endif
                         default:
                             break;

--- a/src/main/rx/crsf.h
+++ b/src/main/rx/crsf.h
@@ -88,6 +88,7 @@ typedef enum {
     CRSF_FRAMETYPE_VARIO_SENSOR = 0x07,
     CRSF_FRAMETYPE_BATTERY_SENSOR = 0x08,
     CRSF_FRAMETYPE_BAROMETER_ALTITUDE = 0x09,
+    CRSF_FRAMETYPE_HEARTBEAT = 0x0B,
     CRSF_FRAMETYPE_LINK_STATISTICS = 0x14,
     CRSF_FRAMETYPE_RC_CHANNELS_PACKED = 0x16,
     CRSF_FRAMETYPE_ATTITUDE = 0x1E,
@@ -104,6 +105,7 @@ typedef enum {
     CRSF_FRAMETYPE_MSP_RESP = 0x7B,  // reply with 58 byte chunked binary
     CRSF_FRAMETYPE_MSP_WRITE = 0x7C,  // write with 8 byte chunked binary (OpenTX outbound telemetry buffer limit)
     CRSF_FRAMETYPE_DISPLAYPORT_CMD = 0x7D, // displayport control command
+    CRSF_FRAMETYPE_CUSTOM_TELEM = 0x88, // custom telemetry
 } crsfFrameType_e;
 
 enum {

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -153,6 +153,11 @@
 #define USE_TELEMETRY_SMARTPORT
 #define USE_TELEMETRY_CRSF
 #define USE_TELEMETRY_JETIEXBUS
+
+#if defined(USE_TELEMETRY_SMARTPORT) || defined(USE_TELEMETRY_CRSF)
+#define USE_CUSTOM_TELEMETRY
+#endif
+
 // These are rather exotic serial protocols
 #define USE_RX_MSP
 #define USE_MSP_RC_OVERRIDE
@@ -222,6 +227,8 @@
     #define SKIP_CLI_COMMAND_HELP
     #undef USE_SERIALRX_SPEKTRUM
     #undef USE_TELEMETRY_SRXL
+    #undef USE_CUSTOM_TELEMETRY
+    #undef USE_ADSB
 #endif
 
 #define USE_EZ_TUNE

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -302,8 +302,7 @@ void crsfSensorEncodeEscRpm(telemetrySensor_t *sensor, sbuf_t *buf)
     }
 }
 
-void crsfSensorEncodeEscTemp(telemetrySensor_t *sensor, sbuf_t *buf)
-{
+void crsfSensorEncodeEscTemp(telemetrySensor_t *sensor, sbuf_t *buf) {
     UNUSED(sensor);
     uint8_t motorCount = MAX(getMotorCount(), 1); //must send at least one motor, to avoid CRSF frame shifting
     motorCount = MIN(getMotorCount(), CRSF_PAYLOAD_SIZE_MAX / 3); // 3 bytes per RPM value
@@ -311,26 +310,10 @@ void crsfSensorEncodeEscTemp(telemetrySensor_t *sensor, sbuf_t *buf)
 
     for (uint8_t i = 0; i < motorCount; i++) {
         const escSensorData_t *escState = getEscTelemetry(i);
-        crsfSerialize16BE(buf, escState->temperature & 0xFFFF);
+        uint32_t temp = (escState) ? (escState->temperature * 10) & 0xFFFFFF : TEMPERATURE_INVALID_VALUE;
+        crsfSerialize24BE(buf, temp);
     }
 }
-
-void crsfSensorEncodeEscTemperature(telemetrySensor_t *sensor, sbuf_t *buf)
-{
-    UNUSED(sensor);
-
-    uint8_t motorCount = MAX(getMotorCount(), 1); //must send at least one motor, to avoid CRSF frame shifting
-    motorCount = MIN(getMotorCount(), CRSF_PAYLOAD_SIZE_MAX / 3); // 3 bytes per RPM value
-    motorCount = MIN(motorCount, MAX_SUPPORTED_MOTORS); // ensure we don't exceed available ESC telemetry data
-
-    for (uint8_t i = 0; i < motorCount; i++) {
-        const escSensorData_t *escState = getEscTelemetry(i);
-        uint32_t rpm = (escState) ? (escState->temperature * 10) & 0xFFFFFF : TEMPERATURE_INVALID_VALUE;
-        crsfSerialize24BE(buf, rpm);
-    }
-
-}
-
 #endif // USE_CUSTOM_TELEMETRY
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -739,7 +739,7 @@ void crsfSendMspResponse(uint8_t *payload, const uint8_t payloadSize)
 
 static bool crsfSendNativeTelemetry(void)
 {
-    if (crsfTelemetryState != CRSFR_TELEMETRY_STATE_NATIVE)
+    if (crsfTelemetryState != TELEMETRY_STATE_LEGACY)
     {
         return false;
     }
@@ -799,7 +799,7 @@ static bool crsfSendNativeTelemetry(void)
 #ifdef USE_CUSTOM_TELEMETRY
 static bool crsfSendCustomTelemetry(void)
 {
-    if (crsfTelemetryState == CRSFR_TELEMETRY_STATE_CUSTOM)
+    if (crsfTelemetryState == TELEMETRY_STATE_CUSTOM)
     {
         size_t sensor_count = 0;
         sbuf_t *dst = crsfInitializeSbuf(); // prepare buffer
@@ -841,7 +841,7 @@ static bool crsfSendCustomTelemetry(void)
 #ifdef USE_CUSTOM_TELEMETRY
 static bool crsfPopulateCustomTelemetry(void)
 {
-    if (crsfTelemetryState == CRSFR_TELEMETRY_STATE_POPULATE)
+    if (crsfTelemetryState == TELEMETRY_STATE_POPULATE)
     {
         static int slot = -10;
 
@@ -883,7 +883,7 @@ static bool crsfPopulateCustomTelemetry(void)
             }
         }
 
-        crsfTelemetryState = CRSFR_TELEMETRY_STATE_CUSTOM;
+        crsfTelemetryState = TELEMETRY_STATE_CUSTOM;
     }
 
     return false;
@@ -985,9 +985,9 @@ void initCrsfTelemetry(void)
     // and feature is enabled, if so, set CRSF telemetry enabled
 
 #ifdef USE_CUSTOM_TELEMETRY
-    crsfTelemetryState = !crsfRxIsActive() ? CRSFR_TELEMETRY_STATE_OFF : (telemetryConfig()->crsf_telemetry_mode == CRSFR_TELEMETRY_STATE_NATIVE ? CRSFR_TELEMETRY_STATE_NATIVE : CRSFR_TELEMETRY_STATE_POPULATE);
+    crsfTelemetryState = !crsfRxIsActive() ? TELEMETRY_STATE_OFF : (telemetryConfig()->telemetry_mode == TELEMETRY_MODE_LEGACY ? TELEMETRY_STATE_LEGACY : TELEMETRY_STATE_POPULATE);
 #else
-    crsfTelemetryState = !crsfRxIsActive() ? CRSFR_TELEMETRY_STATE_OFF : CRSFR_TELEMETRY_STATE_NATIVE;
+    crsfTelemetryState = !crsfRxIsActive() ? TELEMETRY_STATE_OFF : TELEMETRY_STATE_LEGACY;
 #endif
 
     if(crsfTelemetryState) {
@@ -1004,7 +1004,7 @@ void initCrsfTelemetry(void)
         mspReplyPending = false;
 #endif
 #ifdef USE_CUSTOM_TELEMETRY
-        if (crsfTelemetryState == CRSFR_TELEMETRY_STATE_NATIVE) {
+        if (crsfTelemetryState == TELEMETRY_STATE_LEGACY) {
             initCrsfNativeSensors();
         } else {
             initCrsfCustomSensors();

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -460,6 +460,7 @@ static telemetrySensor_t crsfCustomTelemetrySensors[] =
     TLM_SENSOR(CPU_LOAD,                0x1150,   500,  3000,    10,    U8),
     TLM_SENSOR(FLIGHT_MODE,             0x1251,   200,  3000,    0,     U16),
     TLM_SENSOR(ARMING_FLAGS,            0x1252,   200,  3000,    0,     U8),
+    TLM_SENSOR(PROFILES,                0x1253,   200,  3000,    0,     U16),
 };
 
 telemetrySensor_t * crsfGetCustomSensor(sensor_id_e id)

--- a/src/main/telemetry/crsf.h
+++ b/src/main/telemetry/crsf.h
@@ -19,6 +19,7 @@
 
 #include "common/time.h"
 #include "rx/crsf.h"
+#include "telemetry/sensors.h"
 
 #define CRSF_MSP_RX_BUF_SIZE 128
 #define CRSF_MSP_TX_BUF_SIZE 128

--- a/src/main/telemetry/sensors.c
+++ b/src/main/telemetry/sensors.c
@@ -166,6 +166,10 @@ int telemetrySensorValue(sensor_id_e id)
         ////// SYSTEM  //////////////////////////
         case TELEM_FLIGHT_MODE:
             return (int)flightModeFlags;
+        case TELEM_PROFILES:
+            return ((getConfigBatteryProfile() & 0xF) << 8) |
+                   ((getConfigMixerProfile() & 0xF) << 4) |
+                   ((getConfigProfile() & 0xF));
         case TELEM_ARMING_FLAGS:
             return (int)armingFlags;
         case TELEM_CPU_LOAD:
@@ -376,10 +380,11 @@ bool telemetrySensorAllowed(sensor_id_e id)
         ////// SYSTEM  //////////////////////////
         case TELEM_CPU_LOAD:
             return true;
-
         case TELEM_FLIGHT_MODE:
             return true;
         case TELEM_ARMING_FLAGS:
+            return true;
+        case TELEM_PROFILES:
             return true;
 
         ////////////////////////////////////////

--- a/src/main/telemetry/sensors.c
+++ b/src/main/telemetry/sensors.c
@@ -1,0 +1,442 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if defined(USE_TELEMETRY)
+
+#include "sensors.h"
+#include "telemetry.h"
+
+#include "sensors/battery.h"
+#include "sensors//acceleration.h"
+#include "sensors/esc_sensor.h"
+#include "sensors/temperature.h"
+#include "sensors/pitotmeter.h"
+
+#include "drivers/time.h"
+
+#include "navigation/navigation.h"
+
+#include "flight/imu.h"
+#include "flight/mixer.h"
+
+#include "common/crc.h"
+#include "fc/config.h"
+
+#include "scheduler/scheduler.h"
+
+#include "fc/runtime_config.h"
+
+static uint32_t getTupleHash(uint32_t a, uint32_t b)
+{
+    uint32_t data[2] = { a, b };
+    return fnv_update(0x42424242, data, sizeof(data));
+}
+
+int telemetrySensorValue(sensor_id_e id)
+{
+    switch (id) {
+
+        case TELEM_NONE:
+            return 0;
+
+        /////////////////////////////////////////
+        ////// BATERY //////////////////////////
+        case TELEM_BATTERY:
+            return millis();
+        case TELEM_BATTERY_VOLTAGE:
+            if (isBatteryVoltageConfigured()) {
+                return getBatteryVoltage();
+            }
+            return 0;
+        case TELEM_BATTERY_CURRENT:
+            if (isAmperageConfigured()) {
+                return getAmperage();
+            }
+            return 0;
+        case TELEM_BATTERY_CONSUMPTION:
+            return getMAhDrawn();
+        case TELEM_BATTERY_CHARGE_LEVEL:
+            return calculateBatteryPercentage();
+        case TELEM_BATTERY_CELL_COUNT:
+            if (isBatteryVoltageConfigured()) {
+                return getBatteryCellCount();
+            }
+            return 0;
+        case TELEM_BATTERY_CELL_VOLTAGE:
+            return getBatteryAverageCellVoltage();
+        case TELEM_BATTERY_CELL_VOLTAGES:
+            return 0;
+        case TELEM_BATTERY_FUEL:
+            return millis();
+
+        /////////////////////////////////////////
+        ////// MOVING //////////////////////////
+        case TELEM_HEADING:
+            return DECIDEGREES_TO_DEGREES(attitude.values.yaw);
+        case TELEM_ALTITUDE:
+            return (int)(getEstimatedActualPosition(Z)); // cm
+        case TELEM_VARIOMETER:
+            return (int)getEstimatedActualVelocity(Z);
+        case TELEM_ATTITUDE:
+            return millis();
+        case TELEM_ATTITUDE_PITCH:
+            return attitude.values.pitch;
+        case TELEM_ATTITUDE_ROLL:
+            return attitude.values.roll;
+        case TELEM_ATTITUDE_YAW:
+            return attitude.values.yaw;
+
+        case TELEM_ACCEL_X:
+            return (int)(acc.accADCf[X] * 1000);
+        case TELEM_ACCEL_Y:
+            return (int)(acc.accADCf[Y] * 1000);
+        case TELEM_ACCEL_Z:
+            return (int)(acc.accADCf[Z] * 1000);
+
+        /////////////////////////////////////////
+        ////// GPS     //////////////////////////
+#ifdef USE_GPS
+        case TELEM_GPS:
+            return (int)millis();
+        case TELEM_GPS_SATS:
+            return gpsSol.numSat;
+        case TELEM_GPS_HDOP:
+            return gpsSol.hdop;
+        case TELEM_GPS_COORD:
+            return (int)getTupleHash(gpsSol.llh.lat, gpsSol.llh.lon);
+        case TELEM_GPS_ALTITUDE:
+            return gpsSol.llh.alt;
+        case TELEM_GPS_HEADING:
+            return gpsSol.groundCourse;
+        case TELEM_GPS_GROUNDSPEED:
+            return gpsSol.groundSpeed;
+        case TELEM_GPS_HOME_DISTANCE:
+            return (int)GPS_distanceToHome;
+        case TELEM_GPS_HOME_DIRECTION:
+            return GPS_directionToHome;
+        case TELEM_GPS_AZIMUTH:
+            return ((GPS_directionToHome < 0 ? GPS_directionToHome + 360 : GPS_directionToHome) + 180) % 360;
+#endif
+
+#ifdef USE_ESC_SENSOR
+        /////////////////////////////////////////
+        ////// ESC     //////////////////////////
+        case TELEM_ESC_RPM:
+            return (int)millis();
+        case TELEM_ESC1_RPM:
+            return getMotorCount() > 0 ? (int)getEscTelemetry(0)->rpm : 0;
+        case TELEM_ESC2_RPM:
+            return getMotorCount() > 1 ? (int)getEscTelemetry(1)->rpm : 0;
+        case TELEM_ESC3_RPM:
+            return getMotorCount() > 2 ? (int)getEscTelemetry(2)->rpm : 0;
+        case TELEM_ESC4_RPM:
+            return getMotorCount() > 3 ? (int)getEscTelemetry(3)->rpm : 0;
+
+
+        case TELEM_ESC_TEMPERATURE:
+            return (int)millis();
+        case TELEM_ESC1_TEMPERATURE:
+            return getMotorCount() > 0 ? (int)(getEscTelemetry(0)->temperature * 10) : 0;
+        case TELEM_ESC2_TEMPERATURE:
+            return getMotorCount() > 1 ? (int)(getEscTelemetry(1)->temperature * 10) : 0;
+        case TELEM_ESC3_TEMPERATURE:
+            return getMotorCount() > 2 ? (int)(getEscTelemetry(2)->temperature * 10) : 0;
+        case TELEM_ESC4_TEMPERATURE:
+            return getMotorCount() > 3 ? (int)(getEscTelemetry(3)->temperature * 10) : 0;
+#endif
+
+
+        /////////////////////////////////////////
+        ////// SYSTEM  //////////////////////////
+        case TELEM_FLIGHT_MODE:
+            return (int)flightModeFlags;
+        case TELEM_ARMING_FLAGS:
+            return (int)armingFlags;
+        case TELEM_CPU_LOAD:
+            return averageSystemLoadPercent * 10;
+
+        ////////////////////////////////////////
+        ////// LEGACY SMARTPORT  ////////////////
+        case TELEM_LEGACY_VFAS:
+            FALLTHROUGH;
+        case TELEM_LEGACY_CURRENT:
+            FALLTHROUGH;
+        case TELEM_LEGACY_ALTITUDE:
+            FALLTHROUGH;
+        case TELEM_LEGACY_FUEL:
+            FALLTHROUGH;
+        case TELEM_LEGACY_VARIO:
+            FALLTHROUGH;
+        case TELEM_LEGACY_HEADING:
+            FALLTHROUGH;
+        case TELEM_LEGACY_PITCH:
+            FALLTHROUGH;
+        case TELEM_LEGACY_ROLL:
+            FALLTHROUGH;
+        case TELEM_LEGACY_ACCX:
+            FALLTHROUGH;
+        case TELEM_LEGACY_ACCY:
+            FALLTHROUGH;
+        case TELEM_LEGACY_ACCZ:
+            FALLTHROUGH;
+        case TELEM_LEGACY_MODES:
+            FALLTHROUGH;
+        case TELEM_LEGACY_GNSS:
+            FALLTHROUGH;
+        case TELEM_LEGACY_SPEED:
+            FALLTHROUGH;
+        case TELEM_LEGACY_LAT:
+            FALLTHROUGH;
+        case TELEM_LEGACY_LON:
+            FALLTHROUGH;
+        case TELEM_LEGACY_HOME_DIST:
+            FALLTHROUGH;
+        case TELEM_LEGACY_GPS_ALT:
+            FALLTHROUGH;
+        case TELEM_LEGACY_FPV:
+            FALLTHROUGH;
+        case TELEM_LEGACY_AZIMUTH:
+            FALLTHROUGH;
+        case TELEM_LEGACY_A4:
+            FALLTHROUGH;
+        case TELEM_LEGACY_ASPD:
+            return millis();
+        default:
+            return 0;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+#ifdef USE_GPS
+bool shouldSendGpsData(void) {
+    // We send GPS data if the GPS is configured and we have a fix
+    // or the craft has never been armed yet. This way if GPS stops working
+    // while in flight, the user will easily notice because the sensor will stop
+    // updating.
+    return feature(FEATURE_GPS) && (STATE(GPS_FIX)
+#ifdef USE_GPS_FIX_ESTIMATION
+        || STATE(GPS_ESTIMATED_FIX)
+#endif
+        || !ARMING_FLAG(WAS_EVER_ARMED));
+}
+#endif
+
+bool shouldSendDataForMotorIndex(uint8_t motorIndex)
+{
+#ifdef USE_ESC_SENSOR
+    return STATE(ESC_SENSOR_ENABLED) && getMotorCount() > motorIndex;
+#else
+    UNUSED(motorIndex);
+    return false;
+#endif
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+#ifdef USE_CUSTOM_TELEMETRY
+bool telemetrySensorActive(sensor_id_e sid)
+{
+    // system sensors are always active
+    if(sid == TELEM_NONE || sid == TELEM_HEARTBEAT) {
+        return true;
+    }
+
+    for (int i = 0; i < TELEM_SENSOR_SLOT_COUNT; ++i) {
+        if (telemetryConfig()->telemetry_sensors[i] == sid) {
+            return true;
+        }
+    }
+
+    return false;
+}
+#endif
+
+bool telemetrySensorAllowed(sensor_id_e id)
+{
+    switch (id) {
+        case TELEM_NONE:
+            return true;
+
+        case TELEM_HEARTBEAT:
+            return true;
+
+        /////////////////////////////////////////
+        ////// BATERY //////////////////////////
+        case TELEM_BATTERY:
+            return true;
+        case TELEM_BATTERY_VOLTAGE:
+            return isBatteryVoltageConfigured();
+        case TELEM_BATTERY_CURRENT:
+            return isAmperageConfigured();
+        case TELEM_BATTERY_CONSUMPTION:
+            return isAmperageConfigured();
+        case TELEM_BATTERY_CHARGE_LEVEL:
+            FALLTHROUGH;
+        case TELEM_BATTERY_CELL_COUNT:
+            FALLTHROUGH;
+        case TELEM_BATTERY_CELL_VOLTAGE:
+            FALLTHROUGH;
+        case TELEM_BATTERY_CELL_VOLTAGES:
+            return isBatteryVoltageConfigured();
+        case TELEM_BATTERY_FUEL:
+            return true;
+
+        /////////////////////////////////////////
+        ////// MOVING //////////////////////////
+        case TELEM_HEADING:
+            return true;
+        case TELEM_ALTITUDE:
+            return sensors(SENSOR_BARO);
+        case TELEM_ATTITUDE:
+            return true;
+        case TELEM_ATTITUDE_PITCH:
+            return true;
+        case TELEM_ATTITUDE_ROLL:
+            return true;
+        case TELEM_ATTITUDE_YAW:
+            return true;
+        case TELEM_VARIOMETER:
+            return sensors(SENSOR_BARO);
+
+        case TELEM_ACCEL_X:
+            return true;
+        case TELEM_ACCEL_Y:
+            return true;
+        case TELEM_ACCEL_Z:
+            return true;
+
+        /////////////////////////////////////////
+        ////// GPS     //////////////////////////
+#ifdef USE_GPS
+        case TELEM_GPS:
+            FALLTHROUGH;
+        case TELEM_GPS_SATS:
+            FALLTHROUGH;
+        case TELEM_GPS_HDOP:
+            FALLTHROUGH;
+        case TELEM_GPS_COORD:
+            FALLTHROUGH;
+        case TELEM_GPS_ALTITUDE:
+            FALLTHROUGH;
+        case TELEM_GPS_HEADING:
+            FALLTHROUGH;
+        case TELEM_GPS_GROUNDSPEED:
+            FALLTHROUGH;
+        case TELEM_GPS_HOME_DISTANCE:
+            FALLTHROUGH;
+        case TELEM_GPS_HOME_DIRECTION:
+            FALLTHROUGH;
+        case TELEM_GPS_AZIMUTH:
+            return shouldSendGpsData();
+#endif
+
+        /////////////////////////////////////////
+        ////// ESC     //////////////////////////
+
+        case TELEM_ESC_RPM:
+            FALLTHROUGH;
+        case TELEM_ESC1_RPM:
+            return shouldSendDataForMotorIndex(0);
+        case TELEM_ESC2_RPM:
+            return shouldSendDataForMotorIndex(1);
+        case TELEM_ESC3_RPM:
+            return shouldSendDataForMotorIndex(2);
+        case TELEM_ESC4_RPM:
+            return shouldSendDataForMotorIndex(3);;
+
+        case TELEM_TEMPERATURE:
+            return true;
+        case TELEM_ESC_TEMPERATURE:
+            FALLTHROUGH;
+        case TELEM_ESC1_TEMPERATURE:
+            return shouldSendDataForMotorIndex(0);
+        case TELEM_ESC2_TEMPERATURE:
+            return shouldSendDataForMotorIndex(1);
+        case TELEM_ESC3_TEMPERATURE:
+            return shouldSendDataForMotorIndex(2);
+        case TELEM_ESC4_TEMPERATURE:
+            return shouldSendDataForMotorIndex(3);
+
+        /////////////////////////////////////////
+        ////// SYSTEM  //////////////////////////
+        case TELEM_CPU_LOAD:
+            return true;
+
+        case TELEM_FLIGHT_MODE:
+            return true;
+        case TELEM_ARMING_FLAGS:
+            return true;
+
+        ////////////////////////////////////////
+        ////// LEGACY SMARTPORT  ////////////////
+        case TELEM_LEGACY_VFAS:
+            return isBatteryVoltageConfigured();
+        case TELEM_LEGACY_CURRENT:
+            return isAmperageConfigured();
+        case TELEM_LEGACY_ALTITUDE:
+            return sensors(SENSOR_BARO);
+        case TELEM_LEGACY_FUEL:
+            return true;
+        case TELEM_LEGACY_VARIO:
+            return sensors(SENSOR_BARO);
+        case TELEM_LEGACY_HEADING:
+            return true;
+        case TELEM_LEGACY_PITCH:
+            FALLTHROUGH;
+        case TELEM_LEGACY_ROLL:
+            return telemetryConfig()->frsky_pitch_roll;
+        case TELEM_LEGACY_ACCX:
+            FALLTHROUGH;
+        case TELEM_LEGACY_ACCY:
+            FALLTHROUGH;
+        case TELEM_LEGACY_ACCZ:
+            return sensors(SENSOR_ACC) && !telemetryConfig()->frsky_pitch_roll;
+        case TELEM_LEGACY_MODES:
+            return true;
+
+#ifdef USE_GPS
+        case TELEM_LEGACY_GNSS:
+            FALLTHROUGH;
+        case TELEM_LEGACY_SPEED:
+            FALLTHROUGH;
+        case TELEM_LEGACY_LAT:
+            FALLTHROUGH;
+        case TELEM_LEGACY_LON:
+            FALLTHROUGH;
+        case TELEM_LEGACY_HOME_DIST:
+            FALLTHROUGH;
+        case TELEM_LEGACY_GPS_ALT:
+            FALLTHROUGH;
+        case TELEM_LEGACY_FPV:
+            FALLTHROUGH;
+        case TELEM_LEGACY_AZIMUTH:
+            return shouldSendGpsData();
+        case TELEM_LEGACY_A4:
+            return isBatteryVoltageConfigured();
+#endif
+#ifdef USE_PITOT
+        case TELEM_LEGACY_ASPD:
+            return sensors(SENSOR_PITOT) && pitotIsHealthy();
+#endif
+        default:
+            return false;
+    }
+}
+
+////////////////////////////////////////////////////////////
+#endif  // USE_TELEMETRY

--- a/src/main/telemetry/sensors.h
+++ b/src/main/telemetry/sensors.h
@@ -1,0 +1,159 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "common/utils.h"
+
+typedef enum
+{
+    /////////////////////////////////////////
+    ////// SPECIAL //////////////////////////
+    TELEM_NONE                          = 0,
+    TELEM_HEARTBEAT                     = 1,
+
+    /////////////////////////////////////////
+    ////// BATERY //////////////////////////
+    TELEM_BATTERY                       = 2, // start from settings
+    TELEM_BATTERY_VOLTAGE               = 3,
+    TELEM_BATTERY_CURRENT               = 4,
+    TELEM_BATTERY_CONSUMPTION           = 5,
+    TELEM_BATTERY_CHARGE_LEVEL          = 6,
+    TELEM_BATTERY_CELL_COUNT            = 7,
+    TELEM_BATTERY_CELL_VOLTAGE          = 8,
+    TELEM_BATTERY_CELL_VOLTAGES         = 9,
+
+    TELEM_BATTERY_FUEL                  = 10,
+
+    /////////////////////////////////////////
+    ////// MOVING //////////////////////////
+    TELEM_HEADING                       = 11,
+    TELEM_ALTITUDE                      = 12,
+    TELEM_VARIOMETER                    = 13,
+
+    TELEM_ATTITUDE                      = 14,
+    TELEM_ATTITUDE_PITCH                = 15,
+    TELEM_ATTITUDE_ROLL                 = 16,
+    TELEM_ATTITUDE_YAW                  = 17,
+
+    TELEM_ACCEL_X                       = 18,
+    TELEM_ACCEL_Y                       = 19,
+    TELEM_ACCEL_Z                       = 20,
+
+    /////////////////////////////////////////
+    ////// GPS     //////////////////////////
+    TELEM_GPS                           = 21,
+    TELEM_GPS_SATS                      = 22,
+    TELEM_GPS_HDOP                      = 23,
+    TELEM_GPS_COORD                     = 24,
+    TELEM_GPS_ALTITUDE                  = 25,
+    TELEM_GPS_HEADING                   = 26,
+    TELEM_GPS_GROUNDSPEED               = 27,
+    TELEM_GPS_HOME_DISTANCE             = 28,
+    TELEM_GPS_HOME_DIRECTION            = 29,
+    TELEM_GPS_AZIMUTH                   = 30,
+
+    /////////////////////////////////////////
+    ////// ESC     //////////////////////////
+    TELEM_ESC_RPM                       = 31,
+    TELEM_ESC_TEMPERATURE               = 32,
+
+    TELEM_ESC1_RPM                      = 33,
+    TELEM_ESC1_TEMPERATURE              = 34,
+
+    TELEM_ESC2_RPM                      = 35,
+    TELEM_ESC2_TEMPERATURE              = 36,
+
+    TELEM_ESC3_RPM                      = 37,
+    TELEM_ESC3_TEMPERATURE              = 38,
+
+    TELEM_ESC4_RPM                      = 39,
+    TELEM_ESC4_TEMPERATURE              = 40,
+
+    TELEM_TEMPERATURE                   = 41,
+
+    /////////////////////////////////////////
+    ////// SYSTEM  //////////////////////////
+    TELEM_CPU_LOAD                      = 42,
+    TELEM_FLIGHT_MODE                   = 43,
+    TELEM_ARMING_FLAGS                  = 44,
+
+    /////////////////////////////////////////
+    ////// LEGACY SMARTPORT  ////////////////
+    TELEM_LEGACY_VFAS                   = 45,
+    TELEM_LEGACY_CURRENT                = 46,
+    TELEM_LEGACY_ALTITUDE               = 47,
+    TELEM_LEGACY_FUEL                   = 48,
+    TELEM_LEGACY_VARIO                  = 49,
+    TELEM_LEGACY_HEADING                = 50,
+    TELEM_LEGACY_PITCH                  = 51,
+    TELEM_LEGACY_ROLL                   = 52,
+    TELEM_LEGACY_ACCX                   = 53,
+    TELEM_LEGACY_ACCY                   = 54,
+    TELEM_LEGACY_ACCZ                   = 55,
+    TELEM_LEGACY_MODES                  = 56,
+
+    TELEM_LEGACY_GNSS                   = 57,
+    TELEM_LEGACY_SPEED                  = 58,
+    TELEM_LEGACY_LAT                    = 59,
+    TELEM_LEGACY_LON                    = 60,
+    TELEM_LEGACY_HOME_DIST              = 61,
+    TELEM_LEGACY_GPS_ALT                = 62,
+    TELEM_LEGACY_FPV                    = 63,
+    TELEM_LEGACY_AZIMUTH                = 64,
+
+    TELEM_LEGACY_A4                     = 65,
+    TELEM_LEGACY_ASPD                   = 66,
+
+    TELEM_SENSOR_COUNT
+
+} sensor_id_e;
+
+typedef struct telemetrySensor_s telemetrySensor_t;
+
+typedef void (*telemetryEncode_f)(telemetrySensor_t *sensor, void *ptr);
+
+struct telemetrySensor_s {
+
+    uint16_t                index;
+
+    uint16_t                sensor_id;
+    uint32_t                app_id;
+
+    uint16_t                fast_weight;
+    uint16_t                slow_weight;
+    uint16_t                fast_interval;
+    uint16_t                slow_interval;
+
+    int                     ratio_num;
+    int                     ratio_den;
+
+    int                     value;
+
+    bool                    active;
+    bool                    update;
+
+    int                     bucket;
+
+    telemetryEncode_f       encode;
+};
+
+int telemetrySensorValue(sensor_id_e id);
+bool telemetrySensorActive(sensor_id_e id);
+bool telemetrySensorAllowed(sensor_id_e id);

--- a/src/main/telemetry/sensors.h
+++ b/src/main/telemetry/sensors.h
@@ -92,34 +92,35 @@ typedef enum
     ////// SYSTEM  //////////////////////////
     TELEM_CPU_LOAD                      = 42,
     TELEM_FLIGHT_MODE                   = 43,
-    TELEM_ARMING_FLAGS                  = 44,
+    TELEM_PROFILES                      = 44,
+    TELEM_ARMING_FLAGS                  = 45,
 
-    /////////////////////////////////////////
-    ////// LEGACY SMARTPORT  ////////////////
-    TELEM_LEGACY_VFAS                   = 45,
-    TELEM_LEGACY_CURRENT                = 46,
-    TELEM_LEGACY_ALTITUDE               = 47,
-    TELEM_LEGACY_FUEL                   = 48,
-    TELEM_LEGACY_VARIO                  = 49,
-    TELEM_LEGACY_HEADING                = 50,
-    TELEM_LEGACY_PITCH                  = 51,
-    TELEM_LEGACY_ROLL                   = 52,
-    TELEM_LEGACY_ACCX                   = 53,
-    TELEM_LEGACY_ACCY                   = 54,
-    TELEM_LEGACY_ACCZ                   = 55,
-    TELEM_LEGACY_MODES                  = 56,
+/////////////////////////////////////////
+////// LEGACY SMARTPORT  ////////////////
+    TELEM_LEGACY_VFAS                   = 46,
+    TELEM_LEGACY_CURRENT                = 47,
+    TELEM_LEGACY_ALTITUDE               = 48,
+    TELEM_LEGACY_FUEL                   = 49,
+    TELEM_LEGACY_VARIO                  = 50,
+    TELEM_LEGACY_HEADING                = 51,
+    TELEM_LEGACY_PITCH                  = 52,
+    TELEM_LEGACY_ROLL                   = 53,
+    TELEM_LEGACY_ACCX                   = 54,
+    TELEM_LEGACY_ACCY                   = 55,
+    TELEM_LEGACY_ACCZ                   = 56,
+    TELEM_LEGACY_MODES                  = 57,
 
-    TELEM_LEGACY_GNSS                   = 57,
-    TELEM_LEGACY_SPEED                  = 58,
-    TELEM_LEGACY_LAT                    = 59,
-    TELEM_LEGACY_LON                    = 60,
-    TELEM_LEGACY_HOME_DIST              = 61,
-    TELEM_LEGACY_GPS_ALT                = 62,
-    TELEM_LEGACY_FPV                    = 63,
-    TELEM_LEGACY_AZIMUTH                = 64,
+    TELEM_LEGACY_GNSS                   = 58,
+    TELEM_LEGACY_SPEED                  = 59,
+    TELEM_LEGACY_LAT                    = 60,
+    TELEM_LEGACY_LON                    = 61,
+    TELEM_LEGACY_HOME_DIST              = 62,
+    TELEM_LEGACY_GPS_ALT                = 63,
+    TELEM_LEGACY_FPV                    = 64,
+    TELEM_LEGACY_AZIMUTH                = 65,
 
-    TELEM_LEGACY_A4                     = 65,
-    TELEM_LEGACY_ASPD                   = 66,
+    TELEM_LEGACY_A4                     = 66,
+    TELEM_LEGACY_ASPD                   = 67,
 
     TELEM_SENSOR_COUNT
 

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -240,6 +240,7 @@ static telemetrySensor_t smartportTelemetrySensors[] =
         TLM_SENSOR(CPU_LOAD,                0x51D0,   200,  3000,   1,  10,   10,   INT),
         TLM_SENSOR(FLIGHT_MODE,             0x5121,   100,  3000,   1,   1,   0,    INT),
         TLM_SENSOR(ARMING_FLAGS,            0x5122,   100,  3000,   1,   1,   0,    INT),
+        TLM_SENSOR(PROFILES,                0x5123,   100,  3000,   1,   1,   0,    INT),
 
 #ifdef USE_ESC_SENSOR
         TLM_SENSOR(ESC1_RPM,                0x5130,   100,  3000,   1,  10,   0,    INT),

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -287,7 +287,7 @@ static void smartPortWriteFrameInternal(const smartPortPayload_t *payload)
 static void initSmartPortSensors(void)
 {
 #ifdef USE_CUSTOM_TELEMETRY
-    if(telemetryConfig()->smartport_telemetry_mode == SMARTPORT_TELEMETRY_STATE_LEGACY) {
+    if(telemetryConfig()->telemetry_mode == TELEMETRY_MODE_LEGACY) {
         initSmartPortSensorsLegacy();
     } else {
         telemetryScheduleInit(smartportTelemetrySensors, ARRAYLEN(smartportTelemetrySensors));

--- a/src/main/telemetry/smartport.h
+++ b/src/main/telemetry/smartport.h
@@ -1,9 +1,3 @@
-/*
- * smartport.h
- *
- *  Created on: 25 October 2014
- *      Author: Frank26080115
- */
 
 #pragma once
 
@@ -49,7 +43,7 @@ bool initSmartPortTelemetry(void);
 void checkSmartPortTelemetryState(void);
 bool initSmartPortTelemetryExternal(smartPortWriteFrameFn *smartPortWriteFrameExternal);
 
-void handleSmartPortTelemetry(void);
+void handleSmartPortTelemetry(timeUs_t currentTimeUs);
 void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *hasRequest, const uint32_t *requestTimeout);
 
 smartPortPayload_t *smartPortDataReceive(uint16_t c, bool *clearToSend, smartPortCheckQueueEmptyFn *checkQueueEmpty, bool withChecksum);

--- a/src/main/telemetry/smartport_legacy.c
+++ b/src/main/telemetry/smartport_legacy.c
@@ -1,0 +1,399 @@
+/**************************************************************
+**************************************************************
+**************************************************************
+**************************************************************
+**                                                          **
+**                                                          **
+**                  REMOVE IN INAV 11                       **
+**                                                          **
+**                                                          **
+**************************************************************
+**************************************************************
+**************************************************************
+**************************************************************/
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "platform.h"
+
+#if defined(USE_TELEMETRY) && defined(USE_TELEMETRY_SMARTPORT)
+
+#include "smartport_legacy.h"
+#include "common/maths.h"
+#include "common/utils.h"
+
+#include "config/parameter_group_ids.h"
+
+#include "drivers/time.h"
+
+#include "sensors/battery.h"
+
+#include "io/gps.h"
+#include "io/serial.h"
+
+#include "rx/frsky_crc.h"
+
+#include "telemetry/telemetry.h"
+#include "telemetry/smartport.h"
+#include "telemetry/smartport_legacy.h"
+#include "telemetry/msp_shared.h"
+
+#include "common/axis.h"
+#include "common/color.h"
+#include "common/maths.h"
+#include "common/utils.h"
+
+#include "config/feature.h"
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+
+#include "drivers/accgyro/accgyro.h"
+#include "drivers/compass/compass.h"
+#include "drivers/sensor.h"
+#include "drivers/time.h"
+
+#include "fc/config.h"
+#include "fc/rc_controls.h"
+#include "fc/rc_modes.h"
+#include "fc/runtime_config.h"
+
+#include "flight/failsafe.h"
+#include "flight/imu.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+
+#include "io/beeper.h"
+#include "io/gps.h"
+#include "io/serial.h"
+
+#include "navigation/navigation.h"
+
+#include "rx/frsky_crc.h"
+
+#include "sensors/boardalignment.h"
+#include "sensors/sensors.h"
+#include "sensors/battery.h"
+#include "sensors/acceleration.h"
+#include "sensors/barometer.h"
+#include "sensors/compass.h"
+#include "sensors/gyro.h"
+#include "sensors/pitotmeter.h"
+
+#include "rx/rx.h"
+
+#include "telemetry/telemetry.h"
+#include "telemetry/smartport.h"
+#include "telemetry/msp_shared.h"
+
+//////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////
+static uint32_t frskyGetFlightMode(void)
+{
+    uint32_t tmpi = 0;
+
+    // ones column (G)
+    if (!isArmingDisabled())
+        tmpi += 1;
+    else
+        tmpi += 2;
+    if (ARMING_FLAG(ARMED))
+        tmpi += 4;
+
+    // tens column (F)
+    if (FLIGHT_MODE(ANGLE_MODE))
+        tmpi += 10;
+    if (FLIGHT_MODE(HORIZON_MODE))
+        tmpi += 20;
+    if (FLIGHT_MODE(MANUAL_MODE))
+        tmpi += 40;
+
+    // hundreds column (E)
+    if (FLIGHT_MODE(HEADING_MODE))
+        tmpi += 100;
+    if (FLIGHT_MODE(NAV_ALTHOLD_MODE))
+        tmpi += 200;
+    if (FLIGHT_MODE(NAV_POSHOLD_MODE) && !STATE(AIRPLANE))
+        tmpi += 400;
+
+    // thousands column (D)
+    if (FLIGHT_MODE(NAV_RTH_MODE) && !isWaypointMissionRTHActive())
+        tmpi += 1000;
+    if (FLIGHT_MODE(NAV_COURSE_HOLD_MODE)) // intentionally out of order and 'else-ifs' to prevent column overflow
+        tmpi += 8000;
+    else if (FLIGHT_MODE(NAV_WP_MODE))
+        tmpi += 2000;
+    else if (FLIGHT_MODE(HEADFREE_MODE))
+        tmpi += 4000;
+
+    // ten thousands column (C)
+    if (FLIGHT_MODE(FLAPERON))
+        tmpi += 10000;
+    if (FLIGHT_MODE(FAILSAFE_MODE))
+        tmpi += 40000;
+    else if (FLIGHT_MODE(AUTO_TUNE)) // intentionally reverse order and 'else-if' to prevent 16-bit overflow
+        tmpi += 20000;
+
+    // hundred thousands column (B)
+    if (FLIGHT_MODE(NAV_FW_AUTOLAND))
+        tmpi += 100000;
+    if (FLIGHT_MODE(TURTLE_MODE))
+        tmpi += 200000;
+    else if (FLIGHT_MODE(NAV_POSHOLD_MODE) && STATE(AIRPLANE))
+        tmpi += 800000;
+    if (FLIGHT_MODE(NAV_SEND_TO))
+        tmpi += 400000;
+
+    // million column (A)
+    if (FLIGHT_MODE(NAV_RTH_MODE) && isWaypointMissionRTHActive())
+        tmpi += 1000000;
+    if (FLIGHT_MODE(ANGLEHOLD_MODE))
+        tmpi += 2000000;
+
+    return tmpi;
+}
+
+static uint16_t frskyGetGPSState(void)
+{
+    uint16_t tmpi = 0;
+
+    // ones and tens columns (# of satellites 0 - 99)
+    tmpi += constrain(gpsSol.numSat, 0, 99);
+
+    // hundreds column (satellite accuracy HDOP: 0 = worst [HDOP > 5.5], 9 = best [HDOP <= 1.0])
+    tmpi += (9 - constrain((gpsSol.hdop - 51) / 50, 0, 9)) * 100;
+
+    // thousands column (GPS fix status)
+    if (STATE(GPS_FIX))
+        tmpi += 1000;
+    if (STATE(GPS_FIX_HOME))
+        tmpi += 2000;
+    if (ARMING_FLAG(ARMED) && IS_RC_MODE_ACTIVE(BOXHOMERESET) && !FLIGHT_MODE(NAV_RTH_MODE) && !FLIGHT_MODE(NAV_WP_MODE))
+        tmpi += 4000;
+
+    return tmpi;
+}
+
+static void smartPortSensorEncodeINT(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload) {
+    payload->data = sensor->value;
+}
+
+
+static void smartPortSensorEncodeVFAS(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = telemetryConfig()->report_cell_voltage ? getBatteryAverageCellVoltage() : getBatteryVoltage();;
+}
+
+static void smartPortSensorEncodeCurrent(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = getAmperage() / 10;
+}
+
+static void smartPortSensorEncodeAltitude(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = (uint32_t)getEstimatedActualPosition(Z);
+}
+
+static void smartPortSensorEncodeFuel(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    if (telemetryConfig()->smartportFuelUnit == SMARTPORT_FUEL_UNIT_PERCENT) {
+        payload->data = calculateBatteryPercentage(); // Show remaining battery % if smartport_fuel_percent=ON
+    } else if (isAmperageConfigured()) {
+        payload->data = telemetryConfig()->smartportFuelUnit == SMARTPORT_FUEL_UNIT_MAH ? getMAhDrawn() : getMWhDrawn();
+    }
+}
+
+static void smartPortSensorEncodeVario(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = lrintf(getEstimatedActualVelocity(Z));
+}
+
+static void smartPortSensorEncodeHeading(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = attitude.values.yaw * 10;
+}
+
+static void smartPortSensorEncodePitch(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = attitude.values.pitch;
+}
+
+static void smartPortSensorEncodeRoll(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = attitude.values.roll;
+}
+
+static void smartPortSensorEncodeACCX(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = lrintf(100 * acc.accADCf[X]);
+}
+
+static void smartPortSensorEncodeACCY(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = lrintf(100 * acc.accADCf[Y]);
+}
+
+static void smartPortSensorEncodeACCZ(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = lrintf(100 * acc.accADCf[Z]);
+}
+
+static void smartPortSensorEncodeModes(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = frskyGetFlightMode();
+}
+
+#ifdef USE_GPS
+static void smartPortSensorEncodeGNSS(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = frskyGetGPSState();
+}
+
+static void smartPortSensorEncodeSpeed(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    //convert to knots: 1cm/s = 0.0194384449 knots
+    //Speed should be sent in knots/1000 (GPS speed is in cm/s)
+    payload->data = gpsSol.groundSpeed * 1944 / 100;
+}
+
+static void smartPortSensorEncodeLat(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    uint32_t tmpui = abs(gpsSol.llh.lon);  // now we have unsigned value and one bit to spare
+    tmpui = (tmpui + tmpui / 2) / 25 | 0x80000000;  // 6/100 = 1.5/25, division by power of 2 is fast
+    if (gpsSol.llh.lon < 0) tmpui |= 0x40000000;
+
+    payload->data = tmpui;
+}
+
+static void smartPortSensorEncodeLon(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    uint32_t tmpui = abs(gpsSol.llh.lat);  // now we have unsigned value and one bit to spare
+    tmpui = (tmpui + tmpui / 2) / 25;  // 6/100 = 1.5/25, division by power of 2 is fast
+    if (gpsSol.llh.lat < 0) tmpui |= 0x40000000;
+
+    payload->data = tmpui;
+}
+
+static void smartPortSensorEncodeHomeDist(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = GPS_distanceToHome;
+}
+
+static void smartPortSensorEncodeGpsAlt(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = gpsSol.llh.alt;
+}
+
+static void smartPortSensorEncodeFpv(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = gpsSol.groundCourse;
+}
+
+static void smartPortSensorEncodeAzimuth(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    int16_t h = GPS_directionToHome;
+    if (h < 0) {
+        h += 360;
+    }
+    if(h >= 180)
+        h = h - 180;
+    else
+        h = h + 180;
+
+    payload->data = h;
+}
+#endif
+static void smartPortSensorEncodeA4(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = getBatteryAverageCellVoltage();
+}
+
+#ifdef USE_PITOT
+static void smartPortSensorEncodeASPD(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
+{
+    payload->data = (uint32_t)(getAirspeedEstimate() * 0.194384449f);
+}
+#endif
+
+
+//////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////
+#define TLM_SENSOR(NAME, APPID, FAST, SLOW, WF, WS, DENOM, ENC) \
+{ \
+    .sensor_id = TELEM_##NAME, \
+    .app_id = (APPID), \
+    .fast_interval = (FAST), \
+    .slow_interval = (SLOW), \
+    .fast_weight = (WF), \
+    .slow_weight = (WS), \
+    .ratio_num = 1, \
+    .ratio_den = (DENOM), \
+    .value = 0, \
+    .bucket = 0, \
+    .update = 0, \
+    .active = false, \
+    .encode = (telemetryEncode_f)smartPortSensorEncode##ENC, \
+}
+
+static telemetrySensor_t smartportTelemetrySensorsLegacy[] =
+{
+        TLM_SENSOR(HEARTBEAT        , 0x5100, 1000, 1000, 0, 0, 0, INT),
+        TLM_SENSOR(LEGACY_VFAS      , 0x0210,  200,  200, 0, 0, 0, VFAS),
+        TLM_SENSOR(LEGACY_CURRENT   , 0x0200,  200,  200, 0, 0, 0, Current),
+        TLM_SENSOR(LEGACY_ALTITUDE  , 0x0100,  200,  200, 0, 0, 0, Altitude),
+        TLM_SENSOR(LEGACY_FUEL      , 0x0600,  200,  200, 0, 0, 0, Fuel),
+        TLM_SENSOR(LEGACY_VARIO     , 0x0110,  200,  200, 0, 0, 0, Vario),
+        TLM_SENSOR(LEGACY_HEADING   , 0x0840,  200,  200, 0, 0, 0, Heading),
+        TLM_SENSOR(LEGACY_PITCH     , 0x0430,  200,  200, 0, 0, 0, Pitch),
+        TLM_SENSOR(LEGACY_ROLL      , 0x0440,  200,  200, 0, 0, 0, Roll),
+        TLM_SENSOR(LEGACY_ACCX      , 0x0700,  200,  200, 0, 0, 0, ACCX),
+        TLM_SENSOR(LEGACY_ACCY      , 0x0710,  200,  200, 0, 0, 0, ACCY),
+        TLM_SENSOR(LEGACY_ACCZ      , 0x0720,  200,  200, 0, 0, 0, ACCZ),
+        TLM_SENSOR(LEGACY_MODES     , 0x0470,  200,  200, 0, 0, 0, Modes),
+#ifdef USE_GPS
+        TLM_SENSOR(LEGACY_GNSS      , 0x0480,  200,  200, 0, 0, 0, GNSS),
+        TLM_SENSOR(LEGACY_SPEED     , 0x0830,  200,  200, 0, 0, 0, Speed),
+        TLM_SENSOR(LEGACY_LAT       , 0x0800,  200,  200, 0, 0, 0, Lat),
+        TLM_SENSOR(LEGACY_LON       , 0x0800,  200,  200, 0, 0, 0, Lon),
+        TLM_SENSOR(LEGACY_HOME_DIST , 0x0420,  200,  200, 0, 0, 0, HomeDist),
+        TLM_SENSOR(LEGACY_GPS_ALT   , 0x0820,  200,  200, 0, 0, 0, GpsAlt),
+        TLM_SENSOR(LEGACY_FPV       , 0x0450,  200,  200, 0, 0, 0, Fpv),
+        TLM_SENSOR(LEGACY_AZIMUTH   , 0x0460,  200,  200, 0, 0, 0, Azimuth),
+#endif
+        TLM_SENSOR(LEGACY_A4        , 0x0910,  200,  200, 0, 0, 0, A4),
+#ifdef USE_PITOT
+        TLM_SENSOR(LEGACY_ASPD      , 0x0A00,  200,  200, 0, 0, 0, ASPD),
+#endif
+};
+
+void initSmartPortSensorsLegacy(void) {
+    telemetryScheduleInit(smartportTelemetrySensorsLegacy, ARRAYLEN(smartportTelemetrySensorsLegacy));
+
+    for(size_t i = 0; i < ARRAYLEN(smartportTelemetrySensorsLegacy); i++) {
+        if(telemetrySensorAllowed(smartportTelemetrySensorsLegacy[i].sensor_id)) {
+            telemetryScheduleAdd(&smartportTelemetrySensorsLegacy[i]);
+        }
+    }
+
+}
+
+
+#endif

--- a/src/main/telemetry/smartport_legacy.h
+++ b/src/main/telemetry/smartport_legacy.h
@@ -1,0 +1,44 @@
+/**************************************************************
+**************************************************************
+**************************************************************
+**************************************************************
+**                                                          **
+**                                                          **
+**                  REMOVE IN INAV 11                       **
+**                                                          **
+**                                                          **
+**************************************************************
+**************************************************************
+**************************************************************
+**************************************************************/
+
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "platform.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#if defined(USE_TELEMETRY) && defined(USE_TELEMETRY_SMARTPORT)
+
+void initSmartPortSensorsLegacy(void);
+
+#endif

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -103,21 +103,13 @@ PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
 #ifdef USE_TELEMETRY_CRSF
     .crsf_telemetry_link_rate = SETTING_CRSF_TELEMETRY_LINK_RATE_DEFAULT,
     .crsf_telemetry_link_ratio = SETTING_CRSF_TELEMETRY_LINK_RATIO_DEFAULT,
-#ifdef USE_CUSTOM_TELEMETRY
-    .crsf_telemetry_mode = SETTING_CRSF_TELEMETRY_MODE_DEFAULT,
-#endif //USE_CUSTOM_TELEMETRY
 #endif //USE_TELEMETRY_CRSF
 
-#if defined(USE_TELEMETRY_SMARTPORT) && defined(USE_CUSTOM_TELEMETRY)
-#if !defined(SETTING_SMARTPORT_TELEMETRY_MODE_DEFAULT)  // SITL
-    .smartport_telemetry_mode = 0,
-#else
-    .smartport_telemetry_mode = SETTING_SMARTPORT_TELEMETRY_MODE_DEFAULT,
-#endif
-#endif // USE_TELEMETRY_SMARTPORT USE_CUSTOM_TELEMETRY
-#ifdef USE_CUSTOM_TELEMETRY
+#if defined(USE_CUSTOM_TELEMETRY)
+    .telemetry_mode = SETTING_TELEMETRY_MODE_DEFAULT,
     .telemetry_sensors =  { 0x0,  }, // all sensors enabled by default
 #endif
+
 );
 
 void telemetryInit(void)

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -55,16 +55,16 @@ typedef enum {
 } smartportFuelUnit_e;
 
 typedef enum {
-    CRSFR_TELEMETRY_STATE_OFF = 0,
-    CRSFR_TELEMETRY_STATE_NATIVE,
-    CRSFR_TELEMETRY_STATE_CUSTOM,
-    CRSFR_TELEMETRY_STATE_POPULATE,
-} crsfTelemetryMode_e;
+    TELEMETRY_STATE_OFF = 0,
+    TELEMETRY_STATE_LEGACY,
+    TELEMETRY_STATE_CUSTOM,
+    TELEMETRY_STATE_POPULATE,
+} telemetryState_e;
 
 typedef enum {
-    SMARTPORT_TELEMETRY_STATE_LEGACY = 0,
-    SMARTPORT_CRSFR_TELEMETRY_STATE_STANDARD,
-} smartportTelemetryMode_e;
+    TELEMETRY_MODE_LEGACY,
+    TELEMETRY_MODE_CUSTOM,
+} telemetryMode_e;
 
 typedef struct telemetryConfig_s {
     uint8_t telemetry_switch;               // Use aux channel to change serial output & baudrate( MSP / Telemetry ). It disables automatic switching to Telemetry when armed.
@@ -104,18 +104,13 @@ typedef struct telemetryConfig_s {
 #ifdef USE_TELEMETRY_CRSF
     uint16_t crsf_telemetry_link_rate;
     uint16_t crsf_telemetry_link_ratio;
-#ifdef USE_CUSTOM_TELEMETRY
-    uint8_t crsf_telemetry_mode;
-#endif
 #endif
 
-#if defined(USE_TELEMETRY_SMARTPORT) && defined(USE_CUSTOM_TELEMETRY)
-    uint8_t smartport_telemetry_mode;
-#endif
-
-#ifdef USE_CUSTOM_TELEMETRY
+#if  defined(USE_CUSTOM_TELEMETRY)
+    uint8_t telemetry_mode;
     uint16_t telemetry_sensors[TELEM_SENSOR_SLOT_COUNT];
 #endif
+
 } telemetryConfig_t;
 
 typedef struct {


### PR DESCRIPTION
Note: this PR needs updates in INAV Configurator

### Global changes
* added sensor scheduler, for each sensor is possible to set low and high refresh rate, low refresh rate is used if value of sensor is changed
* rewritten smartport and crsf telemetry

### SmarPort
* old legacy sensors have been removed, for ROLL and PITCh were used sensors for TEMP .. etc..
* [new list of telemetry sensors is ](https://github.com/error414/inav/blob/crsf_telemetry_sensor_extended/src/main/telemetry/smartport.c#L203)
* legacy fueID sensors was preserved, setting **smartportFuelUnit** as well
* it's possible to amend next sensors to sensor ID 0x51XX which is reserved for DYI sensor, in ethos must be added manualy, but it's possible use them in lua scripts

#### Ethos DIY sensors, how to add
it's native Ethos functionality, no needed to use any extra LUA script
![20251128_184214](https://github.com/user-attachments/assets/34df1121-6d5d-4ac4-9ae9-98125670ac0d)

#### Ethos sensors
![20251128_184307](https://github.com/user-attachments/assets/7b4c3510-307c-4cb6-ae46-540b103fccd9)

### CRSF
* new setting **crsf_telemetry_mode**, can be set to native (uses CRSF native telemetry), or to CUSTOM, for CUSTOM telemetry sensors are sensors transfered via CRSF frame 0x88, in the transmitter must run lua background script which translates custom sensors to native EdgeTX sensors, or it's possible to parse 0x88 frame directly in LUA script of third sides. 
* new settings **crsf_telemetry_link_rate** and **crsf_telemetry_link_ratio** it's if they match with ELRS settings, but it's not mandatory. 
* [list of NATIVE sensors](https://github.com/error414/inav/blob/crsf_telemetry_sensor_extended/src/main/telemetry/crsf.c#L338)
* [list of CUSTOM sensros](https://github.com/error414/inav/blob/crsf_telemetry_sensor_extended/src/main/telemetry/crsf.c#L349)
* example how could background lua script looks like [snztest.lua](https://github.com/error414/inav_crsf_custom_telemetry_lua/blob/master/snztest.lua)
* for 30 CUSTOMCRSF telemetry sensors is nice to set ELRS telemetry at least to 1500bauds

#### CSFR CUSTOMtelemetry sensors
![20251127_181058](https://github.com/user-attachments/assets/b01ffd7e-3563-41eb-83bc-4e6ffa9b5ebd)

#### CSFR NATIVE telemetry sensors
![20251127_181517](https://github.com/user-attachments/assets/429b2df6-9e23-4e5c-a90f-fabf610bd675)

### For considering
* I would prefer to keep as possible sensors for smartport and custom CRSF sensors as same as possible
* second question if we need extra settings for each sensor, ON/OFF


### Need to do

- [x]  new custom telemetry in INAV
- [ ]  use new custom CSFR telemetry sensors here: [OpenTX-Telemetry-Widget](https://github.com/iNavFlight/OpenTX-Telemetry-Widget)
- [ ] use new SmartPort sensors here: [ETHOS-Telemetry-Dashboard](https://github.com/iNavFlight/ETHOS-Telemetry-Dashboard)
- [ ] add configuration to sensors to [InavConfigurator](https://github.com/iNavFlight/inav-configurator)