### PR TITLE
Fix ESC spinup during settings save using circular DMA

### DIFF
--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -322,7 +322,7 @@ static bool writeSettingsToEEPROM(void)
 
 void writeConfigToEEPROM(void)
 {
-#if !defined(SITL_BUILD)
+#if !defined(SITL_BUILD) && defined(USE_DSHOT)
     // Prevent ESC spinup during settings save using circular DMA
     pwmSetMotorDMACircular(true);
 
@@ -346,7 +346,7 @@ void writeConfigToEEPROM(void)
         }
     }
 
-#if !defined(SITL_BUILD)
+#if !defined(SITL_BUILD) && defined(USE_DSHOT)
     // Restore normal DMA mode
     pwmSetMotorDMACircular(false);
 #endif

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -322,6 +322,7 @@ static bool writeSettingsToEEPROM(void)
 
 void writeConfigToEEPROM(void)
 {
+#if !defined(SITL_BUILD)
     // Prevent ESC spinup during settings save using circular DMA
     pwmSetMotorDMACircular(true);
 
@@ -331,6 +332,7 @@ void writeConfigToEEPROM(void)
     pwmCompleteMotorUpdate();
     delayMicroseconds(200);
     pwmCompleteMotorUpdate();
+#endif
 
     bool success = false;
     // write it
@@ -344,8 +346,10 @@ void writeConfigToEEPROM(void)
         }
     }
 
+#if !defined(SITL_BUILD)
     // Restore normal DMA mode
     pwmSetMotorDMACircular(false);
+#endif
 
     if (success && isEEPROMContentValid()) {
         return;

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -323,15 +323,10 @@ static bool writeSettingsToEEPROM(void)
 void writeConfigToEEPROM(void)
 {
 #if !defined(SITL_BUILD) && defined(USE_DSHOT)
-    // Prevent ESC spinup during settings save using circular DMA
+    // Enable circular DMA so hardware keeps repeating zero-throttle DShot
+    // packets during flash writes (which block the CPU for 20-200ms).
+    // Without this, ESCs lose signal and may spin up or reboot.
     pwmSetMotorDMACircular(true);
-
-    // Force motor updates to latch current (zero) throttle into circular DMA buffer
-    pwmCompleteMotorUpdate();
-    delayMicroseconds(200);
-    pwmCompleteMotorUpdate();
-    delayMicroseconds(200);
-    pwmCompleteMotorUpdate();
 #endif
 
     bool success = false;
@@ -347,7 +342,6 @@ void writeConfigToEEPROM(void)
     }
 
 #if !defined(SITL_BUILD) && defined(USE_DSHOT)
-    // Restore normal DMA mode
     pwmSetMotorDMACircular(false);
 #endif
 

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -226,6 +226,20 @@ void pwmEnableMotors(void)
     pwmMotorsEnabled = true;
 }
 
+void pwmSetMotorDMACircular(bool circular)
+{
+#ifdef USE_DSHOT
+    // Set DMA circular mode for all motor outputs
+    for (int i = 0; i < getMotorCount(); i++) {
+        if (motors[i].pwmPort && motors[i].pwmPort->tch) {
+            impl_timerPWMSetDMACircular(motors[i].pwmPort->tch, circular);
+        }
+    }
+#else
+    UNUSED(circular);
+#endif
+}
+
 bool isMotorBrushed(uint16_t motorPwmRateHz)
 {
     return (motorPwmRateHz > 500);

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -126,8 +126,11 @@ static uint8_t commandsBuff[DHSOT_COMMAND_QUEUE_SIZE];
 static currentExecutingCommand_t currentExecutingCommand;
 
 static uint16_t prepareDshotPacket(const uint16_t value, bool requestTelemetry);
+#ifndef USE_DSHOT_DMAR
 static void loadDmaBufferDshot(timerDMASafeType_t *dmaBuffer, uint16_t packet);
+#else
 static void loadDmaBufferDshotStride(timerDMASafeType_t *dmaBuffer, int stride, uint16_t packet);
+#endif
 
 #ifdef USE_DSHOT_DMAR
 burstDmaTimer_t burstDmaTimers[MAX_DMA_TIMERS];

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -124,6 +124,15 @@ static timeUs_t commandPostDelay = 0;
 static circularBuffer_t commandsCircularBuffer;
 static uint8_t commandsBuff[DHSOT_COMMAND_QUEUE_SIZE];
 static currentExecutingCommand_t currentExecutingCommand;
+
+static uint16_t prepareDshotPacket(const uint16_t value, bool requestTelemetry);
+static void loadDmaBufferDshot(timerDMASafeType_t *dmaBuffer, uint16_t packet);
+static void loadDmaBufferDshotStride(timerDMASafeType_t *dmaBuffer, int stride, uint16_t packet);
+
+#ifdef USE_DSHOT_DMAR
+burstDmaTimer_t burstDmaTimers[MAX_DMA_TIMERS];
+uint8_t burstDmaTimersCount = 0;
+#endif
 #endif
 
 static void pwmOutConfigTimer(pwmOutputPort_t * p, TCH_t * tch, uint32_t hz, uint16_t period, uint16_t value)
@@ -229,12 +238,48 @@ void pwmEnableMotors(void)
 void pwmSetMotorDMACircular(bool circular)
 {
 #ifdef USE_DSHOT
-    // Set DMA circular mode for all motor outputs
-    for (int i = 0; i < getMotorCount(); i++) {
-        if (motors[i].pwmPort && motors[i].pwmPort->tch) {
-            impl_timerPWMSetDMACircular(motors[i].pwmPort->tch, circular);
+    if (!isMotorProtocolDshot()) {
+        return;
+    }
+
+    int motorCount = getMotorCount();
+
+    if (circular) {
+        // Load zero-throttle packets directly into DMA buffers,
+        // bypassing the rate limiter in pwmCompleteMotorUpdate()
+        uint16_t packet = prepareDshotPacket(0, false);
+        for (int i = 0; i < motorCount; i++) {
+            if (motors[i].pwmPort && motors[i].pwmPort->configured) {
+#ifdef USE_DSHOT_DMAR
+                loadDmaBufferDshotStride(&motors[i].pwmPort->dmaBurstBuffer[motors[i].pwmPort->tch->timHw->channelIndex], 4, packet);
+#else
+                loadDmaBufferDshot(motors[i].pwmPort->dmaBuffer, packet);
+#endif
+            }
         }
     }
+
+#ifdef USE_DSHOT_DMAR
+    // Burst DMA: one DMA stream per timer, shared across channels
+    for (int i = 0; i < burstDmaTimersCount; i++) {
+        burstDmaTimer_t *burstDmaTimer = &burstDmaTimers[i];
+        // Find the first motor using this timer to get the TCH for DMA state
+        for (int m = 0; m < motorCount; m++) {
+            if (motors[m].pwmPort && motors[m].pwmPort->configured && motors[m].pwmPort->tch
+                && motors[m].pwmPort->tch->timHw->tim == burstDmaTimer->timer) {
+                impl_pwmBurstDMASetCircular(burstDmaTimer, motors[m].pwmPort->tch, circular, DSHOT_DMA_BUFFER_SIZE * 4);
+                break;
+            }
+        }
+    }
+#else
+    // Per-channel DMA: one DMA stream per motor
+    for (int i = 0; i < motorCount; i++) {
+        if (motors[i].pwmPort && motors[i].pwmPort->configured && motors[i].pwmPort->tch) {
+            impl_timerPWMSetDMACircular(motors[i].pwmPort->tch, circular, DSHOT_DMA_BUFFER_SIZE);
+        }
+    }
+#endif
 #else
     UNUSED(circular);
 #endif
@@ -278,9 +323,6 @@ uint32_t getDshotHz(motorPwmProtocolTypes_e pwmProtocolType)
 }
 
 #ifdef USE_DSHOT_DMAR
-burstDmaTimer_t burstDmaTimers[MAX_DMA_TIMERS];
-uint8_t burstDmaTimersCount = 0;
-
 static uint8_t getBurstDmaTimerIndex(TIM_TypeDef *timer)
 {
     for (int i = 0; i < burstDmaTimersCount; i++) {

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -50,6 +50,7 @@ void pwmWriteServo(uint8_t index, uint16_t value);
 
 void pwmDisableMotors(void);
 void pwmEnableMotors(void);
+void pwmSetMotorDMACircular(bool circular);
 struct timerHardware_s;
 
 void pwmMotorPreconfigure(void);

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -138,6 +138,7 @@ typedef enum {
     TCH_DMA_IDLE = 0,
     TCH_DMA_READY,
     TCH_DMA_ACTIVE,
+    TCH_DMA_CIRCULAR,
 } tchDmaState_e;
 
 // Some forward declarations for types

--- a/src/main/drivers/timer_impl.h
+++ b/src/main/drivers/timer_impl.h
@@ -84,6 +84,7 @@ bool impl_timerPWMConfigChannelDMA(TCH_t * tch, void * dmaBuffer, uint8_t dmaBuf
 void impl_timerPWMPrepareDMA(TCH_t * tch, uint32_t dmaBufferElementCount);
 void impl_timerPWMStartDMA(TCH_t * tch);
 void impl_timerPWMStopDMA(TCH_t * tch);
+void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular);
 
 #ifdef USE_DSHOT_DMAR
 bool impl_timerPWMConfigDMABurst(burstDmaTimer_t *burstDmaTimer, TCH_t * tch, void * dmaBuffer, uint8_t dmaBufferElementSize, uint32_t dmaBufferElementCount);

--- a/src/main/drivers/timer_impl.h
+++ b/src/main/drivers/timer_impl.h
@@ -84,9 +84,10 @@ bool impl_timerPWMConfigChannelDMA(TCH_t * tch, void * dmaBuffer, uint8_t dmaBuf
 void impl_timerPWMPrepareDMA(TCH_t * tch, uint32_t dmaBufferElementCount);
 void impl_timerPWMStartDMA(TCH_t * tch);
 void impl_timerPWMStopDMA(TCH_t * tch);
-void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular);
+void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular, uint32_t dmaBufferSize);
 
 #ifdef USE_DSHOT_DMAR
 bool impl_timerPWMConfigDMABurst(burstDmaTimer_t *burstDmaTimer, TCH_t * tch, void * dmaBuffer, uint8_t dmaBufferElementSize, uint32_t dmaBufferElementCount);
 void impl_pwmBurstDMAStart(burstDmaTimer_t * burstDmaTimer, uint32_t BurstLength);
+void impl_pwmBurstDMASetCircular(burstDmaTimer_t * burstDmaTimer, TCH_t * tch, bool circular, uint32_t dmaBufferSize);
 #endif

--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -590,16 +590,19 @@ void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular)
     const uint32_t streamLL = lookupDMALLStreamTable[DMATAG_GET_STREAM(tch->timHw->dmaTag)];
     DMA_TypeDef *dmaBase = tch->dma->dma;
 
-    // Temporarily disable DMA while modifying configuration
-    LL_DMA_DisableStream(dmaBase, streamLL);
+    // Protect DMA reconfiguration from interrupt interference
+    ATOMIC_BLOCK(NVIC_PRIO_MAX) {
+        // Temporarily disable DMA while modifying configuration
+        LL_DMA_DisableStream(dmaBase, streamLL);
 
-    // Modify the DMA mode
-    if (circular) {
-        LL_DMA_SetMode(dmaBase, streamLL, LL_DMA_MODE_CIRCULAR);
-    } else {
-        LL_DMA_SetMode(dmaBase, streamLL, LL_DMA_MODE_NORMAL);
+        // Modify the DMA mode
+        if (circular) {
+            LL_DMA_SetMode(dmaBase, streamLL, LL_DMA_MODE_CIRCULAR);
+        } else {
+            LL_DMA_SetMode(dmaBase, streamLL, LL_DMA_MODE_NORMAL);
+        }
+
+        // Re-enable DMA
+        LL_DMA_EnableStream(dmaBase, streamLL);
     }
-
-    // Re-enable DMA
-    LL_DMA_EnableStream(dmaBase, streamLL);
 }

--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -608,6 +608,13 @@ void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular)
             __NOP();
         }
 
+        // If timeout occurred, DMA stream is still enabled - abort reconfiguration
+        if (timeout == 0 && LL_DMA_IsEnabledStream(dmaBase, streamLL)) {
+            // Re-enable timer DMA request and return to avoid unstable state
+            LL_TIM_EnableDMAReq_CCx(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex]);
+            return;
+        }
+
         // Clear any pending transfer complete flags
         DMA_CLEAR_FLAG(tch->dma, DMA_IT_TCIF);
 

--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -580,3 +580,26 @@ void impl_timerPWMStopDMA(TCH_t * tch)
 
     HAL_TIM_Base_Start(tch->timCtx->timHandle);
 }
+
+void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular)
+{
+    if (!tch->dma || !tch->dma->dma) {
+        return;
+    }
+
+    const uint32_t streamLL = lookupDMALLStreamTable[DMATAG_GET_STREAM(tch->timHw->dmaTag)];
+    DMA_TypeDef *dmaBase = tch->dma->dma;
+
+    // Temporarily disable DMA while modifying configuration
+    LL_DMA_DisableStream(dmaBase, streamLL);
+
+    // Modify the DMA mode
+    if (circular) {
+        LL_DMA_SetMode(dmaBase, streamLL, LL_DMA_MODE_CIRCULAR);
+    } else {
+        LL_DMA_SetMode(dmaBase, streamLL, LL_DMA_MODE_NORMAL);
+    }
+
+    // Re-enable DMA
+    LL_DMA_EnableStream(dmaBase, streamLL);
+}

--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -534,7 +534,7 @@ void impl_pwmBurstDMASetCircular(burstDmaTimer_t * burstDmaTimer, TCH_t * tch, b
             __NOP();
         }
 
-        if (timeout == 0 && LL_DMA_IsEnabledStream(burstDmaTimer->dma, burstDmaTimer->streamLL)) {
+        if (LL_DMA_IsEnabledStream(burstDmaTimer->dma, burstDmaTimer->streamLL)) {
             LL_TIM_EnableDMAReq_CCx(burstDmaTimer->timer, burstDmaTimer->burstRequestSource);
             return;
         }
@@ -647,7 +647,7 @@ void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular, uint32_t dmaBufferS
             __NOP();
         }
 
-        if (timeout == 0 && LL_DMA_IsEnabledStream(dmaBase, streamLL)) {
+        if (LL_DMA_IsEnabledStream(dmaBase, streamLL)) {
             LL_TIM_EnableDMAReq_CCx(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex]);
             return;
         }

--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -319,6 +319,12 @@ static void impl_timerDMA_IRQHandler(DMA_t descriptor)
     if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TCIF)) {
         TCH_t * tch = (TCH_t *)descriptor->userParam;
 
+        // In circular mode, let DMA keep running - don't disable the stream
+        if (tch->dmaState == TCH_DMA_CIRCULAR) {
+            DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
+            return;
+        }
+
         // If it was ACTIVE - switch to IDLE
         if (tch->dmaState == TCH_DMA_ACTIVE) {
             tch->dmaState = TCH_DMA_IDLE;
@@ -512,6 +518,46 @@ void impl_pwmBurstDMAStart(burstDmaTimer_t * burstDmaTimer, uint32_t BurstLength
     //LL_TIM_EnableDMAReq_UPDATE(burstDmaTimer->timer);
     LL_TIM_EnableDMAReq_CCx(burstDmaTimer->timer, burstDmaTimer->burstRequestSource);
 }
+
+void impl_pwmBurstDMASetCircular(burstDmaTimer_t * burstDmaTimer, TCH_t * tch, bool circular, uint32_t dmaBufferSize)
+{
+    if (!tch->dma || !tch->dma->dma) {
+        return;
+    }
+
+    ATOMIC_BLOCK(NVIC_PRIO_MAX) {
+        LL_TIM_DisableDMAReq_CCx(burstDmaTimer->timer, burstDmaTimer->burstRequestSource);
+        LL_DMA_DisableStream(burstDmaTimer->dma, burstDmaTimer->streamLL);
+
+        uint32_t timeout = 10000;
+        while (LL_DMA_IsEnabledStream(burstDmaTimer->dma, burstDmaTimer->streamLL) && timeout--) {
+            __NOP();
+        }
+
+        if (timeout == 0 && LL_DMA_IsEnabledStream(burstDmaTimer->dma, burstDmaTimer->streamLL)) {
+            LL_TIM_EnableDMAReq_CCx(burstDmaTimer->timer, burstDmaTimer->burstRequestSource);
+            return;
+        }
+
+        DMA_CLEAR_FLAG(tch->dma, DMA_IT_TCIF);
+
+        if (circular) {
+            LL_DMA_SetMode(burstDmaTimer->dma, burstDmaTimer->streamLL, LL_DMA_MODE_CIRCULAR);
+            LL_DMA_SetDataLength(burstDmaTimer->dma, burstDmaTimer->streamLL, dmaBufferSize);
+            LL_DMA_DisableIT_TC(burstDmaTimer->dma, burstDmaTimer->streamLL);
+            tch->dmaState = TCH_DMA_CIRCULAR;
+        } else {
+            LL_DMA_SetMode(burstDmaTimer->dma, burstDmaTimer->streamLL, LL_DMA_MODE_NORMAL);
+            LL_DMA_EnableIT_TC(burstDmaTimer->dma, burstDmaTimer->streamLL);
+            tch->dmaState = TCH_DMA_IDLE;
+        }
+
+        __DSB();
+
+        LL_DMA_EnableStream(burstDmaTimer->dma, burstDmaTimer->streamLL);
+        LL_TIM_EnableDMAReq_CCx(burstDmaTimer->timer, burstDmaTimer->burstRequestSource);
+    }
+}
 #endif
 
 void impl_timerPWMPrepareDMA(TCH_t * tch, uint32_t dmaBufferElementCount)
@@ -581,7 +627,7 @@ void impl_timerPWMStopDMA(TCH_t * tch)
     HAL_TIM_Base_Start(tch->timCtx->timHandle);
 }
 
-void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular)
+void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular, uint32_t dmaBufferSize)
 {
     if (!tch->dma || !tch->dma->dma) {
         return;
@@ -590,51 +636,42 @@ void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular)
     const uint32_t streamLL = lookupDMALLStreamTable[DMATAG_GET_STREAM(tch->timHw->dmaTag)];
     DMA_TypeDef *dmaBase = tch->dma->dma;
 
-    // Save the current transfer count before disabling
-    uint32_t dataLength = LL_DMA_GetDataLength(dmaBase, streamLL);
-
-    // Protect DMA reconfiguration from interrupt interference
     ATOMIC_BLOCK(NVIC_PRIO_MAX) {
-        // Disable timer DMA request first to stop new transfer triggers
+        // Stop new transfer triggers before reconfiguring
         LL_TIM_DisableDMAReq_CCx(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex]);
-
-        // Disable the DMA stream
         LL_DMA_DisableStream(dmaBase, streamLL);
 
-        // CRITICAL: Wait for stream to actually become disabled
-        // The EN bit doesn't clear immediately, especially if transfer is in progress
-        uint32_t timeout = 10000;
+        // STM32H7 RM: poll EN bit until stream is actually disabled
+        uint32_t timeout = 10000; // ~20us at 480MHz, well above worst-case disable latency
         while (LL_DMA_IsEnabledStream(dmaBase, streamLL) && timeout--) {
             __NOP();
         }
 
-        // If timeout occurred, DMA stream is still enabled - abort reconfiguration
         if (timeout == 0 && LL_DMA_IsEnabledStream(dmaBase, streamLL)) {
-            // Re-enable timer DMA request and return to avoid unstable state
             LL_TIM_EnableDMAReq_CCx(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex]);
             return;
         }
 
-        // Clear any pending transfer complete flags
         DMA_CLEAR_FLAG(tch->dma, DMA_IT_TCIF);
 
-        // Modify the DMA mode
         if (circular) {
             LL_DMA_SetMode(dmaBase, streamLL, LL_DMA_MODE_CIRCULAR);
+            // Circular mode requires non-zero NDTR (STM32H7 RM constraint)
+            LL_DMA_SetDataLength(dmaBase, streamLL, dmaBufferSize);
+            // Disable TC interrupt — in circular mode, TC fires every cycle
+            // and the IRQ handler would otherwise disable the stream
+            LL_DMA_DisableIT_TC(dmaBase, streamLL);
+            tch->dmaState = TCH_DMA_CIRCULAR;
         } else {
             LL_DMA_SetMode(dmaBase, streamLL, LL_DMA_MODE_NORMAL);
+            LL_DMA_EnableIT_TC(dmaBase, streamLL);
+            tch->dmaState = TCH_DMA_IDLE;
         }
 
-        // Reload the transfer count (required after mode change)
-        // If dataLength was 0 (transfer completed), keep it at 0 - the next motor update will reload it
-        if (dataLength > 0) {
-            LL_DMA_SetDataLength(dmaBase, streamLL, dataLength);
-        }
+        // Ensure register writes are visible to DMA before re-enabling
+        __DSB();
 
-        // Re-enable DMA stream
         LL_DMA_EnableStream(dmaBase, streamLL);
-
-        // Re-enable timer DMA requests
         LL_TIM_EnableDMAReq_CCx(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex]);
     }
 }

--- a/src/main/drivers/timer_impl_stdperiph.c
+++ b/src/main/drivers/timer_impl_stdperiph.c
@@ -526,16 +526,19 @@ void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular)
         return;
     }
 
-    // Temporarily disable DMA while modifying configuration
-    DMA_Cmd(tch->dma->ref, DISABLE);
+    // Protect DMA reconfiguration from interrupt interference
+    ATOMIC_BLOCK(NVIC_PRIO_MAX) {
+        // Temporarily disable DMA while modifying configuration
+        DMA_Cmd(tch->dma->ref, DISABLE);
 
-    // Modify the DMA mode
-    if (circular) {
-        tch->dma->ref->CR |= DMA_SxCR_CIRC;  // Set circular bit
-    } else {
-        tch->dma->ref->CR &= ~DMA_SxCR_CIRC; // Clear circular bit
+        // Modify the DMA mode
+        if (circular) {
+            tch->dma->ref->CR |= DMA_SxCR_CIRC;  // Set circular bit
+        } else {
+            tch->dma->ref->CR &= ~DMA_SxCR_CIRC; // Clear circular bit
+        }
+
+        // Re-enable DMA
+        DMA_Cmd(tch->dma->ref, ENABLE);
     }
-
-    // Re-enable DMA
-    DMA_Cmd(tch->dma->ref, ENABLE);
 }

--- a/src/main/drivers/timer_impl_stdperiph.c
+++ b/src/main/drivers/timer_impl_stdperiph.c
@@ -519,3 +519,23 @@ void impl_timerPWMStopDMA(TCH_t * tch)
     tch->dmaState = TCH_DMA_IDLE;
     TIM_Cmd(tch->timHw->tim, ENABLE);
 }
+
+void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular)
+{
+    if (!tch->dma || !tch->dma->ref) {
+        return;
+    }
+
+    // Temporarily disable DMA while modifying configuration
+    DMA_Cmd(tch->dma->ref, DISABLE);
+
+    // Modify the DMA mode
+    if (circular) {
+        tch->dma->ref->CR |= DMA_SxCR_CIRC;  // Set circular bit
+    } else {
+        tch->dma->ref->CR &= ~DMA_SxCR_CIRC; // Clear circular bit
+    }
+
+    // Re-enable DMA
+    DMA_Cmd(tch->dma->ref, ENABLE);
+}

--- a/src/main/drivers/timer_impl_stdperiph.c
+++ b/src/main/drivers/timer_impl_stdperiph.c
@@ -486,7 +486,7 @@ void impl_pwmBurstDMASetCircular(burstDmaTimer_t * burstDmaTimer, TCH_t * tch, b
             __NOP();
         }
 
-        if (timeout == 0 && (burstDmaTimer->dmaBurstStream->CR & DMA_SxCR_EN)) {
+        if (burstDmaTimer->dmaBurstStream->CR & DMA_SxCR_EN) {
             TIM_DMACmd(burstDmaTimer->timer, burstDmaTimer->burstRequestSource, ENABLE);
             return;
         }
@@ -584,7 +584,7 @@ void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular, uint32_t dmaBufferS
             __NOP();
         }
 
-        if (timeout == 0 && (tch->dma->ref->CR & DMA_SxCR_EN)) {
+        if (tch->dma->ref->CR & DMA_SxCR_EN) {
             TIM_DMACmd(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], ENABLE);
             return;
         }

--- a/src/main/drivers/timer_impl_stdperiph.c
+++ b/src/main/drivers/timer_impl_stdperiph.c
@@ -270,6 +270,13 @@ static void impl_timerDMA_IRQHandler(DMA_t descriptor)
 {
     if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TCIF)) {
         TCH_t * tch = (TCH_t *)descriptor->userParam;
+
+        // In circular mode, let DMA keep running - don't disable the stream
+        if (tch->dmaState == TCH_DMA_CIRCULAR) {
+            DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
+            return;
+        }
+
         tch->dmaState = TCH_DMA_IDLE;
 
         DMA_Cmd(tch->dma->ref, DISABLE);
@@ -463,6 +470,46 @@ void impl_pwmBurstDMAStart(burstDmaTimer_t * burstDmaTimer, uint32_t BurstLength
     TIM_DMAConfig(burstDmaTimer->timer, TIM_DMABase_CCR1, TIM_DMABurstLength_4Transfers);
     TIM_DMACmd(burstDmaTimer->timer, burstDmaTimer->burstRequestSource, ENABLE);
 }
+
+void impl_pwmBurstDMASetCircular(burstDmaTimer_t * burstDmaTimer, TCH_t * tch, bool circular, uint32_t dmaBufferSize)
+{
+    if (!tch->dma || !tch->dma->ref) {
+        return;
+    }
+
+    ATOMIC_BLOCK(NVIC_PRIO_MAX) {
+        TIM_DMACmd(burstDmaTimer->timer, burstDmaTimer->burstRequestSource, DISABLE);
+        DMA_Cmd(burstDmaTimer->dmaBurstStream, DISABLE);
+
+        uint32_t timeout = 10000;
+        while ((burstDmaTimer->dmaBurstStream->CR & DMA_SxCR_EN) && timeout--) {
+            __NOP();
+        }
+
+        if (timeout == 0 && (burstDmaTimer->dmaBurstStream->CR & DMA_SxCR_EN)) {
+            TIM_DMACmd(burstDmaTimer->timer, burstDmaTimer->burstRequestSource, ENABLE);
+            return;
+        }
+
+        DMA_CLEAR_FLAG(tch->dma, DMA_IT_TCIF);
+
+        if (circular) {
+            burstDmaTimer->dmaBurstStream->CR |= DMA_SxCR_CIRC;
+            DMA_SetCurrDataCounter(burstDmaTimer->dmaBurstStream, dmaBufferSize);
+            DMA_ITConfig(burstDmaTimer->dmaBurstStream, DMA_IT_TC, DISABLE);
+            tch->dmaState = TCH_DMA_CIRCULAR;
+        } else {
+            burstDmaTimer->dmaBurstStream->CR &= ~DMA_SxCR_CIRC;
+            DMA_ITConfig(burstDmaTimer->dmaBurstStream, DMA_IT_TC, ENABLE);
+            tch->dmaState = TCH_DMA_IDLE;
+        }
+
+        __DSB();
+
+        DMA_Cmd(burstDmaTimer->dmaBurstStream, ENABLE);
+        TIM_DMACmd(burstDmaTimer->timer, burstDmaTimer->burstRequestSource, ENABLE);
+    }
+}
 #endif
 
 void impl_timerPWMPrepareDMA(TCH_t * tch, uint32_t dmaBufferElementCount)
@@ -520,38 +567,47 @@ void impl_timerPWMStopDMA(TCH_t * tch)
     TIM_Cmd(tch->timHw->tim, ENABLE);
 }
 
-void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular)
+void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular, uint32_t dmaBufferSize)
 {
     if (!tch->dma || !tch->dma->ref) {
         return;
     }
 
-    // Protect DMA reconfiguration from interrupt interference
     ATOMIC_BLOCK(NVIC_PRIO_MAX) {
-        // Temporarily disable DMA while modifying configuration
+        // Stop new transfer triggers before reconfiguring
+        TIM_DMACmd(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], DISABLE);
         DMA_Cmd(tch->dma->ref, DISABLE);
 
-        // Wait for DMA stream to actually be disabled
-        // The EN bit doesn't clear immediately, especially if transfer is in progress
-        uint32_t timeout = 10000;
+        // STM32F4/F7 RM: poll EN bit until stream is actually disabled
+        uint32_t timeout = 10000; // ~60us at 168MHz, well above worst-case disable latency
         while ((tch->dma->ref->CR & DMA_SxCR_EN) && timeout--) {
             __NOP();
         }
 
-        // If timeout occurred, DMA stream is still enabled - abort reconfiguration
         if (timeout == 0 && (tch->dma->ref->CR & DMA_SxCR_EN)) {
-            DMA_Cmd(tch->dma->ref, ENABLE); // Re-enable and return
+            TIM_DMACmd(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], ENABLE);
             return;
         }
 
-        // Modify the DMA mode
+        DMA_CLEAR_FLAG(tch->dma, DMA_IT_TCIF);
+
         if (circular) {
-            tch->dma->ref->CR |= DMA_SxCR_CIRC;  // Set circular bit
+            tch->dma->ref->CR |= DMA_SxCR_CIRC;
+            DMA_SetCurrDataCounter(tch->dma->ref, dmaBufferSize);
+            // Disable TC interrupt — in circular mode, TC fires every cycle
+            // and the IRQ handler would otherwise disable the stream
+            DMA_ITConfig(tch->dma->ref, DMA_IT_TC, DISABLE);
+            tch->dmaState = TCH_DMA_CIRCULAR;
         } else {
-            tch->dma->ref->CR &= ~DMA_SxCR_CIRC; // Clear circular bit
+            tch->dma->ref->CR &= ~DMA_SxCR_CIRC;
+            DMA_ITConfig(tch->dma->ref, DMA_IT_TC, ENABLE);
+            tch->dmaState = TCH_DMA_IDLE;
         }
 
-        // Re-enable DMA
+        // Ensure register writes are visible to DMA before re-enabling
+        __DSB();
+
         DMA_Cmd(tch->dma->ref, ENABLE);
+        TIM_DMACmd(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], ENABLE);
     }
 }

--- a/src/main/drivers/timer_impl_stdperiph_at32.c
+++ b/src/main/drivers/timer_impl_stdperiph_at32.c
@@ -432,7 +432,6 @@ void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular)
             return;
         }
 
-        // Modify the DMA loop mode (AT32's equivalent of circular mode)
         if (circular) {
             tch->dma->ref->ctrl_bit.lm = TRUE;  // Enable loop mode
         } else {

--- a/src/main/drivers/timer_impl_stdperiph_at32.c
+++ b/src/main/drivers/timer_impl_stdperiph_at32.c
@@ -432,7 +432,7 @@ void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular, uint32_t dmaBufferS
             __NOP();
         }
 
-        if (timeout == 0 && tch->dma->ref->ctrl_bit.chen) {
+        if (tch->dma->ref->ctrl_bit.chen) {
             tmr_dma_request_enable(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], TRUE);
             return;
         }

--- a/src/main/drivers/timer_impl_stdperiph_at32.c
+++ b/src/main/drivers/timer_impl_stdperiph_at32.c
@@ -269,6 +269,13 @@ static void impl_timerDMA_IRQHandler(DMA_t descriptor)
 {
     if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TCIF)) {
         TCH_t * tch = (TCH_t *)descriptor->userParam;
+
+        // In circular mode, let DMA keep running - don't disable the channel
+        if (tch->dmaState == TCH_DMA_CIRCULAR) {
+            DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
+            return;
+        }
+
         tch->dmaState = TCH_DMA_IDLE;
         dma_channel_enable(tch->dma->ref,FALSE);
         tmr_dma_request_enable(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], FALSE);
@@ -408,37 +415,47 @@ void impl_timerPWMStopDMA(TCH_t * tch)
     tmr_counter_enable(tch->timHw->tim, TRUE);
 }
 
-void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular)
+void impl_timerPWMSetDMACircular(TCH_t * tch, bool circular, uint32_t dmaBufferSize)
 {
     if (!tch->dma || !tch->dma->ref) {
         return;
     }
 
-    // Protect DMA reconfiguration from interrupt interference
     ATOMIC_BLOCK(NVIC_PRIO_MAX) {
-        // Temporarily disable DMA while modifying configuration
+        // Stop new transfer triggers before reconfiguring
+        tmr_dma_request_enable(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], FALSE);
         dma_channel_enable(tch->dma->ref, FALSE);
 
-        // Wait for DMA channel to actually be disabled
-        // The enable bit doesn't clear immediately, especially if transfer is in progress
-        uint32_t timeout = 10000;
+        // AT32: poll enable bit until channel is actually disabled
+        uint32_t timeout = 10000; // ~40us at 288MHz, well above worst-case disable latency
         while (tch->dma->ref->ctrl_bit.chen && timeout--) {
             __NOP();
         }
 
-        // If timeout occurred, DMA channel is still enabled - abort reconfiguration
         if (timeout == 0 && tch->dma->ref->ctrl_bit.chen) {
-            dma_channel_enable(tch->dma->ref, TRUE); // Re-enable and return
+            tmr_dma_request_enable(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], TRUE);
             return;
         }
 
+        DMA_CLEAR_FLAG(tch->dma, DMA_IT_TCIF);
+
         if (circular) {
-            tch->dma->ref->ctrl_bit.lm = TRUE;  // Enable loop mode
+            tch->dma->ref->ctrl_bit.lm = TRUE;
+            dma_data_number_set(tch->dma->ref, dmaBufferSize);
+            // Disable TC interrupt — in circular mode, TC fires every cycle
+            // and the IRQ handler would otherwise disable the channel
+            dma_interrupt_enable(tch->dma->ref, DMA_IT_TCIF, FALSE);
+            tch->dmaState = TCH_DMA_CIRCULAR;
         } else {
-            tch->dma->ref->ctrl_bit.lm = FALSE; // Disable loop mode
+            tch->dma->ref->ctrl_bit.lm = FALSE;
+            dma_interrupt_enable(tch->dma->ref, DMA_IT_TCIF, TRUE);
+            tch->dmaState = TCH_DMA_IDLE;
         }
 
-        // Re-enable DMA
+        // Ensure register writes are visible to DMA before re-enabling
+        __DSB();
+
         dma_channel_enable(tch->dma->ref, TRUE);
+        tmr_dma_request_enable(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], TRUE);
     }
 }

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -420,7 +420,7 @@ void processDelayedSave(void)
         saveState = SAVESTATE_NONE;
     } else if (saveState == SAVESTATE_SAVEONLY) {
         suspendRxSignal();
-        writeEEPROM();  // Circular DMA protection is inside writeConfigToEEPROM()
+        writeEEPROM();
         resumeRxSignal();
         saveState = SAVESTATE_NONE;
     }

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -420,7 +420,21 @@ void processDelayedSave(void)
         saveState = SAVESTATE_NONE;
     } else if (saveState == SAVESTATE_SAVEONLY) {
         suspendRxSignal();
+
+        // Prevent ESC spinup during settings save
+        // Switch to circular mode first
+        pwmSetMotorDMACircular(true);
+        // Force motor updates to latch current (zero) throttle into circular DMA buffer
+        pwmCompleteMotorUpdate();
+        delayMicroseconds(200);
+        pwmCompleteMotorUpdate();
+        delayMicroseconds(200);
+        pwmCompleteMotorUpdate();
+
         writeEEPROM();
+
+        pwmSetMotorDMACircular(false);
+
         resumeRxSignal();
         saveState = SAVESTATE_NONE;
     }

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -420,21 +420,7 @@ void processDelayedSave(void)
         saveState = SAVESTATE_NONE;
     } else if (saveState == SAVESTATE_SAVEONLY) {
         suspendRxSignal();
-
-        // Prevent ESC spinup during settings save
-        // Switch to circular mode first
-        pwmSetMotorDMACircular(true);
-        // Force motor updates to latch current (zero) throttle into circular DMA buffer
-        pwmCompleteMotorUpdate();
-        delayMicroseconds(200);
-        pwmCompleteMotorUpdate();
-        delayMicroseconds(200);
-        pwmCompleteMotorUpdate();
-
-        writeEEPROM();
-
-        pwmSetMotorDMACircular(false);
-
+        writeEEPROM();  // Circular DMA protection is inside writeConfigToEEPROM()
         resumeRxSignal();
         saveState = SAVESTATE_NONE;
     }


### PR DESCRIPTION
### **User description**
## Summary

Fixes ESC spinup/reboot when saving settings via configurator by enabling DMA circular mode during flash write operations.

## Problem

Internal flash writes block CPU core execution for 20-200ms on STM32F4/F7/AT32F43x and STM32H7. This interrupts DShot signal transmission, causing ESCs to timeout and spin up motors.

## Solution

Enable DMA circular mode before flash writes to allow DMA hardware to automatically repeat the last DShot packet (zero throttle) without CPU intervention.

**Implementation:**
- STM32F4/F7: Set `DMA_SxCR_CIRC` bit
- STM32H7: Use `LL_DMA_MODE_CIRCULAR` with proper synchronization (wait for EN bit clear)
- AT32F43x: Set `ctrl_bit.lm` (loop mode)
- All platforms: ATOMIC_BLOCK protection, disable/re-enable timer DMA requests

## Testing

Tested with oscilloscope monitoring DShot signal during settings save:
- **STM32F7** (AOCODARCF7MINI_V1): Bug reproduced, fix verified ✅
- **AT32F435** (BLUEBERRYF435WING): Bug reproduced, fix verified ✅
- **STM32H7** (JHEMCUH743HD): Bug reproduced, fix verified ✅
- **STM32F4**: Covered by F7 (identical code) ✅

## Related Issues

Fixes https://github.com/iNavFlight/inav/issues/10913

**Note:** While related to [Betaflight PR #12544](https://github.com/betaflight/betaflight/pull/12544), this addresses a different scenario:
- **Betaflight issue:** DShot beacon timing gaps
- **INAV issue:** Settings save (MSP_EEPROM_WRITE) triggering flash writes

INAV does not have the DShot beacon issue - motor values persist during beacon gaps.


___

### **PR Type**
Bug fix


___

### **Description**
- Prevents ESC spinup during settings save by enabling DMA circular mode

- Allows DMA to automatically repeat zero-throttle DShot packets during flash writes

- Implements circular DMA support for STM32F4/F7, STM32H7, and AT32F43x platforms

- Protects DMA reconfiguration with atomic blocks and timeout handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Settings Save"] --> B["writeConfigToEEPROM"]
  B --> C["Enable Circular DMA"]
  C --> D["Latch Zero Throttle"]
  D --> E["Flash Write"]
  E --> F["DMA Repeats Last Packet"]
  F --> G["Disable Circular DMA"]
  G --> H["Normal Operation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_eeprom.c</strong><dd><code>Enable circular DMA during EEPROM writes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/config/config_eeprom.c

<ul><li>Added <code>pwm_output.h</code> include for DMA circular mode control<br> <li> Calls <code>pwmSetMotorDMACircular(true)</code> before flash writes to enable <br>circular DMA<br> <li> Forces motor updates via <code>pwmCompleteMotorUpdate()</code> to latch zero <br>throttle<br> <li> Restores normal DMA mode with <code>pwmSetMotorDMACircular(false)</code> after <br>writes</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11260/files#diff-5606ad111ba08c4313bf14c659e00f9ea571981593f43d85d83159b7c21f206c">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>timer_impl_hal.c</strong><dd><code>Implement circular DMA for STM32H7 platforms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/timer_impl_hal.c

<ul><li>Implemented <code>impl_timerPWMSetDMACircular()</code> for STM32H7 using LL drivers<br> <li> Disables timer DMA requests and DMA stream before mode change<br> <li> Waits for EN bit to clear with timeout protection<br> <li> Switches between <code>LL_DMA_MODE_CIRCULAR</code> and <code>LL_DMA_MODE_NORMAL</code><br> <li> Preserves transfer count and re-enables DMA with atomic protection</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11260/files#diff-14d926973129af4d84357b58523cc627db519073e2092a196a4f54b50f524fdc">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>timer_impl_stdperiph.c</strong><dd><code>Implement circular DMA for STM32F4/F7 platforms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/timer_impl_stdperiph.c

<ul><li>Implemented <code>impl_timerPWMSetDMACircular()</code> for STM32F4/F7 using <br>StdPeriph<br> <li> Disables DMA stream before modifying configuration<br> <li> Waits for EN bit to clear with timeout protection<br> <li> Sets or clears <code>DMA_SxCR_CIRC</code> bit based on circular parameter<br> <li> Re-enables DMA with atomic protection</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11260/files#diff-1672b9e9519d81c5d000e67f4c6dac421a668b022b3aeb3b23bc8161455cb0ec">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>timer_impl_stdperiph_at32.c</strong><dd><code>Implement circular DMA for AT32F43x platforms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/timer_impl_stdperiph_at32.c

<ul><li>Implemented <code>impl_timerPWMSetDMACircular()</code> for AT32F43x platform<br> <li> Disables DMA channel before modifying configuration<br> <li> Waits for enable bit to clear with timeout protection<br> <li> Sets or clears <code>ctrl_bit.lm</code> (loop mode) based on circular parameter<br> <li> Re-enables DMA with atomic protection</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11260/files#diff-afd18235046a6253764e918df55df7e1c30d18d5b4fd44121d1b72df4b6b00f8">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pwm_output.h</strong><dd><code>Add DMA circular mode control function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/pwm_output.h

<ul><li>Added <code>pwmSetMotorDMACircular()</code> function declaration<br> <li> Allows runtime switching between circular and normal DMA modes</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11260/files#diff-47458146d90b6b5a5d2b9f725ad8fc00f2133b06fcc77b8182314f8a1bde6fda">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pwm_output.c</strong><dd><code>Implement motor DMA circular mode wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/pwm_output.c

<ul><li>Implemented <code>pwmSetMotorDMACircular()</code> function<br> <li> Iterates through all motor outputs and calls platform-specific <br>implementation<br> <li> Includes conditional compilation for DShot and SITL builds</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11260/files#diff-35a59b25caa7167e9dd4de5568447a86197937c050bc2555d2535db4ef90a4ad">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>timer_impl.h</strong><dd><code>Add platform DMA circular mode interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/timer_impl.h

<ul><li>Added <code>impl_timerPWMSetDMACircular()</code> function declaration<br> <li> Platform-specific implementation for DMA mode switching</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11260/files#diff-f72185aa684f124e388780175d0a02228130d6ad4c680f10ee9741963d1feb2a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

