### PR TITLE
Update branching documentation to reflect merge flow

### DIFF
--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -145,12 +145,6 @@ INAV uses maintenance branches for active development and releases. The `master`
 - New features that require coordinated firmware and configurator updates
 - Changes here will be included in the next major version release (e.g., 10.0)
 
-#### Master Branch
-
-The `master` branch receives periodic merges from the current version maintenance branch (e.g., maintenance-9.x). It serves as a mirror of the current version and a safety net - if a contributor accidentally branches from master, they won't pull in breaking changes from the next major version branch.
-
-**Master is NOT a target for pull requests** - contributors should target the appropriate maintenance branch.
-
 ### Choosing the Right Target Branch
 
 When creating a pull request, target the appropriate branch:

--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -127,7 +127,7 @@ You can also perform the git commands using the git client inside Eclipse.  Refe
 
 ## Branching and release workflow
 
-INAV uses maintenance branches for active development and releases. The `master` branch receives merges from maintenance branches.
+INAV uses maintenance branches for active development and releases. The `master` branch tracks the current version by receiving merges from the current version maintenance branch.
 
 ### Branch Types
 
@@ -147,7 +147,9 @@ INAV uses maintenance branches for active development and releases. The `master`
 
 #### Master Branch
 
-The `master` branch receives periodic merges from maintenance branches.
+The `master` branch receives periodic merges from the current version maintenance branch (e.g., maintenance-9.x). It serves as a mirror of the current version and a safety net - if a contributor accidentally branches from master, they won't pull in breaking changes from the next major version branch.
+
+**Master is NOT a target for pull requests** - contributors should target the appropriate maintenance branch.
 
 ### Choosing the Right Target Branch
 
@@ -171,37 +173,47 @@ When creating a pull request, target the appropriate branch:
 1. Development occurs on the current version maintenance branch (e.g., `maintenance-9.x`)
 2. When ready for release, a release candidate is tagged from the maintenance branch
 3. Bug fixes during the RC period continue on the maintenance branch
-4. After final release, the maintenance branch is periodically merged into `master`
+4. After final release, the maintenance branch is periodically merged into `master`, which is then merged into the next version branch
 5. The cycle continues with the maintenance branch receiving new changes for the next release
 
-### Propagating Changes Between Maintenance Branches
+**Merge flow:** `maintenance-9.x` → `master` → `maintenance-10.x`
 
-Changes committed to the current version branch should be merged forward to the next major version branch to prevent regressions.
+### Propagating Changes Between Branches
+
+Changes committed to the current version branch flow through master to the next major version branch.
 
 **Maintainer workflow:**
-- Changes merged to `maintenance-9.x` should be regularly merged into `maintenance-10.x`
+- Changes in `maintenance-9.x` are merged into `master`
+- Changes in `master` are then merged into `maintenance-10.x`
 - This ensures fixes and features aren't lost when the next major version is released
 - Prevents users from experiencing bugs in v10.0 that were already fixed in v9.x
 
-**Example:**
+**Merge flow:**
 ```bash
-# Merge changes from current to next major version
-git checkout maintenance-10.x
+# Step 1: Merge current version to master
+git checkout master
 git merge maintenance-9.x
+git push upstream master
+
+# Step 2: Merge master to next version
+git checkout maintenance-10.x
+git merge master
 git push upstream maintenance-10.x
 ```
 
+**Why use master as intermediate step:** This keeps master synchronized with the current version, so if a contributor accidentally branches from master, they get current version code without breaking changes from maintenance-10.x.
+
 ### Example Timeline
 
-Current state (example):
+**Current state (example - during 9.x series):**
 - `maintenance-9.x` - Active development for INAV 9.1, 9.2, etc.
+- `master` - Mirror of maintenance-9.x (receives merges via merge flow)
 - `maintenance-10.x` - Breaking changes for future INAV 10.0
-- `master` - Receives periodic merges from maintenance branches
 
-After INAV 10.0 is released:
-- `maintenance-10.x` - Active development for INAV 10.1, 10.2, etc.
+**After INAV 10.0 is released:**
+- `maintenance-10.x` - Becomes active development for INAV 10.1, 10.2, etc.
+- `master` - Now mirrors maintenance-10.x (via merge flow)
 - `maintenance-11.x` - Breaking changes for future INAV 11.0
-- `master` - Continues receiving merges
 
 ### Working with Maintenance Branches
 

--- a/docs/development/release-create.md
+++ b/docs/development/release-create.md
@@ -320,11 +320,11 @@ gh api repos/iNavFlight/inav-configurator/git/refs -f ref="refs/heads/maintenanc
 
 ### Branch Usage
 
-- **X.x bugfixes** → PR to maintenance-X.x
-- **Breaking changes** → PR to maintenance-(X+1).x
-- **Non-breaking features** → PR to master
+- **Changes maintaining backward compatibility** → PR to maintenance-X.x (e.g., maintenance-9.x)
+- **Breaking changes** (MSP protocol, settings structure) → PR to maintenance-(X+1).x (e.g., maintenance-10.x)
+- **Master** → NOT a PR target (receives merges only)
 
-Lower version branches are periodically merged into higher version branches (e.g., maintenance-9.x → maintenance-10.x → master).
+Lower version branches are periodically merged into higher version branches (e.g., maintenance-9.x → master → maintenance-10.x).
 
 ## Hotfix Releases
 


### PR DESCRIPTION
### **User description**
Clarify that the merge flow is: maintenance-9.x → master → maintenance-10.x

This keeps master synchronized with the current version branch. If contributors accidentally branch from master, they get current version code without pulling in breaking changes from the next major version.

**Changes:**
- Emphasize master is NOT a PR target (receives merges only)
- Update merge flow in Development.md and release-create.md
- Clarify backward compatibility vs breaking changes
- Add maintainer workflow examples showing 2-step merge process


___

### **PR Type**
Documentation


___

### **Description**
- Clarifies merge flow: maintenance-9.x → master → maintenance-10.x

- Emphasizes master is NOT a PR target, receives merges only

- Adds detailed maintainer workflow examples with step-by-step merge process

- Removes redundant Master Branch section, consolidates branching guidance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  m9["maintenance-9.x<br/>Current version"] -- "merge" --> master["master<br/>Current version mirror"]
  master -- "merge" --> m10["maintenance-10.x<br/>Next major version"]
  m10 -- "future cycle" --> master2["master<br/>Next version mirror"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Development.md</strong><dd><code>Restructure branching documentation with merge flow clarity</code></dd></summary>
<hr>

docs/development/Development.md

<ul><li>Updated master branch description to emphasize it tracks current <br>version via merges<br> <li> Removed redundant Master Branch section, consolidating guidance<br> <li> Clarified merge flow as maintenance-9.x → master → maintenance-10.x<br> <li> Added detailed maintainer workflow with 2-step merge process and bash <br>examples<br> <li> Explained rationale for using master as intermediate step<br> <li> Updated example timeline to show master as mirror of current version</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11227/files#diff-4b48e1dc0ad66b22a48865229fcb3fff6cf58669947c8df5a0938a6f4b5493c0">+23/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release-create.md</strong><dd><code>Update branch usage guidance and merge flow direction</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/development/release-create.md

<ul><li>Clarified branch usage with explicit backward compatibility language<br> <li> Updated merge flow direction from maintenance-9.x → master → <br>maintenance-10.x<br> <li> Added explicit statement that master is NOT a PR target<br> <li> Improved clarity on breaking changes vs non-breaking changes targeting</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11227/files#diff-90b17e9e24e4eec3d637c1ff882219a8373554aee67610974d29df51ff8ec1cc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

