### PR TITLE
Fix STM32H7 DFU mode entry via CLI command

### DIFF
--- a/src/main/drivers/system_stm32h7xx.c
+++ b/src/main/drivers/system_stm32h7xx.c
@@ -62,8 +62,6 @@ uint32_t systemBootloaderAddress(void)
 
 void systemInit(void)
 {
-    checkForBootLoaderRequest();
-
     // Configure NVIC preempt/priority groups
     HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITY_GROUPING);
 

--- a/src/main/target/system_stm32h7xx.c
+++ b/src/main/target/system_stm32h7xx.c
@@ -584,6 +584,9 @@ void SystemInit (void)
 
     initialiseMemorySections();
 
+    // Check for bootloader request BEFORE any clock/peripheral configuration
+    checkForBootLoaderRequest();
+
     // FPU settings
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
     SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  // Set CP10 and CP11 Full Access


### PR DESCRIPTION
### **User description**
## Summary

Fixes the CLI `dfu` command on STM32H743/H750 targets. Previously, the command would reboot the board but it would return as a VCP device instead of entering DFU mode for firmware flashing.

**Root cause:** The bootloader request check was happening too late in the boot sequence (after clock and peripheral initialization). The H7 ROM bootloader requires the RTC backup register check to occur before any system configuration happens.

**Solution:** moved checkForBootLoaderRequest from src/main/drivers/system_stm32h7xx.c  to src/main/target/system_stm32h7xx.c (CMSIS startup, before any hardware initialization). Also enable SYSCFG clock before jumping to bootloader.

## Changes

- **src/main/target/system_stm32h7xx.c:** Added early bootloader check in `SystemInit()` before any clock configuration
- **src/main/drivers/system_stm32h7xx.c:** Removed late bootloader check from `systemInit()`  
- **src/main/drivers/system.c:** Added H7-specific bootloader jump code with SYSCFG clock enablement (properly gated with `#if defined(STM32H7)`)

## Platform Impact

**H7-specific only.** All changes are either in H7-specific files or properly gated with `#if defined(STM32H7)` in shared files. F4/F7/AT32 platforms are completely unaffected.

## Testing

- **Target:** DAKEFPVH743PRO
- **Test:** CLI `dfu` command
- **Result:** ✅ Successfully enters DFU mode (tested with dfu-util)
- **Versions affected:** This issue existed in 7.1.2, 8.0.0, and 9.0.0 (not a regression, never worked on H7)

## Test Plan

- [x] Tested on H743 hardware - DFU entry works
- [x] Verified F4/F7/AT32 code paths unchanged
- [x] Confirmed all changes are H7-specific or properly gated
- [x] Built and tested firmware successfully


___

### **PR Type**
Bug fix


___

### **Description**
- Move bootloader check to early SystemInit() before clock configuration

- Enable SYSCFG clock before jumping to H7 bootloader

- Add H7-specific bootloader jump code with proper gating

- Remove late bootloader check from systemInit() driver function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Boot sequence"] --> B["SystemInit CMSIS startup"]
  B --> C["checkForBootLoaderRequest early"]
  C --> D{"Bootloader request?"}
  D -->|Yes H7| E["Enable SYSCFG clock"]
  E --> F["Jump to bootloader"]
  D -->|No| G["Continue normal boot"]
  D -->|Yes F4/F7| H["Jump to bootloader"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system.c</strong><dd><code>Add H7-specific bootloader jump with SYSCFG clock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/system.c

<ul><li>Added H7-specific bootloader jump code with <br><code>__HAL_RCC_SYSCFG_CLK_ENABLE()</code> call<br> <li> Wrapped H7 bootloader logic with <code>#if defined(STM32H7)</code> preprocessor <br>guard<br> <li> Maintained F4/F7 bootloader jump code in else branch<br> <li> Added comments clarifying reset reason clearing and bootloader jump <br>steps</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11295/files#diff-a57500220a9c96e78829728879bff387066fa5a80df414a26cdad0c54d555f43">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>system_stm32h7xx.c</strong><dd><code>Remove late bootloader check from systemInit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/system_stm32h7xx.c

<ul><li>Removed <code>checkForBootLoaderRequest()</code> call from <code>systemInit()</code> function<br> <li> This call is now performed earlier in <code>SystemInit()</code> before clock <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11295/files#diff-1b39f58923e913512fda3b54dd5309966f64689f44e4ba3437d4342050747af9">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>system_stm32h7xx.c</strong><dd><code>Add early bootloader check in SystemInit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/system_stm32h7xx.c

<ul><li>Added early <code>checkForBootLoaderRequest()</code> call in <code>SystemInit()</code> CMSIS <br>startup function<br> <li> Positioned before FPU configuration and any clock/peripheral <br>initialization<br> <li> Added comment explaining the early check requirement for H7 ROM <br>bootloader</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11295/files#diff-695c2ef373e1f066549eb495e623018e2c1986c1bd52156f872e884e12501ed9">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

