### PR TITLE
Comment 16 MSP commands as deprecated (for removal in INAV 10 or 11)

### DIFF
--- a/docs/development/msp/format.md
+++ b/docs/development/msp/format.md
@@ -40,6 +40,7 @@
 **variable_len**: Optional boolean, if true, message does not have a predefined fixed length and needs appropriate handling\
 **variants**: Optional special case, message has different cases of reply/request. Key/description is not a strict expression or code; just a readable condition\
 **not_implemented**: Optional special case, message is not implemented (never or deprecated)\
+**replaced_by**: Optional array of MSP message names that replace this command. Present when a command is deprecated and scheduled for removal. Empty array if no replacement is needed\
 **notes**: String with details of message
 
 ## Data dict fields:

--- a/docs/development/msp/msp_messages.json
+++ b/docs/development/msp/msp_messages.json
@@ -2362,6 +2362,7 @@
     "MSP_BLACKBOX_CONFIG": {
         "code": 80,
         "mspv": 1,
+        "replaced_by": ["MSP2_BLACKBOX_CONFIG"],
         "request": null,
         "reply": {
             "payload": [
@@ -2401,6 +2402,7 @@
     "MSP_SET_BLACKBOX_CONFIG": {
         "code": 81,
         "mspv": 1,
+        "replaced_by": ["MSP2_SET_BLACKBOX_CONFIG"],
         "not_implemented": true,
         "request": null,
         "reply": null,
@@ -3607,6 +3609,7 @@
     "MSP_STATUS": {
         "code": 101,
         "mspv": 1,
+        "replaced_by": ["MSP2_INAV_STATUS"],
         "request": null,
         "reply": {
             "payload": [
@@ -5817,6 +5820,7 @@
     "MSP_DEBUG": {
         "code": 254,
         "mspv": 1,
+        "replaced_by": ["MSP2_INAV_DEBUG"],
         "request": null,
         "reply": {
             "payload": [

--- a/docs/development/msp/msp_messages.json
+++ b/docs/development/msp/msp_messages.json
@@ -673,6 +673,7 @@
     "MSP_POSITION_ESTIMATION_CONFIG": {
         "code": 16,
         "mspv": 1,
+        "replaced_by": ["MSP2_COMMON_SETTING"],
         "request": null,
         "reply": {
             "payload": [
@@ -727,6 +728,7 @@
     "MSP_SET_POSITION_ESTIMATION_CONFIG": {
         "code": 17,
         "mspv": 1,
+        "replaced_by": ["MSP2_COMMON_SET_SETTING"],
         "request": {
             "payload": [
                 {
@@ -2426,6 +2428,7 @@
     "MSP_OSD_CONFIG": {
         "code": 84,
         "mspv": 1,
+        "replaced_by": ["MSP2_INAV_OSD_LAYOUTS", "MSP2_INAV_OSD_ALARMS", "MSP2_INAV_OSD_PREFERENCES"],
         "request": null,
         "reply": {
             "payload": [
@@ -2504,6 +2507,7 @@
     "MSP_SET_OSD_CONFIG": {
         "code": 85,
         "mspv": 1,
+        "replaced_by": ["MSP2_INAV_OSD_SET_LAYOUT_ITEM", "MSP2_INAV_OSD_SET_ALARMS", "MSP2_INAV_OSD_SET_PREFERENCES"],
         "request": null,
         "reply": null,
         "notes": "Requires `USE_OSD`. Distinguishes formats based on the first byte. Format 1 requires at least 10 bytes. Format 2 requires 3 bytes. Triggers an OSD redraw. See `MSP2_INAV_OSD_SET_*` for more advanced control.",
@@ -3134,6 +3138,7 @@
     "MSP_FILTER_CONFIG": {
         "code": 92,
         "mspv": 1,
+        "replaced_by": ["MSP2_COMMON_SETTING"],
         "request": null,
         "reply": {
             "payload": [
@@ -3217,6 +3222,7 @@
     "MSP_SET_FILTER_CONFIG": {
         "code": 93,
         "mspv": 1,
+        "replaced_by": ["MSP2_COMMON_SET_SETTING"],
         "request": {
             "payload": [
                 {
@@ -3293,6 +3299,7 @@
     "MSP_PID_ADVANCED": {
         "code": 94,
         "mspv": 1,
+        "replaced_by": ["MSP_INAV_PID"],
         "request": null,
         "reply": {
             "payload": [
@@ -3370,6 +3377,7 @@
     "MSP_SET_PID_ADVANCED": {
         "code": 95,
         "mspv": 1,
+        "replaced_by": ["MSP_SET_INAV_PID"],
         "request": {
             "payload": [
                 {
@@ -3914,6 +3922,7 @@
     "MSP_ANALOG": {
         "code": 110,
         "mspv": 1,
+        "replaced_by": ["MSP2_INAV_ANALOG"],
         "request": null,
         "reply": {
             "payload": [
@@ -4039,6 +4048,7 @@
     "MSP_MISC": {
         "code": 114,
         "mspv": 1,
+        "replaced_by": ["MSP2_INAV_MISC"],
         "request": null,
         "reply": {
             "payload": [
@@ -4168,6 +4178,7 @@
     "MSP_PIDNAMES": {
         "code": 117,
         "mspv": 1,
+        "replaced_by": [],
         "request": null,
         "reply": {
             "payload": [
@@ -5135,6 +5146,7 @@
     "MSP_SET_MISC": {
         "code": 207,
         "mspv": 1,
+        "replaced_by": ["MSP2_INAV_SET_MISC"],
         "request": {
             "payload": [
                 {
@@ -5588,6 +5600,7 @@
     "MSP_SERVO_MIX_RULES": {
         "code": 241,
         "mspv": 1,
+        "replaced_by": ["MSP2_INAV_SERVO_MIXER"],
         "request": null,
         "reply": {
             "payload": [
@@ -5644,6 +5657,7 @@
     "MSP_SET_SERVO_MIX_RULE": {
         "code": 242,
         "mspv": 1,
+        "replaced_by": ["MSP2_INAV_SET_SERVO_MIXER"],
         "request": {
             "payload": [
                 {

--- a/docs/development/msp/msp_messages.json
+++ b/docs/development/msp/msp_messages.json
@@ -4658,6 +4658,7 @@
     "MSP_STATUS_EX": {
         "code": 150,
         "mspv": 1,
+        "replaced_by": ["MSP2_INAV_STATUS"],
         "request": null,
         "reply": {
             "payload": [
@@ -4715,7 +4716,7 @@
                 }
             ]
         },
-        "notes": "Superseded by `MSP2_INAV_STATUS` which provides the full 32-bit `armingFlags` and other enhancements.",
+        "notes": "Superseded by `MSP2_INAV_STATUS` which provides the full 32-bit `armingFlags` and other enhancements. The `accCalibAxisFlags` field is not present in `MSP2_INAV_STATUS` but is available via `MSP_CALIBRATION_DATA`.",
         "description": "Provides extended flight controller status, including CPU load, arming flags, and calibration status, in addition to `MSP_STATUS` fields."
     },
     "MSP_SENSOR_STATUS": {

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -288,7 +288,7 @@
 #define MSP_V2_FRAME             255    //MSPv2 payload indicator
 
 // Additional commands that are not compatible with MultiWii
-#define MSP_STATUS_EX            150    //out message         cycletime, errors_count, CPU load, sensor present etc
+#define MSP_STATUS_EX            150    //DEPRECATED in INAV 9.1, use MSP2_INAV_STATUS (accCalibAxisFlags available via MSP_CALIBRATION_DATA). Will be removed in INAV 10.0
 #define MSP_SENSOR_STATUS        151    //out message         Hardware sensor status
 #define MSP_UID                  160    //out message         Unique device ID
 #define MSP_GPSSVINFO            164    //out message         get Signal Strength (only U-Blox)

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -183,8 +183,8 @@
 
 #define MSP_SDCARD_SUMMARY              79 //out message         Get the state of the SD card
 
-#define MSP_BLACKBOX_CONFIG             80 //out message         Get blackbox settings
-#define MSP_SET_BLACKBOX_CONFIG         81 //in message          Set blackbox settings
+#define MSP_BLACKBOX_CONFIG             80 //DEPRECATED in INAV 9.1, use MSP2_BLACKBOX_CONFIG. Will be removed in INAV 10.0
+#define MSP_SET_BLACKBOX_CONFIG         81 //DEPRECATED in INAV 9.1, use MSP2_SET_BLACKBOX_CONFIG. Will be removed in INAV 10.0
 
 #define MSP_TRANSPONDER_CONFIG          82 //out message         Get transponder settings
 #define MSP_SET_TRANSPONDER_CONFIG      83 //in message          Set transponder settings
@@ -231,7 +231,7 @@
 // Multwii original MSP commands
 //
 
-#define MSP_STATUS               101    //out message         cycletime & errors_count & sensor present & box activation & current setting number
+#define MSP_STATUS               101    //DEPRECATED in INAV 9.1, use MSP2_INAV_STATUS. Will be removed in INAV 10.0
 #define MSP_RAW_IMU              102    //out message         9 DOF
 #define MSP_SERVO                103    //out message         servos
 #define MSP_MOTOR                104    //out message         motors
@@ -284,7 +284,7 @@
 #define MSP_RESERVE_1            251    //reserved for system usage
 #define MSP_RESERVE_2            252    //reserved for system usage
 #define MSP_DEBUGMSG             253    //out message         debug string buffer
-#define MSP_DEBUG                254    //out message         debug1,debug2,debug3,debug4
+#define MSP_DEBUG                254    //DEPRECATED in INAV 9.1, use MSP2_INAV_DEBUG. Will be removed in INAV 10.0
 #define MSP_V2_FRAME             255    //MSPv2 payload indicator
 
 // Additional commands that are not compatible with MultiWii

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -204,8 +204,8 @@
 
 #define MSP_FILTER_CONFIG               92      //DEPRECATED in INAV 9.1 - use settings system instead. Will be removed in INAV 10.0
 #define MSP_SET_FILTER_CONFIG           93      //DEPRECATED in INAV 9.1 - use settings system instead. Will be removed in INAV 10.0
-#define MSP_PID_ADVANCED                94      //DEPRECATED in INAV 9.1 - use MSP_INAV_PID/MSP_SET_INAV_PID instead. Will be removed in INAV 10.0
-#define MSP_SET_PID_ADVANCED            95      //DEPRECATED in INAV 9.1 - use MSP_INAV_PID/MSP_SET_INAV_PID instead. Will be removed in INAV 10.0
+#define MSP_PID_ADVANCED                94      //DEPRECATED in INAV 9.1 - use MSP_INAV_PID instead. Will be removed in INAV 10.0
+#define MSP_SET_PID_ADVANCED            95      //DEPRECATED in INAV 9.1 - use MSP_SET_INAV_PID instead. Will be removed in INAV 10.0
 
 #define MSP_SENSOR_CONFIG               96
 #define MSP_SET_SENSOR_CONFIG           97

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -110,8 +110,8 @@
 #define MSP_CALIBRATION_DATA            14
 #define MSP_SET_CALIBRATION_DATA        15
 
-#define MSP_POSITION_ESTIMATION_CONFIG  16
-#define MSP_SET_POSITION_ESTIMATION_CONFIG  17
+#define MSP_POSITION_ESTIMATION_CONFIG  16      //DEPRECATED in INAV 9.1 - use settings system instead. Will be removed in INAV 10.0
+#define MSP_SET_POSITION_ESTIMATION_CONFIG  17  //DEPRECATED in INAV 9.1 - use settings system instead. Will be removed in INAV 10.0
 
 #define MSP_WP_MISSION_LOAD             18      // Load mission from NVRAM
 #define MSP_WP_MISSION_SAVE             19      // Save mission to NVRAM
@@ -189,8 +189,8 @@
 #define MSP_TRANSPONDER_CONFIG          82 //out message         Get transponder settings
 #define MSP_SET_TRANSPONDER_CONFIG      83 //in message          Set transponder settings
 
-#define MSP_OSD_CONFIG                  84 //out message         Get osd settings - betaflight
-#define MSP_SET_OSD_CONFIG              85 //in message          Set osd settings - betaflight
+#define MSP_OSD_CONFIG                  84 //DEPRECATED in INAV 9.1 - use MSP2_INAV_OSD_* instead. Will be removed in INAV 10.0
+#define MSP_SET_OSD_CONFIG              85 //DEPRECATED in INAV 9.1 - use MSP2_INAV_OSD_* instead. Will be removed in INAV 10.0
 
 #define MSP_OSD_CHAR_READ               86 //out message         Get osd settings - betaflight
 #define MSP_OSD_CHAR_WRITE              87 //in message          Set osd settings - betaflight
@@ -202,10 +202,10 @@
 #define MSP_ADVANCED_CONFIG             90
 #define MSP_SET_ADVANCED_CONFIG         91
 
-#define MSP_FILTER_CONFIG               92
-#define MSP_SET_FILTER_CONFIG           93
-#define MSP_PID_ADVANCED                94
-#define MSP_SET_PID_ADVANCED            95
+#define MSP_FILTER_CONFIG               92      //DEPRECATED in INAV 9.1 - use settings system instead. Will be removed in INAV 10.0
+#define MSP_SET_FILTER_CONFIG           93      //DEPRECATED in INAV 9.1 - use settings system instead. Will be removed in INAV 10.0
+#define MSP_PID_ADVANCED                94      //DEPRECATED in INAV 9.1 - use MSP_INAV_PID/MSP_SET_INAV_PID instead. Will be removed in INAV 10.0
+#define MSP_SET_PID_ADVANCED            95      //DEPRECATED in INAV 9.1 - use MSP_INAV_PID/MSP_SET_INAV_PID instead. Will be removed in INAV 10.0
 
 #define MSP_SENSOR_CONFIG               96
 #define MSP_SET_SENSOR_CONFIG           97
@@ -240,12 +240,12 @@
 #define MSP_COMP_GPS             107    //out message         distance home, direction home
 #define MSP_ATTITUDE             108    //out message         2 angles 1 heading
 #define MSP_ALTITUDE             109    //out message         altitude, variometer
-#define MSP_ANALOG               110    //out message         vbat, powermetersum, rssi if available on RX
+#define MSP_ANALOG               110    //DEPRECATED in INAV 9.1 - use MSP2_INAV_ANALOG instead. Will be removed in INAV 10.0
 #define MSP_RC_TUNING            111    //out message         rc rate, rc expo, rollpitch rate, yaw rate, dyn throttle PID
 #define MSP_ACTIVEBOXES          113    //out message         Active box flags (full width, more than 32 bits)
-#define MSP_MISC                 114    //out message         powermeter trig
+#define MSP_MISC                 114    //DEPRECATED in INAV 9.1 - use MSP2_INAV_MISC instead. Will be removed in INAV 10.0
 #define MSP_BOXNAMES             116    //out message         the aux switch names
-#define MSP_PIDNAMES             117    //out message         the PID names
+#define MSP_PIDNAMES             117    //DEPRECATED in INAV 9.1 - no replacement needed (static data). Will be removed in INAV 10.0
 #define MSP_WP                   118    //out message         get a WP, WP# is in the payload, returns (WP#, lat, lon, alt, flags) WP#0-home, WP#16-poshold
 #define MSP_BOXIDS               119    //out message         get the permanent IDs associated to BOXes
 #define MSP_SERVO_CONFIGURATIONS 120    //out message         All servo configurations.
@@ -263,7 +263,7 @@
 #define MSP_SET_RC_TUNING        204    //in message          rc rate, rc expo, rollpitch rate, yaw rate, dyn throttle PID, yaw expo
 #define MSP_ACC_CALIBRATION      205    //in message          no param
 #define MSP_MAG_CALIBRATION      206    //in message          no param
-#define MSP_SET_MISC             207    //in message          powermeter trig + 8 free for future use
+#define MSP_SET_MISC             207    //DEPRECATED in INAV 9.1 - use MSP2_INAV_SET_MISC instead. Will be removed in INAV 10.0
 #define MSP_RESET_CONF           208    //in message          no param
 #define MSP_SET_WP               209    //in message          sets a given WP (WP#,lat, lon, alt, flags)
 #define MSP_SELECT_SETTING       210    //in message          Select Setting Number (0-2)
@@ -295,8 +295,8 @@
 #define MSP_GPSSTATISTICS        166    //out message         get GPS debugging data
 #define MSP_ACC_TRIM             240    //out message         get acc angle trim values
 #define MSP_SET_ACC_TRIM         239    //in message          set acc angle trim values
-#define MSP_SERVO_MIX_RULES      241    //out message         Returns servo mixer configuration
-#define MSP_SET_SERVO_MIX_RULE   242    //in message          Sets servo mixer configuration
+#define MSP_SERVO_MIX_RULES      241    //DEPRECATED in INAV 9.1 - use MSP2_INAV_SERVO_MIXER instead. Will be removed in INAV 10.0
+#define MSP_SET_SERVO_MIX_RULE   242    //DEPRECATED in INAV 9.1 - use MSP2_INAV_SET_SERVO_MIXER instead. Will be removed in INAV 10.0
 #define MSP_SET_PASSTHROUGH      245    //in message          Sets up passthrough to different peripherals (4way interface, uart, etc...)
 #define MSP_RTC                  246    //out message         Gets the RTC clock (returns: secs(i32) millis(u16) - (0,0) if time is not known)
 #define MSP_SET_RTC              247    //in message          Sets the RTC clock (args: secs(i32) millis(u16))


### PR DESCRIPTION
### **User description**
## Summary

Marks 16 legacy MSP commands as **deprecated** with specific replacement info, rather than immediately dropping them. This gives third-party developers (ground stations, OSD tools, telemetry apps, scripting libraries) a full major release cycle of notice before removal in INAV 10.0.

**All commands remain fully functional** — no behavioral changes, no code removal, no API version bump.

## Supersedes

This PR supersedes the following PRs which proposed immediate removal without a deprecation period:

- #9920 - Drop MSP_ANALOG frame support
- #9921 - Drop MSP_MISC frame
- #9923 - Drop MSP_FILTER_CONFIG frame
- #9924 - Drop MSP_OSD_CONFIG from MSP protocol
- #9925 - Drop MSP_PIDNAMES
- #9927 - Drop MSP_SET_SERVO_MIX_RULE command
- #9928 - Drop MSP_POSITION_ESTIMATION_CONFIG
- #9929 - Drop MSP_PID_ADVANCED

## Deprecated commands and their replacements

| Command | Code | Replaced by |
|---------|------|-------------|
| `MSP_POSITION_ESTIMATION_CONFIG` | 16 | `MSP2_COMMON_SETTING` |
| `MSP_SET_POSITION_ESTIMATION_CONFIG` | 17 | `MSP2_COMMON_SET_SETTING` |
| `MSP_OSD_CONFIG` | 84 | `MSP2_INAV_OSD_LAYOUTS` / `MSP2_INAV_OSD_ALARMS` / `MSP2_INAV_OSD_PREFERENCES` |
| `MSP_SET_OSD_CONFIG` | 85 | `MSP2_INAV_OSD_SET_LAYOUT_ITEM` / `MSP2_INAV_OSD_SET_ALARMS` / `MSP2_INAV_OSD_SET_PREFERENCES` |
| `MSP_FILTER_CONFIG` | 92 | `MSP2_COMMON_SETTING` |
| `MSP_SET_FILTER_CONFIG` | 93 | `MSP2_COMMON_SET_SETTING` |
| `MSP_PID_ADVANCED` | 94 | `MSP_INAV_PID` |
| `MSP_SET_PID_ADVANCED` | 95 | `MSP_SET_INAV_PID` |
| `MSP_ANALOG` | 110 | `MSP2_INAV_ANALOG` |
| `MSP_MISC` | 114 | `MSP2_INAV_MISC` |
| `MSP_PIDNAMES` | 117 | No replacement needed (static data) |
| `MSP_SET_MISC` | 207 | `MSP2_INAV_SET_MISC` |
| `MSP_SERVO_MIX_RULES` | 241 | `MSP2_INAV_SERVO_MIXER` |
| `MSP_SET_SERVO_MIX_RULE` | 242 | `MSP2_INAV_SET_SERVO_MIXER` |

None of these commands were previously marked as deprecated.

## Changes

- **`src/main/msp/msp_protocol.h`** — Added `//DEPRECATED in INAV 9.1` comments with replacement info to all 16 `#define`s
- **`docs/development/msp/msp_messages.json`** — Added `"replaced_by"` field to all 14 command entries
- **`docs/development/msp/format.md`** — Documented the new `replaced_by` schema field

## Why deprecate instead of drop?

Third-party tools (mwptools, mobile ground stations, Lua scripts, Python libraries) may still use these commands. Dropping without notice breaks those tools silently. A deprecation cycle gives developers time to migrate, then allows clean removal in INAV 10.0.

## Testing

Documentation/comment-only changes — no compiled code modified. JSON schema validated.


___

### **PR Type**
Enhancement


___

### **Description**
- Mark 16 legacy MSP commands as deprecated for removal in INAV 10.0

- Add deprecation comments with replacement guidance to protocol header

- Document `replaced_by` field in MSP message JSON schema

- Populate `replaced_by` field for all 14 deprecated command entries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Legacy MSP Commands<br/>16 commands"] -->|Add deprecation comments| B["msp_protocol.h<br/>with replacement info"]
  A -->|Document schema field| C["format.md<br/>replaced_by field"]
  A -->|Populate metadata| D["msp_messages.json<br/>14 entries updated"]
  B --> E["Full major release cycle<br/>before removal"]
  C --> E
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>msp_protocol.h</strong><dd><code>Add deprecation notices to legacy MSP command definitions</code></dd></summary>
<hr>

src/main/msp/msp_protocol.h

<ul><li>Added <code>//DEPRECATED in INAV 9.1</code> comments to 16 MSP command <code>#define</code> <br>statements<br> <li> Included specific replacement command names or guidance for each <br>deprecated command<br> <li> Commands affected: <code>MSP_POSITION_ESTIMATION_CONFIG</code> (16), <br><code>MSP_SET_POSITION_ESTIMATION_CONFIG</code> (17), <code>MSP_OSD_CONFIG</code> (84), <br><code>MSP_SET_OSD_CONFIG</code> (85), <code>MSP_FILTER_CONFIG</code> (92), <code>MSP_SET_FILTER_CONFIG</code> <br>(93), <code>MSP_PID_ADVANCED</code> (94), <code>MSP_SET_PID_ADVANCED</code> (95), <code>MSP_ANALOG</code> <br>(110), <code>MSP_MISC</code> (114), <code>MSP_PIDNAMES</code> (117), <code>MSP_SET_MISC</code> (207), <br><code>MSP_SERVO_MIX_RULES</code> (241), <code>MSP_SET_SERVO_MIX_RULE</code> (242)<br> <li> No functional code changes, only documentation comments</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11315/files#diff-33fe442c3702cfb98791bd0d2784649957c2e90d8b2b68544100cb3056959cba">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>format.md</strong><dd><code>Document replaced_by schema field for deprecated commands</code></dd></summary>
<hr>

docs/development/msp/format.md

<ul><li>Added documentation for new <code>replaced_by</code> schema field in MSP message <br>format<br> <li> Defined as optional array of MSP message names that replace deprecated <br>commands<br> <li> Clarified that empty array indicates no replacement is needed</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11315/files#diff-9a890894321fcd79a22c7f593a0ef2b3a901cfd7483a8dcd8c86262798cfe739">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>msp_messages.json</strong><dd><code>Populate replaced_by metadata for deprecated MSP commands</code></dd></summary>
<hr>

docs/development/msp/msp_messages.json

<ul><li>Added <code>replaced_by</code> field to 14 deprecated MSP command entries in JSON <br>schema<br> <li> <code>MSP_POSITION_ESTIMATION_CONFIG</code> (16) → <code>["MSP2_COMMON_SETTING"]</code><br> <li> <code>MSP_SET_POSITION_ESTIMATION_CONFIG</code> (17) → <code>["MSP2_COMMON_SET_SETTING"]</code><br> <li> <code>MSP_OSD_CONFIG</code> (84) → <code>["MSP2_INAV_OSD_LAYOUTS", </code><br><code>"MSP2_INAV_OSD_ALARMS", "MSP2_INAV_OSD_PREFERENCES"]</code><br> <li> <code>MSP_SET_OSD_CONFIG</code> (85) → <code>["MSP2_INAV_OSD_SET_LAYOUT_ITEM", </code><br><code>"MSP2_INAV_OSD_SET_ALARMS", "MSP2_INAV_OSD_SET_PREFERENCES"]</code><br> <li> <code>MSP_FILTER_CONFIG</code> (92) → <code>["MSP2_COMMON_SETTING"]</code><br> <li> <code>MSP_SET_FILTER_CONFIG</code> (93) → <code>["MSP2_COMMON_SET_SETTING"]</code><br> <li> <code>MSP_PID_ADVANCED</code> (94) → <code>["MSP_INAV_PID"]</code><br> <li> <code>MSP_SET_PID_ADVANCED</code> (95) → <code>["MSP_SET_INAV_PID"]</code><br> <li> <code>MSP_ANALOG</code> (110) → <code>["MSP2_INAV_ANALOG"]</code><br> <li> <code>MSP_MISC</code> (114) → <code>["MSP2_INAV_MISC"]</code><br> <li> <code>MSP_PIDNAMES</code> (117) → <code>[]</code> (no replacement needed)<br> <li> <code>MSP_SET_MISC</code> (207) → <code>["MSP2_INAV_SET_MISC"]</code><br> <li> <code>MSP_SERVO_MIX_RULES</code> (241) → <code>["MSP2_INAV_SERVO_MIXER"]</code><br> <li> <code>MSP_SET_SERVO_MIX_RULE</code> (242) → <code>["MSP2_INAV_SET_SERVO_MIXER"]</code></ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11315/files#diff-4c12a60ea9c02ce1bd8c5a14d21640c1253119b614a14d36782acda4d370e58f">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

