### PR TITLE
MSP: Add minimum power index to MSP_VTX_CONFIG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ launch.json
 # Assitnow token and files for test script
 tokens.yaml
 *.ubx
+
+# Local development files
+.semgrepignore
+build_sitl/
+CLAUDE.md
+brother/

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,3 @@ tokens.yaml
 # Local development files
 .semgrepignore
 build_sitl/
-CLAUDE.md
-brother/

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1526,6 +1526,12 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
                 sbufWriteU8(dst, vtxDevice->capability.bandCount);
                 sbufWriteU8(dst, vtxDevice->capability.channelCount);
                 sbufWriteU8(dst, vtxDevice->capability.powerCount);
+
+                uint8_t minPowerIndex = 1;
+                if (deviceType == VTXDEV_MSP) {
+                    minPowerIndex = 0;
+                }
+                sbufWriteU8(dst, minPowerIndex);
             }
             else {
                 sbufWriteU8(dst, VTXDEV_UNKNOWN); // no VTX configured


### PR DESCRIPTION
### **User description**
## Summary

Adds `minPowerIndex` (byte 12) to `MSP_VTX_CONFIG` response to indicate the minimum valid power index for VTX devices.

This complements the existing `powerCount` field and enables configurator to display all available power levels without hardcoding device-specific logic.

**Related Configurator PR:** iNavFlight/inav-configurator#2486

## Changes

**File:** `src/main/fc/fc_msp.c`

Added single byte to `MSP_VTX_CONFIG` response after `powerCount`:

```c
uint8_t minPowerIndex = 1;  // Default for most VTX devices
if (deviceType == VTXDEV_MSP) {
    minPowerIndex = 0;  // MSP supports power off
}
sbufWriteU8(dst, minPowerIndex);
```

**Values:**
- **MSP VTX:** `minPowerIndex = 0` (supports power off at index 0)
- **SmartAudio/Tramp:** `minPowerIndex = 1` (power off not supported)

## Protocol Change

### Before (11 bytes):
1. device_type
2. band
3. channel
4. power
5. pitmode
6. ready
7. low_power_disarm
8. vtxtable_available
9. band_count
10. channel_count
11. power_count

### After (12 bytes):
1-11. (same as above)
12. **minPowerIndex** (NEW)

## Compatibility

### ✅ Backward Compatible
- **Old configurators (9.0) + New firmware (9.1):** Works - old configurators ignore byte 12
- **New configurators (9.1) + Old firmware (9.0):** Works - new configurators have fallback logic

### MSP Power Level Examples

**MSP VTX (minPowerIndex=0, powerCount=4):**
- Valid indices: 0, 1, 2, 3, 4
- Index 0 = power off
- Indices 1-4 = active power levels

**SmartAudio (minPowerIndex=1, powerCount=8):**
- Valid indices: 1, 2, 3, 4, 5, 6, 7, 8
- Power off not supported (pit mode instead)

## Rationale

Current firmware sends `powerCount` (maximum valid index) but not the minimum. This works for most VTX devices which start at index 1, but MSP VTX devices support power off at index 0.

Without this change, configurators must hardcode device-type-specific logic:
```javascript
// Hardcoded logic (bad)
var minPower = (device_type == DEV_MSP) ? 0 : 1;
```

With this change, configurator gets complete info from firmware:
```javascript
// Dynamic from firmware (good)
var minPower = FC.VTX_CONFIG.power_min;
```

## Testing

- ✅ Code compiles cleanly
- ✅ Backward compatibility verified (old configurators ignore extra byte)
- ✅ Forward compatibility verified (new configurator has fallback)
- 🔲 Hardware testing pending (MSP, SmartAudio, Tramp VTX devices)

## Related

- Configurator PR: iNavFlight/inav-configurator#2486
- Original issue: iNavFlight/inav-configurator#2202


### **Description**
- Adds minPowerIndex field to MSP_VTX_CONFIG response

- Enables configurators to display power levels dynamically

- MSP VTX devices report minPowerIndex=0, others report 1

- Maintains backward compatibility with older configurators


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MSP_VTX_CONFIG Request"] --> B["Check Device Type"]
  B --> C{"Is MSP VTX?"}
  C -->|Yes| D["minPowerIndex = 0"]
  C -->|No| E["minPowerIndex = 1"]
  D --> F["Send 12-byte Response"]
  E --> F
  F --> G["Configurator Receives Complete Power Range Info"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fc_msp.c</strong><dd><code>Add minPowerIndex to VTX config response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/fc/fc_msp.c

<ul><li>Added minPowerIndex field (byte 12) to MSP_VTX_CONFIG response<br> <li> Sets minPowerIndex to 0 for VTXDEV_MSP devices, 1 for others<br> <li> Placed after powerCount field in response buffer<br> <li> Enables dynamic power level configuration without hardcoding device <br>logic</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11190/files#diff-e67741f944e959c3f68a81189a5fcd8be50f5e4e567c1fc68f50ac5e86d0a233">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

