### PR TITLE
Added support for switchable 9v BEC for FLYWOOF405HD and FLYWOOF405PRO

### DIFF
--- a/src/main/target/FLYWOOF405PRO/config.c
+++ b/src/main/target/FLYWOOF405PRO/config.c
@@ -31,4 +31,8 @@ void targetConfiguration(void)
 
     timerOverridesMutable(timer2id(TIM3))->outputMode = OUTPUT_MODE_MOTORS;
     timerOverridesMutable(timer2id(TIM2))->outputMode = OUTPUT_MODE_MOTORS;
+
+    // Pinio Box params as per manufacturer specification
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
 }

--- a/src/main/target/FLYWOOF405PRO/target.h
+++ b/src/main/target/FLYWOOF405PRO/target.h
@@ -152,6 +152,12 @@
 #define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
 #define RSSI_ADC_CHANNEL            ADC_CHN_3
 
+// *************** PINIO ***********************
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN              PD6
+#define PINIO2_PIN              PC8
+
 // *************** LED2812 ************************
 #define USE_LED_STRIP
 #define WS2811_PIN                      PA9


### PR DESCRIPTION
Attached USER1 and USER2 to pins PD6 and PC8 as specified by the manufacturer and configured in the default Betaflight configuration for their BNF.

Ended up doing the same as @amstan in #10716 and it works fine for me.

Small thing, for some reason it displays all 4 USER boxes in modes tab. Would be nice if there were only USER1 and USER2. No idea ho to do it.

Also, is there any way how to set custom name the box instead of USER*?