### PR TITLE
Fix #9912: Add I-term stability check to servo autotrim

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -6052,6 +6052,16 @@ When feature SERIALRX is enabled, this allows connection to several receivers wh
 
 ---
 
+### servo_autotrim_iterm_rate_limit
+
+Maximum I-term rate of change (units/sec) for autotrim to be applied. Prevents trim updates during maneuver transitions when I-term is changing rapidly. Only applies when using `feature FW_AUTOTRIM`.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 2 | 0 | 50 |
+
+---
+
 ### servo_autotrim_rotation_limit
 
 Servo midpoints are only updated when total aircraft rotation is less than this threshold [deg/s]. Only applies when using `feature FW_AUTOTRIM`.

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1361,6 +1361,11 @@ groups:
         default_value: 15
         min: 1
         max: 60
+      - name: servo_autotrim_iterm_rate_limit
+        description: "Maximum I-term rate of change (units/sec) for autotrim to be applied. Prevents trim updates during maneuver transitions when I-term is changing rapidly. Only applies when using `feature FW_AUTOTRIM`."
+        default_value: 2
+        min: 0
+        max: 50
 
   - name: PG_CONTROL_PROFILES
     type: controlConfig_t

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -625,6 +625,13 @@ void processContinuousServoAutotrim(const float dT)
     if (ARMING_FLAG(ARMED)) {
         trimState = AUTOTRIM_COLLECTING;
         if ((millis() - lastUpdateTimeMs) > 500) {
+            static float itermRateOfChange[2];
+            for (int axis = FD_ROLL; axis <= FD_PITCH; axis++) {
+                const float currentIterm = getAxisIterm(axis);
+                itermRateOfChange[axis] = fabsf(currentIterm - prevAxisIterm[axis]) / 0.5f;
+                prevAxisIterm[axis] = currentIterm;
+            }
+
             const bool planeIsFlyingStraight = rotRateMagnitudeFiltered <= DEGREES_TO_RADIANS(servoConfig()->servo_autotrim_rotation_limit);
             const bool noRotationCommanded = targetRateMagnitudeFiltered <= servoConfig()->servo_autotrim_rotation_limit;
             const bool sticksAreCentered = !areSticksDeflected();
@@ -642,13 +649,7 @@ void processContinuousServoAutotrim(const float dT)
                 for (int axis = FD_ROLL; axis <= FD_PITCH; axis++) {
                     // For each stabilized axis, add 5 units of I-term to all associated servo midpoints
                     const float axisIterm = getAxisIterm(axis);
-
-                    // Calculate I-term rate of change (per second) to detect stability
-                    const float itermRateOfChange = fabsf(axisIterm - prevAxisIterm[axis]) / 0.5f;
-                    prevAxisIterm[axis] = axisIterm;
-
-                    // Only apply trim if I-term is stable (not changing rapidly due to recent maneuver)
-                    const bool itermIsStable = itermRateOfChange < servoConfig()->servo_autotrim_iterm_rate_limit;
+                    const bool itermIsStable = itermRateOfChange[axis] < servoConfig()->servo_autotrim_iterm_rate_limit;
 
                     if (fabsf(axisIterm) > SERVO_AUTOTRIM_UPDATE_SIZE && itermIsStable) {
                         const int8_t ItermUpdate = axisIterm > 0.0f ? SERVO_AUTOTRIM_UPDATE_SIZE : -SERVO_AUTOTRIM_UPDATE_SIZE;

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -170,6 +170,7 @@ typedef struct servoConfig_s {
     uint8_t servo_protocol;                 // See servoProtocolType_e
     uint8_t tri_unarmed_servo;              // send tail servo correction pulses even when unarmed
     uint8_t servo_autotrim_rotation_limit;  // Max rotation for servo midpoints to be updated
+    uint8_t servo_autotrim_iterm_rate_limit; // Max I-term rate of change (units/sec) to apply autotrim
     uint8_t servo_autotrim_iterm_threshold; // How much of the Iterm is carried over to the servo midpoints on each update
 } servoConfig_t;
 

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -170,8 +170,8 @@ typedef struct servoConfig_s {
     uint8_t servo_protocol;                 // See servoProtocolType_e
     uint8_t tri_unarmed_servo;              // send tail servo correction pulses even when unarmed
     uint8_t servo_autotrim_rotation_limit;  // Max rotation for servo midpoints to be updated
-    uint8_t servo_autotrim_iterm_rate_limit; // Max I-term rate of change (units/sec) to apply autotrim
     uint8_t servo_autotrim_iterm_threshold; // How much of the Iterm is carried over to the servo midpoints on each update
+    uint8_t servo_autotrim_iterm_rate_limit; // Max I-term rate of change (units/sec) to apply autotrim
 } servoConfig_t;
 
 PG_DECLARE(servoConfig_t, servoConfig);


### PR DESCRIPTION
## Summary
Hopefully fixes #9912 - Continuous auto-trim active during maneuvers

Adds I-term stability detection to servo autotrim to prevent transferring transient I-term to servo trim during maneuver transitions.

## Root Cause
The autotrim code verified all flight conditions (level attitude, centered sticks, low rotation rate) but failed to check that the I-term was in a steady state before transferring it to servo trim.

During maneuver transitions (e.g., exiting a turn), I-term accumulates transient error. When the plane momentarily satisfies all level-flight conditions, this transient I-term is incorrectly transferred to servo midpoints.

We want to transfer the I-term only when it's stable, not immediately when the pilot centers the sticks after a hard maneuver.  How stable is "stable"?  I don't know, so I added the temporary setting `servo_autotrim_iterm_rate_limit` to for testing. I anticipate that after testing we'll know what a reasonable value is and won't need to add yet another user-facing facing.


## Testing
- [x] Code compiles successfully (SITL build tested)
- [ ] Flight testing required to validate fix in real-world conditions

**Note:** This PR requires flight testing to validate the fix. The I-term stability threshold may need adjustment based on flight testing feedback.

Because this does introduce a new setting, an "erase all" and reload of the diff/dump would be needed.
If testers prefer, I could also just use 2 or 3 for testing, and skip the setting.

## Related
- Issue #9912


Potentially Fixes #9912

@Yury-MonZon   @ProfDrYoMan
