### PR TITLE
Fix driver ranger finder terra ranger EVO

### DIFF
--- a/src/main/drivers/rangefinder/rangefinder_teraranger_evo.c
+++ b/src/main/drivers/rangefinder/rangefinder_teraranger_evo.c
@@ -62,12 +62,17 @@
 static struct {
     int32_t     teraRangerMeasurementCm;
     uint8_t     dataBuff[3];
-} teraRangerEvo = {};
+} teraRangerEvo = {
+    .teraRangerMeasurementCm = RANGEFINDER_NO_NEW_DATA,
+    .dataBuff = { 0 },
+};
 
-
+static void triggerNewReading(rangefinderDev_t *rangefinder){
+    busWrite(rangefinder->busDev, TERARANGER_EVO_I2C_REGISTRY_TRIGGER_READING, 0x00); //request to next measure, scheduler is much slower than 500uS to we need to wait between write and read
+}
 
 static void teraRangerInit(rangefinderDev_t *rangefinder){
-    busWrite(rangefinder->busDev, TERARANGER_EVO_I2C_REGISTRY_TRIGGER_READING, 0x00); //request measure to be data prepared for first call of teraRangerUpdate
+    triggerNewReading(rangefinder);
 }
 
 static bool deviceDetect(busDevice_t * busDev){
@@ -93,12 +98,14 @@ void teraRangerUpdate(rangefinderDev_t *rangefinder){
     if (busReadBuf(rangefinder->busDev, TERARANGER_EVO_I2C_REGISTRY_TRIGGER_READING, teraRangerEvo.dataBuff, 3)) {
         if (!checkCrc()) {
             teraRangerEvo.teraRangerMeasurementCm = RANGEFINDER_NO_NEW_DATA;
+            triggerNewReading(rangefinder);
             return;
         }
 
         const int32_t teraRangerMeasurementMM = ((int32_t)teraRangerEvo.dataBuff[0] << 8 | (int32_t)teraRangerEvo.dataBuff[1]);
         if (teraRangerMeasurementMM == TERARANGER_EVO_VALUE_TOO_CLOSE || teraRangerMeasurementMM == TERARANGER_EVO_VALUE_OUT_OF_RANGE) {
             teraRangerEvo.teraRangerMeasurementCm = RANGEFINDER_OUT_OF_RANGE;
+            triggerNewReading(rangefinder);
             return;
         }
 
@@ -107,7 +114,7 @@ void teraRangerUpdate(rangefinderDev_t *rangefinder){
         teraRangerEvo.teraRangerMeasurementCm = RANGEFINDER_HARDWARE_FAILURE;
     }
 
-    busWrite(rangefinder->busDev, TERARANGER_EVO_I2C_REGISTRY_TRIGGER_READING, 0x00); //request to next measure, scheduler is much slower than 500uS to we need to wait between write and read
+    triggerNewReading(rangefinder);
 }
 
 

--- a/src/main/drivers/rangefinder/rangefinder_teraranger_evo.c
+++ b/src/main/drivers/rangefinder/rangefinder_teraranger_evo.c
@@ -1,20 +1,26 @@
 /*
- * This file is part of Cleanflight.
+ * This file is part of INAV.
  *
- * Cleanflight is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Cleanflight is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -23,6 +29,9 @@
 #include "common/maths.h"
 
 #if defined(USE_RANGEFINDER) && defined(USE_RANGEFINDER_TERARANGER_EVO_I2C)
+
+//MANUAL
+//https://www.mouser.lt/datasheet/2/944/User_Manual_for_TeraRanger_Evo_single_point_distan-1729051.pdf?srsltid=AfmBOork4pNRMVMmnZ12zIk3yt79aeE066Hq5VpcBHv4wAnv-FSBLAKc
 
 #include "build/build_config.h"
 
@@ -49,42 +58,16 @@
 #define TERARANGER_EVO_VALUE_TOO_CLOSE                0x0000
 #define TERARANGER_EVO_VALUE_OUT_OF_RANGE             0xffff
 
-static      int16_t     minimumReadingIntervalMs = 50;
-            uint8_t     triggerValue[0];
-volatile    int32_t     teraRangerMeasurementCm;
-static      uint32_t    timeOfLastMeasurementMs;
-static      uint8_t     dataBuff[3];
+
+static struct {
+    int32_t     teraRangerMeasurementCm;
+    uint8_t     dataBuff[3];
+} teraRangerEvo = {};
+
+
 
 static void teraRangerInit(rangefinderDev_t *rangefinder){
-    busWriteBuf(rangefinder->busDev, TERARANGER_EVO_I2C_REGISTRY_TRIGGER_READING, triggerValue, 1);
-}
-
-void teraRangerUpdate(rangefinderDev_t *rangefinder){
-    if (busReadBuf(rangefinder->busDev, TERARANGER_EVO_I2C_REGISTRY_TRIGGER_READING, dataBuff, 3)) {
-        teraRangerMeasurementCm = MILLIMETERS_TO_CENTIMETERS(((int32_t)dataBuff[0] << 8 | (int32_t)dataBuff[1]));
-
-        if(dataBuff[2] == crc8_update(0, &dataBuff, 2)){
-            if (teraRangerMeasurementCm == TERARANGER_EVO_VALUE_TOO_CLOSE || teraRangerMeasurementCm == TERARANGER_EVO_VALUE_OUT_OF_RANGE) {
-                teraRangerMeasurementCm = RANGEFINDER_OUT_OF_RANGE;
-            }
-        }
-    } else {
-        teraRangerMeasurementCm = RANGEFINDER_HARDWARE_FAILURE;
-    }
-
-    const timeMs_t timeNowMs = millis();
-    if (timeNowMs > timeOfLastMeasurementMs + minimumReadingIntervalMs) {
-        // measurement repeat interval should be greater than minimumReadingIntervalMs
-        // to avoid interference between connective measurements.
-        timeOfLastMeasurementMs = timeNowMs;
-        busWriteBuf(rangefinder->busDev, TERARANGER_EVO_I2C_ADDRESS, triggerValue, 1);
-    }
-}
-
-
-int32_t teraRangerGetDistance(rangefinderDev_t *rangefinder){
-    UNUSED(rangefinder);
-    return teraRangerMeasurementCm;
+    busWrite(rangefinder->busDev, TERARANGER_EVO_I2C_REGISTRY_TRIGGER_READING, 0x00); //request measure to be data prepared for first call of teraRangerUpdate
 }
 
 static bool deviceDetect(busDevice_t * busDev){
@@ -100,6 +83,37 @@ static bool deviceDetect(busDevice_t * busDev){
     };
 
     return false;
+}
+
+static bool checkCrc(void){
+    return teraRangerEvo.dataBuff[2] == crc8_update(0, teraRangerEvo.dataBuff, 2);
+}
+
+void teraRangerUpdate(rangefinderDev_t *rangefinder){
+    if (busReadBuf(rangefinder->busDev, TERARANGER_EVO_I2C_REGISTRY_TRIGGER_READING, teraRangerEvo.dataBuff, 3)) {
+        if (!checkCrc()) {
+            teraRangerEvo.teraRangerMeasurementCm = RANGEFINDER_NO_NEW_DATA;
+            return;
+        }
+
+        const int32_t teraRangerMeasurementMM = ((int32_t)teraRangerEvo.dataBuff[0] << 8 | (int32_t)teraRangerEvo.dataBuff[1]);
+        if (teraRangerMeasurementMM == TERARANGER_EVO_VALUE_TOO_CLOSE || teraRangerMeasurementMM == TERARANGER_EVO_VALUE_OUT_OF_RANGE) {
+            teraRangerEvo.teraRangerMeasurementCm = RANGEFINDER_OUT_OF_RANGE;
+            return;
+        }
+
+        teraRangerEvo.teraRangerMeasurementCm = MILLIMETERS_TO_CENTIMETERS(teraRangerMeasurementMM);
+    } else {
+        teraRangerEvo.teraRangerMeasurementCm = RANGEFINDER_HARDWARE_FAILURE;
+    }
+
+    busWrite(rangefinder->busDev, TERARANGER_EVO_I2C_REGISTRY_TRIGGER_READING, 0x00); //request to next measure, scheduler is much slower than 500uS to we need to wait between write and read
+}
+
+
+int32_t teraRangerGetDistance(rangefinderDev_t *rangefinder){
+    UNUSED(rangefinder);
+    return teraRangerEvo.teraRangerMeasurementCm;
 }
 
 bool teraRangerDetect(rangefinderDev_t *rangefinder){


### PR DESCRIPTION
### **User description**
Fix driver for terra ranger EVo rangerfinder. 

See: https://github.com/iNavFlight/inav/issues/11310


___

### **PR Type**
Bug fix, New Target


___

### **Description**
- Fix TeraRanger Evo rangefinder driver with improved I2C communication
  - Refactored static variables into struct for better encapsulation
  - Fixed CRC validation logic and measurement timing
  - Corrected license header from Cleanflight to INAV

- Add CRSF frame length validation for MSP requests
  - Prevents buffer overflow by checking frame length before processing

- Add CoreWingF405WingV2 flight controller target
  - Complete target configuration with timer, sensor, and serial definitions

- Improve PG version check script for struct definitions in separate headers
  - Now correctly detects struct changes across companion .c and .h files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TeraRanger Evo Driver"] -->|Refactor variables| B["Static struct"]
  A -->|Fix CRC logic| C["Improved validation"]
  A -->|Fix timing| D["Correct I2C flow"]
  E["CRSF Handler"] -->|Add frame check| F["Length validation"]
  G["New Target"] -->|CoreWingF405WingV2| H["Timer & Sensor Config"]
  I["PG Check Script"] -->|Search companions| J["Struct detection"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rangefinder_teraranger_evo.c</strong><dd><code>Refactor TeraRanger Evo driver with improved I2C handling</code></dd></summary>
<hr>

src/main/drivers/rangefinder/rangefinder_teraranger_evo.c

<ul><li>Updated license header from Cleanflight to INAV/Mozilla Public License<br> <li> Refactored global variables into static struct <code>teraRangerEvo</code> for <br>encapsulation<br> <li> Extracted CRC validation into separate <code>checkCrc()</code> function<br> <li> Simplified <code>teraRangerInit()</code> to use <code>busWrite()</code> instead of <code>busWriteBuf()</code><br> <li> Restructured <code>teraRangerUpdate()</code> with early returns for error <br>conditions<br> <li> Fixed measurement timing by triggering next read after each update<br> <li> Added datasheet reference URL in comments</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11311/files#diff-6baf93ddb4a75831a5e0b64c1fd9c93e8b9e3158f5ef72c7314bf1aac299df81">+57/-43</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>crsf.c</strong><dd><code>Add CRSF frame length validation for MSP frames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/rx/crsf.c

<ul><li>Added frame length validation before processing MSP_REQ and MSP_WRITE <br>frames<br> <li> Checks that <code>frameLength >= 4</code> to prevent buffer overflow<br> <li> Sets <code>crsfFrameDone = false</code> for invalid frame lengths<br> <li> Prevents potential security issue from malformed CRSF packets</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11311/files#diff-d82859eb24a725305958143d71c15f877b0fe70dbbacc198c254974f20181fb1">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>target.h</strong><dd><code>Add CoreWingF405WingV2 target hardware definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/COREWINGF405WINGV2/target.h

<ul><li>New target header file with complete hardware definitions<br> <li> Defines board identifier <code>CW4W2</code> and product string<br> <li> Configures 6 UART ports, 3 SPI buses, and I2C interface<br> <li> Sets up IMU (ICM42605), barometer, magnetometer, and rangefinder <br>sensors<br> <li> Defines ADC channels for voltage, current, RSSI, and airspeed<br> <li> Configures LED strip, OSD, SD card, and other peripherals</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11311/files#diff-f8e25eb75c7c68bb318c15a4041272e2984eeaa4a7c0001a37202103df3b4f02">+174/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>target.c</strong><dd><code>Add CoreWingF405WingV2 timer and sensor configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/COREWINGF405WINGV2/target.c

<ul><li>New target implementation file with timer and sensor configuration<br> <li> Registers ICM42605 IMU on SPI1 with CW270 degree alignment<br> <li> Defines 11 PWM output channels using TIM2, TIM3, TIM4, TIM8, and TIM12<br> <li> Configures LED output on TIM1 and softserial on TIM5<br> <li> Sets up timer hardware mappings with DMA configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11311/files#diff-5432cd65733f28a11463bc6b127738d36ddea8d00a520795be46ef830a3d5565">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.c</strong><dd><code>Add CoreWingF405WingV2 serial and feature configuration</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/COREWINGF405WINGV2/config.c

<ul><li>New target configuration file with serial port and feature setup<br> <li> Assigns USART6 for RX serial, USART5 for GPS, USART1 for MSP<br> <li> Configures pinio box with USER1 permanent ID<br> <li> Provides target-specific initialization in <code>targetConfiguration()</code> <br>function</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11311/files#diff-0e349377a85abea99b1b003d9c0ece8602e837378eadd4b602c96c7fa1d064d9">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Add CoreWingF405WingV2 CMake build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/target/COREWINGF405WINGV2/CMakeLists.txt

<ul><li>New CMake build configuration file for CoreWingF405WingV2 target<br> <li> Specifies STM32F405XG microcontroller variant</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11311/files#diff-68188de20fac555e9e5faa7074e3f56d1b62790b8d767031f2c35f043b753fb0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check-pg-versions.sh</strong><dd><code>Improve PG version check for separate header files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/check-pg-versions.sh

<ul><li>Improved PG_REGISTER detection to check current version instead of <br>diff<br> <li> Enhanced struct definition search to check all changed files, not just <br>current file<br> <li> Added companion file detection (.c <-> .h) to find struct definitions in <br>headers<br> <li> Refined version increment validation with better error messages<br> <li> Improved handling of edge cases where struct and PG_REGISTER are in <br>different files<br> <li> Added detailed logging for struct location and version change <br>recommendations</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11311/files#diff-8686ee43d3ce6625192242c5571cb196e4b70ff35268cb44b9096698f97ca5bb">+81/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

