### PR TITLE
Include cygwin1.dll in Windows SITL artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,11 +256,15 @@ jobs:
           for f in ./build_SITL/*_SITL.exe; do
             mv $f $(echo $f | sed -e 's/_[0-9]\+\.[0-9]\+\.[0-9]\+//')
           done
+      - name: Copy cygwin1.dll
+        run: cp /bin/cygwin1.dll ./build_SITL/
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BUILD_NAME }}_SITL-WIN
-          path: ./build_SITL/*.exe
+          path: |
+            ./build_SITL/*.exe
+            ./build_SITL/cygwin1.dll
 
   test:
     #needs: [build]


### PR DESCRIPTION
### **User description**
## Summary
Adds cygwin1.dll to the Windows SITL build artifact so users can run the SITL executable without having Cygwin installed.

## Changes
- Add step to copy cygwin1.dll from /bin to build_SITL directory
- Update upload-artifact to include both *.exe and cygwin1.dll

## Related
Cherry-picked from #11133 (CI change only, without the FLYSPARKF4 line-ending changes)


___

### **PR Type**
Enhancement


___

### **Description**
- Copies cygwin1.dll to Windows SITL build artifact

- Updates artifact upload to include DLL dependency

- Enables SITL executable to run without Cygwin installation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build SITL"] --> B["Strip version numbers"]
  B --> C["Copy cygwin1.dll"]
  C --> D["Upload artifacts"]
  D --> E["*.exe + cygwin1.dll"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add cygwin1.dll to Windows SITL artifact</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Added step to copy <code>cygwin1.dll</code> from <code>/bin</code> to <code>build_SITL</code> directory<br> <li> Updated artifact upload path to include both <code>*.exe</code> files and <br><code>cygwin1.dll</code><br> <li> Enables Windows SITL executable to run without requiring Cygwin <br>installation</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11203/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

