### PR TITLE
Update vtx_smartaudio.c

### DIFF
--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -62,7 +62,7 @@ static serialPort_t *smartAudioSerialPort = NULL;
 
 uint8_t saPowerCount = VTX_SMARTAUDIO_DEFAULT_POWER_COUNT;
 const char *saPowerNames[VTX_SMARTAUDIO_MAX_POWER_COUNT + 1] = {
-    "----", "25  ", "200 ", "500 ", "800 ", "    ", "    ", "    ", "    "
+    "25", "200  ", "500 ", "1000 ", "3000 ", "    ", "    ", "    ", "    "
 };
 
 // Save powerlevels reported from SA 2.1 devices here


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- This description is generated by an AI tool. It may have inaccuracies

- Corrects SmartAudio power level names array

- Removes invalid "----" placeholder entry

- Updates power values to match actual mW levels (25, 200, 500, 1000, 3000)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old power names<br/>with ---- placeholder"] -- "Remove invalid entry" --> B["New power names<br/>with correct mW values"]
  B -- "25, 200, 500, 1000, 3000" --> C["Accurate power levels"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vtx_smartaudio.c</strong><dd><code>Correct SmartAudio power level names array</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/io/vtx_smartaudio.c

<ul><li>Removed "----" placeholder from the first power level entry<br> <li> Updated power level names to reflect actual milliwatt values (25, 200, <br>500, 1000, 3000)<br> <li> Adjusted spacing in power name strings for consistency<br> <li> Corrected the default power names array to match SmartAudio 2.1 device <br>specifications</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11285/files#diff-8a213843773adccbed4197a4e66e8faacd6ba388205446828ea864ef82faf785">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

