### PR TITLE
Rename profile commands to control_profile

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -27,17 +27,17 @@ Disconnect main power, connect to cli via USB/FTDI.
 dump using cli
 
 ```
-profile 0
+control_profile 0
 dump
 ```
 
-dump profiles using cli if you use them
+dump control_profiles using cli if you use them
 
 ```
-profile 1
-dump profile
-profile 2
-dump profile
+control_profile 1
+dump control_profile
+control_profile 2
+dump control_profile
 ```
 
 copy screen output to a file and save it.
@@ -100,7 +100,7 @@ While connected to the CLI, all Logical Switches are temporarily disabled (5.1.0
 | `osd_layout` | Get or set the layout of OSD items |
 | `pid` | Configurable PID controllers |
 | `play_sound` | `<index>`, or none for next item |
-| `profile` | Change profile |
+| `control_profile` | Change profile |
 | `resource` | View currently used resources |
 | `rxrange` | Configure rx channel ranges |
 | `safehome` | Define safe home locations. See the [safehome documentation](Safehomes.md) for usage information. |


### PR DESCRIPTION
### **User description**
Update CLI.md as it still referenced the old `profile`.

Fixes #11301


___

### **PR Type**
Documentation


___

### **Description**
- Update CLI documentation to reflect renamed profile commands

- Replace all `profile` command references with `control_profile`

- Update command examples and descriptions in CLI.md


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI.md Documentation"] -- "Replace profile with control_profile" --> B["Updated Command References"]
  B -- "Examples" --> C["control_profile 0, 1, 2"]
  B -- "Command Table" --> D["control_profile entry"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cli.md</strong><dd><code>Rename profile commands to control_profile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Cli.md

<ul><li>Renamed all <code>profile</code> command references to <code>control_profile</code> throughout <br>the file<br> <li> Updated command examples showing profile switching (0, 1, 2) to use <br>new command name<br> <li> Updated command table entry description from <code>profile</code> to <br><code>control_profile</code><br> <li> Updated descriptive text mentioning "dump profiles" to "dump <br>control_profiles"</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11302/files#diff-1db191b5e32dace6ccb3ee09d1e51ae3f61c483ea30cb97167867f791865cceb">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

