### PR TITLE
Fix SPI register masking in busWriteBuf

### DIFF
--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -283,7 +283,7 @@ bool busWriteBuf(const busDevice_t * dev, uint8_t reg, const uint8_t * data, uin
                 return spiBusWriteBuffer(dev, reg, data, length);
             }
             else {
-                return spiBusWriteBuffer(dev, reg | 0x80, data, length);
+                return spiBusWriteBuffer(dev, reg & 0x7F, data, length);
             }
 #else
             return false;


### PR DESCRIPTION
### **User description**
## Summary

Corrects SPI register address masking in busWriteBuf() to clear the MSB instead of setting it.

## Problem

For SPI protocol, the MSB indicates read (1) or write (0) operations. The busWriteBuf() function incorrectly used `reg | 0x80` which sets the MSB, when it should use `reg & 0x7F` to clear it for write operations.

This is inconsistent with the correct implementation in busWrite() at line 318.

## Solution

Change line 286 from:
```c
return spiBusWriteBuffer(dev, reg | 0x80, data, length);
```

To:
```c
return spiBusWriteBuffer(dev, reg & 0x7F, data, length);
```

## Impact

**Current hardware:** None - all devices using busWriteBuf() are I2C-based (VL53L0X, VL53L1X, MLX90393, TERARANGER_EVO, US42 rangefinders).

**Future hardware:** Prevents silent failures if SPI devices use multi-byte buffer writes.

This is a defensive fix for code correctness.

Fixes #10674


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects SPI register masking in busWriteBuf() to clear MSB for writes

- Changes register operation from OR (0x80) to AND (0x7F) masking

- Aligns implementation with correct busWrite() function behavior

- Prevents future silent failures in SPI multi-byte buffer writes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["busWriteBuf SPI path"] --> B["Register masking operation"]
  B --> C["Previous: reg | 0x80 sets MSB"]
  B --> D["Fixed: reg & 0x7F clears MSB"]
  D --> E["Correct write operation"]
  C --> F["Incorrect read operation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bus.c</strong><dd><code>Fix SPI write register masking operation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/bus.c

<ul><li>Changed SPI register masking from <code>reg | 0x80</code> to <code>reg & 0x7F</code> in <br>busWriteBuf()<br> <li> Corrects MSB handling for write operations in SPI protocol<br> <li> Aligns with correct implementation in busWrite() function<br> <li> Affects only theoretical future SPI devices; current devices are <br>I2C-based</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11242/files#diff-3cf3b7a3a7511be68014487c77db2a4c8bab93e3e55a4adc65b02b20ce1e081e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

