### PR TITLE
Power and Current Limiting fix and documentation

### DIFF
--- a/docs/Battery.md
+++ b/docs/Battery.md
@@ -296,8 +296,8 @@ Enable these in the OSD tab to monitor limiting during flight.
 ### Calibration Tips
 
 1. **Find your battery's limits**: Check manufacturer specifications for continuous and burst C-ratings
-   - Continuous limit = `battery_capacity_mAh × continuous_C_rating / 1000` (in dA)
-   - Burst limit = `battery_capacity_mAh × burst_C_rating / 1000` (in dA)
+   - Continuous limit = `battery_capacity_mAh × continuous_C_rating / 100` (in dA)
+   - Burst limit = `battery_capacity_mAh × burst_C_rating / 100` (in dA)
 
 2. **Test incrementally**: Start with conservative limits and increase gradually
 

--- a/src/main/flight/power_limits.c
+++ b/src/main/flight/power_limits.c
@@ -73,7 +73,10 @@ static bool wasLimitingPower = false;
 #endif
 
 void powerLimiterInit(void) {
-    if (currentBatteryProfile->powerLimits.burstCurrent < currentBatteryProfile->powerLimits.continuousCurrent) {
+    // Only enforce burst >= continuous if burst is enabled (non-zero)
+    // A value of 0 means "disabled/unlimited", not "zero amps allowed"
+    if (currentBatteryProfile->powerLimits.burstCurrent > 0 &&
+        currentBatteryProfile->powerLimits.burstCurrent < currentBatteryProfile->powerLimits.continuousCurrent) {
         currentBatteryProfileMutable->powerLimits.burstCurrent = currentBatteryProfile->powerLimits.continuousCurrent;
     }
 
@@ -87,7 +90,9 @@ void powerLimiterInit(void) {
     pt1FilterInitRC(&currentThrLimitingBaseFilter, LIMITING_THR_FILTER_TCONST, 0);
 
 #ifdef USE_ADC
-    if (currentBatteryProfile->powerLimits.burstPower < currentBatteryProfile->powerLimits.continuousPower) {
+    // Only enforce burst >= continuous if burst is enabled (non-zero)
+    if (currentBatteryProfile->powerLimits.burstPower > 0 &&
+        currentBatteryProfile->powerLimits.burstPower < currentBatteryProfile->powerLimits.continuousPower) {
         currentBatteryProfileMutable->powerLimits.burstPower = currentBatteryProfile->powerLimits.continuousPower;
     }
 


### PR DESCRIPTION
\## Summary

Documents INAV's power and current limiting feature (added in 3.0.0) which has never had sufficient user-facing documentation, and fixes a bug where burst limit of 0 (unlimited) was incorrectly overwritten to match continuous limit.

## Changes

### 1. Documentation (`docs/Battery.md`) - 149 lines added
- Power and Current Limiting section explaining burst vs continuous modes
- Configuration tables for all 8 limit settings
- Three practical examples: battery protection, racing compliance, combined limits
- OSD elements and calibration tips

### 2. Bug Fix (`src/main/flight/power_limits.c`)

**Problem:** Setting `limit_burst_current = 0` (unlimited) was overwritten to match `limit_cont_current` because 0 was treated numerically instead of as "disabled".

**Example:**
```
set limit_cont_current = 1000    # 100A continuous
set limit_burst_current = 0      # Want unlimited bursts
save
# After reboot: limit_burst_current = 1000 (incorrect)
```

**Fix:** Only enforce `burst >= continuous` when burst is non-zero. Applied to both current and power limits.