### PR TITLE
docs: Update Development.md with maintenance branch workflow

### DIFF
--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -107,10 +107,12 @@ The main flow for a contributing is as follows:
 7. `git add <files that have changed>`
 8. `git commit`
 9. `git push origin my-new-code`
-10. Create pull request using github UI to merge your changes from your new branch into `inav/master`
+10. Create pull request using github UI to merge your changes from your new branch into the appropriate target branch (see "Branching and release workflow" below)
 11. Repeat from step 4 for new other changes.
 
 The primary thing to remember is that separate pull requests should be created for separate branches.  Never create a pull request from your `master` branch.
+
+**Important:** Most contributions should target a maintenance branch, not `master`. See the branching section below for guidance on choosing the correct target branch.
 
 Later, you can get the changes from the INAV repo into your `master` branch by adding INAV as a git remote and merging from it as follows:
 
@@ -125,10 +127,88 @@ You can also perform the git commands using the git client inside Eclipse.  Refe
 
 ## Branching and release workflow
 
-Normally, all development occurs on the `master` branch. Every release will have it's own branch named `release_x.y.z`.
+INAV uses maintenance branches for active development and releases. The `master` branch receives merges from maintenance branches.
 
-During release candidate cycle we will follow the process outlined below:
+### Branch Types
 
-1. Create a release branch `release_x.y.z`
-2. All bug fixes found in the release candidates will be merged into `release_x.y.z` branch and not into the `master`.
-3. After final release is made, the branch `release_x.y.z` is locked, and merged into `master` bringing all of the bug fixes into the development branch. Merge conflicts that may arise at this stage are resolved manually.
+#### Maintenance Branches (Current and Next Major Version)
+
+**Current version branch** (e.g., `maintenance-9.x`):
+- Used for backward-compatible changes
+- Bug fixes, new features, and improvements that don't break compatibility
+- Changes here will be included in the next release of the current major version (e.g., 9.1, 9.2)
+- Does not create compatibility issues between firmware and configurator within the same major version
+
+**Next major version branch** (e.g., `maintenance-10.x`):
+- Used for changes that introduce compatibility requirements
+- Breaking changes that would cause issues between different major versions
+- New features that require coordinated firmware and configurator updates
+- Changes here will be included in the next major version release (e.g., 10.0)
+
+#### Master Branch
+
+The `master` branch receives periodic merges from maintenance branches.
+
+### Choosing the Right Target Branch
+
+When creating a pull request, target the appropriate branch:
+
+**Target the current version branch** (e.g., `maintenance-9.x`) if your change:
+- Fixes a bug
+- Adds a new feature that is backward-compatible
+- Updates documentation
+- Adds or updates hardware targets
+- Makes improvements that work with existing releases
+
+**Target the next major version branch** (e.g., `maintenance-10.x`) if your change:
+- Breaks compatibility with the current major version
+- Requires coordinated firmware and configurator updates
+- Changes MSP protocol in an incompatible way
+- Modifies data structures in a breaking way
+
+### Release Workflow
+
+1. Development occurs on the current version maintenance branch (e.g., `maintenance-9.x`)
+2. When ready for release, a release candidate is tagged from the maintenance branch
+3. Bug fixes during the RC period continue on the maintenance branch
+4. After final release, the maintenance branch is periodically merged into `master`
+5. The cycle continues with the maintenance branch receiving new changes for the next release
+
+### Example Timeline
+
+Current state (example):
+- `maintenance-9.x` - Active development for INAV 9.1, 9.2, etc.
+- `maintenance-10.x` - Breaking changes for future INAV 10.0
+- `master` - Receives periodic merges from maintenance branches
+
+After INAV 10.0 is released:
+- `maintenance-10.x` - Active development for INAV 10.1, 10.2, etc.
+- `maintenance-11.x` - Breaking changes for future INAV 11.0
+- `master` - Continues receiving merges
+
+### Working with Maintenance Branches
+
+To branch from the current maintenance branch instead of master:
+
+```bash
+# Fetch latest changes
+git fetch upstream
+
+# Create your feature branch from the maintenance branch
+git checkout -b my-new-feature upstream/maintenance-9.x
+
+# Make changes, commit, and push
+git push origin my-new-feature
+
+# Create PR targeting maintenance-9.x (not master)
+```
+
+When updating your fork:
+
+```bash
+# Get the latest maintenance branch changes
+git fetch upstream
+git checkout maintenance-9.x
+git merge upstream/maintenance-9.x
+git push origin maintenance-9.x
+```

--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -174,6 +174,23 @@ When creating a pull request, target the appropriate branch:
 4. After final release, the maintenance branch is periodically merged into `master`
 5. The cycle continues with the maintenance branch receiving new changes for the next release
 
+### Propagating Changes Between Maintenance Branches
+
+Changes committed to the current version branch should be merged forward to the next major version branch to prevent regressions.
+
+**Maintainer workflow:**
+- Changes merged to `maintenance-9.x` should be regularly merged into `maintenance-10.x`
+- This ensures fixes and features aren't lost when the next major version is released
+- Prevents users from experiencing bugs in v10.0 that were already fixed in v9.x
+
+**Example:**
+```bash
+# Merge changes from current to next major version
+git checkout maintenance-10.x
+git merge maintenance-9.x
+git push upstream maintenance-10.x
+```
+
 ### Example Timeline
 
 Current state (example):
@@ -208,7 +225,7 @@ When updating your fork:
 ```bash
 # Get the latest maintenance branch changes
 git fetch upstream
-git checkout maintenance-9.x
-git merge upstream/maintenance-9.x
-git push origin maintenance-9.x
+
+# Push directly from upstream to your fork (no local checkout needed)
+git push origin upstream/maintenance-9.x:maintenance-9.x
 ```


### PR DESCRIPTION
### **User description**
## Summary

Updates the "Branching and release workflow" section in Development.md to reflect the current maintenance branch strategy instead of the outdated release branch workflow.

## Changes

- **Replaced outdated workflow:** Removed references to old `release_x.y.z` branches and "all development occurs on master" 
- **Documented maintenance branches:** Explains current version (e.g., `maintenance-9.x`) and next major version (e.g., `maintenance-10.x`) branches
- **Generic terminology:** Uses "current version" and "next major version" with examples, so documentation remains valid when version 11, 12, etc. arrive
- **Target branch guidance:** Clear criteria for choosing between current version vs next major version branches
- **Updated workflow examples:** Git commands now show branching from `upstream/maintenance-9.x` instead of `master`

## Motivation

The existing documentation was misleading contributors:
- Stated "Normally, all development occurs on the `master` branch" (no longer true)
- Described `release_x.y.z` branches that aren't used in current workflow
- Didn't mention `maintenance-X.x` branches that are actively used
- Contributed to PRs being incorrectly targeted at `master` instead of maintenance branches

## Testing

- [x] Documentation builds correctly (Markdown format)
- [x] Examples use current branch names (`maintenance-9.x`, `maintenance-10.x`)
- [x] Future-proof terminology ensures docs won't need rewriting for version 11+

## Related

- Complements PR #11148 (GitHub Action that suggests maintenance branches)
- Addresses findings in recent PR targeting analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Replaces outdated release branch workflow with current maintenance branch strategy

- Documents maintenance-X.x branches for backward-compatible and breaking changes

- Provides clear guidance on choosing correct target branch for contributions

- Updates workflow examples to branch from maintenance branches instead of master

- Adds emphasis that most contributions should target maintenance branches


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Contributor"] -->|"Creates feature branch from"| B["maintenance-9.x<br/>Current Version"]
  A -->|"Creates feature branch from"| C["maintenance-10.x<br/>Next Major Version"]
  B -->|"Bug fixes &<br/>backward-compatible changes"| D["Release Candidate"]
  C -->|"Breaking changes &<br/>new major features"| E["Future Major Release"]
  D -->|"Periodic merge"| F["master"]
  E -->|"Periodic merge"| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Development.md</strong><dd><code>Update branching documentation to maintenance branch workflow</code></dd></summary>
<hr>

docs/development/Development.md

<ul><li>Replaced outdated <code>release_x.y.z</code> branch references with current <br><code>maintenance-X.x</code> strategy<br> <li> Added comprehensive branching section explaining current version and <br>next major version branches<br> <li> Documented decision criteria for targeting appropriate maintenance <br>branch<br> <li> Included practical git command examples for working with maintenance <br>branches<br> <li> Added warning that most contributions should target maintenance <br>branches, not master</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11191/files#diff-4b48e1dc0ad66b22a48865229fcb3fff6cf58669947c8df5a0938a6f4b5493c0">+86/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

