### PR TITLE
Allow for quicker updates of OSD element data

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4772,6 +4772,16 @@ Value above which to make the OSD distance from home indicator blink (meters)
 
 ---
 
+### osd_elements_updated_per_cycle
+
+Number of OSD elements to update per OSD cycle. Increase this value to reduce the time it takes to update all OSD elements, at the cost of higher CPU usage. Decrease this value to reduce CPU usage, at the cost of slower OSD element updates.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 5 | 1 | 15 |
+
+---
+
 ### osd_esc_rpm_precision
 
 Number of characters used to display the RPM value.

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4778,7 +4778,7 @@ Number of OSD elements to update per OSD cycle. Increase this value to reduce th
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 5 | 1 | 15 |
+| 5 | 1 | 10 |
 
 ---
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3329,6 +3329,12 @@ groups:
         max: 600
         type: int16_t
         field: msp_displayport_fullframe_interval
+      - name: osd_elements_updated_per_cycle
+        description: "Number of OSD elements to update per OSD cycle. Increase this value to reduce the time it takes to update all OSD elements, at the cost of higher CPU usage. Decrease this value to reduce CPU usage, at the cost of slower OSD element updates."
+        default_value: 5
+        field: elements_updated_per_cycle
+        min: 1
+        max: 15
       - name: osd_units
         description: "IMPERIAL, METRIC, UK"
         default_value: "METRIC"

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3334,7 +3334,7 @@ groups:
         default_value: 5
         field: elements_updated_per_cycle
         min: 1
-        max: 15
+        max: 10
       - name: osd_units
         description: "IMPERIAL, METRIC, UK"
         default_value: "METRIC"

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -4245,13 +4245,15 @@ uint8_t osdIncElementIndex(uint8_t elementIndex)
 void osdDrawNextElements(void)
 {
     static uint8_t elementIndex = 0;
-    uint8_t index = elementIndex;
 
-    for (uint8_t i = 1; i <= osdConfig()->elements_updated_per_cycle; ++i) {
-        elementIndex = osdIncElementIndex(elementIndex);
-    
+    for (uint8_t i = 1; i <= osdConfig()->elements_updated_per_cycle; i++) {
         // Flag for end of loop, also prevents infinite loop when no elements are enabled
-        if (!osdDrawSingleElement(elementIndex) && index == elementIndex) {
+        uint8_t index = elementIndex;
+        do {
+            elementIndex = osdIncElementIndex(elementIndex);
+        } while (!osdDrawSingleElement(elementIndex) && index != elementIndex);
+    
+        if (index == elementIndex || elementIndex == 0) {
             break;
         }
     }

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -451,6 +451,7 @@ typedef struct osdConfig_s {
     videoSystem_e   video_system;
     uint8_t         row_shiftdown;
     int16_t         msp_displayport_fullframe_interval;
+    uint8_t         elements_updated_per_cycle;
 
     // Preferences
     uint8_t         main_voltage_decimals;


### PR DESCRIPTION
This allows *X* elements to be updated per OSD cycle. From 1 element (current behaviour) to 15 elements. This should allow for plenty of data update speed without causing unnecessary delays or overheads. This defaults to 5, which should be a good value for most OSDs. The OSD is updated at 250Hz, on a low priority, by the task scheduler. The elements are updated at 1/4 this frequency (62.5Hz).

Update rates based on current update method
| Number of OSD elements | ~Update rate |
|---|---|
| 1 | 62.5Hz |
| 5 | 12.5Hz |
| 10 | 6.3Hz |
| 15 | 4.2Hz |
| 20 | 3.1Hz |
| 25 | 2.5Hz |
| 30 | 2.1Hz |

Update rates based on the new default of 5 elements per cycle
| Number of OSD elements | ~Update rate |
|---|---|
| 1 - 5 | 62.5Hz |
| 6 - 10 | 31.3Hz |
| 11 - 15 | 20.8Hz |
| 16 - 20 | 15.6Hz |
| 21 - 25 | 12.5Hz |
| 26 - 30 | 10.4Hz |

So even on the default setting `5`, having 26-30 elements. They would update 10 times per second. Fast enough for any OSD element.

- It maintains the protections for end of loop and no elements enabled
- Will exit automatically if there are less elements to draw than set to be drawn per cycle.
- A check has been added to see if the AHI is enabled before drawing it

Alternative option to https://github.com/iNavFlight/inav/pull/11206
Fixes #9907