### PR TITLE
Fix SD card busy-wait loops that can lock up flight controller

### DIFF
--- a/src/main/drivers/sdcard/sdcard_spi.c
+++ b/src/main/drivers/sdcard/sdcard_spi.c
@@ -62,7 +62,17 @@ static void sdcardSpi_deselect(void)
     // As per the SD-card spec, give the card 8 dummy clocks so it can finish its operation
     //spiTransferByte(SDCARD_SPI_INSTANCE, 0xFF);
 
-    while (busIsBusy(sdcard.dev)) { __NOP(); }
+    int timeout = 100000;
+    while (busIsBusy(sdcard.dev)) {
+        if (timeout-- == 0) {
+            sdcard.failureCount++;
+            if (sdcard.failureCount >= SDCARD_MAX_CONSECUTIVE_FAILURES) {
+                sdcard.state = SDCARD_STATE_NOT_PRESENT;
+            }
+            break;
+        }
+        __NOP();
+    }
 
     busDeselectDevice(sdcard.dev);
 }

--- a/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c
+++ b/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c
@@ -549,7 +549,8 @@ static void SD_StartBlockTransfert(uint32_t* pBuffer, uint32_t BlockSize, uint32
     }
 
     pDMA->CR &= ~DMA_SxCR_EN;                                                                       // Disable the Peripheral
-    while (pDMA->CR & DMA_SxCR_EN);
+    int dmaTimeout = 10000;
+    while ((pDMA->CR & DMA_SxCR_EN) && dmaTimeout-- > 0);
 
     pDMA->NDTR = (uint32_t) (BlockSize * NumberOfBlocks) / 4;                                       // Configure DMA Stream data length
     pDMA->M0AR = (uint32_t) pBuffer;                                                                // Configure DMA Stream memory address
@@ -1014,7 +1015,11 @@ SD_Error_t SD_HighSpeed(void)
             return ErrorState;
         }
 
+        uint32_t swTimeout = SD_DATATIMEOUT;
         while ((SDIO->STA & (SDIO_STA_RXOVERR | SDIO_STA_DCRCFAIL | SDIO_STA_DTIMEOUT | SDIO_STA_DBCKEND)) == 0) {
+            if (swTimeout-- == 0) {
+                break;
+            }
             if ((SDIO->STA & SDIO_STA_RXFIFOHF) != 0) {
                 for(Count = 0; Count < 8; Count++) {
                     *(Buffer + Count) = SDIO->FIFO;
@@ -1124,7 +1129,11 @@ SD_Error_t SD_GetCardStatus(SD_CardStatus_t* pCardStatus)
     }
 
     // Get status data
+    uint32_t statTimeout = SD_DATATIMEOUT;
     while ((SDIO->STA & (SDIO_STA_RXOVERR | SDIO_STA_DCRCFAIL | SDIO_STA_DTIMEOUT | SDIO_STA_DBCKEND)) == 0) {
+        if (statTimeout-- == 0) {
+            break;
+        }
         if ((SDIO->STA & SDIO_STA_RXFIFOHF) != 0) {
             for(Count = 0; Count < 8; Count++) {
                 Status[Count] = SDIO->FIFO;
@@ -1318,7 +1327,11 @@ static SD_Error_t SD_FindSCR(uint32_t *pSCR)
 
             // Send ACMD51 SD_APP_SEND_SCR with argument as 0
             if ((ErrorState = SD_TransmitCommand((SD_CMD_SD_APP_SEND_SCR | SD_CMD_RESPONSE_SHORT), 0, 1)) == SD_OK) {
+                uint32_t scrTimeout = SD_DATATIMEOUT;
                 while ((SDIO->STA & (SDIO_STA_RXOVERR | SDIO_STA_DCRCFAIL | SDIO_STA_DTIMEOUT | SDIO_STA_DBCKEND)) == 0) {
+                    if (scrTimeout-- == 0) {
+                        break;
+                    }
                     if ((SDIO->STA & SDIO_STA_RXDAVL) != 0) {
                         *(tempscr + Index) = SDIO->FIFO;
                         Index++;

--- a/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c
+++ b/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c
@@ -552,6 +552,11 @@ static void SD_StartBlockTransfert(uint32_t* pBuffer, uint32_t BlockSize, uint32
     int dmaTimeout = 10000;
     while ((pDMA->CR & DMA_SxCR_EN) && dmaTimeout-- > 0);
 
+    if (pDMA->CR & DMA_SxCR_EN) {
+        SD_Handle.TransferError = SD_DATA_TIMEOUT;
+        return;
+    }
+
     pDMA->NDTR = (uint32_t) (BlockSize * NumberOfBlocks) / 4;                                       // Configure DMA Stream data length
     pDMA->M0AR = (uint32_t) pBuffer;                                                                // Configure DMA Stream memory address
 


### PR DESCRIPTION
### **User description**
## Summary

- Add timeout guards to unbounded busy-wait loops in the SD card SPI and SDIO drivers
- A problematic SD card could cause `sdcardSpi_deselect()` to spin forever on `busIsBusy()`, freezing the entire FC since blackbox runs inline with the PID loop via `processBlackbox()` in `fc_core.c`
- This is a safety-critical fix: peripheral failures must never take down the flight controller

### Changes

**`sdcard_spi.c`** — `sdcardSpi_deselect()` (called ~15 times after every SPI transaction):
- Replace unbounded `while (busIsBusy) { __NOP(); }` with 100K-iteration timeout (~4µs at 168MHz)
- On timeout: increment `failureCount`, disable card at threshold (8), always release SPI CS line
- Matches the existing timeout pattern in `sdcardSpi_init()` (line 864)
- Transient recovery: `failureCount` resets to 0 on any successful read/write

**`sdmmc_sdio_f4xx.c`** — DMA disable loop:
- Add 10K-iteration timeout to `while (pDMA->CR & DMA_SxCR_EN)` (~0.4µs)
- DMA disable normally completes in a few bus cycles; subsequent SDIO hardware timeout catches failures

**`sdmmc_sdio_f4xx.c`** — FIFO read loops (3 locations: `SD_HighSpeed`, `SD_GetCardStatus`, `SD_FindSCR`):
- Add `SD_DATATIMEOUT` software iteration counter as defense-in-depth behind hardware `SDIO_STA_DTIMEOUT`
- These are init-only code paths (not in PID loop), so the large counter is acceptable

## Test plan

- [x] Build for MATEKF405 (F4/SDIO target) — clean
- [x] Build for OMNIBUSF4V3 (F4/SPI-SD target) — clean
- [ ] Hardware test with known-good SD card (regression)
- [ ] Hardware test with problematic/removed SD card (timeout recovery)


___

### **PR Type**
Bug fix


___

### **Description**
- Add timeout guards to unbounded busy-wait loops in SD card drivers
  - `sdcard_spi.c`: 100K-iteration timeout in `sdcardSpi_deselect()` with failure tracking
  - `sdmmc_sdio_f4xx.c`: 10K-iteration timeout for DMA disable loop
  - `sdmmc_sdio_f4xx.c`: Software timeout backstops in three FIFO read loops

- Prevents flight controller lockup from problematic SD cards during blackbox operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Problematic SD Card"] -->|triggers unbounded loop| B["busIsBusy/DMA/FIFO loops"]
  B -->|without timeout| C["Flight Controller Lockup"]
  B -->|with timeout| D["Graceful Failure Handling"]
  D -->|increment failureCount| E["Disable Card at Threshold"]
  D -->|release resources| F["Continue Operation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sdcard_spi.c</strong><dd><code>Add timeout to SPI deselect busy-wait loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/sdcard/sdcard_spi.c

<ul><li>Replace unbounded <code>while (busIsBusy)</code> loop with 100K-iteration timeout <br>(~4µs at 168MHz)<br> <li> Increment <code>failureCount</code> on timeout and disable card when threshold (8) <br>is reached<br> <li> Always release SPI CS line via <code>busDeselectDevice()</code> after timeout<br> <li> Matches existing timeout pattern from <code>sdcardSpi_init()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11321/files#diff-f6e45e876afb9ea7a42ce4f0a8f6af35bbb99e3f28a453af9c2a3c0f633a25f5">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sdmmc_sdio_f4xx.c</strong><dd><code>Add timeouts to DMA and FIFO read loops</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/drivers/sdcard/sdmmc_sdio_f4xx.c

<ul><li>Add 10K-iteration timeout to DMA disable loop in <br><code>SD_StartBlockTransfert()</code> (~0.4µs)<br> <li> Add <code>SD_DATATIMEOUT</code> software iteration counter to three FIFO read <br>loops: <code>SD_HighSpeed()</code>, <code>SD_GetCardStatus()</code>, and <code>SD_FindSCR()</code><br> <li> Software timeouts provide defense-in-depth behind hardware <br><code>SDIO_STA_DTIMEOUT</code><br> <li> Init-only code paths allow larger timeout counters without PID loop <br>impact</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11321/files#diff-2a11680a248e94b27f007e0e3a346759c8217227e6541499e85360b6faac44c9">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

