### PR TITLE
Add support for Puya PY25Q128HA flash chip

### DIFF
--- a/docs/Blackbox.md
+++ b/docs/Blackbox.md
@@ -120,6 +120,7 @@ These chips are also supported:
 * Winbond W25Q64 - 64 Mbit / 8 MByte
 * Micron N25Q0128 - 128 Mbit / 16 MByte
 * Winbond W25Q128 - 128 Mbit / 16 MByte
+* Puya PY25Q128HA - 128 Mbit / 16 MByte
 * Winbond W25N01  - 1 Gbit / 128 MByte
 * Winbond W25N02  - 2 Gbit / 256 MByte
 

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -99,6 +99,9 @@ struct {
     // Winbond W25Q128_DTR
     // Datasheet: https://www.winbond.com/resource-files/w25q128jv%20dtr%20revb%2011042016.pdf
     {0xEF7018, 256, 256},
+    // Puya PY25Q128HA
+    // Datasheet: https://www.puyasemi.com/cpzx3/info_271_itemid_87.html
+    {0x856018, 256, 256},
     // Winbond W25Q256
     // Datasheet: https://www.winbond.com/resource-files/w25q256jv%20spi%20revb%2009202016.pdf
     {0xEF4019, 512, 256},


### PR DESCRIPTION
### **User description**
## Summary

Adds detection and support for the Puya PY25Q128HA flash chip, a W25Q128-compatible 128Mbit (16MB) SPI NOR flash commonly found on flight controllers.

## Changes

**Driver Support (flash_m25p16.c:102-104)**
- Added JEDEC ID entry (0x856018) to `m25p16FlashConfig[]` array for automatic chip detection

**Documentation (Blackbox.md:123)**
- Added PY25Q128HA to the list of supported flash chips

## Technical Details

- **JEDEC ID**: 0x856018
  - Manufacturer: 0x85 (Puya Semiconductor)
  - Memory Type: 0x60
  - Capacity: 0x18 (128Mbit)
- **Geometry**: 256 sectors × 256 pages × 256 bytes = 16 MByte
- **Command Set**: Standard W25Q128-compatible (no driver changes needed)

## Testing

The PY25Q128HA uses an identical command set to the W25Q128 and other supported flash chips. The existing M25P16-compatible driver already supports all necessary operations:
- JEDEC ID detection (0x9F)
- Read/write/erase operations
- Standard timing parameters

## Compatibility

This is a backwards-compatible change:
- Adds new chip detection only
- No changes to existing driver logic
- No impact on boards without this chip
- Boards with PY25Q128HA will now auto-detect the chip at boot

## Files Changed

- `src/main/drivers/flash_m25p16.c` - Added JEDEC ID entry
- `docs/Blackbox.md` - Updated documentation


___

### **PR Type**
Enhancement


___

### **Description**
- Adds JEDEC ID detection for Puya PY25Q128HA flash chip

- Enables automatic chip recognition during initialization

- Updates documentation with new supported flash chip


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Puya PY25Q128HA<br/>JEDEC ID: 0x856018"] -- "Added to detection table" --> B["flash_m25p16FlashConfig[]"]
  B -- "Auto-detection at boot" --> C["Chip Support Enabled"]
  D["Documentation Updated"] -- "Lists supported chips" --> E["Blackbox.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flash_m25p16.c</strong><dd><code>Add Puya PY25Q128HA JEDEC ID to flash config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/flash_m25p16.c

<ul><li>Added Puya PY25Q128HA JEDEC ID entry (0x856018) to <code>m25p16FlashConfig[]</code> <br>array<br> <li> Included datasheet reference link for the chip<br> <li> Configured with 256 sectors and 256 pages matching W25Q128 geometry</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11166/files#diff-2ad78b94f71be2b6a76102ec4dbc7373808d625d14bc22b4efe36428be9ed456">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Blackbox.md</strong><dd><code>Document Puya PY25Q128HA support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Blackbox.md

<ul><li>Added Puya PY25Q128HA to the list of supported flash chips<br> <li> Documented chip capacity as 128 Mbit / 16 MByte<br> <li> Maintains consistent formatting with existing chip entries</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11166/files#diff-d1fcf9c932a9dc968671225678219c98d0d419640ae4ad49e4d9aad48737ad1c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

