### PR TITLE
Position estimator position and velocity corrections fix

### DIFF
--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -752,14 +752,11 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
     estimationPredict(&ctx);
 
     /* Correction stage: Z */
-    const bool estZCorrectOk =
-        estimationCalculateCorrection_Z(&ctx);
+    const bool estZCorrectOk = estimationCalculateCorrection_Z(&ctx);
 
     /* Correction stage: XY: GPS, FLOW */
     // FIXME: Handle transition from FLOW to GPS and back - seamlessly fly indoor/outdoor
-    const bool estXYCorrectOk =
-        estimationCalculateCorrection_XY_GPS(&ctx) ||
-        estimationCalculateCorrection_XY_FLOW(&ctx);
+    const bool estXYCorrectOk = estimationCalculateCorrection_XY_GPS(&ctx) || estimationCalculateCorrection_XY_FLOW(&ctx);
 
     // If we can't apply correction or accuracy is off the charts - decay velocity to zero
     if (!estXYCorrectOk || ctx.newEPH > max_eph_epv) {
@@ -778,7 +775,7 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
     // Constrain corrections to prevent instability
     for (uint8_t axis = 0; axis < 3; axis++) {
         ctx.estPosCorr.v[axis] = constrainf(ctx.estPosCorr.v[axis], -INAV_EST_CORR_LIMIT_VALUE, INAV_EST_CORR_LIMIT_VALUE);
-        ctx.estVelCorr.v[axis] = constrainf(ctx.estPosCorr.v[axis], -INAV_EST_CORR_LIMIT_VALUE, INAV_EST_CORR_LIMIT_VALUE);
+        ctx.estVelCorr.v[axis] = constrainf(ctx.estVelCorr.v[axis], -INAV_EST_CORR_LIMIT_VALUE, INAV_EST_CORR_LIMIT_VALUE);
     }
 
     // Apply corrections

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -773,9 +773,10 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
     vectorScale(&ctx.estVelCorr, &ctx.estVelCorr, 1.0f / posEstimator.imu.accWeightFactor);
 
     // Constrain corrections to prevent instability
+    const float corrLimit = INAV_EST_CORR_LIMIT_VALUE * ctx.dt;
     for (uint8_t axis = 0; axis < 3; axis++) {
-        ctx.estPosCorr.v[axis] = constrainf(ctx.estPosCorr.v[axis], -INAV_EST_CORR_LIMIT_VALUE, INAV_EST_CORR_LIMIT_VALUE);
-        ctx.estVelCorr.v[axis] = constrainf(ctx.estVelCorr.v[axis], -INAV_EST_CORR_LIMIT_VALUE, INAV_EST_CORR_LIMIT_VALUE);
+        ctx.estPosCorr.v[axis] = constrainf(ctx.estPosCorr.v[axis], -corrLimit, corrLimit);
+        ctx.estVelCorr.v[axis] = constrainf(ctx.estVelCorr.v[axis], -corrLimit, corrLimit);
     }
 
     // Apply corrections

--- a/src/main/navigation/navigation_pos_estimator_private.h
+++ b/src/main/navigation/navigation_pos_estimator_private.h
@@ -34,6 +34,8 @@
 
 #define INAV_ACC_BIAS_ACCEPTANCE_VALUE      (GRAVITY_CMSS * 0.25f)   // Max accepted bias correction of 0.25G - unlikely we are going to be that much off anyway
 
+#define INAV_EST_CORR_LIMIT_VALUE           2.0f   // Max allowed pos/vel estimate correction value per loop
+
 #define INAV_GPS_GLITCH_RADIUS              250.0f  // 2.5m GPS glitch radius
 #define INAV_GPS_GLITCH_ACCEL               1000.0f // 10m/s/s max possible acceleration for GPS glitch detection
 

--- a/src/main/navigation/navigation_pos_estimator_private.h
+++ b/src/main/navigation/navigation_pos_estimator_private.h
@@ -34,7 +34,7 @@
 
 #define INAV_ACC_BIAS_ACCEPTANCE_VALUE      (GRAVITY_CMSS * 0.25f)   // Max accepted bias correction of 0.25G - unlikely we are going to be that much off anyway
 
-#define INAV_EST_CORR_LIMIT_VALUE           2.0f   // Max allowed pos/vel estimate correction value per loop
+#define INAV_EST_CORR_LIMIT_VALUE           4000.0f   // Sanity constraint limit for pos/vel estimate correction value (max 40m correction per s)
 
 #define INAV_GPS_GLITCH_RADIUS              250.0f  // 2.5m GPS glitch radius
 #define INAV_GPS_GLITCH_ACCEL               1000.0f // 10m/s/s max possible acceleration for GPS glitch detection


### PR DESCRIPTION
### **User description**
Should provide a fix for #10360, #10391, #10893 and #11049.

See https://github.com/iNavFlight/inav/issues/11049#issuecomment-3781647432 for explanation and reason for change.

HITL testing shows the estimate instability is fixed with the PR changes. Not easy to flight test given the odd set of circumstances need to trigger the problem in the first place.

`INAV_EST_CORR_LIMIT_VALUE `may need tweaking. It corresponds to around 40m residual error for x/y position at the default loop rate.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix position estimator instability by directly resetting estimates instead of accumulating corrections

- Add correction limiting to prevent excessive estimate adjustments per loop iteration

- Constrain uncertainty estimates to prevent unbounded growth

- Simplify velocity decay calculation and improve code clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Invalid Estimate Detection"] -->|Direct Reset| B["Position/Velocity Set to GPS"]
  C["Correction Calculation"] -->|Limit Corrections| D["Constrained Corrections Applied"]
  E["Uncertainty Update"] -->|Bounded Growth| F["Capped EPH/EPV Values"]
  B --> D
  D --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation_pos_estimator.c</strong><dd><code>Correct estimate initialization and add correction limits</code></dd></summary>
<hr>

src/main/navigation/navigation_pos_estimator.c

<ul><li>Changed invalid estimate initialization from accumulating corrections <br>to directly resetting position and velocity to GPS values<br> <li> Added correction limiting loop to constrain position and velocity <br>corrections within <code>INAV_EST_CORR_LIMIT_VALUE</code> bounds<br> <li> Simplified velocity decay calculations by removing redundant <code>0.0f -</code> <br>operations<br> <li> Added constraints to EPH and EPV uncertainty estimates to prevent <br>unbounded growth<br> <li> Improved code formatting with consistent spacing<br> <li> Changed loop variable declaration from <code>int</code> to <code>uint8_t</code> for type <br>consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11270/files#diff-96b2ec94699623edbea79fee247a79dab05792380c09884bd38eb55da6d0a74f">+20/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation_pos_estimator_private.h</strong><dd><code>Define correction limit constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/navigation/navigation_pos_estimator_private.h

<ul><li>Added new constant <code>INAV_EST_CORR_LIMIT_VALUE</code> set to 2.0f to limit <br>maximum position/velocity correction per loop iteration<br> <li> Constant corresponds to approximately 40m residual error for x/y <br>position at default loop rate</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11270/files#diff-0ad09eee725551a7147de461a8dd3ff064201f157fe48a5b3518c49876f2837a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

