### PR TITLE
Small C nitpicks from static analysis

### DIFF
--- a/src/main/fc/config.h
+++ b/src/main/fc/config.h
@@ -63,7 +63,7 @@ typedef enum {
     FEATURE_PWM_OUTPUT_ENABLE = 1 << 28,
     FEATURE_OSD = 1 << 29,
     FEATURE_FW_LAUNCH = 1 << 30,
-    FEATURE_FW_AUTOTRIM = 1 << 31,
+    FEATURE_FW_AUTOTRIM = 1U << 31,
 } features_e;
 
 typedef struct systemConfig_s {

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -172,8 +172,8 @@ static const char* const gpsFixTypeText[] = {
     "3D"
 };
 
-static const char* tickerCharacters = "|/-\\"; // use 2/4/8 characters so that the divide is optimal.
-#define TICKER_CHARACTER_COUNT (sizeof(tickerCharacters) / sizeof(char))
+static const char tickerCharacters[] = "|/-\\"; // use 2/4/8 characters so that the divide is optimal.
+#define TICKER_CHARACTER_COUNT (sizeof(tickerCharacters) - 1)
 
 static timeUs_t nextPageAt;
 static bool forcePageChange;

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -160,6 +160,11 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *rxCallbackData)
     // full frame length includes the length of the address and framelength fields
     const int fullFrameLength = crsfFramePosition < 3 ? 5 : crsfFrame.frame.frameLength + CRSF_FRAME_LENGTH_ADDRESS + CRSF_FRAME_LENGTH_FRAMELENGTH;
 
+    if (fullFrameLength > CRSF_FRAME_SIZE_MAX) {
+        crsfFramePosition = 0;
+        return;
+    }
+
     if (crsfFramePosition < fullFrameLength) {
         crsfFrame.bytes[crsfFramePosition++] = (uint8_t)c;
         crsfFrameDone = crsfFramePosition < fullFrameLength ? false : true;

--- a/src/main/sensors/temperature.c
+++ b/src/main/sensors/temperature.c
@@ -98,7 +98,7 @@ static void newSensorCheckAndEnter(uint8_t type, uint64_t addr)
 
 void temperatureInit(void)
 {
-    memset(sensorStatus, 0, sizeof(sensorStatus) * sizeof(*sensorStatus));
+    memset(sensorStatus, 0, sizeof(sensorStatus));
 
     sensorsSet(SENSOR_TEMP);
 


### PR DESCRIPTION
### **User description**
## Summary

Minor fixes found during cppcheck static analysis review. None of these are likely to cause issues in practice, but they're worth cleaning up.

## Changes

- **fc/config.h**: Use `1U << 31` instead of `1 << 31` for FEATURE_FW_AUTOTRIM to avoid signed integer overflow with a different compiler (undefined behavior in C)
- **sensors/temperature.c**: Fix doubled sizeof in memset - was `sizeof(array) * sizeof(*array)`, should be just `sizeof(array)`
- **rx/crsf.c**: Add bounds check on frame length to prevent potential buffer overflow from malformed packets
- **io/dashboard.c**: Change `tickerCharacters` from pointer to array so sizeof() returns string length, not pointer size



