### PR TITLE
Position estimator: guard against NaN, div-by-zero & timer anomalies

### DIFF
--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -726,6 +726,7 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
 
     /* Calculate dT */
     ctx.dt = US2S(currentTimeUs - posEstimator.est.lastUpdateTime);
+    ctx.dt = constrainf(ctx.dt, 0.0f, 1.0f);   // Sanity check: limit to 1 second to handle timer wraparound or initialization
     posEstimator.est.lastUpdateTime = currentTimeUs;
 
     /* If IMU is not ready we can't estimate anything */
@@ -769,14 +770,21 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
     }
 
     // Boost the corrections based on accWeight
-    vectorScale(&ctx.estPosCorr, &ctx.estPosCorr, 1.0f / posEstimator.imu.accWeightFactor);
-    vectorScale(&ctx.estVelCorr, &ctx.estVelCorr, 1.0f / posEstimator.imu.accWeightFactor);
+    if (posEstimator.imu.accWeightFactor > 0.001f) {
+        vectorScale(&ctx.estPosCorr, &ctx.estPosCorr, 1.0f / posEstimator.imu.accWeightFactor);
+        vectorScale(&ctx.estVelCorr, &ctx.estVelCorr, 1.0f / posEstimator.imu.accWeightFactor);
+    }
 
-    // Constrain corrections to prevent instability
+    // Constrain corrections to prevent instability. Zero out NaN since constrainf cannot catch it.
     const float corrLimit = INAV_EST_CORR_LIMIT_VALUE * ctx.dt;
     for (uint8_t axis = 0; axis < 3; axis++) {
-        ctx.estPosCorr.v[axis] = constrainf(ctx.estPosCorr.v[axis], -corrLimit, corrLimit);
-        ctx.estVelCorr.v[axis] = constrainf(ctx.estVelCorr.v[axis], -corrLimit, corrLimit);
+        if (isnan(ctx.estPosCorr.v[axis]) || isnan(ctx.estVelCorr.v[axis])) {
+            ctx.estPosCorr.v[axis] = 0.0f;
+            ctx.estVelCorr.v[axis] = 0.0f;
+        } else {
+            ctx.estPosCorr.v[axis] = constrainf(ctx.estPosCorr.v[axis], -corrLimit, corrLimit);
+            ctx.estVelCorr.v[axis] = constrainf(ctx.estVelCorr.v[axis], -corrLimit, corrLimit);
+        }
     }
 
     // Apply corrections
@@ -786,14 +794,13 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
     /* Correct accelerometer bias */
     const float w_acc_bias = positionEstimationConfig()->w_acc_bias;
     if (w_acc_bias > 0.0f) {
-        /* Correct accel bias */
-        posEstimator.imu.accelBias.x += ctx.accBiasCorr.x * w_acc_bias * ctx.dt;
-        posEstimator.imu.accelBias.y += ctx.accBiasCorr.y * w_acc_bias * ctx.dt;
-        posEstimator.imu.accelBias.z += ctx.accBiasCorr.z * w_acc_bias * ctx.dt;
-
-        posEstimator.imu.accelBias.x = constrainf(posEstimator.imu.accelBias.x, -INAV_ACC_BIAS_ACCEPTANCE_VALUE, INAV_ACC_BIAS_ACCEPTANCE_VALUE);
-        posEstimator.imu.accelBias.y = constrainf(posEstimator.imu.accelBias.y, -INAV_ACC_BIAS_ACCEPTANCE_VALUE, INAV_ACC_BIAS_ACCEPTANCE_VALUE);
-        posEstimator.imu.accelBias.z = constrainf(posEstimator.imu.accelBias.z, -INAV_ACC_BIAS_ACCEPTANCE_VALUE, INAV_ACC_BIAS_ACCEPTANCE_VALUE);
+        /* Correct accel bias - discard NaN to prevent permanent bias corruption */
+        for (uint8_t axis = 0; axis < 3; axis++) {
+            if (!isnan(ctx.accBiasCorr.v[axis])) {
+                posEstimator.imu.accelBias.v[axis] += ctx.accBiasCorr.v[axis] * w_acc_bias * ctx.dt;
+            }
+            posEstimator.imu.accelBias.v[axis] = constrainf(posEstimator.imu.accelBias.v[axis], -INAV_ACC_BIAS_ACCEPTANCE_VALUE, INAV_ACC_BIAS_ACCEPTANCE_VALUE);
+        }
     }
 
     /* Update ground course */

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -775,14 +775,17 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
         vectorScale(&ctx.estVelCorr, &ctx.estVelCorr, 1.0f / posEstimator.imu.accWeightFactor);
     }
 
-    // Constrain corrections to prevent instability. Zero out NaN since constrainf cannot catch it.
+    // Constrain corrections to prevent instability. Discard non-finite values (NaN/Inf) since constrainf cannot catch NaN.
     const float corrLimit = INAV_EST_CORR_LIMIT_VALUE * ctx.dt;
     for (uint8_t axis = 0; axis < 3; axis++) {
-        if (isnan(ctx.estPosCorr.v[axis]) || isnan(ctx.estVelCorr.v[axis])) {
+        if (!isfinite(ctx.estPosCorr.v[axis])) {
             ctx.estPosCorr.v[axis] = 0.0f;
-            ctx.estVelCorr.v[axis] = 0.0f;
         } else {
             ctx.estPosCorr.v[axis] = constrainf(ctx.estPosCorr.v[axis], -corrLimit, corrLimit);
+        }
+        if (!isfinite(ctx.estVelCorr.v[axis])) {
+            ctx.estVelCorr.v[axis] = 0.0f;
+        } else {
             ctx.estVelCorr.v[axis] = constrainf(ctx.estVelCorr.v[axis], -corrLimit, corrLimit);
         }
     }
@@ -794,12 +797,16 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
     /* Correct accelerometer bias */
     const float w_acc_bias = positionEstimationConfig()->w_acc_bias;
     if (w_acc_bias > 0.0f) {
-        /* Correct accel bias - discard NaN to prevent permanent bias corruption */
+        /* Correct accel bias - discard non-finite values to prevent permanent bias corruption */
         for (uint8_t axis = 0; axis < 3; axis++) {
-            if (!isnan(ctx.accBiasCorr.v[axis])) {
+            if (isfinite(ctx.accBiasCorr.v[axis])) {
                 posEstimator.imu.accelBias.v[axis] += ctx.accBiasCorr.v[axis] * w_acc_bias * ctx.dt;
             }
-            posEstimator.imu.accelBias.v[axis] = constrainf(posEstimator.imu.accelBias.v[axis], -INAV_ACC_BIAS_ACCEPTANCE_VALUE, INAV_ACC_BIAS_ACCEPTANCE_VALUE);
+            if (!isfinite(posEstimator.imu.accelBias.v[axis])) {
+                posEstimator.imu.accelBias.v[axis] = 0.0f;
+            } else {
+                posEstimator.imu.accelBias.v[axis] = constrainf(posEstimator.imu.accelBias.v[axis], -INAV_ACC_BIAS_ACCEPTANCE_VALUE, INAV_ACC_BIAS_ACCEPTANCE_VALUE);
+            }
         }
     }
 


### PR DESCRIPTION
### **User description**
## Summary

Adds defensive numerical guards to `updateEstimatedTopic()` in the position estimator, building on the corrections fix in #11270.

The existing code has three pathways where floating-point corruption (Inf/NaN) can enter the position/velocity estimates and permanently corrupt navigation:

1. **Division by zero in `1/accWeightFactor`** — `accWeightFactor` is initialized to 0 and only set to a valid value once `updateIMUEstimationWeight()` runs. If the division executes before then, `1/0 = Inf` propagates into corrections. Subsequent arithmetic (`Inf - Inf`) produces NaN.

2. **NaN passes through `constrainf()`** — Since NaN comparisons are always false, `constrainf(NaN, -limit, limit)` returns NaN unchanged. The correction clamping added in #11270 catches Inf but not NaN.

3. **Timer anomalies in `ctx.dt`** — On first call, `lastUpdateTime` is 0, producing a dt of the full uptime. Timer wraparound could also produce anomalous values. A huge dt defeats the per-iteration correction limits (`corrLimit = 4000 * dt`).

## Changes

- **Guard `accWeightFactor` division**: Skip the `1/accWeightFactor` boost when factor is near zero (< 0.001). Corrections are applied at 1x magnitude instead of Inf.
- **NaN protection on corrections**: If any position or velocity correction is NaN, zero both for that axis (skipping one iteration is safer than permanent corruption). Also guard `accBiasCorr` — discard NaN values before adding to accelerometer bias to prevent permanent bias corruption.
- **Clamp `ctx.dt` to [0, 1s]**: Prevents timer wraparound or initialization from producing values that defeat correction limits or cause huge prediction jumps.

___

### **PR Type**
Bug fix


___

### **Description**
- Guard against division by zero in accWeightFactor boost calculation

- Protect position/velocity corrections from NaN propagation via constrainf

- Clamp ctx.dt to [0, 1s] to prevent timer anomalies and initialization issues

- Guard accelerometer bias correction against NaN values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["updateEstimatedTopic"] --> B["Clamp ctx.dt to 0-1s"]
  A --> C["Check accWeightFactor > 0.001"]
  C -->|Yes| D["Apply correction boost"]
  C -->|No| E["Skip boost"]
  A --> F["Check for NaN in corrections"]
  F -->|NaN detected| G["Zero out corrections"]
  F -->|Valid| H["Apply constrainf limits"]
  A --> I["Guard accBiasCorr for NaN"]
  I -->|NaN detected| J["Skip bias update"]
  I -->|Valid| K["Update accelerometer bias"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation_pos_estimator.c</strong><dd><code>Add defensive guards against numerical corruption</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/navigation/navigation_pos_estimator.c

<ul><li>Added clamping of <code>ctx.dt</code> to [0, 1s] range to handle timer wraparound <br>and initialization anomalies<br> <li> Added guard check for <code>accWeightFactor > 0.001f</code> before division to <br>prevent Inf propagation<br> <li> Added NaN detection and zeroing for position and velocity corrections <br>before constrainf application<br> <li> Refactored accelerometer bias correction to skip NaN values and <br>prevent permanent bias corruption</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11323/files#diff-96b2ec94699623edbea79fee247a79dab05792380c09884bd38eb55da6d0a74f">+20/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

