### PR TITLE
docs: Document CMAKE_BUILD_TYPE=Release for production builds

### DIFF
--- a/docs/development/Building in Linux.md
+++ b/docs/development/Building in Linux.md
@@ -92,7 +92,7 @@ cmake -DCOMPILER_VERSION_CHECK=OFF ..
 
 `cmake` will generate a number of files in your `build` directory, including a cache of generated build settings `CMakeCache.txt` and a `Makefile`.
 
-## Bulding the firmware
+## Building the firmware
 
 Once `cmake` has generated the `build/Makefile`, this `Makfile` (with `make`) is used to build the firmware, again from the `build` directory. It is not necessary to re-run `cmake` unless the INAV cmake configuration is changed (i.e. a new release) or you wish to swap between the ARM SDK compiler and a distro or other external compiler.
 
@@ -101,7 +101,7 @@ The generated `Makefile` uses different a target selection mechanism from the ol
 Typically, to build a single target, just pass the target name to `make`; note that unlike earlier releases, `make` without a target specified will build **all** targets.
 
 ```
-# Build the MATEKF405 firmware
+# Build the MATEKF405 firmware (includes debug symbols by default)
 make MATEKF405
 ```
 
@@ -111,6 +111,31 @@ One can also build multiple targets from a single `make` command:
 # parallel build using all but 1 CPU core
 make -j $(($(nproc)-1)) MATEKF405 MATEKF722
 ```
+
+### Building All Targets or Release Builds
+
+**⚠️ Important for CI or building many targets:** By default, INAV builds with `-DCMAKE_BUILD_TYPE=RelWithDebInfo`, which includes maximum debug symbols. When building all ~100 targets, this uses **~109 GB of disk space**. The debug symbols are automatically stripped from the final `.hex` files, so they provide no benefit for production builds.
+
+**For production builds, CI, or when building many targets, use Release mode:**
+
+```bash
+cd inav
+mkdir build-release
+cd build-release
+cmake -DCMAKE_BUILD_TYPE=Release ..
+
+# Build specific targets
+make MATEKF405
+
+# Or build all official release targets
+make release
+```
+
+**Disk usage comparison:**
+- `RelWithDebInfo` (default): ~109 GB for all targets
+- `Release`: ~4-6 GB for all targets (96% reduction)
+
+The final `.hex` and `.bin` files are identical in both cases.
 
 The resultant hex file are in the `build` directory.
 

--- a/docs/development/release-create.md
+++ b/docs/development/release-create.md
@@ -208,6 +208,25 @@ gh release list --repo iNavFlight/inav-nightly --limit 5
 gh release download <nightly-tag> --repo iNavFlight/inav-nightly --pattern "*.hex"
 ```
 
+#### Building Firmware Locally (if needed)
+
+**⚠️ Important:** Always use Release mode when building firmware for releases to save disk space:
+
+```bash
+cd inav
+mkdir build-release
+cd build-release
+cmake -DCMAKE_BUILD_TYPE=Release ..
+
+# Build all official release targets
+make release
+
+# Or build specific targets
+make MATEKF405 MATEKF722
+```
+
+**Disk usage:** Release mode uses ~4-6 GB vs ~109 GB for default RelWithDebInfo mode (96% reduction). The debug symbols are stripped from final `.hex` files anyway, so Release mode produces identical output.
+
 #### Renaming Firmware Files
 
 Remove CI suffix and add RC number for RC releases:


### PR DESCRIPTION
## Summary

Adds documentation about using `CMAKE_BUILD_TYPE=Release` to save disk space when building firmware for production, CI, or release purposes.

## Problem

By default, INAV builds with `CMAKE_BUILD_TYPE=RelWithDebInfo` which includes maximum debug symbols (`-ggdb3`). When building all ~100 targets, this consumes **~109 GB of disk space**. The debug symbols are automatically stripped from the final `.hex` files, so they provide no benefit for production builds.

## Solution

Document the use of `CMAKE_BUILD_TYPE=Release` for production builds, which reduces disk usage to **~4-6 GB (96% reduction)** while producing identical final binaries.

## Changes

### docs/development/Building in Linux.md
- Added brief note about debug symbols in single target build section
- Added new "Building All Targets or Release Builds" section with:
  - Warning about 109 GB disk usage with default mode
  - Instructions for using Release mode
  - Disk usage comparison table

### docs/development/release-create.md
- Added "Building Firmware Locally (if needed)" section with:
  - Release mode build commands
  - Disk usage comparison
  - Explanation that final binaries are identical

## Key Points Documented

- **Default (RelWithDebInfo):** ~109 GB for all targets
- **Release mode:** ~4-6 GB for all targets (96% reduction)
- **Command:** `cmake -DCMAKE_BUILD_TYPE=Release ..`
- **Use cases:** Production builds, CI, building many targets
- **Important:** Final `.hex` and `.bin` files are identical in both modes

## Also Includes

- Typo fix: "Bulding" → "Building"

## Testing

Documentation changes only. No code modifications.