### PR TITLE
Fix DShot beeper arming feedback loop

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -595,7 +595,10 @@ void tryArm(void)
     }
 
     if (!ARMING_FLAG(ARMED)) {
-        beeperConfirmationBeeps(1);
+        // Only beep if blocked by something other than DShot beeper guard delay to avoid feedback loop
+        if (armingFlags & ~ARMING_DISABLED_DSHOT_BEEPER) {
+            beeperConfirmationBeeps(1);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a feedback loop where the DShot beeper feature prevents arming indefinitely when enabled. When arming fails, the FC plays a confirmation beep using DShot. This sets a guard delay (1.12 seconds) that blocks arming to comply with DShot protocol timing. If the user attempts to arm again within this period, it fails due to ARMING_DISABLED_DSHOT_BEEPER and beeps again, resetting the timer and creating an infinite loop.

## Changes

- Modified `src/main/fc/fc_core.c` line 599
- Added conditional check: only beep if `(armingFlags & ~ARMING_DISABLED_DSHOT_BEEPER)`
- Prevents beeping when the ONLY arming blocker is the DShot beeper guard delay itself
- Preserves all useful audio feedback for GPS, calibration, RC link, and other legitimate arming issues

## Root Cause

The guard delay is necessary and correct per DShot protocol specification (beep duration + transmission time + minimum spacing = 1.12s). However, beeping to notify the user "you can't arm because I just beeped" provides no value and triggers the loop.

## Testing

- ✅ Built SITL target successfully - compiles with no errors
- ✅ Test script created: `claude/developer/scripts/testing/inav/dshot/test_dshot_beeper_arming_loop_fix.py`
- ✅ Test coverage: 4 scenarios validating fix breaks loop while preserving normal beeping
- ✅ Code review performed with inav-code-review agent - no critical issues

**Logical verification confirms:**
1. Arming failure beeps when blocked by GPS, calibration, RC, etc. (preserved)
2. No beep when blocked ONLY by DShot beeper guard delay (prevents loop)
3. Guard delay expires naturally without being reset (loop broken)
4. DShot beeper works normally for lost aircraft locating (unchanged)

## Impact

Fixes user reports of continuous motor beeping and inability to arm when DShot beeper is enabled. Risk is low - the change is narrowly scoped to prevent only the specific beep that causes the loop.