### PR TITLE
Add maintenance-9.x to nightly build workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -2,11 +2,12 @@ name: Build pre-release
 # Don't enable CI on push, just on PR. If you
 # are working on the main repo and want to trigger
 # a CI build submit a draft PR.
-on: 
+on:
   push:
     branches:
       - master
       - maintenance-8.x.x
+      - maintenance-9.x
     paths:
       - 'src/**'
       - '.github/**'


### PR DESCRIPTION
## Summary
Add maintenance-9.x branch to the nightly build workflow triggers.

This enables automatic pre-release builds when commits are pushed to the maintenance-9.x branch, providing complete firmware artifacts (hex files + SITL binaries) for RC releases.

## Problem
Currently, CI runs on PR creation but not on merge. After merging multiple PRs to maintenance-9.x, there's no CI run containing all the merged changes. This makes it impossible to get complete firmware artifacts for RC releases.

## Solution
Add `maintenance-9.x` to the branch list in `.github/workflows/nightly-build.yml` (alongside `master` and `maintenance-8.x.x`).

## Changes
- Added `maintenance-9.x` to the push trigger branches