### PR TITLE
Fix altitude hold climb rate calculation deadband issue

### DIFF
--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -148,6 +148,11 @@ bool adjustMulticopterAltitudeFromRCInput(void)
                 (getMaxThrottle() - altHoldThrottleRCZero) :
                 (altHoldThrottleRCZero - getThrottleIdleValue());
 
+            // Defensive check - should never trigger with valid configuration
+            if (limitValue <= 0) {
+                limitValue = 1;  // Prevent division by zero/negative
+            }
+
             int16_t rcClimbRate = ABS(rcThrottleAdjustment) * navConfig()->mc.max_manual_climb_rate / limitValue;
             updateClimbRateToAltitudeController(rcClimbRate, 0, ROC_TO_ALT_CONSTANT);
 

--- a/src/main/navigation/navigation_multicopter.c
+++ b/src/main/navigation/navigation_multicopter.c
@@ -143,9 +143,10 @@ bool adjustMulticopterAltitudeFromRCInput(void)
             /* Set velocity proportional to stick movement
              * Scale from altHoldThrottleRCZero to maxthrottle or minthrottle to altHoldThrottleRCZero */
 
-            // Calculate max up or min down limit value scaled for deadband
-            int16_t limitValue = rcThrottleAdjustment > 0 ? getMaxThrottle() : getThrottleIdleValue();
-            limitValue = applyDeadbandRescaled(limitValue - altHoldThrottleRCZero, rcControlsConfig()->alt_hold_deadband, -500, 500);
+            // Calculate max up or min down limit value (raw range, deadband already applied to rcThrottleAdjustment)
+            int16_t limitValue = rcThrottleAdjustment > 0 ?
+                (getMaxThrottle() - altHoldThrottleRCZero) :
+                (altHoldThrottleRCZero - getThrottleIdleValue());
 
             int16_t rcClimbRate = ABS(rcThrottleAdjustment) * navConfig()->mc.max_manual_climb_rate / limitValue;
             updateClimbRateToAltitudeController(rcClimbRate, 0, ROC_TO_ALT_CONSTANT);


### PR DESCRIPTION
### **User description**
## Summary

Removes double application of RC deadband in multicopter altitude hold climb rate calculation.

## Problem

The deadband was being applied twice:
1. To the stick input () at line 140
2. To the scaling limit () at line 148

This caused the actual climb rate to not match the configured value in the configurator.

## Solution

Remove the second deadband application from . The limit value now uses the raw throttle range for proper scaling, while the deadband remains applied only to the stick input.

## Testing

- [x] SITL build passes
- [ ] Functional testing recommended with SITL runtime

## Impact

Fixes user-reported issue where manual climb rate doesn't match configurator setting.

Fixes #10660


___

### **PR Type**
Bug fix


___

### **Description**
- Removes double application of RC deadband in altitude hold climb rate calculation

- Fixes climb rate not matching configurator settings

- Applies deadband only to stick input, uses raw throttle range for scaling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RC Throttle Input"] -->|applyDeadbandRescaled| B["rcThrottleAdjustment"]
  B -->|used for scaling| C["rcClimbRate Calculation"]
  D["Max/Min Throttle"] -->|raw range| E["limitValue"]
  E -->|denominator| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation_multicopter.c</strong><dd><code>Fix double deadband application in climb rate calculation</code></dd></summary>
<hr>

src/main/navigation/navigation_multicopter.c

<ul><li>Removed duplicate <code>applyDeadbandRescaled()</code> call on <code>limitValue</code> <br>calculation<br> <li> Changed <code>limitValue</code> to use raw throttle range (difference from <br><code>altHoldThrottleRCZero</code>)<br> <li> Updated comment to clarify deadband is only applied to <br><code>rcThrottleAdjustment</code><br> <li> Maintains single deadband application to stick input for proper climb <br>rate scaling</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11241/files#diff-e33be78b5d53e884542e578bd59e894d66822b5f81249d078059952e15e4a665">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

