### PR TITLE
Fix missing magnetometer support on NEXUSX target

### DIFF
--- a/src/main/target/NEXUSX/target.h
+++ b/src/main/target/NEXUSX/target.h
@@ -57,6 +57,9 @@
 #define BARO_I2C_BUS            BUS_I2C3
 #define USE_BARO_SPL06
 
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C3
+
 #define TEMPERATURE_I2C_BUS     DEFAULT_I2C
 
 #define PITOT_I2C_BUS           DEFAULT_I2C

--- a/src/main/target/NEXUSX/target.h
+++ b/src/main/target/NEXUSX/target.h
@@ -58,7 +58,8 @@
 #define USE_BARO_SPL06
 
 #define USE_MAG
-#define MAG_I2C_BUS             BUS_I2C3
+#define MAG_I2C_BUS             DEFAULT_I2C
+#define USE_MAG_ALL
 
 #define TEMPERATURE_I2C_BUS     DEFAULT_I2C
 


### PR DESCRIPTION
### **User description**
## Summary
Fixes "Invalid name" CLI error when users attempt to configure magnetometer settings on NEXUSX target.

## Problem
The NEXUSX target was missing `USE_MAG` definition, causing all magnetometer-related CLI settings to be excluded from the settings table. Users received "Invalid name" errors when trying to use:
- `set align_mag_roll=<value>`
- `set align_mag_pitch=<value>`
- `set align_mag_yaw=<value>`
- Other compass settings (mag_hardware, mag_declination, etc.)

## Root Cause
The PG_COMPASS_CONFIG parameter group in settings.yaml has `condition: USE_MAG` (line 558), which excludes all magnetometer settings when USE_MAG is not defined for the target.

## Solution
Added magnetometer support to NEXUSX target:
- Added `#define USE_MAG` to target.h
- Configured `MAG_I2C_BUS` to use I2C3 (same bus as barometer)

## Hardware Compatibility
NEXUSX board has I2C3 available for external magnetometer:
- I2C3 SCL: PA8
- I2C3 SDA: PC9  
- Barometer already on I2C3 (SPL06)
- Compatible with standard I2C magnetometers (HMC5883L, QMC5883, IST8310, LIS3MDL, etc.)

## Testing
✅ Built NEXUSX target successfully  
✅ Verified settings present in binary via strings command  
✅ All compass settings now available:
  - align_mag_roll, align_mag_pitch, align_mag_yaw (-1800 to 3600 decidegrees)
  - mag_hardware (AUTO, HMC5883, QMC5883, IST8310, etc.)
  - mag_declination (-18000 to 18000)
  - magzero_x/y/z, maggain_x/y/z
  - mag_calibration_time (20-120 seconds)

## Impact
- **Risk**: Low - Only enables missing functionality, no behavior changes
- **Flash**: Minimal increase (<1KB)
- **Default**: No change (mag hardware defaults to AUTO, disabled if not detected)
- **Backward compatibility**: Existing configurations unaffected

## Files Changed
- `src/main/target/NEXUSX/target.h` - Added USE_MAG and MAG_I2C_BUS definitions


___

### **PR Type**
Bug fix


___

### **Description**
- Enables missing magnetometer support on NEXUSX target

- Adds USE_MAG definition and configures MAG_I2C_BUS to I2C3

- Resolves "Invalid name" CLI errors for compass settings

- Allows external magnetometer configuration via I2C3 bus


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NEXUSX Target"] -->|Missing USE_MAG| B["CLI Errors"]
  B -->|Invalid name| C["Compass Settings Unavailable"]
  A -->|Add USE_MAG| D["Magnetometer Enabled"]
  D -->|Configure MAG_I2C_BUS| E["I2C3 Bus"]
  E -->|Shared with| F["Barometer SPL06"]
  D -->|Enable| G["Compass Settings Available"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Enable magnetometer on I2C3 bus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/NEXUSX/target.h

<ul><li>Added <code>#define USE_MAG</code> to enable magnetometer support<br> <li> Added <code>#define MAG_I2C_BUS BUS_I2C3</code> to configure magnetometer I2C bus<br> <li> Magnetometer shares I2C3 bus with existing barometer (SPL06)<br> <li> Enables all compass-related CLI settings (align_mag_roll/pitch/yaw, <br>mag_hardware, mag_declination, etc.)</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11157/files#diff-68db77ab2521a8e5f5a4b3aed5a8c2a94e9520310fb496af593a9b343caf5135">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

