### PR TITLE
Add target OMNIBUSF4V3_ICM to OMNIBUSF4 and mark as SKIP_RELEASES

### DIFF
--- a/src/main/target/OMNIBUSF4/CMakeLists.txt
+++ b/src/main/target/OMNIBUSF4/CMakeLists.txt
@@ -9,3 +9,4 @@ target_stm32f405xg(OMNIBUSF4V3_S6_SS)
 # OMNIBUSF4V3 is a (almost identical) variant of OMNIBUSF4PRO target,
 # except for an inverter on UART6.
 target_stm32f405xg(OMNIBUSF4V3)
+target_stm32f405xg(OMNIBUSF4V3_ICM)

--- a/src/main/target/OMNIBUSF4/CMakeLists.txt
+++ b/src/main/target/OMNIBUSF4/CMakeLists.txt
@@ -9,4 +9,4 @@ target_stm32f405xg(OMNIBUSF4V3_S6_SS)
 # OMNIBUSF4V3 is a (almost identical) variant of OMNIBUSF4PRO target,
 # except for an inverter on UART6.
 target_stm32f405xg(OMNIBUSF4V3)
-target_stm32f405xg(OMNIBUSF4V3_ICM)
+target_stm32f405xg(OMNIBUSF4V3_ICM SKIP_RELEASES)

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -84,7 +84,7 @@
   #define IMU_MPU6000_ALIGN       CW180_DEG
 #endif
 
-// Support for OMNIBUS F4 PRO CORNER - it has MPU6500 instead of MPU6000
+// Support for OMNIBUS F4 PRO CORNER - it has MPU6500/ICM20608 instead of MPU6000
 #if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)
   #define MPU6500_CS_PIN          MPU6000_CS_PIN
   #define MPU6500_SPI_BUS         MPU6000_SPI_BUS

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -259,7 +259,7 @@
 #define SENSORS_SET (SENSOR_ACC|SENSOR_MAG|SENSOR_BARO)
 
 #define USE_LED_STRIP
-#if (defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)) || defined(OMNIBUSF4V3_ICM) && !defined(OMNIBUSF4PRO_LEDSTRIPM5)
+#if (defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)) && !defined(OMNIBUSF4PRO_LEDSTRIPM5)
   #define WS2811_PIN                   PB6
 #else
   #define WS2811_PIN                   PA1

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -30,6 +30,8 @@
 #define TARGET_BOARD_IDENTIFIER "OBSD"
 #elif defined(OMNIBUSF4V3)
 #define TARGET_BOARD_IDENTIFIER "OB43"
+#elif defined(OMNIBUSF4V3_ICM)
+#define TARGET_BOARD_IDENTIFIER "OB4I"
 #elif defined(DYSF4PRO)
 #define TARGET_BOARD_IDENTIFIER "DYS4"
 #elif defined(DYSF4PROV2)
@@ -67,7 +69,14 @@
 #define MPU6000_CS_PIN          PA4
 #define MPU6000_SPI_BUS         BUS_SPI1
 
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4V3_ICM)
+  #define USE_IMU_ICM42605
+  #define IMU_ICM42605_ALIGN      CW180_DEG
+  #define ICM42605_CS_PIN         PA4
+  #define ICM42605_SPI_BUS        BUS_SPI1
+#endif
+
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)
   #define USE_IMU_MPU6000
   #define IMU_MPU6000_ALIGN       CW270_DEG
 #else
@@ -75,8 +84,8 @@
   #define IMU_MPU6000_ALIGN       CW180_DEG
 #endif
 
-// Support for OMNIBUS F4 PRO CORNER - it has ICM20608 instead of MPU6000
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+// Support for OMNIBUS F4 PRO CORNER - it has MPU6500 instead of MPU6000
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)
   #define MPU6500_CS_PIN          MPU6000_CS_PIN
   #define MPU6500_SPI_BUS         MPU6000_SPI_BUS
   #define USE_IMU_MPU6500
@@ -97,7 +106,7 @@
 
 #define USE_BARO
 
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)
   #define USE_BARO_BMP280
   #define BMP280_SPI_BUS        BUS_SPI3
   #define BMP280_CS_PIN         PB3 // v1
@@ -121,7 +130,7 @@
 #define VBUS_SENSING_PIN        PC5
 #define VBUS_SENSING_ENABLED
 
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)
 #define USE_UART_INVERTER
 #endif
 
@@ -140,12 +149,12 @@
 #define USE_UART6
 #define UART6_RX_PIN            PC7
 #define UART6_TX_PIN            PC6
-#if defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)
   #define INVERTER_PIN_UART6_RX PC8
   #define INVERTER_PIN_UART6_TX PC9
 #endif
 
-#if defined(OMNIBUSF4V3) && !(defined(OMNIBUSF4V3_S6_SS) || defined(OMNIBUSF4V3_S5S6_SS) || defined(OMNIBUSF4V3_S5_S6_2SS))
+#if (defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)) && !(defined(OMNIBUSF4V3_S6_SS) || defined(OMNIBUSF4V3_S5S6_SS) || defined(OMNIBUSF4V3_S5_S6_2SS))
 #define USE_SOFTSERIAL1
 #define SOFTSERIAL_1_RX_PIN     PC6     // shared with UART6 TX
 #define SOFTSERIAL_1_TX_PIN     PC6     // shared with UART6 TX
@@ -193,7 +202,7 @@
 
 #define USE_SPI_DEVICE_1
 
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)
   #define USE_SPI_DEVICE_2
   #define SPI2_NSS_PIN          PB12
   #define SPI2_SCK_PIN          PB13
@@ -202,7 +211,7 @@
 #endif
 
 #define USE_SPI_DEVICE_3
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)
   #define SPI3_NSS_PIN          PA15
 #else
   #define SPI3_NSS_PIN          PB3
@@ -215,7 +224,7 @@
 #define MAX7456_SPI_BUS         BUS_SPI3
 #define MAX7456_CS_PIN          PA15
 
-#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)
+#if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)
   #define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
   #define USE_SDCARD
   #define USE_SDCARD_SPI
@@ -250,7 +259,7 @@
 #define SENSORS_SET (SENSOR_ACC|SENSOR_MAG|SENSOR_BARO)
 
 #define USE_LED_STRIP
-#if (defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3)) && !defined(OMNIBUSF4PRO_LEDSTRIPM5)
+#if (defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)) || defined(OMNIBUSF4V3_ICM) && !defined(OMNIBUSF4PRO_LEDSTRIPM5)
   #define WS2811_PIN                   PB6
 #else
   #define WS2811_PIN                   PA1


### PR DESCRIPTION
### **User description**
There is an ongoing need for a new OMNIBUSF4V3 target with ICM42605/ICM42688 gyro per:
https://www.reddit.com/r/fpv/comments/1fx8zvp/comment/ntxlvic/
This latest FC version is attractively priced for fixed wing applications.

This PR adds OMNIBUSF4V3_ICM as a variant of the OMNIBUSF4V3 target by only adding ICM42605 support and nothing else. A custom build as uploaded to Issue #11181 was successfully verified on target hardware. User reported improved performance compared to original OMNIBUSF4V3 target:
> Hi, thank you for your custom firmware. The UARTs are working well, and everything is working better than the previous custom firmware I flashed. However, your custom firmware has one small issue: the gyro is reversed.
> And the cpu load is reduced in this firmware! the last one is 50% but this one only 17 -> 25%
> sometime < 10%

After changing gyro alignment from CW0_DEG to CW180_DEG:
> It working well !
> I think it’s ready to fly. I’ve tested all the important features, and they’re working well. Thank you for your support.
> Can I share this firmware with the Vietnamese community? It would help a lot.

User also shared video capture from Inav Configurator.

Since the INAV devs do not appear to have official hardware to test, this target is being marked as SKIP_RELEASES.

https://github.com/user-attachments/assets/0aacac41-c24b-4bcd-bcac-3f31a71982d6


___

### **PR Type**
New Target


___

### **Description**
- Add OMNIBUSF4V3_ICM target variant with ICM42605/ICM42688 gyro support

- Configure ICM42605 with CW180_DEG alignment and SPI1 bus

- Mark new target as SKIP_RELEASES due to lack of official hardware

- Update conditional compilation directives to include new target variant


___

### Diagram Walkthrough


```mermaid
flowchart LR
  OMNIBUSF4["OMNIBUSF4 Target Family"]
  OMNIBUSF4V3["OMNIBUSF4V3<br/>MPU6000 Gyro"]
  OMNIBUSF4V3_ICM["OMNIBUSF4V3_ICM<br/>ICM42605 Gyro"]
  OMNIBUSF4 --> OMNIBUSF4V3
  OMNIBUSF4 --> OMNIBUSF4V3_ICM
  OMNIBUSF4V3_ICM -- "Board ID: OB4I" --> Config["SPI1 Configuration<br/>CW180_DEG Alignment"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>New target</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Configure ICM42605 gyro and target conditionals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/OMNIBUSF4/target.h

<ul><li>Add board identifier "OB4I" for OMNIBUSF4V3_ICM target<br> <li> Configure ICM42605 IMU with CW180_DEG alignment on SPI1 bus<br> <li> Update multiple conditional compilation blocks to include <br>OMNIBUSF4V3_ICM variant<br> <li> Update comment to clarify MPU6500/ICM20608 support</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11192/files#diff-d1bdd3ed7f09746e0ae1b18501fd54d8268c1fd3111da118074f6126a656c4ed">+20/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Add OMNIBUSF4V3_ICM target build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/OMNIBUSF4/CMakeLists.txt

<ul><li>Add new OMNIBUSF4V3_ICM target with STM32F405XG MCU<br> <li> Mark target with SKIP_RELEASES flag to prevent release builds</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11192/files#diff-9a885c3e1aec519c74c0c72bad07d8e440ed2e8576b29be970528ac4e76a9b82">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

