### PR TITLE
Add Parameter Group system documentation for developers

### DIFF
--- a/docs/development/parameter_groups/README.md
+++ b/docs/development/parameter_groups/README.md
@@ -1,0 +1,257 @@
+# Parameter Groups System
+
+## Overview
+
+Parameter Groups (PG) is INAV's system for managing persistent configuration settings. Each configuration struct is registered with a unique ID and version number, stored in EEPROM/flash, and automatically validated on boot.
+
+## Quick Reference
+
+**When modifying a parameter group struct:**
+- ✅ **Increment version** - Safest option, always works
+- ⚠️ **Don't increment** - Only safe for comments or non-structural changes
+
+**Key files:**
+- `src/main/config/parameter_group.h` - Macros and registry structure
+- `src/main/config/parameter_group.c` - Runtime load/store functions
+- `src/main/config/parameter_group_ids.h` - PGN definitions
+- `src/main/fc/settings.yaml` - Maps CLI settings to PG fields
+
+## How It Works
+
+### Registration
+
+Parameter groups use linker sections to build a compile-time registry:
+
+```c
+// In yourfeature.h
+typedef struct yourFeatureConfig_s {
+    uint8_t enabled;
+    uint16_t rate;
+} yourFeatureConfig_t;
+
+PG_DECLARE(yourFeatureConfig_t, yourFeatureConfig);
+
+// In yourfeature.c
+PG_REGISTER_WITH_RESET_TEMPLATE(
+    yourFeatureConfig_t,
+    yourFeatureConfig,
+    PG_YOUR_FEATURE_CONFIG,  // Unique ID from parameter_group_ids.h
+    0                        // Version number
+);
+
+PG_RESET_TEMPLATE(yourFeatureConfig_t, yourFeatureConfig,
+    .enabled = 1,
+    .rate = 100
+);
+```
+
+### Version Checking
+
+On boot, `pgLoad()` validates versions before loading settings:
+
+```c
+void pgLoad(const pgRegistry_t* reg, int profileIndex,
+            const void *from, int size, int version)
+{
+    pgReset(reg, profileIndex);  // Always reset to defaults first
+
+    if (version == pgVersion(reg)) {
+        // Only copy if versions match
+        const int take = MIN(size, pgSize(reg));
+        memcpy(pgOffset(reg, profileIndex), from, take);
+    }
+    // If version mismatch: defaults remain, no corruption
+}
+```
+
+**Key behavior:** Version mismatch causes settings to remain at defaults. This prevents corruption when struct layout changes.
+
+## Version Management
+
+### When to Increment Version
+
+Version numbers are stored in the top 4 bits of the PGN field (valid range: 0-15).
+
+**The safe rule:** When modifying a parameter group struct, increment the version.
+
+**Changes requiring version increment:**
+- Removing a field
+- Changing field type or size
+- Reordering fields
+- Adding packing attributes
+
+**Example - Removing a field:**
+
+```c
+// Before: version 4
+typedef struct blackboxConfig_s {
+    uint16_t rate_num;
+    uint16_t rate_denom;
+    uint8_t device;
+    uint8_t invertedCardDetection;  // Removing this
+    uint32_t includeFlags;
+    int8_t arm_control;
+} blackboxConfig_t;
+PG_REGISTER_WITH_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 4);
+
+// After: version 5 (MUST increment!)
+typedef struct blackboxConfig_s {
+    uint16_t rate_num;
+    uint16_t rate_denom;
+    uint8_t device;
+    // invertedCardDetection removed - field offsets changed!
+    uint32_t includeFlags;  // Now at different offset
+    int8_t arm_control;     // Now at different offset
+} blackboxConfig_t;
+PG_REGISTER_WITH_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 5);
+```
+
+**Why:** Without version increment, `pgLoad()` sees matching versions (4==4) and copies old data, but field offsets have changed. Result: `includeFlags` reads wrong bytes from EEPROM, causing corruption.
+
+With version increment (4→5), `pgLoad()` detects mismatch and keeps defaults instead.
+
+### Changes NOT Requiring Version Increment
+
+- Comments only
+- Default values in `PG_RESET_TEMPLATE` (doesn't affect EEPROM layout)
+- settings.yaml entries (CLI mapping, not struct layout)
+
+### Technical Note on Appending
+
+The `pgLoad()` function uses `MIN(size, pgSize(reg))` when copying data. This means:
+- If new firmware has larger struct, it copies available bytes and keeps defaults for new fields
+- If new firmware has smaller struct, it copies only what fits
+
+This behavior theoretically allows appending fields at the end without version increment. However, **the recommended practice is to always increment** unless you have specific reason not to and understand the implications.
+
+## Complete Example
+
+### yourfeature.h
+```c
+#pragma once
+
+#include <stdint.h>
+#include "config/parameter_group.h"
+
+typedef struct yourFeatureConfig_s {
+    uint8_t enabled;
+    uint16_t updateRate;
+    uint32_t flags;
+} yourFeatureConfig_t;
+
+PG_DECLARE(yourFeatureConfig_t, yourFeatureConfig);
+```
+
+### yourfeature.c
+```c
+#include "yourfeature.h"
+#include "config/parameter_group_ids.h"
+
+PG_REGISTER_WITH_RESET_TEMPLATE(
+    yourFeatureConfig_t,
+    yourFeatureConfig,
+    PG_YOUR_FEATURE_CONFIG,
+    0
+);
+
+PG_RESET_TEMPLATE(yourFeatureConfig_t, yourFeatureConfig,
+    .enabled = 1,
+    .updateRate = 100,
+    .flags = 0
+);
+
+void yourFeatureInit(void)
+{
+    if (!yourFeatureConfig()->enabled) {
+        return;
+    }
+    // Use configuration...
+}
+```
+
+### parameter_group_ids.h
+```c
+typedef enum {
+    // ... existing entries ...
+    PG_YOUR_FEATURE_CONFIG = 150,  // Choose unused ID
+    // ...
+} pgn_e;
+```
+
+### settings.yaml
+```yaml
+- name: your_feature_enable
+  description: "Enable yourFeature"
+  field: yourFeatureConfig.enabled
+  type: uint8_t
+  min: 0
+  max: 1
+  default_value: 1
+
+- name: your_feature_rate
+  description: "Update rate in Hz"
+  field: yourFeatureConfig.updateRate
+  type: uint16_t
+  min: 1
+  max: 1000
+  default_value: 100
+```
+
+## Accessing Configuration
+
+### Read-only (preferred)
+```c
+if (yourFeatureConfig()->enabled) {
+    processAtRate(yourFeatureConfig()->updateRate);
+}
+```
+
+### Mutable (use sparingly)
+```c
+yourFeatureConfigMutable()->updateRate = newRate;
+```
+
+## Registration Macros
+
+| Macro | Use |
+|-------|-----|
+| `PG_DECLARE(type, name)` | Declare system PG in header |
+| `PG_DECLARE_PROFILE(type, name)` | Declare profile PG in header |
+| `PG_REGISTER_WITH_RESET_TEMPLATE(...)` | Register with template defaults |
+| `PG_REGISTER_WITH_RESET_FN(...)` | Register with custom reset function |
+| `PG_RESET_TEMPLATE(type, name, ...)` | Define default values |
+
+## Common Patterns
+
+### Boolean Fields
+```c
+uint8_t enabled;  // Use uint8_t, not bool (EEPROM needs fixed sizes)
+```
+
+### Enums
+```c
+typedef enum { MODE_A = 0, MODE_B = 1 } mode_e;
+uint8_t mode;  // Store enum as uint8_t
+```
+
+### Bitfields
+```c
+#define FLAG_A (1 << 0)
+#define FLAG_B (1 << 1)
+uint32_t flags;
+```
+
+## Testing Version Changes
+
+When incrementing a version:
+
+1. Flash old firmware, configure non-default settings, save
+2. Flash new firmware with incremented version
+3. Verify settings reset to defaults (not corrupted)
+4. Check for errors in CLI
+
+## See Also
+
+- `src/main/config/parameter_group.h` - Full macro definitions
+- `src/main/config/parameter_group.c` - Implementation
+- Betaflight PG documentation: https://betaflight.com/docs/development/ParameterGroups


### PR DESCRIPTION
### **User description**
## Summary
Add comprehensive developer documentation for INAV's Parameter Group (PG) system to help developers understand when to increment PG version numbers and how to register parameter groups correctly.

## Changes
- Add `docs/development/parameter_groups/README.md` with practical guide
- Documents compile-time registry using linker sections
- Explains version validation mechanism in `pgLoad()`
- Provides clear rules for when to increment PG versions
- Includes complete working examples based on actual code

## Key Topics Covered
- How the PG registry works (linker sections, `__pg_registry_start/end`)
- Version encoding in top 4 bits of PGN field
- Version checking: `pgLoad()` resets to defaults on mismatch
- When to increment version (struct layout changes)
- Registration macros (`PG_REGISTER_WITH_RESET_TEMPLATE`, etc.)
- Complete examples developers can copy

## Documentation Approach
- Based only on verified code (`parameter_group.h/c`)
- Conservative recommendations (increment version when in doubt)
- References real examples (blackbox config)
- Compared with Betaflight PG documentation for consistency

## Related Context
- Addresses confusion seen in PR #11236 (field removal requiring version increment)
- References PR #5308 (reset function usage)
- References PR #11122 (renaming without version increment)


___

### **PR Type**
Documentation


___

### **Description**
- Add comprehensive Parameter Group system documentation for developers

- Explains compile-time registry using linker sections and version validation

- Documents when to increment PG version numbers with practical examples

- Provides complete working examples and registration macro reference


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Developer needs PG guidance"] --> B["README.md documentation"]
  B --> C["How PG registry works"]
  B --> D["Version management rules"]
  B --> E["Complete code examples"]
  C --> F["Linker sections and macros"]
  D --> G["When to increment versions"]
  E --> H["Ready to implement PG"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Parameter Group system developer guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/development/parameter_groups/README.md

<ul><li>New comprehensive documentation file covering Parameter Group system <br>architecture<br> <li> Explains registration mechanism using linker sections and compile-time <br>registry<br> <li> Documents version checking behavior in <code>pgLoad()</code> and when to increment <br>versions<br> <li> Includes practical code examples for declaring, registering, and <br>accessing parameter groups<br> <li> Provides reference tables for registration macros and common patterns<br> <li> Addresses real-world scenarios like field removal with version <br>increment examples</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11271/files#diff-c62ffec91583e51601a496ceed093efbc3c002980b706b2415a29c2fe3a04e99">+257/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

