### PR TITLE
Fix H743 USB MSC regression and SDIO reliability issues

### DIFF
--- a/src/main/drivers/sdcard/sdcard_impl.h
+++ b/src/main/drivers/sdcard/sdcard_impl.h
@@ -32,6 +32,7 @@
 
 #define SDCARD_TIMEOUT_INIT_MILLIS                  200
 #define SDCARD_MAX_CONSECUTIVE_FAILURES             8
+#define SDCARD_MAX_OPERATION_RETRIES                3
 
 typedef enum {
     // In these states we run at the initialization 400kHz clockspeed:
@@ -62,6 +63,7 @@ typedef struct sdcard_t {
     uint32_t operationStartTime;
 
     uint8_t failureCount;
+    uint8_t operationRetries;  // Retry count for current operation before reset
 
     uint8_t version;
     bool highCapacity;

--- a/src/main/drivers/usb_msc_h7xx.c
+++ b/src/main/drivers/usb_msc_h7xx.c
@@ -84,7 +84,9 @@ uint8_t mscStart(void)
     IOInit(IOGetByTag(IO_TAG(PA11)), OWNER_USB, 0, 0);
     IOInit(IOGetByTag(IO_TAG(PA12)), OWNER_USB, 0, 0);
 
-    USBD_Init(&USBD_Device, &VCP_Desc, 0);
+    // Use MSC descriptor for standalone MSC mode (not composite)
+    // This fixes Windows enumeration issue with new USB library v2.11.3
+    USBD_Init(&USBD_Device, &MSC_Desc, 0);
 
     /** Regsiter class */
     USBD_RegisterClass(&USBD_Device, USBD_MSC_CLASS);

--- a/src/main/msc/usbd_storage_sd_spi.c
+++ b/src/main/msc/usbd_storage_sd_spi.c
@@ -29,6 +29,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "platform.h"
 #include "common/utils.h"
@@ -39,6 +40,7 @@
 #include "drivers/light_led.h"
 #include "drivers/io.h"
 #include "drivers/bus_spi.h"
+#include "drivers/time.h"
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
@@ -55,6 +57,12 @@
 #define STORAGE_LUN_NBR                  1
 #define STORAGE_BLK_NBR                  0x10000
 #define STORAGE_BLK_SIZ                  0x200
+
+// H7 SDIO DMA requires 32-byte aligned buffers
+// USB MSC bot_data buffer is only 16-byte aligned, so we need an intermediate buffer
+#if defined(STM32H7) && defined(USE_SDCARD_SDIO)
+__attribute__((aligned(32))) static uint8_t alignedBuffer[512];
+#endif
 
 static int8_t STORAGE_Init (uint8_t lun);
 
@@ -143,10 +151,21 @@ static int8_t STORAGE_Init (uint8_t lun)
 {
 	UNUSED(lun);
 	LED0_OFF;
-	sdcard_init();
-	while (sdcard_poll() == 0);
+
+	// Only initialize if not already initialized (e.g., by blackbox)
+	if (!sdcard_isInitialized()) {
+		sdcard_init();
+	}
+
+	// Poll with timeout to avoid infinite loop
+	uint32_t timeout = 0;
+	while (sdcard_poll() == 0 && timeout < 1000) {
+		timeout++;
+		delay(1);
+	}
+
 	LED0_ON;
-	return 0;
+	return (timeout < 1000) ? 0 : -1;
 }
 
 /*******************************************************************************
@@ -213,9 +232,18 @@ static int8_t STORAGE_Read (uint8_t lun,
 	UNUSED(lun);
 	LED1_ON;
 	for (int i = 0; i < blk_len; i++) {
+#if defined(STM32H7) && defined(USE_SDCARD_SDIO)
+		// H7 SDIO DMA requires 32-byte aligned buffers
+		// USB MSC buffer may not be aligned, so use intermediate buffer
+		while (sdcard_readBlock(blk_addr + i, alignedBuffer, NULL, 0) == 0)
+			sdcard_poll();
+		while (sdcard_poll() == 0);
+		memcpy(buf + (512 * i), alignedBuffer, 512);
+#else
 		while (sdcard_readBlock(blk_addr + i, buf + (512 * i), NULL, 0) == 0)
 			sdcard_poll();
 		while (sdcard_poll() == 0);
+#endif
 	}
 	LED1_OFF;
 	return 0;
@@ -235,10 +263,20 @@ static int8_t STORAGE_Write (uint8_t lun,
 	UNUSED(lun);
 	LED1_ON;
 	for (int i = 0; i < blk_len; i++) {
+#if defined(STM32H7) && defined(USE_SDCARD_SDIO)
+		// H7 SDIO DMA requires 32-byte aligned buffers
+		// USB MSC buffer may not be aligned, so use intermediate buffer
+		memcpy(alignedBuffer, buf + (i * 512), 512);
+		while (sdcard_writeBlock(blk_addr + i, alignedBuffer, NULL, 0) != SDCARD_OPERATION_IN_PROGRESS) {
+			sdcard_poll();
+		}
+		while (sdcard_poll() == 0);
+#else
 		while (sdcard_writeBlock(blk_addr + i, buf + (i * 512), NULL, 0) != SDCARD_OPERATION_IN_PROGRESS) {
 			sdcard_poll();
 		}
 		while (sdcard_poll() == 0);
+#endif
 	}
 	LED1_OFF;
 	return 0;

--- a/src/main/vcp_hal/usbd_desc.c
+++ b/src/main/vcp_hal/usbd_desc.c
@@ -91,6 +91,24 @@ USBD_DescriptorsTypeDef VCP_Desc = {
   USBD_VCP_InterfaceStrDescriptor,
 };
 
+#ifdef USE_USB_MSC
+/* MSC-specific descriptor functions */
+static uint8_t *USBD_MSC_DeviceDescriptorCallback(USBD_SpeedTypeDef speed, uint16_t *length);
+static uint8_t *USBD_MSC_ProductStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+static uint8_t *USBD_MSC_ConfigStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+static uint8_t *USBD_MSC_InterfaceStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+
+USBD_DescriptorsTypeDef MSC_Desc = {
+  USBD_MSC_DeviceDescriptorCallback,
+  USBD_VCP_LangIDStrDescriptor,           // Reuse VCP LangID
+  USBD_VCP_ManufacturerStrDescriptor,     // Reuse VCP Manufacturer
+  USBD_MSC_ProductStrDescriptor,          // MSC-specific
+  USBD_VCP_SerialStrDescriptor,           // Reuse VCP Serial
+  USBD_MSC_ConfigStrDescriptor,           // MSC-specific
+  USBD_MSC_InterfaceStrDescriptor,        // MSC-specific
+};
+#endif
+
 /* USB Standard Device Descriptor */
 #if defined ( __ICCARM__ ) /*!< IAR Compiler */
   #pragma data_alignment=4
@@ -338,4 +356,77 @@ static void IntToUnicode (uint32_t value , uint8_t *pbuf , uint8_t len)
     pbuf[ 2* idx + 1] = 0;
   }
 }
+
+#ifdef USE_USB_MSC
+/**
+  * @brief  Returns the MSC device descriptor.
+  * @param  speed: Current device speed
+  * @param  length: Pointer to data length variable
+  * @retval Pointer to descriptor buffer
+  */
+static uint8_t *USBD_MSC_DeviceDescriptorCallback(USBD_SpeedTypeDef speed, uint16_t *length)
+{
+  (void)speed;
+  *length = sizeof(USBD_MSC_DeviceDesc);
+  return (uint8_t*)USBD_MSC_DeviceDesc;
+}
+
+/**
+  * @brief  Returns the MSC product string descriptor.
+  * @param  speed: Current device speed
+  * @param  length: Pointer to data length variable
+  * @retval Pointer to descriptor buffer
+  */
+static uint8_t *USBD_MSC_ProductStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
+{
+  if (speed == USBD_SPEED_HIGH)
+  {
+    USBD_GetString((uint8_t *)"STM32 Mass Storage in HS Mode", USBD_StrDesc, length);
+  }
+  else
+  {
+    USBD_GetString((uint8_t *)"STM32 Mass Storage in FS Mode", USBD_StrDesc, length);
+  }
+  return USBD_StrDesc;
+}
+
+/**
+  * @brief  Returns the MSC configuration string descriptor.
+  * @param  speed: Current device speed
+  * @param  length: Pointer to data length variable
+  * @retval Pointer to descriptor buffer
+  */
+static uint8_t *USBD_MSC_ConfigStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
+{
+  if (speed == USBD_SPEED_HIGH)
+  {
+    USBD_GetString((uint8_t *)"MSC Config", USBD_StrDesc, length);
+  }
+  else
+  {
+    USBD_GetString((uint8_t *)"MSC Config", USBD_StrDesc, length);
+  }
+  return USBD_StrDesc;
+}
+
+/**
+  * @brief  Returns the MSC interface string descriptor.
+  * @param  speed: Current device speed
+  * @param  length: Pointer to data length variable
+  * @retval Pointer to descriptor buffer
+  */
+static uint8_t *USBD_MSC_InterfaceStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
+{
+  if (speed == USBD_SPEED_HIGH)
+  {
+    USBD_GetString((uint8_t *)"MSC Interface", USBD_StrDesc, length);
+  }
+  else
+  {
+    USBD_GetString((uint8_t *)"MSC Interface", USBD_StrDesc, length);
+  }
+  return USBD_StrDesc;
+}
+#endif /* USE_USB_MSC */
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/main/vcp_hal/usbd_desc.h
+++ b/src/main/vcp_hal/usbd_desc.h
@@ -60,6 +60,10 @@
 /* Exported functions ------------------------------------------------------- */
 extern USBD_DescriptorsTypeDef VCP_Desc;
 
+#ifdef USE_USB_MSC
+extern USBD_DescriptorsTypeDef MSC_Desc;
+#endif
+
 #endif /* __USBD_DESC_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
### **User description**
## Summary
Fixes USB Mass Storage mode on H743 boards and improves SDIO SD card reliability.

## Problem Statement
USB MSC mode is broken on H743 flight controllers in INAV 8.0.1+:
- Windows shows "Virtual COM Port in FS Mode" error instead of mass storage device
- SD card reports "device offline" errors when accessed via USB MSC
- Users report occasional blackbox recording gaps and slow/unreliable SD writes on H7

## Root Causes Identified

### 1. USB Descriptor Mismatch
The USB library update (v2.5.3 → v2.11.3) in commit 16ebb27 introduced stricter descriptor requirements. H7 MSC mode was attemtpoing to use composite mode with both mass storage (MSC) and CDC (VCP) descriptors, but that failed because the HAL changed between 2018 and 2024. This caused Windows enumeration to fail.

### 2. SDIO DMA Alignment Requirements  
H7 SDIO DMA requires 32-byte aligned buffers, but the USB MSC library's `bot_data` buffer is only 16-byte aligned (at offset 16 in the structure). This caused USB MSC read operations to fail with `SD_ADDR_MISALIGNED` errors.

### 3. Aggressive Error Handling
Any SDIO operation failure immediately triggered a full card reset, causing recording gaps. This was also problematic when USB interrupts interfered with SDIO DMA completion.

## Changes

### USB MSC Descriptor Fix (`src/main/vcp_hal/usbd_desc.c`, `usbd_desc.h`)
- Added standalone MSC descriptor structure (`MSC_Desc`) separate from VCP descriptors
- Provides proper device class (0x00) and product strings for MSC mode
- Modified H7 MSC initialization to use `MSC_Desc` instead of `VCP_Desc`

### SDIO DMA Alignment Fix (`src/main/msc/usbd_storage_sd_spi.c`)
- Added 32-byte aligned intermediate buffer for H7+SDIO configurations
- Modified `STORAGE_Read()` and `STORAGE_Write()` to copy data through aligned buffer
- Platform-specific using `#if defined(STM32H7) && defined(USE_SDCARD_SDIO)`
- No impact on F4/F7 or SPI-based SD card implementations

### Retry Logic (`src/main/drivers/sdcard/sdcard_impl.h`, `sdcard_sdio.c`)
- Added `operationRetries` counter to sdcard state structure
- Retry failed operations up to 3 times with 1ms delays before triggering card reset
- Applied to both read and write paths
- Counter reset on successful operations and card initialization

## Testing
* ✅ USB MSC enumeration works on Linux
 * [x] USB MSC enumeration works on Windows
* ✅ SD card accessible via USB MSC mode (31.3GB detected)
* ✅ Normal VCP mode confirmed working
* ✅ Build successful for BROTHERHOBBYH743 target


## Technical Details
- F7 SDIO driver skips alignment check (`#ifndef STM32F7`)  
- H7 requires alignment due to D-Cache invalidation requirements
- USB MSC buffer misalignment measured at offset 16 (needs offset 0 or 32)
- Intermediate buffer adds minimal overhead (single memcpy per 512-byte block)
- Retry logic adds only ~128 bytes to firmware size

## Benefits
- Restores USB MSC functionality on H7 boards
- Reduces blackbox recording gaps from spurious SD card resets  
- Improves overall SD card reliability when USB is active
- Handles transient DMA/bus conflicts gracefully

## Platform Impact
- **H7 only**: Alignment fix and retry logic most beneficial
- **F4/F7**: Retry logic provides minor reliability improvement
- **SPI SD cards**: Unaffected by alignment changes

## Fixes
Closes #10800

## Related Issues
- Issue #10800: H7 USB MSC regression in 8.0.1


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
This description is generated by an AI tool. It may have inaccuracies

- Fix H743 USB MSC regression by using standalone MSC descriptors instead of VCP descriptors
  - Resolves Windows enumeration failure with USB library v2.11.3
  - Provides proper MSC device class and product strings

- Add 32-byte aligned intermediate buffer for H7 SDIO DMA operations
  - Fixes SD_ADDR_MISALIGNED errors during USB MSC read/write operations
  - Platform-specific implementation for H7+SDIO configurations only

- Implement retry logic for transient SDIO operation failures
  - Retries up to 3 times with 1ms delays before triggering card reset
  - Reduces blackbox recording gaps from spurious SD card resets

- Improve SD card initialization with timeout and existing state checks
  - Prevents infinite loops and handles already-initialized cards gracefully


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["USB MSC Mode"] -->|"Use MSC_Desc"| B["Standalone MSC Descriptors"]
  B -->|"Proper Device Class"| C["Windows Enumeration Fixed"]
  D["H7 SDIO DMA"] -->|"32-byte Aligned Buffer"| E["Intermediate Buffer"]
  E -->|"Copy Data"| F["Aligned Read/Write"]
  G["SDIO Operation"] -->|"Fails"| H["Retry Logic"]
  H -->|"< 3 Retries"| I["Retry with Delay"]
  H -->|">= 3 Retries"| J["Card Reset"]
  I -->|"Success"| K["Reset Counter"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sdcard_impl.h</strong><dd><code>Add operation retry counter to SD card state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/sdcard/sdcard_impl.h

<ul><li>Added <code>SDCARD_MAX_OPERATION_RETRIES</code> constant set to 3<br> <li> Added <code>operationRetries</code> field to sdcard state structure to track retry <br>attempts</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11194/files#diff-7fd752620a239ee45738c9a8395640e526a7c2513fef7b7dbc89b2f4c20bc62c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sdcard_sdio.c</strong><dd><code>Add retry logic for transient SDIO failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/sdcard/sdcard_sdio.c

<ul><li>Implemented retry logic in <code>sdcardSdio_writeBlock()</code> with 1ms delays <br>before card reset<br> <li> Implemented retry logic in <code>sdcardSdio_readBlock()</code> with same retry <br>mechanism<br> <li> Reset retry counter on successful operations and card initialization<br> <li> Added timeout to SD card polling loop in <code>sdcardSdio_init()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11194/files#diff-47d90340284308588aac1fd062e20b6480332d2ed9f938d7e3601cfb40fc2ff3">+29/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>usbd_desc.c</strong><dd><code>Add standalone MSC descriptor structure and callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/vcp_hal/usbd_desc.c

<ul><li>Created new <code>MSC_Desc</code> descriptor structure for standalone MSC mode<br> <li> Implemented MSC-specific descriptor callback functions for device, <br>product, config, and interface strings<br> <li> Reused VCP descriptors for language ID, manufacturer, and serial <br>number<br> <li> All MSC descriptor functions conditionally compiled with <code>USE_USB_MSC</code> <br>guard</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11194/files#diff-5196afaebb2697be25103cad15f12b2b9bf07d3d5bd980e2cd19022e42de595b">+91/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>usbd_desc.h</strong><dd><code>Export MSC descriptor for USB MSC mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/vcp_hal/usbd_desc.h

<ul><li>Exported <code>MSC_Desc</code> descriptor structure for use in USB MSC <br>initialization<br> <li> Added conditional compilation guard for MSC descriptor export</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11194/files#diff-c3bce1d3254558f1e8a48050d1ce07b5ec8d9c31c66ffce140311075c8a46de9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usb_msc_h7xx.c</strong><dd><code>Use MSC descriptor for H7 USB MSC mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/usb_msc_h7xx.c

<ul><li>Changed USB descriptor initialization from <code>VCP_Desc</code> to <code>MSC_Desc</code> for <br>standalone MSC mode<br> <li> Added comment explaining the fix for Windows enumeration issue with <br>USB library v2.11.3</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11194/files#diff-f9a4a380fce2362bd8e12ab3f6c56c01f7ba2a75f827db23899816f5e68aa8b8">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>usbd_storage_sd_spi.c</strong><dd><code>Add aligned buffer for H7 SDIO DMA operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/msc/usbd_storage_sd_spi.c

<ul><li>Added 32-byte aligned intermediate buffer for H7+SDIO configurations<br> <li> Modified <code>STORAGE_Read()</code> to copy data through aligned buffer on H7 SDIO<br> <li> Modified <code>STORAGE_Write()</code> to copy data through aligned buffer on H7 <br>SDIO<br> <li> Improved <code>STORAGE_Init()</code> with timeout and existing initialization <br>checks<br> <li> Added necessary includes for <code>string.h</code> and <code>drivers/time.h</code></ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11194/files#diff-30b788f16bbc939cc25ef1bd2ac100fe1c1c3ff97bc29566800bc42c2caa39e7">+41/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

