### PR TITLE
Fix servo throttle mix outputting wrong position when disarmed

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -425,6 +425,16 @@ void servoMixer(float dT)
 	simulatorData.input[INPUT_STABILIZED_THROTTLE] = input[INPUT_STABILIZED_THROTTLE];
 #endif
 
+    /*
+     * When disarmed, force throttle inputs to minimum so the mixer pipeline
+     * computes the correct safe servo position accounting for servo reversal
+     * and negative mixer weights.
+     */
+    if (!ARMING_FLAG(ARMED)) {
+        input[INPUT_STABILIZED_THROTTLE] = -500;
+        input[INPUT_RC_THROTTLE] = -500;
+    }
+
     for (int i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
         servo[i] = 0;
     }
@@ -487,19 +497,6 @@ void servoMixer(float dT)
         servo[i] = constrain(servo[i], servoParams(i)->min, servoParams(i)->max);
     }
 
-    /*
-     * When not armed, apply servo low position to all outputs that include a throttle or stabilizet throttle in the mix
-     */
-    if (!ARMING_FLAG(ARMED)) {
-        for (int i = 0; i < servoRuleCount; i++) {
-            const uint8_t target = currentServoMixer[i].targetChannel;
-            const uint8_t from = currentServoMixer[i].inputSource;
-
-            if (from == INPUT_STABILIZED_THROTTLE || from == INPUT_RC_THROTTLE) {
-                servo[target] = motorConfig()->mincommand;
-            }
-        }
-    }
 }
 
 #define SERVO_AUTOTRIM_TIMER_MS     2000


### PR DESCRIPTION
### **User description**
## Summary

Fix a safety issue where reversed throttle servos and servos with negative mixer weights go to the wrong position when disarmed.

When disarmed, the servo mixer was unconditionally overwriting servo outputs with `motorConfig()->mincommand` (typically 1000µs) for any servo with a throttle mixer rule. This ignored servo reversal (negative `servoParams` rate) and negative mixer weights, causing certain servo configurations to output full throttle instead of minimum on disarm.

## Changes

- Force throttle inputs (`INPUT_STABILIZED_THROTTLE` and `INPUT_RC_THROTTLE`) to -500 (minimum) before the mixer loop when disarmed, so the existing mixer pipeline correctly computes safe positions accounting for servo reversal and negative weights
- Remove the post-hoc override at the end of `servoMixer()` that was setting `servo[target] = motorConfig()->mincommand`

## Testing

Tested with SITL using automated MSP test script covering 5 scenarios:

| Scenario | Before (Bug) | After (Fix) | Expected |
|----------|-------------|-------------|----------|
| Normal servo + normal weight | 1000 | 1000 | 1000 |
| Reversed servo + normal weight | **1000** | **2000** | **2000** |
| Normal servo + negative weight | **1000** | **2000** | **2000** |
| Reversed + negative (double inversion) | 1000 | 1000 | 1000 |
| Non-throttle servo (pitch only) | 1500 | 1500 | 1500 |

All 5 tests pass after the fix. The two previously failing cases (reversed servo, negative weight) now correctly compute the safe position.

Built successfully for SITL, MATEKF405, and SPEEDYBEEF405WING.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes safety issue where reversed throttle servos output wrong position when disarmed

- Forces throttle inputs to minimum before mixer pipeline instead of post-hoc override

- Ensures servo reversal and negative mixer weights are correctly accounted for

- Removes broken unconditional mincommand override that ignored servo configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Disarmed State"] --> B["Force Throttle Inputs to -500"]
  B --> C["Mixer Pipeline Processes Inputs"]
  C --> D["Applies Servo Reversal & Weights"]
  D --> E["Correct Safe Position Output"]
  F["Old Approach: Post-hoc Override"] -.->|removed| G["Ignored Reversal & Weights"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>servos.c</strong><dd><code>Replace post-hoc override with input forcing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/flight/servos.c

<ul><li>Added logic to force throttle inputs (<code>INPUT_STABILIZED_THROTTLE</code> and <br><code>INPUT_RC_THROTTLE</code>) to -500 when disarmed, before the mixer loop <br>executes<br> <li> Removed the broken post-hoc override that unconditionally set servo <br>outputs to <code>motorConfig()->mincommand</code> for throttle-mixed servos<br> <li> This allows the existing mixer pipeline to correctly compute safe <br>positions accounting for servo reversal and negative mixer weights</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11318/files#diff-c90491cca5be9a11d702c750699464d7fbc1cc617e32cd982070552522a70207">+10/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

