### PR TITLE
Add GPS hardware version to MSP and optimize defaults for M8/M9/M10

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1734,11 +1734,11 @@ Which SBAS mode to be used
 
 ### gps_ublox_nav_hz
 
-Navigation update rate for UBLOX receivers. Some receivers may limit the maximum number of satellites tracked when set to a higher rate or even stop sending navigation updates if the value is too high. Some M10 devices can do up to 25Hz. 10 is a safe value for M8 and newer.
+Navigation update rate for UBLOX receivers. M9 modules limit satellite tracking to 16 satellites at 10Hz or higher, but use 32 satellites below 10Hz for better accuracy. M10 modules work well at 8Hz with 3 constellations. Some M10 devices with high-performance clock can do up to 25Hz with 4 constellations. 8Hz is a safe, accurate default for M8/M9/M10.
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 10 | 5 | 200 |
+| 8 | 5 | 200 |
 
 ---
 
@@ -1748,7 +1748,7 @@ Enable use of Beidou satellites. This is at the expense of other regional conste
 
 | Default | Min | Max |
 | --- | --- | --- |
-| OFF | OFF | ON |
+| ON | OFF | ON |
 
 ---
 
@@ -1758,7 +1758,7 @@ Enable use of Galileo satellites. This is at the expense of other regional const
 
 | Default | Min | Max |
 | --- | --- | --- |
-| OFF | OFF | ON |
+| ON | OFF | ON |
 
 ---
 

--- a/docs/development/msp/msp_messages.json
+++ b/docs/development/msp/msp_messages.json
@@ -4896,6 +4896,12 @@
                     "ctype": "uint16_t",
                     "desc": "Estimated Vertical Position Accuracy (`gpsSol.epv`)",
                     "units": "cm"
+                },
+                {
+                    "name": "hwVersion",
+                    "ctype": "uint32_t",
+                    "desc": "GPS hardware version (`gpsState.hwVersion`). Values: 500=UBLOX5, 600=UBLOX6, 700=UBLOX7, 800=UBLOX8, 900=UBLOX9, 1000=UBLOX10, 0=UNKNOWN",
+                    "units": "Version code"
                 }
             ]
         },

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1009,6 +1009,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         sbufWriteU16(dst, gpsSol.hdop);
         sbufWriteU16(dst, gpsSol.eph);
         sbufWriteU16(dst, gpsSol.epv);
+        sbufWriteU32(dst, gpsState.hwVersion);
         break;
 #endif
     case MSP2_ADSB_VEHICLE_LIST:

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1757,12 +1757,12 @@ groups:
         type: uint8_t
       - name: gps_ublox_use_galileo
         description: "Enable use of Galileo satellites. This is at the expense of other regional constellations, so benefit may also be regional. Requires M8N and Ublox firmware 3.x (or later) [OFF/ON]."
-        default_value: OFF
+        default_value: ON
         field: ubloxUseGalileo
         type: bool
       - name: gps_ublox_use_beidou
         description: "Enable use of Beidou satellites. This is at the expense of other regional constellations, so benefit may also be regional. Requires gps hardware support [OFF/ON]."
-        default_value: OFF
+        default_value: ON
         field: ubloxUseBeidou
         type: bool
       - name: gps_ublox_use_glonass
@@ -1777,8 +1777,8 @@ groups:
         min: 5
         max: 10
       - name: gps_ublox_nav_hz
-        description: "Navigation update rate for UBLOX receivers. Some receivers may limit the maximum number of satellites tracked when set to a higher rate or even stop sending navigation updates if the value is too high. Some M10 devices can do up to 25Hz. 10 is a safe value for M8 and newer."
-        default_value: 10
+        description: "Navigation update rate for UBLOX receivers. M9 modules limit satellite tracking to 16 satellites at 10Hz or higher, but use 32 satellites below 10Hz for better accuracy. M10 modules work well at 8Hz with 3 constellations. Some M10 devices with high-performance clock can do up to 25Hz with 4 constellations. 8Hz is a safe, accurate default for M8/M9/M10."
+        default_value: 8
         field: ubloxNavHz
         type: uint8_t
         min: 5

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -451,6 +451,9 @@ void gpsInit(void)
     gpsStats.errors = 0;
     gpsStats.timeouts = 0;
 
+    // Initialize hardware version to unknown (for MSP_GPSSTATISTICS)
+    gpsState.hwVersion = 0;
+
     // Reset solution, timeout and prepare to start
     gpsResetSolution(&gpsSolDRV);
     gpsResetSolution(&gpsSol);


### PR DESCRIPTION
### **User description**
## Summary

Extends MSP_GPSSTATISTICS to include GPS hardware version (hwVersion) for auto-detection, and updates GPS defaults for better out-of-box accuracy across all u-blox modules.

This enables the configurator to automatically detect GPS module type (M8/M9/M10) and apply optimal presets. 

<img width="459" height="303" alt="image" src="https://github.com/user-attachments/assets/5eefd507-396e-4e87-a635-34ea5d87d0d8" />


## Changes

### MSP Extension
- **src/main/fc/fc_msp.c**: Extended MSP_GPSSTATISTICS from 20 to 24 bytes to include `gpsState.hwVersion`
- **docs/development/msp/msp_messages.json**: Documented hwVersion field with value mappings (800=M8, 900=M9, 1000=M10, 0=Unknown)
- **Backward compatible**: Old configurators ignore the extra bytes

### GPS Defaults
- **gps_ublox_use_galileo**: OFF → ON
- **gps_ublox_use_beidou**: OFF → ON  
- **gps_ublox_use_glonass**: OFF (unchanged)
- **gps_ublox_nav_hz**: 10 → 8

### Rationale for Defaults based on research on the u-blox forum, PX4 discussion, Clive Turvey (u-blox expert), and Jetrell's testing

- **8Hz rate** allows M9 modules to use 32 satellites (vs 16 at ≥10Hz hardware limitation)
- **3 constellations** (GPS+Galileo+Beidou) provide excellent global coverage
- **Safe for all modules**: M8 handles it easily, M9 gets full accuracy, M10 optimized at default clock
- **Glonass OFF** avoids unnecessary processing overhead, especially on M10

Updated `gps_ublox_nav_hz` description in settings.yaml to document M9's 16-satellite limitation at ≥10Hz.

## Research & Citations

This work is based on research and community contributions:

### u-blox Forum Research
- **M9 16-satellite limitation**
- u-blox forum posts documenting 10Hz threshold:
  - https://portal.u-blox.com/s/question/0D52p00008HKEbOCAX/can-neom9n-only-use-16-satellites-with-nav-update-rate-5hz
  - https://portal.u-blox.com/s/question/0D52p00009IsVqkCAF/is-the-neom9n-limited-to-16-svs-for-the-navigation-solution
  - https://portal.u-blox.com/s/question/0D52p0000990yQ1CAI/neom9n-reduced-satellites-at-increased-rates-is-there-a-way-around-it

### Clive Turvey's Code Analysis
- Documented undocumented configuration key **CFG-NAVSPG-CONSTR_GNSS** (0x20110011 / 0xD5)
- Code: https://github.com/cturvey/RandomNinjaChef/blob/main/M9_channels.c
- Shows M9 hardware enforces 16-sat limit at ≥10Hz, 32-sat below 10Hz

### PX4 GPS Driver Decision
- PX4 GPS drivers chose **5Hz for M9** for better accuracy (32 satellites)
- PR discussion: https://github.com/PX4/PX4-GPSDrivers/pull/57
- Confirms industry consensus on prioritizing accuracy over latency

### Field Testing
- **Jetrell's INAV testing** contributed to understanding real-world M9 behavior
- Community-reported HDOP improvements: ~1.0-1.3 at 5Hz vs ~2.0-2.5 at 10Hz

## Testing

### Tested ✅
- **Build**: AOCODARCF4V3_SD target compiles successfully
- **Flash**: Firmware flashes and boots correctly
- **MSP Extension**: hwVersion field correctly reports 800 for M8 module
- **Backward Compatibility**: Old configurators work with extended message
- **Settings**: New defaults apply correctly on fresh config

### Testing Needed ⚠️
- **M9 modules**: Community testing needed to verify hwVersion=900 detection
- **M10 modules**: Community testing needed to verify hwVersion=1000 detection
- **Satellite tracking**: Verify M9 actually uses 32 sats at 8Hz vs 16 at 10Hz
- **Various GPS modules**: Test with different M8/M9/M10 variants

## Related PR
- Configurator PR: [will be linked after configurator PR is created]
- The configurator PR adds preset UI with auto-detection using this hwVersion field

## Documentation
- Updated Settings.md (auto-generated from settings.yaml)
- MSP message documentation in msp_messages.json

---

**Testing help appreciated!** If you have M9 or M10 modules connected, please test and report auto-detection


___

### **PR Type**
Enhancement


___

### **Description**
- Extend MSP_GPSSTATISTICS with GPS hardware version field
  - Add `hwVersion` field for auto-detection of M8/M9/M10 modules
  - Backward compatible with existing configurators

- Optimize GPS defaults for improved accuracy across all u-blox modules
  - Change `gps_ublox_nav_hz` from 10Hz to 8Hz (enables 32 satellites on M9)
  - Enable Galileo and Beidou constellations by default
  - Provides 3-constellation coverage for better global positioning

- Document M9 satellite limitation and rationale in settings
  - M9 limited to 16 satellites at ≥10Hz, 32 satellites below 10Hz
  - 8Hz default balances accuracy and latency across M8/M9/M10


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MSP_GPSSTATISTICS<br/>Extended Message"] -->|"Add hwVersion<br/>field"| B["GPS Module<br/>Auto-detection"]
  C["GPS Defaults<br/>Configuration"] -->|"8Hz rate<br/>3 constellations"| D["Improved Accuracy<br/>M8/M9/M10"]
  B -->|"Enables"| E["Configurator<br/>Preset UI"]
  D -->|"Supports"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fc_msp.c</strong><dd><code>Add hwVersion field to MSP_GPSSTATISTICS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/fc/fc_msp.c

<ul><li>Add <code>sbufWriteU32(dst, gpsState.hwVersion)</code> to MSP_GPSSTATISTICS message<br> <li> Extends message from 20 to 24 bytes with hardware version field<br> <li> Maintains backward compatibility with existing configurators</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11262/files#diff-e67741f944e959c3f68a81189a5fcd8be50f5e4e567c1fc68f50ac5e86d0a233">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>msp_messages.json</strong><dd><code>Document GPS hardware version field in MSP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/development/msp/msp_messages.json

<ul><li>Document new <code>hwVersion</code> field in MSP_GPSSTATISTICS (message 166)<br> <li> Define version code mappings (500=UBLOX5, 600=UBLOX6, 700=UBLOX7, <br>800=UBLOX8, 900=UBLOX9, 1000=UBLOX10, 0=UNKNOWN)<br> <li> Specify field type as <code>uint32_t</code> with units as "Version code"</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11262/files#diff-4c12a60ea9c02ce1bd8c5a14d21640c1253119b614a14d36782acda4d370e58f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Settings.md</strong><dd><code>Update GPS settings documentation with new defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Settings.md

<ul><li>Update <code>gps_ublox_nav_hz</code> default value from 10 to 8 in table<br> <li> Expand description with M9 16-satellite limitation at ≥10Hz<br> <li> Document 32-satellite capability below 10Hz for better accuracy<br> <li> Update <code>gps_ublox_use_beidou</code> default from OFF to ON<br> <li> Update <code>gps_ublox_use_galileo</code> default from OFF to ON</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11262/files#diff-ae20939faff30a268f1d311e9654bb2788d52d5ecdc9a897340914a5ca0c8b44">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.yaml</strong><dd><code>Update GPS defaults and navigation rate documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/fc/settings.yaml

<ul><li>Change <code>gps_ublox_nav_hz</code> default from 10 to 8 Hz<br> <li> Enable <code>gps_ublox_use_galileo</code> by default (OFF → ON)<br> <li> Enable <code>gps_ublox_use_beidou</code> by default (OFF → ON)<br> <li> Update <code>gps_ublox_nav_hz</code> description with M9 satellite limitation <br>details</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11262/files#diff-4569ee6a30a1d30a1f5aeff4e218a1fbdc14e4373abdcece1af2160926e85f76">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

