### PR TITLE
Add support for ICM42688P IMU in target.h

### DIFF
--- a/src/main/target/OMNIBUSF4/target.h
+++ b/src/main/target/OMNIBUSF4/target.h
@@ -75,6 +75,12 @@
   #define ICM42605_CS_PIN         PA4
   #define ICM42605_SPI_BUS        BUS_SPI1
 #endif
+#if defined(OMNIBUSF4V3_ICM)
+  #define USE_IMU_ICM42688P
+  #define IMU_ICM42688P_ALIGN      CW180_DEG
+  #define ICM42688P_CS_PIN         PA4
+  #define ICM42688P_SPI_BUS        BUS_SPI1
+#endif
 
 #if defined(OMNIBUSF4PRO) || defined(OMNIBUSF4V3) || defined(OMNIBUSF4V3_ICM)
   #define USE_IMU_MPU6000


### PR DESCRIPTION
para controladora de vuelo f4 s3v plus

Subject: [DRAFT] Add ICM42688P support for OMNIBUSF4V3_ICM (clone boards)

This PR adds support for ICM42688P gyro found on Omnibus F4 V3.1S clone boards (red spacer). 
These boards currently work in Betaflight 4.3.2 with target OMNIBUSF4SD-ICM.

Changes:
- Added USE_IMU_ICM42688P with CW180_DEG alignment on SPI1 (CS: PA4)
- Conditional on OMNIBUSF4V3_ICM target
- Tested working by user with exact same hardware

This is a DRAFT. I understand this is a non-official target and will likely be marked SKIP_RELEASES.
Submitting for reference in case others need this.