### PR TITLE
Fix YAML syntax error in workflow file

### DIFF
--- a/.github/workflows/pg-version-check.yml
+++ b/.github/workflows/pg-version-check.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           script: |
             // Use the captured output from the previous step
-            const output = `${{ steps.pg_check.outputs.output }}`;
+            const output = '${{ steps.pg_check.outputs.output }}';
             let issuesContent = '';
 
             try {
@@ -73,29 +73,23 @@ jobs:
               issuesContent = '*Unable to extract detailed issues*';
             }
 
-            const commentBody = `## ⚠️ Parameter Group Version Check
-
-The following parameter groups may need version increments:
-
-${issuesContent}
-
-**Why this matters:**
-Modifying PG struct fields without incrementing the version can cause settings corruption when users flash new firmware. The \`pgLoad()\` function validates versions and will use defaults if there's a mismatch, preventing corruption.
-
-**When to increment the version:**
-- ✅ Adding/removing fields
-- ✅ Changing field types or sizes
-- ✅ Reordering fields
-- ✅ Adding/removing packing attributes
-- ❌ Only changing default values in \`PG_RESET_TEMPLATE\`
-- ❌ Only changing comments
-
-**Reference:**
-- [Parameter Group Documentation](../docs/development/parameter_groups/)
-- Example: [PR #11236](https://github.com/iNavFlight/inav/pull/11236) (field removal requiring version increment)
-
----
-*This is an automated check. False positives are possible. If you believe the version increment is not needed, please explain in a comment.*`;
+            const commentBody = '## ⚠️ Parameter Group Version Check\n\n' +
+              'The following parameter groups may need version increments:\n\n' +
+              issuesContent + '\n\n' +
+              '**Why this matters:**\n' +
+              'Modifying PG struct fields without incrementing the version can cause settings corruption when users flash new firmware. The `pgLoad()` function validates versions and will use defaults if there\'s a mismatch, preventing corruption.\n\n' +
+              '**When to increment the version:**\n' +
+              '- ✅ Adding/removing fields\n' +
+              '- ✅ Changing field types or sizes\n' +
+              '- ✅ Reordering fields\n' +
+              '- ✅ Adding/removing packing attributes\n' +
+              '- ❌ Only changing default values in `PG_RESET_TEMPLATE`\n' +
+              '- ❌ Only changing comments\n\n' +
+              '**Reference:**\n' +
+              '- [Parameter Group Documentation](../docs/development/parameter_groups/)\n' +
+              '- Example: [PR #11236](https://github.com/iNavFlight/inav/pull/11236) (field removal requiring version increment)\n\n' +
+              '---\n' +
+              '*This is an automated check. False positives are possible. If you believe the version increment is not needed, please explain in a comment.*';
 
             try {
               // Check if we already commented


### PR DESCRIPTION
### **User description**
Replace JavaScript template literals with string concatenation to avoid YAML parser confusion with template literal interpolation syntax. GitHub Actions YAML parser can misinterpret template literal dollar-brace syntax as expression delimiters.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace template literals with string concatenation in GitHub Actions workflow

- Avoid YAML parser confusion with template literal dollar-brace syntax

- Fix potential expression delimiter misinterpretation by GitHub Actions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Template Literals<br/>with dollar-brace syntax"] -->|Replace with| B["String Concatenation<br/>with explicit newlines"]
  B -->|Result| C["YAML Parser<br/>Compatible Syntax"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pg-version-check.yml</strong><dd><code>Replace template literals with string concatenation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pg-version-check.yml

<ul><li>Replaced JavaScript template literal for <code>output</code> variable with <br>single-quoted string<br> <li> Converted multi-line template literal for <code>commentBody</code> to string <br>concatenation with explicit newline characters<br> <li> Maintained identical comment content while using compatible YAML <br>syntax<br> <li> Escaped single quotes in concatenated strings where necessary</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11277/files#diff-1cb3a512fb0a1a9eff1283d988a66c87f375c7305891bd71466fd9e33e7e8e7d">+18/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

