### PR TITLE
Fix AGL velocity estimation using squared acceleration weight factor

### DIFF
--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -354,7 +354,7 @@ static bool gravityCalibrationComplete(void)
 static void updateIMUEstimationWeight(const float dt)
 {
     static float acc_clip_factor = 1.0f;
-    // If accelerometer measurement is clipped - drop the acc weight to 0.3
+    // If accelerometer measurement is clipped - drop the acc weight to 0.5
     // and gradually restore weight back to 1.0 over time
     if (accIsClipped()) {
         acc_clip_factor = 0.5f;

--- a/src/main/navigation/navigation_pos_estimator_agl.c
+++ b/src/main/navigation/navigation_pos_estimator_agl.c
@@ -149,7 +149,7 @@ void estimationCalculateAGL(estimationContext_t * ctx)
         // Update estimate
         posEstimator.est.aglAlt += posEstimator.est.aglVel * ctx->dt;
         posEstimator.est.aglAlt += posEstimator.imu.accelNEU.z * sq(ctx->dt) / 2.0f * posEstimator.imu.accWeightFactor;
-        posEstimator.est.aglVel += posEstimator.imu.accelNEU.z * ctx->dt * sq(posEstimator.imu.accWeightFactor);
+        posEstimator.est.aglVel += posEstimator.imu.accelNEU.z * ctx->dt * posEstimator.imu.accWeightFactor;
 
         // Apply correction
         if (posEstimator.est.aglQual == SURFACE_QUAL_HIGH) {


### PR DESCRIPTION
### **User description**
## Summary

Fixes mathematical inconsistency in AGL velocity estimation where velocity update uses squared acceleration weight factor while altitude update uses linear weight factor.

## Problem

In `navigation_pos_estimator_agl.c` line 152, the velocity update incorrectly uses `sq(accWeightFactor)` while line 151 (altitude update) correctly uses linear `accWeightFactor`. This creates physical inconsistency where position and velocity respond differently to the same acceleration measurement.

**Impact with accWeightFactor=0.3**
- Altitude receives 30% of acceleration contribution (correct)
- Velocity receives 9% of acceleration contribution (wrong - squared factor)
- Result: Large error in velocity response during degraded accelerometer conditions

## Changes

- Removed `sq()` wrapper from `accWeightFactor` in AGL velocity update (line 152)
- Makes velocity integration physically consistent with altitude integration
- Both now use linear weight factor as per standard kinematic equations

## Testing

- Built SITL target successfully with fix applied
- Code review performed with inav-code-review agent - no issues found
- Fix verified mathematically: both altitude and velocity now scale linearly with weight factor
- Theoretical analysis confirms 50% velocity error is eliminated

## Code Review

Reviewed with inav-code-review agent - APPROVED. The fix correctly addresses a mathematical inconsistency and makes the kinematic integration physically consistent.

## Related Issues

May fix https://github.com/iNavFlight/inav/pull/10314
May be related to https://github.com/iNavFlight/inav/issues/10567


___

### **PR Type**
Bug fix


___

### **Description**
- Removes squared acceleration weight factor from AGL velocity update

- Makes velocity integration consistent with altitude integration

- Fixes velocity error during degraded accelerometer conditions

- Both altitude and velocity now use linear weight factor scaling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  accel["Acceleration measurement"]
  weight["Weight factor"]
  alt["Altitude update"]
  vel["Velocity update"]
  accel -- "linear factor" --> alt
  accel -- "squared factor (BEFORE)" --> vel
  accel -- "linear factor (AFTER)" --> vel
  weight --> alt
  weight --> vel
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation_pos_estimator_agl.c</strong><dd><code>Remove squared weight factor from velocity update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/navigation/navigation_pos_estimator_agl.c

<ul><li>Removed <code>sq()</code> wrapper from <code>accWeightFactor</code> in AGL velocity update at <br>line 152<br> <li> Changed velocity integration to use linear weight factor instead of <br>squared<br> <li> Aligns velocity update with altitude update which already uses linear <br>weight factor<br> <li> Maintains kinematic consistency between position and velocity <br>integration</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11255/files#diff-65b29001b3fa98df2b79027b582d45814c8a0d44c51eb40b422ba159df9c6629">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

