### PR TITLE
Add prominent download links to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,20 @@ Fly safe, fly smart with INAV 7.1 and a compass by your side!
 * [INAV Discord Server](https://discord.gg/peg2hhbYwN)
 * [INAV Official on Facebook](https://www.facebook.com/groups/INAVOfficial)
 
+## Downloads
+
+### INAV Configurator
+
+**Get the latest version:** **[Download INAV Configurator](https://github.com/iNavFlight/inav-configurator/releases/latest)** - Available for Windows, macOS, and Linux
+
+The INAV Configurator is the official desktop application for configuring your INAV flight controller. Choose your platform from the Assets section on the releases page.
+
+### INAV Firmware
+
+**Get the latest firmware:** **[Download INAV Firmware](https://github.com/iNavFlight/inav/releases/latest)**
+
+Download the latest INAV flight controller firmware. Flash it to your flight controller using the configurator.
+
 ## Features
 
 * Runs on the most popular F4, AT32, F7 and H7 flight controllers


### PR DESCRIPTION
## Summary

This PR makes it easier for users to find and download INAV Configurator and firmware by adding a dedicated **Downloads** section near the top of the README.

## Problem

Currently, download links are buried in the **Tools** section lower in the document. New users have to:
1. Land on the README
2. Scroll down to find "Tools"
3. Find the configurator link within that section
4. Click through to releases

This is too many steps for a common user task.

## Solution

Added a prominent **Downloads** section immediately after the **INAV Community** section with:
- **INAV Configurator** download link using `/releases/latest` URL
- **INAV Firmware** download link using `/releases/latest` URL
- Clear instructions to select platform from Assets

## Benefits

- ✅ Reduces user friction - fewer clicks to find downloads
- ✅ Improves UX for new users landing on the project
- ✅ `/releases/latest` URLs automatically show the most current version
- ✅ Clear platform selection instructions
- ✅ Both configurator and firmware easily accessible


