### PR TITLE
Add optional DFU mode parameter to MSP_REBOOT command

### DIFF
--- a/docs/USB Flashing.md
+++ b/docs/USB Flashing.md
@@ -68,14 +68,26 @@ With the board connected and in bootloader mode (reset it by sending the charact
 
 Put the device into DFU mode by **one** of the following:
 
-* Use the hardware button on the board
-* Send a single 'R' character to the serial device, e.g. on POSIX OS using `/dev/ttyACM0` at 115200 baudrate.
+* **Hardware button:** Press and hold the DFU/BOOT button while plugging in USB
 
+* **Serial CLI sequence:** Send `####\r\n`, wait for CLI prompt, then send `dfu\r\n`
+
+```bash
+# Enter CLI mode
+echo -ne '####\r\n' > /dev/ttyACM0
+
+# Wait for "CLI" prompt (important - don't skip!)
+# Recommended: use a proper script that reads serial response
+
+# Send DFU command
+echo -ne 'dfu\r\n' > /dev/ttyACM0
 ```
-stty 115200 < /dev/ttyACM0
-echo -ne 'R' > /dev/ttyACM0
-```
-* Use the CLI command `dfu`
+
+**Note:** The simple single 'R' character method shown in older documentation is unreliable. The above sequence is required for proper CLI entry.
+
+* **CLI command:** If already connected to CLI via configurator or terminal: type `dfu`
+
+* **MSP command:** Use MSP_REBOOT with DFU parameter (INAV 9.x+) - most reliable programmatic method
 
 It is necessary to convert the `.hex` file into `Intel binary`. This can be done using the GCC `objcopy` command; e.g. for the notional `inav_x.y.z_NNNNNN.hex`.
 

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -377,8 +377,10 @@ static void serializeDataflashReadReply(sbuf_t *dst, uint32_t address, uint16_t 
  * Returns true if the command was processd, false otherwise.
  * May set mspPostProcessFunc to a function to be called once the command has been processed
  */
-static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst)
+static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn)
 {
+    UNUSED(mspPostProcessFn);
+
     switch (cmdMSP) {
     case MSP_API_VERSION:
         sbufWriteU8(dst, MSP_PROTOCOL_VERSION);
@@ -4476,7 +4478,7 @@ mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostPro
 
     if (MSP2_IS_SENSOR_MESSAGE(cmdMSP)) {
         ret = mspProcessSensorCommand(cmdMSP, src);
-    } else if (mspFcProcessOutCommand(cmdMSP, dst)) {
+    } else if (mspFcProcessOutCommand(cmdMSP, dst, mspPostProcessFn)) {
         ret = MSP_RESULT_ACK;
     } else if (cmdMSP == MSP_SET_PASSTHROUGH) {
         mspFcSetPassthroughCommand(dst, src, mspPostProcessFn);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -370,7 +370,7 @@ static void serializeDataflashReadReply(sbuf_t *dst, uint32_t address, uint16_t 
  * Returns true if the command was processd, false otherwise.
  * May set mspPostProcessFunc to a function to be called once the command has been processed
  */
-static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn)
+static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst)
 {
     switch (cmdMSP) {
     case MSP_API_VERSION:
@@ -4469,7 +4469,7 @@ mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostPro
 
     if (MSP2_IS_SENSOR_MESSAGE(cmdMSP)) {
         ret = mspProcessSensorCommand(cmdMSP, src);
-    } else if (mspFcProcessOutCommand(cmdMSP, dst, mspPostProcessFn)) {
+    } else if (mspFcProcessOutCommand(cmdMSP, dst)) {
         ret = MSP_RESULT_ACK;
     } else if (cmdMSP == MSP_SET_PASSTHROUGH) {
         mspFcSetPassthroughCommand(dst, src, mspPostProcessFn);


### PR DESCRIPTION
### **User description**
## Summary

Add optional parameter to MSP_REBOOT (message 68) to trigger DFU mode directly via MSP protocol. This provides a reliable programmatic method for tools and scripts to enter DFU mode without CLI timing issues or manual hardware button presses.

## Changes

**Firmware (`src/main/fc/fc_msp.c`):**
- Add static variable `mspRebootBootloader` to store DFU mode flag
- Modify `mspRebootFn()` to use bootloader flag when calling `fcReboot()`
- Add `mspFcRebootCommand()` helper function to read optional parameter
- Update `mspFcProcessCommand()` to handle MSP_REBOOT with new logic

**Documentation (`docs/USB Flashing.md`):**
- Update DFU mode entry methods with proper CLI sequence
- Remove deprecated 'R' character method
- Add MSP_REBOOT method as recommended programmatic approach

## Protocol Details

**Backwards Compatibility:**
- Empty payload (existing behavior) = normal reboot
- Parameter `0x00` = explicit normal reboot  
- Parameter `0x01` = reboot to DFU/bootloader mode

**MSP Message:**
- Message ID: 68 (MSP_REBOOT)
- Payload: 0 or 1 byte
- Direction: IN (configurator → FC)

## Testing

Tested on AOCODARCF722AIO hardware:
- ✅ Empty payload reboots normally (backwards compatible with existing tools)
- ✅ Parameter `0x00` reboots normally
- ✅ Parameter `0x01` enters DFU mode (verified with `dfu-util -l` showing device 0483:df11)

All three test cases passed successfully.

## Motivation

Current DFU entry methods have limitations:
- **Hardware button:** Requires physical access and manual intervention
- **CLI sequence:** Timing-sensitive, requires waiting for prompt, prone to race conditions
- **Single 'R' character:** Can be triggered accidentally

The MSP_REBOOT method:
- Works through standard MSP protocol
- No CLI timing issues
- Suitable for automation and scripting
- Backwards compatible with existing configurator implementations


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add optional DFU mode parameter to MSP_REBOOT command for programmatic bootloader entry

- Support backwards-compatible reboot behavior with optional bootloader flag parameter

- Improve DFU mode entry documentation with reliable serial CLI sequence

___

### Diagram Walkthrough


```mermaid
flowchart LR
  MSP["MSP_REBOOT Command"] -->|"Empty payload"| Normal["Normal Reboot"]
  MSP -->|"Parameter 0x00"| Normal
  MSP -->|"Parameter 0x01"| DFU["DFU/Bootloader Mode"]
  DFU --> Device["Device enters bootloader"]
  Normal --> Reboot["System reboots normally"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fc_msp.c</strong><dd><code>Implement MSP_REBOOT DFU mode parameter support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/fc/fc_msp.c

<ul><li>Add static variable <code>mspRebootBootloader</code> to store DFU mode flag<br> <li> Create new <code>mspFcRebootCommand()</code> function to parse optional bootloader <br>parameter from MSP payload<br> <li> Modify <code>mspRebootFn()</code> to use bootloader flag when calling <code>fcReboot()</code><br> <li> Move MSP_REBOOT handling from <code>mspFcProcessOutCommand()</code> to main command <br>processor with proper armed state check</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11238/files#diff-e67741f944e959c3f68a81189a5fcd8be50f5e4e567c1fc68f50ac5e86d0a233">+25/-9</a>&nbsp; &nbsp; </td>

</tr>


</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>USB Flashing.md</strong><dd><code>Improve DFU mode entry documentation with reliable methods</code></dd></summary>
<hr>

docs/USB Flashing.md

<ul><li>Replace unreliable single 'R' character method with proper serial CLI <br>sequence documentation<br> <li> Add detailed bash example showing <code>####</code> CLI entry followed by <code>dfu</code> <br>command<br> <li> Add warning about timing requirements and importance of waiting for <br>CLI prompt<br> <li> Add MSP_REBOOT as recommended programmatic DFU entry method for INAV <br>9.x+<br> <li> Clarify hardware button method with explicit instructions</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11238/files#diff-4d2d5d1ea36f0a85c7df6bea1c7d7fcef6cd1f9c45f5aa0b86082bf31650252f">+18/-6</a>&nbsp; &nbsp; </td>

</tr>

</details>

___

