### PR TITLE
Configurable OSD refresh rate

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4842,6 +4842,16 @@ Force OSD to work in grid mode even if the OSD device supports pixel level acces
 
 ---
 
+### osd_framerate_hz
+
+Target refresh rate for OSD elements in Hz. Each element is redrawn at approximately this rate. Values above 10 Hz provide no visible improvement for typical flight data but increase CPU load. Artificial horizon and telemetry are always updated every cycle regardless of this setting. Set to -1 for legacy behavior (one element per frame).
+
+| Default | Min | Max |
+| --- | --- | --- |
+| -1 | -1 | 15 |
+
+---
+
 ### osd_gforce_alarm
 
 Value above which the OSD g force indicator will blink (g)

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -79,6 +79,7 @@ typedef enum {
     DEBUG_GPS,
     DEBUG_LULU,
     DEBUG_SBUS2,
+    DEBUG_OSD_REFRESH,
     DEBUG_COUNT // also update debugModeNames in cli.c
 } debugType_e;
 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -219,7 +219,8 @@ static const char *debugModeNames[DEBUG_COUNT] = {
     "HEADTRACKER",
     "GPS",
     "LULU",
-    "SBUS2"
+    "SBUS2",
+    "OSD_REFRESH"
 };
 
 /* Sensor names (used in lookup tables for *_hardware settings and in status

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3329,6 +3329,13 @@ groups:
         max: 600
         type: int16_t
         field: msp_displayport_fullframe_interval
+      - name: osd_framerate_hz
+        description: "OSD element refresh rate in Hz. Controls how often OSD elements are updated (except artificial horizon and telemetry which are always updated). Higher values provide smoother updates but increase CPU load. Set to -1 for legacy mode (one element per frame). Default: -1"
+        default_value: -1
+        min: -1
+        max: 60
+        type: int8_t
+        field: osd_framerate_hz
       - name: osd_units
         description: "IMPERIAL, METRIC, UK"
         default_value: "METRIC"

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3329,6 +3329,13 @@ groups:
         max: 600
         type: int16_t
         field: msp_displayport_fullframe_interval
+      - name: osd_framerate_hz
+        description: "Target refresh rate for OSD elements in Hz. Each element is redrawn at approximately this rate. Values above 12-15 Hz provide no visible improvement for typical flight data. Artificial horizon and telemetry are always updated every cycle regardless of this setting. Set to -1 for legacy behavior (one element per frame)."
+        default_value: -1
+        min: -1
+        max: 15
+        type: int8_t
+        field: osd_framerate_hz
       - name: osd_units
         description: "IMPERIAL, METRIC, UK"
         default_value: "METRIC"

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3329,13 +3329,6 @@ groups:
         max: 600
         type: int16_t
         field: msp_displayport_fullframe_interval
-      - name: osd_framerate_hz
-        description: "OSD element refresh rate in Hz. Controls how often OSD elements are updated (except artificial horizon and telemetry which are always updated). Higher values provide smoother updates but increase CPU load. Set to -1 for legacy mode (one element per frame). Default: -1"
-        default_value: -1
-        min: -1
-        max: 60
-        type: int8_t
-        field: osd_framerate_hz
       - name: osd_units
         description: "IMPERIAL, METRIC, UK"
         default_value: "METRIC"

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -84,7 +84,7 @@ tables:
       "VIBE", "CRUISE", "REM_FLIGHT_TIME", "SMARTAUDIO", "ACC",
       "NAV_YAW", "PCF8574", "DYN_GYRO_LPF", "AUTOLEVEL", "ALTITUDE",
       "AUTOTRIM", "AUTOTUNE", "RATE_DYNAMICS", "LANDING", "POS_EST",
-      "ADAPTIVE_FILTER", "HEADTRACKER", "GPS", "LULU", "SBUS2"]
+      "ADAPTIVE_FILTER", "HEADTRACKER", "GPS", "LULU", "SBUS2", "OSD_REFRESH"]
   - name: aux_operator
     values: ["OR", "AND"]
     enum: modeActivationOperator_e

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3330,7 +3330,7 @@ groups:
         type: int16_t
         field: msp_displayport_fullframe_interval
       - name: osd_framerate_hz
-        description: "Target refresh rate for OSD elements in Hz. Each element is redrawn at approximately this rate. Values above 12-15 Hz provide no visible improvement for typical flight data. Artificial horizon and telemetry are always updated every cycle regardless of this setting. Set to -1 for legacy behavior (one element per frame)."
+        description: "Target refresh rate for OSD elements in Hz. Each element is redrawn at approximately this rate. Values above 10 Hz provide no visible improvement for typical flight data but increase CPU load. Artificial horizon and telemetry are always updated every cycle regardless of this setting. Set to -1 for legacy behavior (one element per frame)."
         default_value: -1
         min: -1
         max: 15

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -4275,7 +4275,8 @@ void osdDrawNextElement(void)
 
     DEBUG_SET(DEBUG_OSD_REFRESH, 0, elementsPerCycle);
     DEBUG_SET(DEBUG_OSD_REFRESH, 1, activeElements);
-    DEBUG_SET(DEBUG_OSD_REFRESH, 2, framerate_hz);
+    DEBUG_SET(DEBUG_OSD_REFRESH, 2, elementIndex);
+    DEBUG_SET(DEBUG_OSD_REFRESH, 3, framerate_hz);
 
     for (uint8_t i = 0; i < elementsPerCycle; i++) {
         uint8_t index = elementIndex;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -29,6 +29,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <inttypes.h>
+#include <limits.h>
 
 #include "platform.h"
 
@@ -4271,6 +4272,10 @@ void osdDrawNextElement(void)
         if (elementsPerCycle < 1) elementsPerCycle = 1;
         if (elementsPerCycle > activeElements) elementsPerCycle = activeElements;
     }
+
+    DEBUG_SET(DEBUG_OSD_REFRESH, 0, elementsPerCycle);
+    DEBUG_SET(DEBUG_OSD_REFRESH, 1, activeElements);
+    DEBUG_SET(DEBUG_OSD_REFRESH, 2, framerate_hz);
 
     for (uint8_t i = 0; i < elementsPerCycle; i++) {
         uint8_t index = elementIndex;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -4244,9 +4244,11 @@ uint8_t osdIncElementIndex(uint8_t elementIndex)
 
 static void osdDrawAllElements(void)
 {
-    for (uint8_t element = 0; element < OSD_ITEM_COUNT; element++) {
+    uint8_t element = 0;
+    do {
         osdDrawSingleElement(element);
-    }
+        element = osdIncElementIndex(element);
+    } while (element != 0);
 
     osdDrawSingleElement(OSD_ARTIFICIAL_HORIZON);
     if (osdConfig()->telemetry>0){
@@ -4316,7 +4318,7 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .video_system = SETTING_OSD_VIDEO_SYSTEM_DEFAULT,
     .row_shiftdown = SETTING_OSD_ROW_SHIFTDOWN_DEFAULT,
     .msp_displayport_fullframe_interval = SETTING_OSD_MSP_DISPLAYPORT_FULLFRAME_INTERVAL_DEFAULT,
-    .framerate_hz = SETTING_OSD_FRAMERATE_HZ_DEFAULT,
+    .osd_framerate_hz = SETTING_OSD_FRAMERATE_HZ_DEFAULT,
 
     .ahi_reverse_roll = SETTING_OSD_AHI_REVERSE_ROLL_DEFAULT,
     .ahi_max_pitch = SETTING_OSD_AHI_MAX_PITCH_DEFAULT,

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -4242,18 +4242,19 @@ uint8_t osdIncElementIndex(uint8_t elementIndex)
     return elementIndex;
 }
 
-static void osdDrawAllElements(void)
-{
-    uint8_t element = 0;
-    do {
-        osdDrawSingleElement(element);
-        element = osdIncElementIndex(element);
-    } while (element != 0);
+#define OSD_TIME_BUDGET_PERCENT 70
 
-    osdDrawSingleElement(OSD_ARTIFICIAL_HORIZON);
-    if (osdConfig()->telemetry>0){
-        osdDisplayTelemetry();
-    }
+static uint32_t osdCalculateSafeTimeBudget(void)
+{
+    uint32_t pidLooptimeUs = getLooptime();
+    uint32_t gyroLooptimeUs = getGyroLooptime();
+    uint32_t criticalLooptimeUs = MIN(pidLooptimeUs, gyroLooptimeUs);
+    uint32_t safeBudgetUs = (criticalLooptimeUs * OSD_TIME_BUDGET_PERCENT) / 100;
+
+    if (safeBudgetUs < 100) safeBudgetUs = 100;
+    if (safeBudgetUs > 2000) safeBudgetUs = 2000;
+
+    return safeBudgetUs;
 }
 
 void osdDrawNextElement(void)
@@ -5992,25 +5993,31 @@ static void osdRefresh(timeUs_t currentTimeUs)
             fullRedraw = false;
         }
 
-        if (osdConfig()->osd_framerate_hz == -1) {
-            osdDrawNextElement();
-        } else {
-            static uint32_t lastDrawAllTimeUs = 0;
-            const int8_t hz = osdConfig()->osd_framerate_hz;
-            const uint32_t drawAllIntervalUs = (hz > 0) ? (1000000 / hz) : 0;
+        // Draw elements until time budget 
+        static uint8_t elementIndex = 0;
+        const uint32_t timeBudgetUs = osdCalculateSafeTimeBudget();
+        const uint32_t startUs = micros();
+        const uint8_t startElement = elementIndex;
+        uint8_t elementsDrawn = 0;
 
-            const bool forceDraw = (drawAllIntervalUs == 0);
-            const bool intervalExceeded = (currentTimeUs - lastDrawAllTimeUs) >= drawAllIntervalUs;
+        // Draw elements in round-robin fashion until time budget expires
+        do {
+            elementIndex = osdIncElementIndex(elementIndex);
+            osdDrawSingleElement(elementIndex);
+            elementsDrawn++;
 
-            if (forceDraw || intervalExceeded) {
-                osdDrawAllElements();
-                lastDrawAllTimeUs = currentTimeUs;
+            const bool timeBudgetExceeded = (micros() - startUs) >= timeBudgetUs;
+            const bool completedFullCycle = (elementIndex == startElement);
+
+            if (timeBudgetExceeded || completedFullCycle) {
+                break;
             }
 
-            osdDrawSingleElement(OSD_ARTIFICIAL_HORIZON);
-            if (osdConfig()->telemetry>0){
-                osdDisplayTelemetry();
-            }
+        } while (true);
+
+        osdDrawSingleElement(OSD_ARTIFICIAL_HORIZON);
+        if (osdConfig()->telemetry > 0) {
+            osdDisplayTelemetry();
         }
 
         displayHeartbeat(osdDisplayPort);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -4242,33 +4242,46 @@ uint8_t osdIncElementIndex(uint8_t elementIndex)
     return elementIndex;
 }
 
-#define OSD_TIME_BUDGET_PERCENT 70
-
-static uint32_t osdCalculateSafeTimeBudget(void)
-{
-    uint32_t pidLooptimeUs = getLooptime();
-    uint32_t gyroLooptimeUs = getGyroLooptime();
-    uint32_t criticalLooptimeUs = MIN(pidLooptimeUs, gyroLooptimeUs);
-    uint32_t safeBudgetUs = (criticalLooptimeUs * OSD_TIME_BUDGET_PERCENT) / 100;
-
-    if (safeBudgetUs < 100) safeBudgetUs = 100;
-    if (safeBudgetUs > 2000) safeBudgetUs = 2000;
-
-    return safeBudgetUs;
-}
-
 void osdDrawNextElement(void)
 {
     static uint8_t elementIndex = 0;
-    // Flag for end of loop, also prevents infinite loop when no elements are enabled
-    uint8_t index = elementIndex;
-    do {
-        elementIndex = osdIncElementIndex(elementIndex);
-    } while (!osdDrawSingleElement(elementIndex) && index != elementIndex);
+    static uint8_t activeElements = 0;
+    static unsigned lastLayout = UINT_MAX;
+
+    // Recount visible elements on layout change
+    if (currentLayout != lastLayout) {
+        lastLayout = currentLayout;
+        activeElements = 0;
+        uint8_t idx = 0;
+        do {
+            idx = osdIncElementIndex(idx);
+            if (OSD_VISIBLE(osdLayoutsConfig()->item_pos[currentLayout][idx])) {
+                activeElements++;
+            }
+        } while (idx > 0);
+    }
+
+    int8_t framerate_hz = osdConfig()->osd_framerate_hz;
+
+    uint8_t elementsPerCycle;
+    if (framerate_hz <= 0 || activeElements == 0) {
+        elementsPerCycle = 1; // legacy: one element per cycle
+    } else {
+        elementsPerCycle = ((uint16_t)activeElements * framerate_hz * 2 + 124) / 125;
+        if (elementsPerCycle < 1) elementsPerCycle = 1;
+        if (elementsPerCycle > activeElements) elementsPerCycle = activeElements;
+    }
+
+    for (uint8_t i = 0; i < elementsPerCycle; i++) {
+        uint8_t index = elementIndex;
+        do {
+            elementIndex = osdIncElementIndex(elementIndex);
+        } while (!osdDrawSingleElement(elementIndex) && index != elementIndex);
+    }
 
     // Draw artificial horizon + tracking telemetry last
     osdDrawSingleElement(OSD_ARTIFICIAL_HORIZON);
-    if (osdConfig()->telemetry>0){
+    if (osdConfig()->telemetry > 0) {
         osdDisplayTelemetry();
     }
 }
@@ -5992,40 +6005,7 @@ static void osdRefresh(timeUs_t currentTimeUs)
             displayClearScreen(osdDisplayPort);
             fullRedraw = false;
         }
-
-        // Draw elements until time budget 
-        static uint8_t elementIndex = 0;
-        const uint32_t timeBudgetUs = osdCalculateSafeTimeBudget();
-        const uint32_t startUs = micros();
-        const uint8_t startElement = elementIndex;
-        uint8_t elementsDrawn = 0;
-
-        // Draw elements in round-robin fashion until time budget expires
-        do {
-            elementIndex = osdIncElementIndex(elementIndex);
-            osdDrawSingleElement(elementIndex);
-            elementsDrawn++;
-
-            const bool timeBudgetExceeded = (micros() - startUs) >= timeBudgetUs;
-            const bool completedFullCycle = (elementIndex == startElement);
-
-            if (timeBudgetExceeded || completedFullCycle) {
-                break;
-            }
-
-        } while (true);
-
-        const uint32_t actualTimeUs = micros() - startUs;
-        DEBUG_SET(DEBUG_OSD_REFRESH, 0, elementsDrawn);
-        DEBUG_SET(DEBUG_OSD_REFRESH, 1, actualTimeUs);
-        DEBUG_SET(DEBUG_OSD_REFRESH, 2, timeBudgetUs);
-        DEBUG_SET(DEBUG_OSD_REFRESH, 3, actualTimeUs >= timeBudgetUs);
-
-        osdDrawSingleElement(OSD_ARTIFICIAL_HORIZON);
-        if (osdConfig()->telemetry > 0) {
-            osdDisplayTelemetry();
-        }
-
+        osdDrawNextElement();
         displayHeartbeat(osdDisplayPort);
         displayCommitTransaction(osdDisplayPort);
 #ifdef OSD_CALLS_CMS

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -6015,6 +6015,12 @@ static void osdRefresh(timeUs_t currentTimeUs)
 
         } while (true);
 
+        const uint32_t actualTimeUs = micros() - startUs;
+        DEBUG_SET(DEBUG_OSD_REFRESH, 0, elementsDrawn);
+        DEBUG_SET(DEBUG_OSD_REFRESH, 1, actualTimeUs);
+        DEBUG_SET(DEBUG_OSD_REFRESH, 2, timeBudgetUs);
+        DEBUG_SET(DEBUG_OSD_REFRESH, 3, actualTimeUs >= timeBudgetUs);
+
         osdDrawSingleElement(OSD_ARTIFICIAL_HORIZON);
         if (osdConfig()->telemetry > 0) {
             osdDisplayTelemetry();

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -451,6 +451,7 @@ typedef struct osdConfig_s {
     videoSystem_e   video_system;
     uint8_t         row_shiftdown;
     int16_t         msp_displayport_fullframe_interval;
+    int8_t          osd_framerate_hz;
 
     // Preferences
     uint8_t         main_voltage_decimals;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -451,7 +451,6 @@ typedef struct osdConfig_s {
     videoSystem_e   video_system;
     uint8_t         row_shiftdown;
     int16_t         msp_displayport_fullframe_interval;
-    int8_t          osd_framerate_hz;
 
     // Preferences
     uint8_t         main_voltage_decimals;


### PR DESCRIPTION
### Summary
Implements configurable OSD refresh rate via `osd_framerate_hz` CLI command. 

Fixes mentioned [here](https://github.com/iNavFlight/inav/issues/9907) behaviour.

### Problem
INAVs element drawing updates only one element per frame. With many enabled elements (e.g., 30), each element updates at ~2Hz (62.5Hz / 30) which doesn't help when flying in harsh conditions. Only artificial horizon and telemetry updates as fast as possible (each frame)

### Solution
- Added `osd_framerate_hz` setting (range: `-1` to `60` Hz)
  - `-1` (default): Legacy (current) mode
  - `1-60`: all elements update at specified Hz
  - `0`: all elements update each frame
  
  
 Video showing default behaviour, `osd_framerate_hz=12` (default in betaflight) and `osd_framerate_hz=0` (each frame)

https://github.com/user-attachments/assets/5b12b89f-6730-458b-913b-8b9b190a3d43


  