### PR TITLE
Firmware support for improved mixer wizard (MSP2_INAV_MOTOR_LOCATE command for motor identification)

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -298,6 +298,8 @@ main_sources(COMMON_SRC
     fc/firmware_update.h
     fc/firmware_update_common.c
     fc/firmware_update_common.h
+    fc/motor_locate.c
+    fc/motor_locate.h
     fc/multifunction.c
     fc/multifunction.h
     fc/rc_smoothing.c

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -64,7 +64,7 @@
 #define DSHOT_COMMAND_DELAY_US 1000
 #define DSHOT_COMMAND_INTERVAL_US 10000
 #define DSHOT_COMMAND_QUEUE_LENGTH 8
-#define DHSOT_COMMAND_QUEUE_SIZE   DSHOT_COMMAND_QUEUE_LENGTH * sizeof(dshotCommandWithMotor_t)
+#define DSHOT_COMMAND_QUEUE_SIZE   DSHOT_COMMAND_QUEUE_LENGTH * sizeof(dshotCommandWithMotor_t)
 #endif
 
 typedef void (*pwmWriteFuncPtr)(uint8_t index, uint16_t value);  // function pointer used to write motors
@@ -122,7 +122,7 @@ static timeUs_t lastCommandSent = 0;
 static timeUs_t commandPostDelay = 0;
     
 static circularBuffer_t commandsCircularBuffer;
-static uint8_t commandsBuff[DHSOT_COMMAND_QUEUE_SIZE];
+static uint8_t commandsBuff[DSHOT_COMMAND_QUEUE_SIZE];
 static currentExecutingCommand_t currentExecutingCommand;
 #endif
 
@@ -413,7 +413,7 @@ void sendDShotCommandToMotor(uint8_t motorIndex, dshotCommands_e cmd) {
 }
 
 void initDShotCommands(void) {
-    circularBufferInit(&commandsCircularBuffer, commandsBuff, DHSOT_COMMAND_QUEUE_SIZE, sizeof(dshotCommandWithMotor_t));
+    circularBufferInit(&commandsCircularBuffer, commandsBuff, DSHOT_COMMAND_QUEUE_SIZE, sizeof(dshotCommandWithMotor_t));
 
     currentExecutingCommand.remainingRepeats = 0;
 }

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -64,7 +64,7 @@
 #define DSHOT_COMMAND_DELAY_US 1000
 #define DSHOT_COMMAND_INTERVAL_US 10000
 #define DSHOT_COMMAND_QUEUE_LENGTH 8
-#define DHSOT_COMMAND_QUEUE_SIZE   DSHOT_COMMAND_QUEUE_LENGTH * sizeof(dshotCommands_e)
+#define DHSOT_COMMAND_QUEUE_SIZE   DSHOT_COMMAND_QUEUE_LENGTH * sizeof(dshotCommandWithMotor_t)
 #endif
 
 typedef void (*pwmWriteFuncPtr)(uint8_t index, uint16_t value);  // function pointer used to write motors
@@ -397,11 +397,23 @@ void pwmRequestMotorTelemetry(int motorIndex)
 
 #ifdef USE_DSHOT
 void sendDShotCommand(dshotCommands_e cmd) {
-    circularBufferPushElement(&commandsCircularBuffer, (uint8_t *) &cmd);
+    dshotCommandWithMotor_t cmdWithMotor = {
+        .cmd = cmd,
+        .motorIndex = 0xFF  // 0xFF = all motors
+    };
+    circularBufferPushElement(&commandsCircularBuffer, (uint8_t *) &cmdWithMotor);
+}
+
+void sendDShotCommandToMotor(uint8_t motorIndex, dshotCommands_e cmd) {
+    dshotCommandWithMotor_t cmdWithMotor = {
+        .cmd = cmd,
+        .motorIndex = motorIndex
+    };
+    circularBufferPushElement(&commandsCircularBuffer, (uint8_t *) &cmdWithMotor);
 }
 
 void initDShotCommands(void) {
-    circularBufferInit(&commandsCircularBuffer, commandsBuff,DHSOT_COMMAND_QUEUE_SIZE, sizeof(dshotCommands_e));
+    circularBufferInit(&commandsCircularBuffer, commandsBuff, DHSOT_COMMAND_QUEUE_SIZE, sizeof(dshotCommandWithMotor_t));
 
     currentExecutingCommand.remainingRepeats = 0;
 }
@@ -422,17 +434,17 @@ static int getDShotCommandRepeats(dshotCommands_e cmd) {
 }
 
 static bool executeDShotCommands(void){
-    
+
     timeUs_t tNow = micros();
 
     if(currentExecutingCommand.remainingRepeats == 0) {
        const int isTherePendingCommands = !circularBufferIsEmpty(&commandsCircularBuffer);
         if (isTherePendingCommands && (tNow - lastCommandSent > DSHOT_COMMAND_INTERVAL_US)){
             //Load the command
-            dshotCommands_e cmd;
+            dshotCommandWithMotor_t cmd;
             circularBufferPopHead(&commandsCircularBuffer, (uint8_t *) &cmd);
             currentExecutingCommand.cmd = cmd;
-            currentExecutingCommand.remainingRepeats = getDShotCommandRepeats(cmd);
+            currentExecutingCommand.remainingRepeats = getDShotCommandRepeats(cmd.cmd);
             commandPostDelay = DSHOT_COMMAND_INTERVAL_US;
         } else {
             if (commandPostDelay) {
@@ -443,14 +455,28 @@ static bool executeDShotCommands(void){
             }
 
             return true;
-        }  
+        }
     }
-    for (uint8_t i = 0; i < getMotorCount(); i++) {
-         motors[i].requestTelemetry = true;
-         motors[i].value = currentExecutingCommand.cmd;
+
+    // Apply command to specific motor or all motors
+    uint8_t motorCount = getMotorCount();
+    if (currentExecutingCommand.cmd.motorIndex == 0xFF) {
+        // All motors
+        for (uint8_t i = 0; i < motorCount; i++) {
+            motors[i].requestTelemetry = true;
+            motors[i].value = currentExecutingCommand.cmd.cmd;
+        }
+    } else {
+        // Specific motor only
+        uint8_t targetMotor = currentExecutingCommand.cmd.motorIndex;
+        if (targetMotor < motorCount) {
+            motors[targetMotor].requestTelemetry = true;
+            motors[targetMotor].value = currentExecutingCommand.cmd.cmd;
+        }
     }
+
     if (tNow - lastCommandSent >= DSHOT_COMMAND_DELAY_US) {
-        currentExecutingCommand.remainingRepeats--; 
+        currentExecutingCommand.remainingRepeats--;
         lastCommandSent = tNow;
         return true;
     } else {

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -37,8 +37,6 @@ typedef enum {
     DSHOT_CMD_SPIN_DIRECTION_REVERSED = 21,
 } dshotCommands_e;
 
-#define DSHOT_CMD_ALL_MOTORS 255
-
 typedef struct {
     dshotCommands_e cmd;
     int remainingRepeats;
@@ -69,7 +67,6 @@ void pwmWriteBeeper(bool onoffBeep);
 void beeperPwmInit(ioTag_t tag, uint16_t frequency);
 
 void sendDShotCommand(dshotCommands_e cmd);
-void sendDShotCommandToMotor(uint8_t motorIndex, dshotCommands_e cmd);
 void initDShotCommands(void);
 
 uint32_t getEscUpdateFrequency(void);

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -27,9 +27,17 @@
 #define MAX_PWM_OUTPUTS (MAX_PWM_OUTPUT_PORTS)
 #endif
 typedef enum {
+    DSHOT_CMD_MOTOR_STOP = 0,
+    DSHOT_CMD_BEACON1 = 1,
+    DSHOT_CMD_BEACON2 = 2,
+    DSHOT_CMD_BEACON3 = 3,
+    DSHOT_CMD_BEACON4 = 4,
+    DSHOT_CMD_BEACON5 = 5,
     DSHOT_CMD_SPIN_DIRECTION_NORMAL = 20,
     DSHOT_CMD_SPIN_DIRECTION_REVERSED = 21,
 } dshotCommands_e;
+
+#define DSHOT_CMD_ALL_MOTORS 255
 
 typedef struct {
     dshotCommands_e cmd;
@@ -61,6 +69,7 @@ void pwmWriteBeeper(bool onoffBeep);
 void beeperPwmInit(ioTag_t tag, uint16_t frequency);
 
 void sendDShotCommand(dshotCommands_e cmd);
+void sendDShotCommandToMotor(uint8_t motorIndex, dshotCommands_e cmd);
 void initDShotCommands(void);
 
 uint32_t getEscUpdateFrequency(void);

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -39,6 +39,11 @@ typedef enum {
 
 typedef struct {
     dshotCommands_e cmd;
+    uint8_t motorIndex;  // 0-7 for specific motor, 0xFF for all motors
+} dshotCommandWithMotor_t;
+
+typedef struct {
+    dshotCommandWithMotor_t cmd;
     int remainingRepeats;
 } currentExecutingCommand_t;
 
@@ -67,6 +72,7 @@ void pwmWriteBeeper(bool onoffBeep);
 void beeperPwmInit(ioTag_t tag, uint16_t frequency);
 
 void sendDShotCommand(dshotCommands_e cmd);
+void sendDShotCommandToMotor(uint8_t motorIndex, dshotCommands_e cmd);
 void initDShotCommands(void);
 
 uint32_t getEscUpdateFrequency(void);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1731,12 +1731,18 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
 #ifdef USE_DSHOT
     case MSP2_INAV_MOTOR_LOCATE:
         {
-            // Motor locate requires 1 byte: motor index
+            // Motor locate requires 1 byte: motor index (255 = stop)
             if (dataSize < 1) {
                 return MSP_RESULT_ERROR;
             }
             uint8_t motorIndex = sbufReadU8(src);
-            bool success = motorLocateStart(motorIndex);
+            bool success;
+            if (motorIndex == 255) {
+                motorLocateStop();
+                success = true;
+            } else {
+                success = motorLocateStart(motorIndex);
+            }
             sbufWriteU8(dst, success ? 1 : 0);
         }
         break;

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -68,6 +68,7 @@
 #include "fc/fc_msp.h"
 #include "fc/fc_msp_box.h"
 #include "fc/firmware_update.h"
+#include "fc/motor_locate.h"
 #include "fc/rc_adjustments.h"
 #include "fc/rc_controls.h"
 #include "fc/rc_modes.h"
@@ -1723,6 +1724,20 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
                 const escSensorData_t *escState = getEscTelemetry(i); //Get ESC telemetry
                 sbufWriteDataSafe(dst, escState, sizeof(escSensorData_t));
             }
+        }
+        break;
+#endif
+
+#ifdef USE_DSHOT
+    case MSP2_INAV_MOTOR_LOCATE:
+        {
+            // Motor locate requires 1 byte: motor index
+            if (dataSize < 1) {
+                return MSP_RESULT_ERROR;
+            }
+            uint8_t motorIndex = sbufReadU8(src);
+            bool success = motorLocateStart(motorIndex);
+            sbufWriteU8(dst, success ? 1 : 0);
         }
         break;
 #endif

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1728,26 +1728,6 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         break;
 #endif
 
-#ifdef USE_DSHOT
-    case MSP2_INAV_MOTOR_LOCATE:
-        {
-            // Motor locate requires 1 byte: motor index (255 = stop)
-            if (dataSize < 1) {
-                return MSP_RESULT_ERROR;
-            }
-            uint8_t motorIndex = sbufReadU8(src);
-            bool success;
-            if (motorIndex == 255) {
-                motorLocateStop();
-                success = true;
-            } else {
-                success = motorLocateStart(motorIndex);
-            }
-            sbufWriteU8(dst, success ? 1 : 0);
-        }
-        break;
-#endif
-
 #ifdef USE_EZ_TUNE
 
     case MSP2_INAV_EZ_TUNE:
@@ -3674,6 +3654,29 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         }
         break;
 
+
+#ifdef USE_DSHOT
+    case MSP2_INAV_MOTOR_LOCATE:
+        {
+            // Motor locate requires 1 byte: motor index (255 = stop)
+            if (dataSize < 1) {
+                return MSP_RESULT_ERROR;
+            }
+            uint8_t motorIndex = sbufReadU8(src);
+            bool success;
+            if (motorIndex == 255) {
+                motorLocateStop();
+                // success = true;
+            } else {
+			  motorLocateStart(motorIndex);
+                // success = motorLocateStart(motorIndex);
+            }
+            // sbufWriteU8(dst, success ? 1 : 0);
+        }
+        break;
+#endif
+
+
     default:
         return MSP_RESULT_ERROR;
     }
@@ -4064,6 +4067,8 @@ void mspWriteSimulatorOSD(sbuf_t *dst)
 	}
 }
 #endif
+
+
 
 bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResult_e *ret)
 {

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -3658,7 +3658,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #ifdef USE_DSHOT
     case MSP2_INAV_MOTOR_LOCATE:
         {
-            // Motor locate requires 1 byte: motor index (255 = stop)
+            /* Motor locate requires 1 byte: motor index (255 = stop) */
             if (dataSize < 1) {
                 return MSP_RESULT_ERROR;
             }

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -3663,15 +3663,11 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
                 return MSP_RESULT_ERROR;
             }
             uint8_t motorIndex = sbufReadU8(src);
-            bool success;
             if (motorIndex == 255) {
                 motorLocateStop();
-                // success = true;
             } else {
-			  motorLocateStart(motorIndex);
-                // success = motorLocateStart(motorIndex);
+                motorLocateStart(motorIndex);
             }
-            // sbufWriteU8(dst, success ? 1 : 0);
         }
         break;
 #endif

--- a/src/main/fc/motor_locate.c
+++ b/src/main/fc/motor_locate.c
@@ -1,0 +1,207 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#ifdef USE_DSHOT
+
+#include "drivers/pwm_output.h"
+#include "drivers/time.h"
+#include "flight/mixer.h"
+#include "fc/motor_locate.h"
+#include "fc/runtime_config.h"
+
+// Timing constants (in microseconds)
+#define LOCATE_JERK_DURATION_US     100000  // 100ms motor jerk
+#define LOCATE_JERK_PAUSE_US        100000  // 100ms pause after jerk
+#define LOCATE_BEEP_ON_US            80000  // 80ms beep on
+#define LOCATE_BEEP_OFF_US           80000  // 80ms beep off
+#define LOCATE_CYCLE_DURATION_US   2000000  // 2 seconds total cycle
+
+// Motor throttle for jerk (~12% throttle)
+// DShot range: 48 (0%) to 2047 (100%)
+#define LOCATE_JERK_THROTTLE    288  // 48 + (1999 * 0.12) ≈ 288
+
+typedef enum {
+    LOCATE_STATE_IDLE,
+    LOCATE_STATE_JERK,
+    LOCATE_STATE_JERK_PAUSE,
+    LOCATE_STATE_BEEP1_ON,
+    LOCATE_STATE_BEEP1_OFF,
+    LOCATE_STATE_BEEP2_ON,
+    LOCATE_STATE_BEEP2_OFF,
+    LOCATE_STATE_BEEP3_ON,
+    LOCATE_STATE_BEEP3_PAUSE,
+} motorLocateState_e;
+
+// Global flag for fast inline check in FAST_CODE path
+bool motorLocateActive = false;
+
+static struct {
+    motorLocateState_e state;
+    uint8_t motorIndex;
+    timeUs_t stateStartTime;
+    timeUs_t cycleStartTime;
+} locateState = {
+    .state = LOCATE_STATE_IDLE,
+    .motorIndex = 0,
+    .stateStartTime = 0,
+    .cycleStartTime = 0,
+};
+
+// Forward declarations
+static void transitionToState(motorLocateState_e newState, timeUs_t now);
+static timeUs_t getStateDuration(motorLocateState_e state);
+
+bool motorLocateStart(uint8_t motorIndex)
+{
+    // Don't allow if already running
+    if (locateState.state != LOCATE_STATE_IDLE) {
+        return false;
+    }
+
+    // Validate motor index
+    if (motorIndex >= getMotorCount()) {
+        return false;
+    }
+
+    // Only allow when disarmed
+    if (ARMING_FLAG(ARMED)) {
+        return false;
+    }
+
+    // Only allow with DShot protocol
+    if (!isMotorProtocolDshot()) {
+        return false;
+    }
+
+    timeUs_t now = micros();
+    locateState.motorIndex = motorIndex;
+    locateState.cycleStartTime = now;
+    transitionToState(LOCATE_STATE_JERK, now);
+    motorLocateActive = true;
+
+    return true;
+}
+
+void motorLocateStop(void)
+{
+    locateState.state = LOCATE_STATE_IDLE;
+    motorLocateActive = false;
+}
+
+bool motorLocateIsActive(void)
+{
+    return locateState.state != LOCATE_STATE_IDLE;
+}
+
+static void transitionToState(motorLocateState_e newState, timeUs_t now)
+{
+    locateState.state = newState;
+    locateState.stateStartTime = now;
+}
+
+static timeUs_t getStateDuration(motorLocateState_e state)
+{
+    switch (state) {
+        case LOCATE_STATE_JERK:
+            return LOCATE_JERK_DURATION_US;
+        case LOCATE_STATE_JERK_PAUSE:
+            return LOCATE_JERK_PAUSE_US;
+        case LOCATE_STATE_BEEP1_ON:
+        case LOCATE_STATE_BEEP2_ON:
+        case LOCATE_STATE_BEEP3_ON:
+            return LOCATE_BEEP_ON_US;
+        case LOCATE_STATE_BEEP1_OFF:
+        case LOCATE_STATE_BEEP2_OFF:
+            return LOCATE_BEEP_OFF_US;
+        case LOCATE_STATE_BEEP3_PAUSE:
+            return LOCATE_JERK_PAUSE_US;
+        default:
+            return 0;
+    }
+}
+
+static motorLocateState_e getNextState(motorLocateState_e state)
+{
+    switch (state) {
+        case LOCATE_STATE_JERK:        return LOCATE_STATE_JERK_PAUSE;
+        case LOCATE_STATE_JERK_PAUSE:  return LOCATE_STATE_BEEP1_ON;
+        case LOCATE_STATE_BEEP1_ON:    return LOCATE_STATE_BEEP1_OFF;
+        case LOCATE_STATE_BEEP1_OFF:   return LOCATE_STATE_BEEP2_ON;
+        case LOCATE_STATE_BEEP2_ON:    return LOCATE_STATE_BEEP2_OFF;
+        case LOCATE_STATE_BEEP2_OFF:   return LOCATE_STATE_BEEP3_ON;
+        case LOCATE_STATE_BEEP3_ON:    return LOCATE_STATE_BEEP3_PAUSE;
+        case LOCATE_STATE_BEEP3_PAUSE: return LOCATE_STATE_JERK;  // Loop back
+        default:                       return LOCATE_STATE_IDLE;
+    }
+}
+
+static uint16_t getMotorValueForState(motorLocateState_e state, uint8_t motorIdx, uint8_t targetMotorIdx)
+{
+    // All motors except target get MOTOR_STOP
+    if (motorIdx != targetMotorIdx) {
+        return DSHOT_CMD_MOTOR_STOP;
+    }
+
+    // Target motor value depends on state
+    switch (state) {
+        case LOCATE_STATE_JERK:
+            return LOCATE_JERK_THROTTLE;
+        case LOCATE_STATE_BEEP1_ON:
+        case LOCATE_STATE_BEEP2_ON:
+        case LOCATE_STATE_BEEP3_ON:
+            return DSHOT_CMD_BEACON1;
+        default:
+            return DSHOT_CMD_MOTOR_STOP;
+    }
+}
+
+bool motorLocateUpdate(void)
+{
+    if (locateState.state == LOCATE_STATE_IDLE) {
+        return false;
+    }
+
+    timeUs_t now = micros();
+
+    // Check if total cycle time exceeded
+    if (cmpTimeUs(now, locateState.cycleStartTime) >= LOCATE_CYCLE_DURATION_US) {
+        motorLocateStop();
+        return false;
+    }
+
+    // Check for state transition
+    timeUs_t stateDuration = getStateDuration(locateState.state);
+    if (cmpTimeUs(now, locateState.stateStartTime) >= stateDuration) {
+        transitionToState(getNextState(locateState.state), now);
+    }
+
+    // Apply motor values for current state
+    uint8_t motorCount = getMotorCount();
+    for (uint8_t i = 0; i < motorCount; i++) {
+        uint16_t value = getMotorValueForState(locateState.state, i, locateState.motorIndex);
+        pwmWriteMotor(i, value);
+    }
+
+    return true;
+}
+
+#endif // USE_DSHOT

--- a/src/main/fc/motor_locate.c
+++ b/src/main/fc/motor_locate.c
@@ -29,11 +29,11 @@
 #include "fc/runtime_config.h"
 
 // Timing constants (in microseconds)
-#define LOCATE_JERK_DURATION_US     100000  // 100ms motor jerk
-#define LOCATE_JERK_PAUSE_US        100000  // 100ms pause after jerk
-#define LOCATE_BEEP_ON_US            80000  // 80ms beep on
-#define LOCATE_BEEP_OFF_US           80000  // 80ms beep off
-#define LOCATE_CYCLE_DURATION_US   2000000  // 2 seconds total cycle
+#define LOCATE_JERK_DURATION_US       10000 // 10ms motor jerk (safety: minimal movement)
+#define LOCATE_JERK_PAUSE_US          10000 // 10ms pause after jerk
+#define LOCATE_BEEP_ON_US             80000 // 80ms beep on
+#define LOCATE_BEEP_OFF_US            80000 // 80ms beep off
+#define LOCATE_CYCLE_DURATION_US     2000000 // 2000ms total cycle
 
 // Motor throttle for jerk (~12% throttle)
 // DShot range: 48 (0%) to 2047 (100%)
@@ -117,6 +117,12 @@ static void transitionToState(motorLocateState_e newState, timeUs_t now)
 {
     locateState.state = newState;
     locateState.stateStartTime = now;
+
+    // Send beacon command once when entering BEEP_ON state
+    if (newState == LOCATE_STATE_BEEP_ON) {
+        dshotCommands_e beaconCmd = DSHOT_CMD_BEACON1 + locateState.beepCount;
+        sendDShotCommandToMotor(locateState.motorIndex, beaconCmd);
+    }
 }
 
 static timeUs_t getStateDuration(motorLocateState_e state)
@@ -155,23 +161,6 @@ static motorLocateState_e advanceToNextState(motorLocateState_e state)
     }
 }
 
-static uint16_t getMotorValueForState(motorLocateState_e state, uint8_t motorIdx, uint8_t targetMotorIdx)
-{
-    if (motorIdx != targetMotorIdx) {
-        return DSHOT_CMD_MOTOR_STOP;
-    }
-
-    switch (state) {
-        case LOCATE_STATE_JERK:
-            return LOCATE_JERK_THROTTLE;
-        case LOCATE_STATE_BEEP_ON:
-            // Ascending tones help humans locate sound using multiple hearing mechanisms
-            return DSHOT_CMD_BEACON1 + locateState.beepCount;
-        default:
-            return DSHOT_CMD_MOTOR_STOP;
-    }
-}
-
 bool motorLocateUpdate(void)
 {
     if (locateState.state == LOCATE_STATE_IDLE) {
@@ -193,16 +182,33 @@ bool motorLocateUpdate(void)
     }
 
     // Check for state transition
-    timeUs_t stateDuration = getStateDuration(locateState.state);
+    timeDelta_t stateDuration = getStateDuration(locateState.state);
     if (cmpTimeUs(now, locateState.stateStartTime) >= stateDuration) {
         transitionToState(advanceToNextState(locateState.state), now);
     }
 
     // Apply motor values for current state
     uint8_t motorCount = getMotorCount();
-    for (uint8_t i = 0; i < motorCount; i++) {
-        uint16_t value = getMotorValueForState(locateState.state, i, locateState.motorIndex);
-        pwmWriteMotor(i, value);
+
+    if (locateState.state == LOCATE_STATE_JERK) {
+        // For jerk state, use direct PWM write with throttle value
+        pwmWriteMotor(locateState.motorIndex, LOCATE_JERK_THROTTLE);
+        // Set all other motors to stop
+        for (uint8_t i = 0; i < motorCount; i++) {
+            if (i != locateState.motorIndex) {
+                pwmWriteMotor(i, DSHOT_CMD_MOTOR_STOP);
+            }
+        }
+    } else if (locateState.state == LOCATE_STATE_BEEP_ON || locateState.state == LOCATE_STATE_BEEP_OFF) {
+        // For beep states, beacon command already sent, just keep motors stopped
+        for (uint8_t i = 0; i < motorCount; i++) {
+            pwmWriteMotor(i, DSHOT_CMD_MOTOR_STOP);
+        }
+    } else {
+        // For other states (pause, etc.), ensure all motors stopped
+        for (uint8_t i = 0; i < motorCount; i++) {
+            pwmWriteMotor(i, DSHOT_CMD_MOTOR_STOP);
+        }
     }
 
     return true;

--- a/src/main/fc/motor_locate.c
+++ b/src/main/fc/motor_locate.c
@@ -28,16 +28,13 @@
 #include "fc/motor_locate.h"
 #include "fc/runtime_config.h"
 
-// Timing constants (in microseconds)
-#define LOCATE_JERK_DURATION_US       10000 // 10ms motor jerk (safety: minimal movement)
-#define LOCATE_JERK_PAUSE_US          10000 // 10ms pause after jerk
-#define LOCATE_BEEP_ON_US             80000 // 80ms beep on
-#define LOCATE_BEEP_OFF_US            80000 // 80ms beep off
-#define LOCATE_CYCLE_DURATION_US     2000000 // 2000ms total cycle
+#define LOCATE_JERK_DURATION_US       20000
+#define LOCATE_JERK_PAUSE_US          20000
+#define LOCATE_BEEP_ON_US             80000
+#define LOCATE_BEEP_OFF_US            80000
+#define LOCATE_CYCLE_DURATION_US     2000000
 
-// Motor throttle for jerk (~12% throttle)
-// DShot range: 48 (0%) to 2047 (100%)
-#define LOCATE_JERK_THROTTLE    288  // 48 + (1999 * 0.12) ≈ 288
+#define LOCATE_JERK_THROTTLE    288  // ~12% throttle: 48 + (1999 * 0.12)
 
 typedef enum {
     LOCATE_STATE_IDLE,
@@ -49,7 +46,6 @@ typedef enum {
 
 #define LOCATE_NUM_BEEPS 4
 
-// Global flag for fast inline check in FAST_CODE path
 bool motorLocateActive = false;
 
 static struct {
@@ -118,7 +114,6 @@ static void transitionToState(motorLocateState_e newState, timeUs_t now)
     locateState.state = newState;
     locateState.stateStartTime = now;
 
-    // Send beacon command once when entering BEEP_ON state
     if (newState == LOCATE_STATE_BEEP_ON) {
         dshotCommands_e beaconCmd = DSHOT_CMD_BEACON1 + locateState.beepCount;
         sendDShotCommandToMotor(locateState.motorIndex, beaconCmd);
@@ -191,21 +186,13 @@ bool motorLocateUpdate(void)
     uint8_t motorCount = getMotorCount();
 
     if (locateState.state == LOCATE_STATE_JERK) {
-        // For jerk state, use direct PWM write with throttle value
         pwmWriteMotor(locateState.motorIndex, LOCATE_JERK_THROTTLE);
-        // Set all other motors to stop
         for (uint8_t i = 0; i < motorCount; i++) {
             if (i != locateState.motorIndex) {
                 pwmWriteMotor(i, DSHOT_CMD_MOTOR_STOP);
             }
         }
-    } else if (locateState.state == LOCATE_STATE_BEEP_ON || locateState.state == LOCATE_STATE_BEEP_OFF) {
-        // For beep states, beacon command already sent, just keep motors stopped
-        for (uint8_t i = 0; i < motorCount; i++) {
-            pwmWriteMotor(i, DSHOT_CMD_MOTOR_STOP);
-        }
     } else {
-        // For other states (pause, etc.), ensure all motors stopped
         for (uint8_t i = 0; i < motorCount; i++) {
             pwmWriteMotor(i, DSHOT_CMD_MOTOR_STOP);
         }

--- a/src/main/fc/motor_locate.h
+++ b/src/main/fc/motor_locate.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Global flag for fast inline check - avoids function call in FAST_CODE path
+extern bool motorLocateActive;
+
+// Start motor locate cycle for specified motor index
+// Runs jerk+beep pattern for ~2 seconds then stops automatically
+// Returns false if locate is already running or motor index invalid
+bool motorLocateStart(uint8_t motorIndex);
+
+// Stop any running motor locate cycle
+void motorLocateStop(void);
+
+// Check if motor locate is currently active
+bool motorLocateIsActive(void);
+
+// Called from motor update loop to apply locate overrides
+// Returns true if locate is active and motor values were overridden
+bool motorLocateUpdate(void);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -39,6 +39,7 @@
 #include "drivers/time.h"
 
 #include "fc/config.h"
+#include "fc/motor_locate.h"
 #include "fc/rc_controls.h"
 #include "fc/rc_modes.h"
 #include "fc/runtime_config.h"
@@ -369,6 +370,12 @@ static void applyTurtleModeToMotors(void) {
 void FAST_CODE writeMotors(void)
 {
 #if !defined(SITL_BUILD)
+#ifdef USE_DSHOT
+    if (motorLocateActive && motorLocateUpdate()) {
+        return;
+    }
+#endif
+
     for (int i = 0; i < motorCount; i++) {
         uint16_t motorValue;
 #ifdef USE_DSHOT

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -370,12 +370,6 @@ static void applyTurtleModeToMotors(void) {
 void FAST_CODE writeMotors(void)
 {
 #if !defined(SITL_BUILD)
-#ifdef USE_DSHOT
-    if (motorLocateActive && motorLocateUpdate()) {
-        return;
-    }
-#endif
-
     for (int i = 0; i < motorCount; i++) {
         uint16_t motorValue;
 #ifdef USE_DSHOT

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -48,6 +48,7 @@
 #ifdef USE_DSHOT
 #include "drivers/pwm_output.h"
 #include "fc/fc_core.h"
+#include "fc/motor_locate.h"
 #include "flight/mixer.h"
 static timeUs_t lastDshotBeeperCommandTimeUs;
 #endif
@@ -314,6 +315,12 @@ void beeperGpsStatus(void)
  */
 void beeperUpdate(timeUs_t currentTimeUs)
 {
+#ifdef USE_DSHOT
+    if (motorLocateActive && motorLocateUpdate()) {
+        return;
+    }
+#endif
+
     // If beeper option from AUX switch has been selected
     if (IS_RC_MODE_ACTIVE(BOXBEEPERON)) {
 #ifdef USE_GPS

--- a/src/main/msp/msp_protocol_v2_inav.h
+++ b/src/main/msp/msp_protocol_v2_inav.h
@@ -93,6 +93,7 @@
 
 #define MSP2_INAV_ESC_RPM                       0x2040
 #define MSP2_INAV_ESC_TELEM                     0x2041
+#define MSP2_INAV_MOTOR_LOCATE                  0x2042
 
 #define MSP2_INAV_LED_STRIP_CONFIG_EX           0x2048
 #define MSP2_INAV_SET_LED_STRIP_CONFIG_EX       0x2049


### PR DESCRIPTION
### **User description**
In Configurator 9.1 I want to be able to have a very simple, intuitive, motor mixer wizard, where the user just clicks on which motor is beeping and jerking:

![motor-wizard-demo](https://github.com/user-attachments/assets/6df74632-50a5-4c3e-80bc-e7a8529b3226)

This PR is firmware side of that, to have one motor signal.

Adds a new MSP command (MSP2_INAV_MOTOR_LOCATE, 0x2042) that beeps and jerks a specific motor to help users identify motor positions during configuration.

## Changes

- New `motor_locate` module with state machine for motor identification pattern
- MSP2_INAV_MOTOR_LOCATE (0x2042) command handler in fc_msp.c
- Integration with mixer to override motor outputs during locate cycle

## How It Works

When the command is received with a motor index:
1. Motor does a brief 100ms jerk at ~12% throttle
2. Followed by 3 DShot beacon beeps
3. Pattern repeats for 2 seconds total
4. Only works when disarmed and with DShot protocol

## Safety

- Only activates when aircraft is disarmed
- Automatically stops after 2 seconds
- Low throttle (12%)

## Testing

- Built SITL successfully
- MSP command handler tested via configurator connection
- Full motor spin testing requires hardware with DShot ESCs

## Related

Companion PR: iNavFlight/inav-configurator#2516
