### PR TITLE
F4V3 with MPOSD on TX4

### DIFF
--- a/src/main/target/OMNIBUSF4/CMakeLists.txt
+++ b/src/main/target/OMNIBUSF4/CMakeLists.txt
@@ -3,6 +3,7 @@ target_stm32f405xg(DYSF4PROV2)
 target_stm32f405xg(OMNIBUSF4)
 # the OMNIBUSF4SD has an SDCARD instead of flash, a BMP280 baro and therefore a slightly different ppm/pwm and SPI mapping
 target_stm32f405xg(OMNIBUSF4PRO)
+target_stm32f405xg(OMNIBUSF4PRO_MPOSD)
 target_stm32f405xg(OMNIBUSF4V3_S5_S6_2SS)
 target_stm32f405xg(OMNIBUSF4V3_S5S6_SS)
 target_stm32f405xg(OMNIBUSF4V3_S6_SS)

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -154,6 +154,7 @@
 #if defined(OMNIBUSF4PRO_MPOSD)
 #define USE_UART4
 #define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            NONE
 #endif
 
 #define USE_UART6

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -17,6 +17,11 @@
 
 #pragma once
 
+//OMNIBUSF4PRO_MPOSD = OMNIBUSF4PRO_LEDSTRIPM5 and MPOSD on adc rssi pin for openipc camera
+#ifdef OMNIBUSF4PRO_MPOSD
+#define OMNIBUSF4PRO_LEDSTRIPM5
+#endif
+
 //Same target as OMNIBUSF4PRO with LED strip in M5
 #ifdef OMNIBUSF4PRO_LEDSTRIPM5
 #define OMNIBUSF4PRO
@@ -146,6 +151,11 @@
 #define UART3_RX_PIN            PB11
 #define UART3_TX_PIN            PB10
 
+#if defined(OMNIBUSF4PRO_MPOSD)
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#endif
+
 #define USE_UART6
 #define UART6_RX_PIN            PC7
 #define UART6_TX_PIN            PC6
@@ -242,6 +252,7 @@
   #define USE_FLASH_M25P16
 #endif
 
+#if !defined(OMNIBUSF4PRO_MPOSD)
 #define USE_ADC
 #define ADC_CHANNEL_1_PIN               PC1
 #define ADC_CHANNEL_2_PIN               PC2
@@ -255,6 +266,7 @@
 #define CURRENT_METER_ADC_CHANNEL       ADC_CHN_1
 #define VBAT_ADC_CHANNEL                ADC_CHN_2
 #define RSSI_ADC_CHANNEL                ADC_CHN_3
+#endif
 
 #define SENSORS_SET (SENSOR_ACC|SENSOR_MAG|SENSOR_BARO)
 

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -253,7 +253,7 @@
   #define USE_FLASH_M25P16
 #endif
 
-#if !defined(OMNIBUSF4PRO_MPOSD)
+
 #define USE_ADC
 #define ADC_CHANNEL_1_PIN               PC1
 #define ADC_CHANNEL_2_PIN               PC2
@@ -261,13 +261,15 @@
 #ifdef DYSF4PRO
     #define ADC_CHANNEL_3_PIN               PC3
 #else
-    #define ADC_CHANNEL_3_PIN               PA0
+    #if !defined(OMNIBUSF4PRO_MPOSD)
+        #define ADC_CHANNEL_3_PIN               PA0
+    #endif
 #endif
 
 #define CURRENT_METER_ADC_CHANNEL       ADC_CHN_1
 #define VBAT_ADC_CHANNEL                ADC_CHN_2
 #define RSSI_ADC_CHANNEL                ADC_CHN_3
-#endif
+
 
 #define SENSORS_SET (SENSOR_ACC|SENSOR_MAG|SENSOR_BARO)
 


### PR DESCRIPTION
### **User description**
Hi,

Using an elrs RX and OpenIPC the ADC RSSI needs to be remapped to TX4 for being able to output OSD to the camera.
Remapping the pad and mposd worked on betaflight, now the target needs to be ported on Inav.


___

### **PR Type**
Enhancement, New Target


___

### **Description**
- Add OMNIBUSF4PRO_MPOSD target variant for OpenIPC camera support

- Configure UART4 with TX on PA0 for MPOSD output

- Remap ADC channel 3 pin to avoid conflict with UART4_TX

- Inherit OMNIBUSF4PRO_LEDSTRIPM5 configuration for new target


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OMNIBUSF4PRO_MPOSD<br/>New Target"] -->|"Inherits from"| B["OMNIBUSF4PRO_LEDSTRIPM5"]
  A -->|"Configures"| C["UART4 on PA0"]
  A -->|"Disables"| D["ADC_CHANNEL_3_PIN<br/>on PA0"]
  C -->|"Outputs to"| E["MPOSD/Camera"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Configure UART4 and remap ADC for MPOSD</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/OMNIBUSF4/target.h

<ul><li>Added conditional block for OMNIBUSF4PRO_MPOSD target that inherits <br>OMNIBUSF4PRO_LEDSTRIPM5 configuration<br> <li> Configured UART4 with TX pin on PA0 and RX pin set to NONE for MPOSD <br>output<br> <li> Modified ADC_CHANNEL_3_PIN definition to exclude PA0 when <br>OMNIBUSF4PRO_MPOSD is defined, preventing pin conflict<br> <li> Added documentation comment explaining OMNIBUSF4PRO_MPOSD purpose for <br>OpenIPC camera integration</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11243/files#diff-d1bdd3ed7f09746e0ae1b18501fd54d8268c1fd3111da118074f6126a656c4ed">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Register new OMNIBUSF4PRO_MPOSD build target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/OMNIBUSF4/CMakeLists.txt

- Added OMNIBUSF4PRO_MPOSD as a new STM32F405 target variant


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11243/files#diff-9a885c3e1aec519c74c0c72bad07d8e440ed2e8576b29be970528ac4e76a9b82">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

