### PR TITLE
Add NEXUS target for RadioMaster Nexus (Original) flight controller

### DIFF
--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -52,6 +52,13 @@ static void usartConfigurePinInversion(uartPort_t *uartPort) {
             uartPort->Handle.AdvancedInit.TxPinLevelInvert = UART_ADVFEATURE_TXINV_ENABLE;
         }
     }
+
+#ifdef USE_UART4_SWAP
+    if (uartPort->Handle.Instance == UART4) {
+        uartPort->Handle.AdvancedInit.AdvFeatureInit |= UART_ADVFEATURE_SWAP_INIT;
+        uartPort->Handle.AdvancedInit.Swap = UART_ADVFEATURE_SWAP_ENABLE;
+    }
+#endif
 }
 
 static void uartReconfigure(uartPort_t *uartPort)

--- a/src/main/target/NEXUS/CMakeLists.txt
+++ b/src/main/target/NEXUS/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f722xe(NEXUS)

--- a/src/main/target/NEXUS/README.md
+++ b/src/main/target/NEXUS/README.md
@@ -1,0 +1,144 @@
+# RadioMaster Nexus (Original)
+
+Flight controller originally designed for helicopters using Rotorflight.
+Based on STM32F722RET6. This is the **original** (discontinued) Nexus,
+not the Nexus-X or Nexus-XR.
+
+For the Nexus-X and Nexus-XR, use the `NEXUSX` target instead.
+
+## Hardware
+
+| Component | Spec |
+|-----------|------|
+| MCU | STM32F722RET6 (216MHz, 256KB RAM, 512KB flash) |
+| IMU | ICM-42688-P (SPI1), CW90 alignment |
+| Barometer | SPL06-001 (I2C1, internal) |
+| Blackbox | W25N01G 128MB (SPI2) |
+| Input voltage | 5 - 12.6V |
+| BEC output | 5V / 2A on Port A, B, C |
+| DSM power | 3.3V / 0.5A |
+| Dimensions | 41.3 x 25.4 x 13.1mm |
+| Weight | 16.8g |
+
+## Differences from Nexus-X/XR
+
+| | OG Nexus | Nexus-X/XR |
+|---|----------|------------|
+| IMU EXTI | PA15 | PB8 |
+| IMU alignment | CW90 | CW180 |
+| Baro I2C | I2C1 (PB8/PB9) | I2C2 (PB10/PB11) |
+| Flash | W25N01G (128MB) | W25N02K (256MB) |
+| Internal ELRS RX | None | RP4TD-M on UART5 |
+| PINIO1 (RX power) | None | PC8 |
+| UART1 pins | PA9/PA10 | PB6/PB7 |
+| Voltage input | 5-12.6V | 3.6-70V |
+| Servo outputs | 5 | 7 default (9 max) |
+| Rotorflight target | NEXUS_F7 | NEXUSX |
+
+## Pin Functions
+
+### Default Output Assignment
+
+| Output | Pin | Timer | Connector |
+|--------|-----|-------|-----------|
+| S1 | PB4 | TIM3_CH1 | Servo header |
+| S2 | PB5 | TIM3_CH2 | Servo header |
+| S3 | PB0 | TIM3_CH3 | Servo header |
+| S4 | PB3 | TIM2_CH2 | Servo header (Tail) |
+| M1 | PB6 | TIM4_CH1 | ESC header |
+
+### UART Ports
+
+| UART | Label | TX | RX | Notes |
+|------|-------|----|----|-------|
+| UART1 | DSM | PA9 | PA10 | |
+| UART2 | SBUS | PA2 | PA3 | Shared with FREQ/PPM |
+| UART3 | Port C | PB11 | PB10 | Shared with I2C2 |
+| UART4 | Port A | PA1 | PA0 | Primary receiver (CRSF) |
+| UART6 | Port B | PC7 | PC6 | |
+
+### I2C Buses
+
+| Bus | SCL | SDA | Usage |
+|-----|-----|-----|-------|
+| I2C1 | PB8 | PB9 | Internal barometer (SPL06) |
+| I2C2 | PB10 | PB11 | External sensors via Port C |
+
+### ADC Channels
+
+| Channel | Pin | Divider | Usage |
+|---------|-----|---------|-------|
+| BUS | PC2 | 320 | External battery voltage (mapped as VBAT) |
+| BEC | PC1 | 160 | 5V BEC rail monitoring |
+
+### Connector Pinouts
+
+**Port A (UART4 - CRSF receiver):**
+1. GND
+2. 5V
+3. RX (PA0, connect to receiver TX)
+4. TX (PA1, connect to receiver RX / telemetry)
+
+**Port B (UART6):**
+1. GND
+2. 5V
+3. TX (PC7)
+4. RX (PC6)
+
+**Port C (UART3 / I2C2):**
+1. GND
+2. 5V
+3. SCL/TX (PB10)
+4. SDA/RX (PB11)
+
+**ESC Header:**
+- Signal: PB6 (TIM4_CH1 PWM)
+
+## Typical Glider Setup (Elevon / Flying Wing)
+
+For a 5-channel elevon glider like the Kunai:
+
+1. Flash NEXUS target via DFU
+2. Set aircraft type: **Flying Wing**
+3. Connect RP3-H receiver to **Port A** (CRSF on UART4)
+4. Connect ESC to **ESC header** (M1)
+5. Connect left elevon servo to **S1**
+6. Connect right elevon servo to **S2**
+7. Configure elevon mixing in the Mixer tab
+8. Vario: SPL06 baro provides altitude-based vario out of the box
+9. GPS (Phase 2): Connect to **Port B** (UART6)
+
+## Verified on Hardware
+
+- [x] MCU boots, LEDs active (PC14, PC15)
+- [x] USB CDC enumeration and iNAV CLI
+- [x] IMU (gyro + accel) detected and responding
+- [x] iNAV Configurator 9.0 connects, 3D model tracks board movement
+- [ ] Barometer (SPL06 on I2C1) — fixed bus assignment, needs retest
+- [ ] VBAT ADC (PC2) — fixed pin assignment, needs retest
+- [ ] BEC ADC (PC1) — needs test
+- [ ] Gyro alignment (CW90) — fixed, needs retest
+- [ ] All servo outputs — need test
+- [ ] CRSF receiver on UART4 — needs test
+- [ ] Blackbox logging — needs test
+- [ ] VBAT scale calibration with multimeter
+
+## Building
+
+Requires NixOS flake (included in repo root) or standard iNAV build deps.
+
+```sh
+nix develop --impure   # or set up arm-none-eabi-gcc manually
+mkdir -p build && cd build
+cmake -GNinja -DCOMPILER_VERSION_CHECK=OFF ..
+ninja NEXUS
+```
+
+## Flashing via DFU
+
+Hold button while connecting USB, then:
+
+```sh
+arm-none-eabi-objcopy -O binary build/bin/NEXUS.elf build/NEXUS.bin
+dfu-util -a 0 -s 0x08000000:leave -D build/NEXUS.bin
+```

--- a/src/main/target/NEXUS/README.md
+++ b/src/main/target/NEXUS/README.md
@@ -31,7 +31,7 @@ For the Nexus-X and Nexus-XR, use the `NEXUSX` target instead.
 | Internal ELRS RX | None | RP4TD-M on UART5 |
 | PINIO1 (RX power) | None | PC8 |
 | UART1 pins | PA9/PA10 | PB6/PB7 |
-| Voltage input | 5-12.6V | 3.6-70V |
+| Voltage sense | Vin ADC only (5-12.6V) | EXT-V input (3.6-70V) |
 | Servo outputs | 5 | 7 default (9 max) |
 | Rotorflight target | NEXUS_F7 | NEXUSX |
 
@@ -68,8 +68,11 @@ For the Nexus-X and Nexus-XR, use the `NEXUSX` target instead.
 
 | Channel | Pin | Divider | Usage |
 |---------|-----|---------|-------|
-| BUS | PC2 | 320 | External battery voltage (mapped as VBAT) |
+| BUS | PC2 | 320 | Vin rail, 5-12.6V (mapped as VBAT) |
 | BEC | PC1 | 160 | 5V BEC rail monitoring |
+
+Note: Unlike the Nexus-X/XR, the OG Nexus has no dedicated EXT-V
+high-voltage battery sense input. VBAT monitors the board input power.
 
 ### Connector Pinouts
 
@@ -88,8 +91,8 @@ For the Nexus-X and Nexus-XR, use the `NEXUSX` target instead.
 **Port C (UART3 / I2C2):**
 1. GND
 2. 5V
-3. SCL/TX (PB10)
-4. SDA/RX (PB11)
+3. SDA/TX (PB11)
+4. SCL/RX (PB10)
 
 **ESC Header:**
 - Signal: PB6 (TIM4_CH1 PWM)
@@ -113,15 +116,17 @@ For a 5-channel elevon glider like the Kunai:
 - [x] MCU boots, LEDs active (PC14, PC15)
 - [x] USB CDC enumeration and iNAV CLI
 - [x] IMU (gyro + accel) detected and responding
-- [x] iNAV Configurator 9.0 connects, 3D model tracks board movement
-- [ ] Barometer (SPL06 on I2C1) — fixed bus assignment, needs retest
-- [ ] VBAT ADC (PC2) — fixed pin assignment, needs retest
-- [ ] BEC ADC (PC1) — needs test
-- [ ] Gyro alignment (CW90) — fixed, needs retest
-- [ ] All servo outputs — need test
-- [ ] CRSF receiver on UART4 — needs test
-- [ ] Blackbox logging — needs test
-- [ ] VBAT scale calibration with multimeter
+- [x] Gyro alignment (CW90) confirmed
+- [x] Accelerometer working
+- [x] Barometer (SPL06 on I2C1) working
+- [x] VBAT ADC (PC2) working (scale 320)
+- [x] All UART ports (1-4, 6) verified
+- [x] UART4 CRSF receiver working (TX/RX swap confirmed)
+- [x] DShot on all motor outputs
+- [x] Servo outputs working
+- [x] Blackbox logging working
+- [x] LEDs working
+- [x] I2C2 bus working
 
 ## Building
 

--- a/src/main/target/NEXUS/config.c
+++ b/src/main/target/NEXUS/config.c
@@ -1,0 +1,19 @@
+/*
+ * RadioMaster Nexus (Original) - Target configuration defaults
+ *
+ * Unlike the Nexus-X/XR, the OG Nexus has no internal ELRS receiver,
+ * so there is no PINIO / USER1 box configuration needed here.
+ */
+
+#include <stdint.h>
+#include "platform.h"
+#include "drivers/pwm_mapping.h"
+
+void targetConfiguration(void)
+{
+    // Force M1/ESC (PB6/TIM4) to motor mode so the PWM auto-allocator
+    // picks it as the motor output first. Without this, it walks the
+    // timer table in order, converts TIM3 (S1/S2/S3) to motors via
+    // pwmClaimTimer(), and leaves no timers available for servos.
+    timerOverridesMutable(timer2id(TIM4))->outputMode = OUTPUT_MODE_MOTORS;
+}

--- a/src/main/target/NEXUS/target.c
+++ b/src/main/target/NEXUS/target.c
@@ -1,0 +1,29 @@
+/*
+ * RadioMaster Nexus (Original) - Timer/PWM hardware configuration
+ *
+ * Timer allocation (from Rotorflight NEXUS_F7 dump):
+ *   TIM3: S1 (PB4/CH1), S2 (PB5/CH2), S3 (PB0/CH3)
+ *   TIM2: S4 (PB3/CH2)
+ *   TIM4: M1 (PB6/CH1) - ESC output
+ *
+ * Note: PA2/PA3 are FREQ/PPM inputs in Rotorflight. In iNAV they
+ * can be repurposed as servo outputs when UART2 is not assigned.
+ */
+
+#include <stdint.h>
+#include "platform.h"
+#include "drivers/io.h"
+#include "drivers/timer.h"
+#include "drivers/pwm_mapping.h"
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM3, CH1, PB4, TIM_USE_OUTPUT_AUTO, 0, 0),  // S1
+    DEF_TIM(TIM3, CH2, PB5, TIM_USE_OUTPUT_AUTO, 0, 0),  // S2
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_OUTPUT_AUTO, 0, 0),  // S3
+    DEF_TIM(TIM2, CH2, PB3, TIM_USE_OUTPUT_AUTO, 0, 0),  // S4
+    DEF_TIM(TIM4, CH1, PB6, TIM_USE_OUTPUT_AUTO, 0, 0),  // M1/ESC
+    DEF_TIM(TIM5, CH3, PA2, TIM_USE_OUTPUT_AUTO, 0, 0),  // shared w/ UART2 TX
+    DEF_TIM(TIM9, CH2, PA3, TIM_USE_OUTPUT_AUTO, 0, 0),  // shared w/ UART2 RX
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/NEXUS/target.h
+++ b/src/main/target/NEXUS/target.h
@@ -1,0 +1,173 @@
+/*
+ * RadioMaster Nexus (Original) - iNAV target
+ *
+ * Based on the NEXUSX target by functionpointer, adapted for the
+ * original (discontinued) Nexus hardware.
+ *
+ * Key differences from Nexus-X/XR:
+ *   - IMU EXTI on PA15 (X/XR uses PB8)
+ *   - IMU alignment CW90 (X/XR uses CW180)
+ *   - Flash is W25N01G 128MB (X/XR uses W25N02K 256MB)
+ *   - No internal ELRS receiver (X/XR has RP4TD-M on UART5)
+ *   - No PINIO1 receiver power gate
+ *   - Voltage input 5-12.6V (X/XR supports 3.6-70V)
+ *   - 5 servo/motor outputs vs 7-9 on X/XR
+ *   - Baro on I2C1 (PB8/PB9), not I2C2
+ *   - UART1 on PA9/PA10, not PB6/PB7
+ *
+ * Pin mapping derived from:
+ *   - Rotorflight NEXUS_F7 target (authoritative)
+ *   - groundflight project (joshperry/groundflight)
+ *   - RadioMaster documentation
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "NEXS"
+#define USBD_PRODUCT_STRING     "RadioMaster Nexus"
+
+/* ---- LEDs ---- */
+#define LED0                    PC14  // active low
+#define LED1                    PC15  // active low
+
+/* ---- Beeper ---- */
+// No dedicated beeper pin on Nexus hardware
+
+/* ---- SPI ---- */
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+/* ---- IMU: ICM-42688-P ---- */
+// iNAV uses ICM42605 driver which is register-compatible with ICM42688P
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW90_DEG
+#define ICM42605_CS_PIN         PA4
+#define ICM42605_SPI_BUS        BUS_SPI1
+#define ICM42605_EXTI_PIN       PA15
+
+/* ---- I2C ---- */
+// I2C1: PB8/PB9 - internal, used for barometer
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+
+// I2C2: PB10/PB11 - external via Port C connector (shared with UART3)
+// Available for external sensors (magnetometer, rangefinder, etc.)
+#define USE_I2C_DEVICE_2
+#define I2C2_SCL                PB10
+#define I2C2_SDA                PB11
+#define I2C_DEVICE_2_SHARES_UART3
+
+/* ---- Barometer: SPL06-001 ---- */
+// Confirmed on I2C1 per Rotorflight NEXUS_F7 dump
+#define USE_BARO
+#define USE_BARO_SPL06
+#define BARO_I2C_BUS            BUS_I2C1
+
+/* ---- Magnetometer (external, optional via Port C / I2C2) ---- */
+#define USE_MAG
+#define USE_MAG_ALL
+#define MAG_I2C_BUS             BUS_I2C2
+
+/* ---- Flash: W25N01G (128MB) ---- */
+#define USE_FLASHFS
+#define USE_FLASH_W25N01G
+#define W25N01G_SPI_BUS         BUS_SPI2
+#define W25N01G_CS_PIN          PB12
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+/* ---- UARTs ---- */
+// OG Nexus UART layout (confirmed from Rotorflight NEXUS_F7 dump):
+//   UART1 [DSM port]  : PA9 (TX) / PA10 (RX)
+//   UART2 [SBUS/FREQ] : PA2 (TX) / PA3 (RX) - shared with RPM/TLM pins
+//   UART3 [Port C]    : PB11 (TX) / PB10 (RX) - shared with I2C2
+//   UART4 [Port A]    : PA1 (TX) / PA0 (RX) - primary CRSF receiver
+//   UART6 [Port B]    : PC7 (TX) / PC6 (RX)
+//
+// NOTE: No UART5 on OG Nexus (X/XR uses UART5 for internal ELRS)
+
+#define USE_VCP
+#define USE_USB_DETECT
+#define USB_DETECT_PIN          NONE
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define USE_UART3
+#define UART3_TX_PIN            PB11
+#define UART3_RX_PIN            PB10
+
+#define USE_UART4
+#define USE_UART4_SWAP
+#define UART4_TX_PIN            PA1
+#define UART4_RX_PIN            PA0
+
+#define USE_UART6
+#define UART6_TX_PIN            PC7
+#define UART6_RX_PIN            PC6
+
+#define SERIAL_PORT_COUNT       6  // VCP + UART1-4 + UART6
+
+/* ---- Default serial receiver ---- */
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART4
+
+
+/* ---- ADC ---- */
+// From Rotorflight dump:
+//   ADC_BEC = PC1, divider 160 (BEC 5V rail monitoring)
+//   ADC_BUS = PC2, divider 320 (external battery voltage)
+// Map BUS voltage as VBAT for iNAV since that's the flight battery
+#define USE_ADC
+#define ADC_INSTANCE            ADC1
+#define ADC_CHANNEL_1_PIN       PC2   // BUS voltage (external battery)
+#define VBAT_ADC_CHANNEL        ADC_CHN_1
+#define ADC_CHANNEL_2_PIN       PC1   // BEC voltage (5V rail)
+// VBAT scale: Rotorflight vbus_divider = 320
+// iNAV scale = divider * ~3.44 (ADC ref / resolution factor)
+// Start with 1100, calibrate with multimeter
+#define VBAT_SCALE_DEFAULT      1100
+
+/* ---- Sensors ---- */
+#define SENSORS_SET             (SENSOR_ACC | SENSOR_BARO)
+
+/* ---- PWM / Servo / Motor outputs ---- */
+// OG Nexus outputs (from Rotorflight dump):
+//   S1:   PB4  (TIM3_CH1)  - Servo header
+//   S2:   PB5  (TIM3_CH2)  - Servo header
+//   S3:   PB0  (TIM3_CH3)  - Servo header
+//   S4:   PB3  (TIM2_CH2)  - Servo header (Tail)
+//   M1:   PB6  (TIM4_CH1)  - ESC header (motor only, NOT UART1)
+//
+// Pin multiplexing when UARTs freed:
+//   PA2 (TIM5_CH3) - shared with UART2 TX / FREQ input
+//   PA3 (TIM9_CH2) - shared with UART2 RX / PPM input
+
+#define MAX_PWM_OUTPUT_PORTS    7
+
+/* ---- No internal receiver ---- */
+// OG Nexus has no internal ELRS receiver.
+// No UART5, no PINIO1 power gate.
+
+/* ---- Platform ---- */
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+
+#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX)

--- a/src/main/target/NEXUS/target.h
+++ b/src/main/target/NEXUS/target.h
@@ -6,7 +6,8 @@
  *
  * Key differences from Nexus-X/XR:
  *   - IMU EXTI on PA15 (X/XR uses PB8)
- *   - IMU alignment CW90 (X/XR uses CW180)
+ *   - IMU alignment CW180 (Rotorflight uses CW90 with a different
+ *     board orientation reference; iNAV uses the arrow on the case)
  *   - Flash is W25N01G 128MB (X/XR uses W25N02K 256MB)
  *   - No internal ELRS receiver (X/XR has RP4TD-M on UART5)
  *   - No PINIO1 receiver power gate
@@ -48,7 +49,7 @@
 /* ---- IMU: ICM-42688-P ---- */
 // iNAV uses ICM42605 driver which is register-compatible with ICM42688P
 #define USE_IMU_ICM42605
-#define IMU_ICM42605_ALIGN      CW90_DEG
+#define IMU_ICM42605_ALIGN      CW180_DEG
 #define ICM42605_CS_PIN         PA4
 #define ICM42605_SPI_BUS        BUS_SPI1
 #define ICM42605_EXTI_PIN       PA15

--- a/src/main/target/NEXUS/target.h
+++ b/src/main/target/NEXUS/target.h
@@ -129,19 +129,18 @@
 
 
 /* ---- ADC ---- */
-// From Rotorflight dump:
-//   ADC_BEC = PC1, divider 160 (BEC 5V rail monitoring)
-//   ADC_BUS = PC2, divider 320 (external battery voltage)
-// Map BUS voltage as VBAT for iNAV since that's the flight battery
+// OG Nexus has no EXT-V input (unlike X/XR which has a dedicated
+// high-voltage sense on PC0). Only two ADC channels:
+//   ADC_BUS = PC2, divider 320 (Vin rail, 5-12.6V)
+//   ADC_BEC = PC1, divider 160 (BEC 5V rail)
+// Map Vin as VBAT since it's the primary power input
 #define USE_ADC
 #define ADC_INSTANCE            ADC1
-#define ADC_CHANNEL_1_PIN       PC2   // BUS voltage (external battery)
+#define ADC_CHANNEL_1_PIN       PC2   // Vin (input power rail)
 #define VBAT_ADC_CHANNEL        ADC_CHN_1
-#define ADC_CHANNEL_2_PIN       PC1   // BEC voltage (5V rail)
-// VBAT scale: Rotorflight vbus_divider = 320
-// iNAV scale = divider * ~3.44 (ADC ref / resolution factor)
-// Start with 1100, calibrate with multimeter
-#define VBAT_SCALE_DEFAULT      1100
+#define ADC_CHANNEL_2_PIN       PC1   // BEC 5V rail
+// VBAT scale: hardware-verified value (divider ratio ~320)
+#define VBAT_SCALE_DEFAULT      320
 
 /* ---- Sensors ---- */
 #define SENSORS_SET             (SENSOR_ACC | SENSOR_BARO)


### PR DESCRIPTION
STM32F722-based target for the original (discontinued) Nexus, distinct from the Nexus-X/XR (NEXUSX target). Pin mapping derived from Rotorflight NEXUS_F7 dump and verified on hardware.

Key hardware support:
- ICM-42688-P IMU on SPI1 (CW90 alignment, EXTI PA15)
- SPL06 barometer on I2C1 (PB8/PB9, separate from external I2C2)
- W25N01G 128MB blackbox flash on SPI2
- 5 servo/motor outputs (S1-S4 + M1), expandable to 7
- UART4 with TX/RX swap for CRSF receiver on Port A
- UART1 on PA9/PA10 (not PB6/PB7 as on Nexus-X/XR)

Also includes:
- USE_UART4_SWAP support in serial_uart_hal.c