### PR TITLE
Multifunction add battery voltage warnings

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3092,16 +3092,6 @@ Mask of RX channels that may be overridden by MSP `SET_RAW_RC`. Note that this r
 
 ---
 
-### multifunction_warning_cycle_time
-
-Cycle time for display of full multifunction warning messages [s]. Full warnings will be displayed for 5s on a rolling cycle using this setting with only the total number of warnings indicated otherwise. Warnings will always be displayed in full if set to 0.
-
-| Default | Min | Max |
-| --- | --- | --- |
-| 5 | 0 | 60 |
-
----
-
 ### name
 
 Craft name

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3098,7 +3098,7 @@ Cycle time for display of full multifunction warning messages [s]. Full warnings
 
 | Default | Min | Max |
 | --- | --- | --- |
-| 30 | 0 | 60 |
+| 5 | 0 | 60 |
 
 ---
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3092,6 +3092,16 @@ Mask of RX channels that may be overridden by MSP `SET_RAW_RC`. Note that this r
 
 ---
 
+### multifunction_warning_cycle_time
+
+Cycle time for display of full multifunction warning messages [s]. Full warnings will be displayed for 5s on a rolling cycle using this setting with only the total number of warnings indicated otherwise. Warnings will always be displayed in full if set to 0.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 30 | 0 | 60 |
+
+---
+
 ### name
 
 Craft name

--- a/src/main/fc/multifunction.c
+++ b/src/main/fc/multifunction.c
@@ -45,32 +45,29 @@ static void multiFunctionApply(multi_function_e selectedItem)
     switch (selectedItem) {
     case MULTI_FUNC_NONE:
         break;
-    case MULTI_FUNC_1:  // redisplay current warnings
-        osdResetWarningFlags();
-        break;
-    case MULTI_FUNC_2:  // control manual emergency landing
+    case MULTI_FUNC_1:  // control manual emergency landing
         checkManualEmergencyLandingControl(ARMING_FLAG(ARMED));
         break;
-    case MULTI_FUNC_3:  // toggle Safehome suspend
+    case MULTI_FUNC_2:  // toggle Safehome suspend
 #if defined(USE_SAFE_HOME)
         if (navConfig()->general.flags.safehome_usage_mode != SAFEHOME_USAGE_OFF) {
             MULTI_FUNC_FLAG(MF_SUSPEND_SAFEHOMES) ? MULTI_FUNC_FLAG_DISABLE(MF_SUSPEND_SAFEHOMES) : MULTI_FUNC_FLAG_ENABLE(MF_SUSPEND_SAFEHOMES);
         }
 #endif
         break;
-    case MULTI_FUNC_4:  // toggle RTH Trackback suspend
+    case MULTI_FUNC_3:  // toggle RTH Trackback suspend
         if (navConfig()->general.flags.rth_trackback_mode != RTH_TRACKBACK_OFF) {
             MULTI_FUNC_FLAG(MF_SUSPEND_TRACKBACK) ? MULTI_FUNC_FLAG_DISABLE(MF_SUSPEND_TRACKBACK) : MULTI_FUNC_FLAG_ENABLE(MF_SUSPEND_TRACKBACK);
         }
         break;
-    case MULTI_FUNC_5:
+    case MULTI_FUNC_4:
 #ifdef USE_DSHOT
         if (STATE(MULTIROTOR)) {    // toggle Turtle mode
             MULTI_FUNC_FLAG(MF_TURTLE_MODE) ? MULTI_FUNC_FLAG_DISABLE(MF_TURTLE_MODE) : MULTI_FUNC_FLAG_ENABLE(MF_TURTLE_MODE);
         }
 #endif
         break;
-    case MULTI_FUNC_6:  // emergency ARM
+    case MULTI_FUNC_5:  // emergency ARM
         if (!ARMING_FLAG(ARMED)) {
             emergencyArmingUpdate(true, true);
         }

--- a/src/main/fc/multifunction.h
+++ b/src/main/fc/multifunction.h
@@ -26,6 +26,13 @@
 
 #include <stdbool.h>
 
+typedef struct multiFunctionWarning_s {
+    uint8_t osdWarningsFlags;  // bitfield
+    bool newWarningActive;
+} multiFunctionWarning_t;
+
+extern multiFunctionWarning_t multiFunctionWarning;
+
 #ifdef USE_MULTI_FUNCTIONS
 
 extern uint8_t multiFunctionFlags;
@@ -47,7 +54,6 @@ typedef enum {
     MULTI_FUNC_3,
     MULTI_FUNC_4,
     MULTI_FUNC_5,
-    MULTI_FUNC_6,
     MULTI_FUNC_END,
 } multi_function_e;
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3909,7 +3909,7 @@ groups:
         field: multifunction_warning_cycle_time
         min: 0
         max: 60
-        default_value: 30
+        default_value: 5
 
   - name: PG_OSD_COMMON_CONFIG
     type: osdCommonConfig_t

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3904,6 +3904,13 @@ groups:
         field: osd_switch_indicators_align_left
         type: bool
         default_value: ON
+      - name: multifunction_warning_cycle_time
+        description: "Cycle time for display of full multifunction warning messages [s]. Full warnings will be displayed for 5s on a rolling cycle using this setting with only the total number of warnings indicated otherwise. Warnings will always be displayed in full if set to 0."
+        field: multifunction_warning_cycle_time
+        min: 0
+        max: 60
+        default_value: 30
+
   - name: PG_OSD_COMMON_CONFIG
     type: osdCommonConfig_t
     headers: ["io/osd_common.h"]

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3904,12 +3904,6 @@ groups:
         field: osd_switch_indicators_align_left
         type: bool
         default_value: ON
-      - name: multifunction_warning_cycle_time
-        description: "Cycle time for display of full multifunction warning messages [s]. Full warnings will be displayed for 5s on a rolling cycle using this setting with only the total number of warnings indicated otherwise. Warnings will always be displayed in full if set to 0."
-        field: multifunction_warning_cycle_time
-        min: 0
-        max: 60
-        default_value: 5
 
   - name: PG_OSD_COMMON_CONFIG
     type: osdCommonConfig_t

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -6603,7 +6603,6 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
     if (messageCount) {
         message = messages[OSD_ALTERNATING_CHOICES(1000, messageCount)];    // display each warning on 1s cycle
         strcpy(buff, message);
-        TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
     } else if (warningsCount) {
         buff[0] = SYM_ALERT;
         tfp_sprintf(buff + 1, "%u        ", warningsCount);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -203,8 +203,9 @@ static bool fullRedraw = false;
 
 static uint8_t armState;
 
+// Multifunction
 static textAttributes_t osdGetMultiFunctionMessage(char *buff);
-static uint8_t osdWarningsFlags = 0;
+multiFunctionWarning_t multiFunctionWarning;
 
 typedef struct osdMapData_s {
     uint32_t scale;
@@ -4355,7 +4356,6 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .use_pilot_logo = SETTING_OSD_USE_PILOT_LOGO_DEFAULT,
     .inav_to_pilot_logo_spacing = SETTING_OSD_INAV_TO_PILOT_LOGO_SPACING_DEFAULT,
     .arm_screen_display_time = SETTING_OSD_ARM_SCREEN_DISPLAY_TIME_DEFAULT,
-    .multifunction_warning_cycle_time = SETTING_MULTIFUNCTION_WARNING_CYCLE_TIME_DEFAULT,
 
 #ifdef USE_WIND_ESTIMATOR
     .estimations_wind_compensation = SETTING_OSD_ESTIMATIONS_WIND_COMPENSATION_DEFAULT,
@@ -6406,49 +6406,35 @@ textAttributes_t osdGetSystemMessage(char *buff, size_t buff_size, bool isCenter
     return elemAttr;
 }
 
-void osdResetWarningFlags(void)
+static bool osdCheckWarning(bool condition, uint8_t warningFlag)
 {
-    osdWarningsFlags = 0;
-}
-
-static bool osdCheckWarning(bool condition, uint8_t warningFlag, uint8_t *warningsCount)
-{
-#define WARNING_REDISPLAY_DURATION 5000;    // milliseconds
-
+    static timeMs_t newWarningEndTime = 0;
+    static uint8_t newWarningFlags = 0;  // bitfield
     const timeMs_t currentTimeMs = millis();
-    static timeMs_t warningDisplayStartTime = 0;
-    static timeMs_t redisplayStartTimeMs = 0;
-    static uint16_t osdWarningTimerDuration;
-    static uint8_t newWarningFlags;
 
+    /* New warnings dislayed individually for 10s with blinking after which
+     * all current warnings displayed without blinking on 1 second cycle */
     if (condition) {    // condition required to trigger warning
-        if (!(osdWarningsFlags & warningFlag)) {
-            osdWarningsFlags |= warningFlag;
+        if (!(multiFunctionWarning.osdWarningsFlags & warningFlag)) {  // check for new warnings
+            multiFunctionWarning.osdWarningsFlags |= warningFlag;
             newWarningFlags |= warningFlag;
-            redisplayStartTimeMs = 0;
+            newWarningEndTime = currentTimeMs + 10000;
+            multiFunctionWarning.newWarningActive = true;
         }
 #ifdef USE_DEV_TOOLS
         if (systemConfig()->groundTestMode) {
             return true;
         }
 #endif
-        /* Warnings displayed in full for set time before shrinking down to alert symbol with warning count only.
-         * All current warnings are redisplayed in full for 5s on a rolling cycle with time set by multifunction_warning_cycle_time.
-         * New warnings dislayed individually for 10s */
-        if (currentTimeMs > redisplayStartTimeMs) {
-            warningDisplayStartTime = currentTimeMs;
-            osdWarningTimerDuration = newWarningFlags ? 10000 : WARNING_REDISPLAY_DURATION;
-            redisplayStartTimeMs = currentTimeMs + osdWarningTimerDuration + S2MS(osdConfig()->multifunction_warning_cycle_time);
-        }
-
-        if (currentTimeMs - warningDisplayStartTime < osdWarningTimerDuration) {
-            return (newWarningFlags & warningFlag) || osdWarningTimerDuration == WARNING_REDISPLAY_DURATION;
+        if (currentTimeMs < newWarningEndTime) {
+            return (newWarningFlags & warningFlag);  // filter out new warnings excluding older warnings
         } else {
             newWarningFlags = 0;
+            multiFunctionWarning.newWarningActive = false;
         }
-        *warningsCount += 1;
-    } else if (osdWarningsFlags & warningFlag) {
-        osdWarningsFlags &= ~warningFlag;
+        return true;
+    } else if (multiFunctionWarning.osdWarningsFlags & warningFlag) {
+        multiFunctionWarning.osdWarningsFlags &= ~warningFlag;
     }
 
     return false;
@@ -6459,7 +6445,6 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
     /* Message length limit 10 char max */
 
     textAttributes_t elemAttr = TEXT_ATTRIBUTES_NONE;
-    static uint8_t warningsCount;
     const char *message = NULL;
 
 #ifdef USE_MULTI_FUNCTIONS
@@ -6472,12 +6457,9 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
         switch (selectedFunction) {
         case MULTI_FUNC_NONE:
         case MULTI_FUNC_1:
-            message = warningsCount ? "WARNINGS !" : "0 WARNINGS";
-            break;
-        case MULTI_FUNC_2:
             message = posControl.flags.manualEmergLandActive ? "ABORT LAND" : "EMERG LAND";
             break;
-        case MULTI_FUNC_3:
+        case MULTI_FUNC_2:
 #if defined(USE_SAFE_HOME)
             if (navConfig()->general.flags.safehome_usage_mode != SAFEHOME_USAGE_OFF) {
                 message = MULTI_FUNC_FLAG(MF_SUSPEND_SAFEHOMES) ? "USE SFHOME" : "SUS SFHOME";
@@ -6486,14 +6468,14 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
 #endif
             activeFunction++;
             FALLTHROUGH;
-        case MULTI_FUNC_4:
+        case MULTI_FUNC_3:
             if (navConfig()->general.flags.rth_trackback_mode != RTH_TRACKBACK_OFF) {
                 message = MULTI_FUNC_FLAG(MF_SUSPEND_TRACKBACK) ? "USE TKBACK" : "SUS TKBACK";
                 break;
             }
             activeFunction++;
             FALLTHROUGH;
-        case MULTI_FUNC_5:
+        case MULTI_FUNC_4:
 #ifdef USE_DSHOT
             if (STATE(MULTIROTOR)) {
                 message = MULTI_FUNC_FLAG(MF_TURTLE_MODE) ? "END TURTLE" : "USE TURTLE";
@@ -6502,7 +6484,7 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
 #endif
             activeFunction++;
             FALLTHROUGH;
-        case MULTI_FUNC_6:
+        case MULTI_FUNC_5:
             message = ARMING_FLAG(ARMED) ? "NOW ARMED " : "EMERG ARM ";
             break;
         case MULTI_FUNC_END:
@@ -6528,13 +6510,12 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
     const char *messages[8];
     uint8_t messageCount = 0;
     bool warningCondition = false;
-    warningsCount = 0;
     uint8_t warningFlagID = 1;
 
     // Low Battery Voltage
     const batteryState_e batteryVoltageState = checkBatteryVoltageState();
     warningCondition = batteryVoltageState == BATTERY_CRITICAL || batteryVoltageState == BATTERY_WARNING;
-    if (osdCheckWarning(warningCondition, warningFlagID, &warningsCount)) {
+    if (osdCheckWarning(warningCondition, warningFlagID)) {
         messages[messageCount++] = batteryVoltageState == BATTERY_CRITICAL ? "VBATT LAND" : "VBATT LOW ";
     }
 
@@ -6542,14 +6523,14 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
     if (batteryUsesCapacityThresholds()) {
         const batteryState_e batteryState = getBatteryState();
         warningCondition = batteryState == BATTERY_CRITICAL || batteryState == BATTERY_WARNING;
-        if (osdCheckWarning(warningCondition, warningFlagID <<= 1, &warningsCount)) {
+        if (osdCheckWarning(warningCondition, warningFlagID <<= 1)) {
             messages[messageCount++] = batteryState == BATTERY_CRITICAL ? "BATT EMPTY" : "BATT DYING";
         }
     }
 #if defined(USE_GPS)
     // GPS Fix and Failure
     if (feature(FEATURE_GPS)) {
-        if (osdCheckWarning(!STATE(GPS_FIX), warningFlagID <<= 1, &warningsCount)) {
+        if (osdCheckWarning(!STATE(GPS_FIX), warningFlagID <<= 1)) {
             bool gpsFailed = getHwGPSStatus() == HW_SENSOR_UNAVAILABLE;
             messages[messageCount++] = gpsFailed ? "GPS FAILED" : "NO GPS FIX";
         }
@@ -6558,12 +6539,12 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
     // RTH sanity (warning if RTH heads 200m further away from home than closest point)
     warningCondition = NAV_Status.state == MW_NAV_STATE_RTH_ENROUTE && !posControl.flags.rthTrackbackActive &&
                        (posControl.homeDistance - posControl.rthSanityChecker.minimalDistanceToHome) > 20000;
-    if (osdCheckWarning(warningCondition, warningFlagID <<= 1, &warningsCount)) {
+    if (osdCheckWarning(warningCondition, warningFlagID <<= 1)) {
         messages[messageCount++] = "RTH SANITY";
     }
 
     // Altitude sanity (warning if significant mismatch between estimated and GPS altitude)
-    if (osdCheckWarning(posControl.flags.gpsCfEstimatedAltitudeMismatch, warningFlagID <<= 1, &warningsCount)) {
+    if (osdCheckWarning(posControl.flags.gpsCfEstimatedAltitudeMismatch, warningFlagID <<= 1)) {
         messages[messageCount++] = "ALT SANITY";
     }
 #endif
@@ -6572,7 +6553,7 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
     // Magnetometer failure
     if (requestedSensors[SENSOR_INDEX_MAG] != MAG_NONE) {
         hardwareSensorStatus_e magStatus = getHwCompassStatus();
-        if (osdCheckWarning(magStatus == HW_SENSOR_UNAVAILABLE || magStatus == HW_SENSOR_UNHEALTHY, warningFlagID <<= 1, &warningsCount)) {
+        if (osdCheckWarning(magStatus == HW_SENSOR_UNAVAILABLE || magStatus == HW_SENSOR_UNHEALTHY, warningFlagID <<= 1)) {
             messages[messageCount++] = "MAG FAILED";
         }
     }
@@ -6581,7 +6562,7 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
 #if defined(USE_PITOT)
     // Pitot sensor validation failure (blocked/failed pitot tube)
     if (sensors(SENSOR_PITOT) && detectedSensors[SENSOR_INDEX_PITOT] != PITOT_VIRTUAL) {
-        if (osdCheckWarning(pitotHasFailed(), warningFlagID <<= 1, &warningsCount)) {
+        if (osdCheckWarning(pitotHasFailed(), warningFlagID <<= 1)) {
             messages[messageCount++] = "PITOT FAIL";
         }
     }
@@ -6595,7 +6576,7 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
     // }
 
 #ifdef USE_DEV_TOOLS
-    if (osdCheckWarning(systemConfig()->groundTestMode, warningFlagID <<= 1, &warningsCount)) {
+    if (osdCheckWarning(systemConfig()->groundTestMode, warningFlagID <<= 1)) {
         messages[messageCount++] = "GRD TEST !";
     }
 #endif
@@ -6603,9 +6584,9 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
     if (messageCount) {
         message = messages[OSD_ALTERNATING_CHOICES(1000, messageCount)];    // display each warning on 1s cycle
         strcpy(buff, message);
-    } else if (warningsCount) {
-        buff[0] = SYM_ALERT;
-        tfp_sprintf(buff + 1, "%u        ", warningsCount);
+        if (multiFunctionWarning.newWarningActive) {
+            TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
+        }
     }
 
     return elemAttr;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -6543,7 +6543,7 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
         const batteryState_e batteryState = getBatteryState();
         warningCondition = batteryState == BATTERY_CRITICAL || batteryState == BATTERY_WARNING;
         if (osdCheckWarning(warningCondition, warningFlagID <<= 1, &warningsCount)) {
-            messages[messageCount++] = batteryState == BATTERY_CRITICAL ? "BATT EMPTY" : "BATT LOW  ";
+            messages[messageCount++] = batteryState == BATTERY_CRITICAL ? "BATT EMPTY" : "BATT DYING";
         }
     }
 #if defined(USE_GPS)

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -4355,6 +4355,7 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .use_pilot_logo = SETTING_OSD_USE_PILOT_LOGO_DEFAULT,
     .inav_to_pilot_logo_spacing = SETTING_OSD_INAV_TO_PILOT_LOGO_SPACING_DEFAULT,
     .arm_screen_display_time = SETTING_OSD_ARM_SCREEN_DISPLAY_TIME_DEFAULT,
+    .multifunction_warning_cycle_time = SETTING_MULTIFUNCTION_WARNING_CYCLE_TIME_DEFAULT,
 
 #ifdef USE_WIND_ESTIMATOR
     .estimations_wind_compensation = SETTING_OSD_ESTIMATIONS_WIND_COMPENSATION_DEFAULT,
@@ -6432,12 +6433,12 @@ static bool osdCheckWarning(bool condition, uint8_t warningFlag, uint8_t *warnin
         }
 #endif
         /* Warnings displayed in full for set time before shrinking down to alert symbol with warning count only.
-         * All current warnings then redisplayed for 5s on 30s rolling cycle.
+         * All current warnings are redisplayed in full for 5s on a rolling cycle with time set by multifunction_warning_cycle_time.
          * New warnings dislayed individually for 10s */
         if (currentTimeMs > redisplayStartTimeMs) {
             warningDisplayStartTime = currentTimeMs;
             osdWarningTimerDuration = newWarningFlags ? 10000 : WARNING_REDISPLAY_DURATION;
-            redisplayStartTimeMs = currentTimeMs + osdWarningTimerDuration + 30000;
+            redisplayStartTimeMs = currentTimeMs + osdWarningTimerDuration + S2MS(osdConfig()->multifunction_warning_cycle_time);
         }
 
         if (currentTimeMs - warningDisplayStartTime < osdWarningTimerDuration) {
@@ -6524,13 +6525,20 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
 #endif  // MULTIFUNCTION - functions only, warnings always defined
 
     /* --- WARNINGS --- */
-    const char *messages[7];
+    const char *messages[8];
     uint8_t messageCount = 0;
     bool warningCondition = false;
     warningsCount = 0;
     uint8_t warningFlagID = 1;
 
-    // Low Battery
+    // Low Battery Voltage
+    const batteryState_e batteryVoltageState = checkBatteryVoltageState();
+    warningCondition = batteryVoltageState == BATTERY_CRITICAL || batteryVoltageState == BATTERY_WARNING;
+    if (osdCheckWarning(warningCondition, warningFlagID, &warningsCount)) {
+        messages[messageCount++] = batteryVoltageState == BATTERY_CRITICAL ? "VBATT CRIT" : "VBATT LOW ";
+    }
+
+    // Low Battery Capacity
     const batteryState_e batteryState = getBatteryState();
     warningCondition = batteryState == BATTERY_CRITICAL || batteryState == BATTERY_WARNING;
     if (osdCheckWarning(warningCondition, warningFlagID, &warningsCount)) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -6535,16 +6535,17 @@ static textAttributes_t osdGetMultiFunctionMessage(char *buff)
     const batteryState_e batteryVoltageState = checkBatteryVoltageState();
     warningCondition = batteryVoltageState == BATTERY_CRITICAL || batteryVoltageState == BATTERY_WARNING;
     if (osdCheckWarning(warningCondition, warningFlagID, &warningsCount)) {
-        messages[messageCount++] = batteryVoltageState == BATTERY_CRITICAL ? "VBATT CRIT" : "VBATT LOW ";
+        messages[messageCount++] = batteryVoltageState == BATTERY_CRITICAL ? "VBATT LAND" : "VBATT LOW ";
     }
 
     // Low Battery Capacity
-    const batteryState_e batteryState = getBatteryState();
-    warningCondition = batteryState == BATTERY_CRITICAL || batteryState == BATTERY_WARNING;
-    if (osdCheckWarning(warningCondition, warningFlagID, &warningsCount)) {
-        messages[messageCount++] = batteryState == BATTERY_CRITICAL ? "BATT EMPTY" : "BATT LOW !";
+    if (batteryUsesCapacityThresholds()) {
+        const batteryState_e batteryState = getBatteryState();
+        warningCondition = batteryState == BATTERY_CRITICAL || batteryState == BATTERY_WARNING;
+        if (osdCheckWarning(warningCondition, warningFlagID <<= 1, &warningsCount)) {
+            messages[messageCount++] = batteryState == BATTERY_CRITICAL ? "BATT EMPTY" : "BATT LOW  ";
+        }
     }
-
 #if defined(USE_GPS)
     // GPS Fix and Failure
     if (feature(FEATURE_GPS)) {

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -525,7 +525,6 @@ typedef struct osdConfig_s {
     bool            use_pilot_logo;                     // If enabled, the pilot logo (last 40 characters of page 2 font) will be used with the INAV logo.
     uint8_t         inav_to_pilot_logo_spacing;         // The space between the INAV and pilot logos, if pilot logo is used. This number may be adjusted so that it fits the odd/even col width.
     uint16_t        arm_screen_display_time;            // Length of time the arm screen is displayed
-    uint8_t         multifunction_warning_cycle_time;   // Cycle time for display of full multifunction warning messages (s)
 #ifndef DISABLE_MSP_DJI_COMPAT
     bool            highlight_djis_missing_characters;  // If enabled, show question marks where there is no character in DJI's font to represent an OSD element symbol
 #endif
@@ -585,8 +584,6 @@ void osdFormatAltitudeSymbol(char *buff, int32_t alt);
 int osdFormatVelocityStr(char* buff, int32_t vel, osd_SpeedTypes_e speedType, bool _max);
 // Returns a heading angle in degrees normalized to [0, 360).
 int osdGetHeadingAngle(int angle);
-
-void osdResetWarningFlags(void);
 
 int16_t osdGetPanServoOffset(void);
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -525,6 +525,7 @@ typedef struct osdConfig_s {
     bool            use_pilot_logo;                     // If enabled, the pilot logo (last 40 characters of page 2 font) will be used with the INAV logo.
     uint8_t         inav_to_pilot_logo_spacing;         // The space between the INAV and pilot logos, if pilot logo is used. This number may be adjusted so that it fits the odd/even col width.
     uint16_t        arm_screen_display_time;            // Length of time the arm screen is displayed
+    uint8_t         multifunction_warning_cycle_time;   // Cycle time for display of full multifunction warning messages (s)
 #ifndef DISABLE_MSP_DJI_COMPAT
     bool            highlight_djis_missing_characters;  // If enabled, show question marks where there is no character in DJI's font to represent an OSD element symbol
 #endif

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -288,7 +288,7 @@ static void updateBatteryVoltage(timeUs_t timeDelta, bool justConnected)
             }
             break;
 #endif
-        
+
 #if defined(USE_FAKE_BATT_SENSOR)
     case VOLTAGE_SENSOR_FAKE:
         vbat = fakeBattSensorGetVBat();
@@ -328,30 +328,32 @@ static void updateBatteryVoltage(timeUs_t timeDelta, bool justConnected)
 batteryState_e checkBatteryVoltageState(void)
 {
     uint16_t stateVoltage = getBatteryVoltage();
-    switch (batteryState)
+    static batteryState_e currentBatteryVoltageState = BATTERY_OK;
+
+    switch (currentBatteryVoltageState)
     {
         case BATTERY_OK:
             if (stateVoltage <= (batteryWarningVoltage - VBATT_HYSTERESIS)) {
-                return BATTERY_WARNING;
+                currentBatteryVoltageState = BATTERY_WARNING;
             }
             break;
         case BATTERY_WARNING:
             if (stateVoltage <= (batteryCriticalVoltage - VBATT_HYSTERESIS)) {
-                return BATTERY_CRITICAL;
+                currentBatteryVoltageState = BATTERY_CRITICAL;
             } else if (stateVoltage > (batteryWarningVoltage + VBATT_HYSTERESIS)){
-                return BATTERY_OK;
+                currentBatteryVoltageState = BATTERY_OK;
             }
             break;
         case BATTERY_CRITICAL:
             if (stateVoltage > (batteryCriticalVoltage + VBATT_HYSTERESIS)) {
-                return BATTERY_WARNING;
+                currentBatteryVoltageState = BATTERY_WARNING;
             }
             break;
         default:
             break;
     }
 
-    return batteryState;
+    return currentBatteryVoltageState;
 }
 
 static void checkBatteryCapacityState(void)


### PR DESCRIPTION
### **User description**
Adds battery voltage warning to Multifunction OSD element.

Also changes the warning display logic. The warnings now display constantly without blinking with the exception of new warnings which are displayed individually for 10s with blinking to highlight the fact it's a new warning. After the 10s all current warnings are displayed on a 1s cycle without blinking. The multifunction option to redisplay warnings has been removed as it's no longer needed.

Minor bug fixed causing inconsistency checking battery voltage status when battery capacity being used for battery status.

Should close https://github.com/iNavFlight/inav/issues/11259.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds battery voltage warning to multifunction OSD element

- Introduces configurable warning cycle time setting (0-60s)

- Separates voltage and capacity battery warnings for clarity

- Updates warning display logic to use configurable cycle time


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Battery Voltage State"] -->|Check voltage| B["VBATT CRIT/LOW Warning"]
  C["Multifunction Warning Cycle Time Setting"] -->|Configure display duration| D["Warning Redisplay Logic"]
  B -->|Display in full| E["Multifunction OSD Element"]
  D -->|Apply cycle time| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>osd.c</strong><dd><code>Implement voltage warning and configurable cycle time</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/io/osd.c

<ul><li>Added <code>multifunction_warning_cycle_time</code> field initialization in OSD <br>config reset template<br> <li> Updated warning redisplay logic to use configurable cycle time instead <br>of hardcoded 30s<br> <li> Added battery voltage state checking with separate VBATT CRIT/LOW <br>warnings<br> <li> Increased messages array size from 7 to 8 to accommodate new voltage <br>warning<br> <li> Updated comment to reflect dynamic warning cycle time behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11308/files#diff-a680ca1e23901579e9214c055509004e8b5c05e3f7281ed74ac1edfc38caabae">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>osd.h</strong><dd><code>Add warning cycle time configuration field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/io/osd.h

<ul><li>Added <code>multifunction_warning_cycle_time</code> field to <code>osdConfig_s</code> structure<br> <li> Field stores cycle time in seconds for multifunction warning display</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11308/files#diff-3068caba983519cf482ddaf6361cace17ccb3d2b198030058801555fedc0f502">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.yaml</strong><dd><code>Register warning cycle time in settings schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/fc/settings.yaml

<ul><li>Added <code>multifunction_warning_cycle_time</code> setting definition to OSD <br>settings group<br> <li> Configured with min value 0, max value 60, default value 30<br> <li> Included description explaining warning display behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11308/files#diff-4569ee6a30a1d30a1f5aeff4e218a1fbdc14e4373abdcece1af2160926e85f76">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Settings.md</strong><dd><code>Document multifunction warning cycle time setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Settings.md

<ul><li>Added documentation for <code>multifunction_warning_cycle_time</code> setting<br> <li> Documented default value of 30s with range 0-60s<br> <li> Explained behavior when set to 0 (always display warnings in full)</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11308/files#diff-ae20939faff30a268f1d311e9654bb2788d52d5ecdc9a897340914a5ca0c8b44">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

