### PR TITLE
Improve blackbox DEBUG documentation

### DIFF
--- a/docs/Blackbox.md
+++ b/docs/Blackbox.md
@@ -166,13 +166,36 @@ The CLI command `blackbox` allows setting which Blackbox fields are recorded to 
 * `PEAKS_R` - Roll axis noise peak
 * `PEAKS_P` - Pitch axis noise peak
 * `PEAKS_Y` - Yaw axis noise peak
+* `SERVOS` - Servo outputs (for planes, tris, etc.)
 
 Usage:
 
 * `blackbox` currently enabled Blackbox fields
 * `blackbox list` all available fields
 * `blackbox -MOTORS` disable MOTORS logging
-* `blackbox MOTOR` enable MOTORS logging
+* `blackbox MOTORS` enable MOTORS logging
+
+### Debug Mode Logging
+
+In addition to the standard blackbox fields above, INAV supports logging debug values for troubleshooting and analysis via the `debug_mode` setting. When a debug mode is active, it populates 8 debug values (`debug[0]` through `debug[7]`) with mode-specific data that gets logged to the blackbox.
+
+Available debug modes include:
+- `FLOW_RAW` - Optical flow sensor raw data (useful for sensor alignment)
+- `LANDING` - Landing mode debugging
+- `POS_EST` - Position estimation debugging
+- `GPS` - GPS debugging
+- `ALTITUDE` - Altitude estimation debugging
+- And 20+ other modes for specific subsystems
+
+To use debug mode logging:
+```
+set debug_mode = FLOW_RAW    # Enable a specific debug mode
+set debug_mode = NONE        # Disable debug mode (default)
+```
+
+You can view current debug values in the CLI with the `debug` command, or display them in real-time on your OSD using the `OSD_DEBUG` element.
+
+For technical details on debug logging and blackbox internals, see the [Blackbox Internals](development/Blackbox%20Internals.md) documentation.
 
 ## Usage
 


### PR DESCRIPTION
### **User description**
## Summary
Improves blackbox DEBUG documentation in `docs/Blackbox.md` to help users discover debug logging functionality.

## Changes
- Add missing `SERVOS` field to blackbox field list
- Fix typo: `blackbox MOTOR` → `blackbox MOTORS` 
- Add new "Debug Mode Logging" section explaining `debug_mode` setting
- Include examples of common debug modes (FLOW_RAW, LANDING, POS_EST, GPS, ALTITUDE)
- Add CLI usage examples for debug mode
- Reference Blackbox Internals.md for technical details
- Mention OSD_DEBUG element for real-time display

## Motivation
The `debug_mode` setting and debug value logging were previously only documented in the technical "Blackbox Internals" document. This made it difficult for users to discover this powerful troubleshooting feature. This PR adds user-facing documentation with practical examples.

## Test Plan
- Documentation changes only
- Verified against source code (cli.c and debug.h)
- Cross-referenced with Blackbox Internals.md

## Files Modified
- `docs/Blackbox.md`


___

### **PR Type**
Documentation


___

### **Description**
- Add missing `SERVOS` field to blackbox field list

- Fix typo: `blackbox MOTOR` → `blackbox MOTORS`

- Add new "Debug Mode Logging" section with examples

- Include CLI usage examples and OSD_DEBUG reference


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Blackbox.md Documentation"] --> B["Add SERVOS Field"]
  A --> C["Fix MOTOR Typo"]
  A --> D["New Debug Mode Section"]
  D --> E["Debug Mode Examples"]
  D --> F["CLI Usage Examples"]
  D --> G["OSD_DEBUG Reference"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Blackbox.md</strong><dd><code>Enhance blackbox documentation with debug mode details</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Blackbox.md

<ul><li>Added missing <code>SERVOS</code> field to the blackbox field list for servo output <br>logging<br> <li> Corrected CLI command typo from <code>blackbox MOTOR</code> to <code>blackbox MOTORS</code><br> <li> Introduced new "Debug Mode Logging" section explaining the <code>debug_mode</code> <br>setting<br> <li> Provided practical examples of common debug modes (FLOW_RAW, LANDING, <br>POS_EST, GPS, ALTITUDE)<br> <li> Added CLI usage examples for enabling/disabling debug modes<br> <li> Included reference to Blackbox Internals documentation and OSD_DEBUG <br>element</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11239/files#diff-d1fcf9c932a9dc968671225678219c98d0d419640ae4ad49e4d9aad48737ad1c">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

