### PR TITLE
Update target.h for OMNIBUSF4PRO_MPOSD configuration

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -21,6 +21,7 @@
 #ifdef OMNIBUSF4PRO_MPOSD
 #define OMNIBUSF4PRO
 #define OMNIBUSF4PRO_LEDSTRIPM5
+#define USE_MPOSD_ON_PA0
 #endif
 
 //Same target as OMNIBUSF4V3 with softserial in M5 and M6

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -17,10 +17,12 @@
 
 #pragma once
 
-//Same target as OMNIBUSF4PRO with LED strip in M5
-#ifdef OMNIBUSF4PRO_LEDSTRIPM5
+// OMNIBUSF4PRO_MPOSD: OMNIBUSF4PRO with LED strip on M5 and MPOSD on PA0 (OpenIPC).
+#ifdef OMNIBUSF4PRO_MPOSD
 #define OMNIBUSF4PRO
+#define OMNIBUSF4PRO_LEDSTRIPM5
 #endif
+
 //Same target as OMNIBUSF4V3 with softserial in M5 and M6
 #if defined(OMNIBUSF4V3_S6_SS) || defined(OMNIBUSF4V3_S5S6_SS) || defined(OMNIBUSF4V3_S5_S6_2SS)
 #define OMNIBUSF4V3
@@ -146,6 +148,11 @@
 #define UART3_RX_PIN            PB11
 #define UART3_TX_PIN            PB10
 
+#if defined(USE_MPOSD_ON_PA0)
+#define USE_UART4
+#define UART4_TX_PIN PA0
+#endif
+
 #define USE_UART6
 #define UART6_RX_PIN            PC7
 #define UART6_TX_PIN            PC6
@@ -249,12 +256,18 @@
 #ifdef DYSF4PRO
     #define ADC_CHANNEL_3_PIN               PC3
 #else
-    #define ADC_CHANNEL_3_PIN               PA0
+  #if !defined(USE_MPOSD_ON_PA0)
+    #define ADC_CHANNEL_3_PIN PA0
+  #endif
 #endif
 
 #define CURRENT_METER_ADC_CHANNEL       ADC_CHN_1
 #define VBAT_ADC_CHANNEL                ADC_CHN_2
-#define RSSI_ADC_CHANNEL                ADC_CHN_3
+#if defined(OMNIBUSF4PRO_MPOSD)
+  #define RSSI_ADC_CHANNEL                ADC_CHN_NONE
+#else
+  #define RSSI_ADC_CHANNEL                ADC_CHN_3
+#endif
 
 #define SENSORS_SET (SENSOR_ACC|SENSOR_MAG|SENSOR_BARO)
 

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -266,7 +266,7 @@
 
 #define CURRENT_METER_ADC_CHANNEL       ADC_CHN_1
 #define VBAT_ADC_CHANNEL                ADC_CHN_2
-#if defined(OMNIBUSF4PRO_MPOSD)
+#if defined(USE_MPOSD_ON_PA0)
   #define RSSI_ADC_CHANNEL                ADC_CHN_NONE
 #else
   #define RSSI_ADC_CHANNEL                ADC_CHN_3

--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -257,8 +257,10 @@
 #ifdef DYSF4PRO
     #define ADC_CHANNEL_3_PIN               PC3
 #else
-  #if !defined(USE_MPOSD_ON_PA0)
-    #define ADC_CHANNEL_3_PIN PA0
+  #if defined(USE_MPOSD_ON_PA0)
+    #define ADC_CHANNEL_3_PIN               NONE
+  #else
+    #define ADC_CHANNEL_3_PIN               PA0
   #endif
 #endif
 


### PR DESCRIPTION
### **User description**
Updated target.h as suggested by qodo-code-review[bot] on maintenance branch for having MSPOD on PA0 for OpenIPC cameras and ground stations.


___

### **PR Type**
Enhancement


___

### **Description**
- Add OMNIBUSF4PRO_MPOSD target configuration with MPOSD on PA0

- Configure UART4 on PA0 for OpenIPC camera support

- Conditionally disable ADC_CHANNEL_3 and RSSI when MPOSD is enabled

- Refactor OMNIBUSF4PRO_LEDSTRIPM5 definition structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OMNIBUSF4PRO_MPOSD<br/>Configuration"] -->|Enables| B["UART4 on PA0<br/>for OpenIPC"]
  A -->|Disables| C["ADC_CHANNEL_3<br/>and RSSI"]
  A -->|Inherits| D["OMNIBUSF4PRO<br/>with LED Strip M5"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Add OMNIBUSF4PRO_MPOSD configuration with PA0 MPOSD support</code></dd></summary>
<hr>

src/main/target/OMNIBUSF4/target.h

<ul><li>Renamed <code>OMNIBUSF4PRO_LEDSTRIPM5</code> ifdef to <code>OMNIBUSF4PRO_MPOSD</code> with <br>updated documentation<br> <li> Added conditional <code>OMNIBUSF4PRO_LEDSTRIPM5</code> definition within the new <br><code>OMNIBUSF4PRO_MPOSD</code> block<br> <li> Added UART4 configuration on PA0 when <code>USE_MPOSD_ON_PA0</code> is defined<br> <li> Protected <code>ADC_CHANNEL_3_PIN</code> assignment to avoid conflict with MPOSD on <br>PA0<br> <li> Made RSSI_ADC_CHANNEL conditional: set to <code>ADC_CHN_NONE</code> for <br>OMNIBUSF4PRO_MPOSD, otherwise <code>ADC_CHN_3</code></ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11244/files#diff-d1bdd3ed7f09746e0ae1b18501fd54d8268c1fd3111da118074f6126a656c4ed">+17/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

