### PR TITLE
Fix GPS capability poll blocking for 500ms every 5 seconds

### DIFF
--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -1228,14 +1228,15 @@ STATIC_PROTOTHREAD(gpsProtocolStateThread)
             if ((millis() - gpsState.lastCapaPoolMs) > GPS_CAPA_INTERVAL) {
                 gpsState.lastCapaPoolMs = millis();
 
+                // MON-class messages respond with data, not ACK/NAK - wait on response data
                 if (gpsState.hwVersion == UBX_HW_VERSION_UNKNOWN)
                 {
                     pollVersion();
-                    ptWaitTimeout((_ack_state == UBX_ACK_GOT_ACK || _ack_state == UBX_ACK_GOT_NAK), GPS_CFG_CMD_TIMEOUT_MS);
+                    ptWaitTimeout((gpsState.hwVersion != UBX_HW_VERSION_UNKNOWN), GPS_CFG_CMD_TIMEOUT_MS);
                 }
 
                 pollGnssCapabilities();
-                ptWaitTimeout((_ack_state == UBX_ACK_GOT_ACK || _ack_state == UBX_ACK_GOT_NAK), GPS_CFG_CMD_TIMEOUT_MS);
+                ptWaitTimeout((gpsState.lastCapaUpdMs > gpsState.lastCapaPoolMs), GPS_CFG_CMD_TIMEOUT_MS);
             }
         }
     }

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -1228,15 +1228,12 @@ STATIC_PROTOTHREAD(gpsProtocolStateThread)
             if ((millis() - gpsState.lastCapaPoolMs) > GPS_CAPA_INTERVAL) {
                 gpsState.lastCapaPoolMs = millis();
 
-                // MON-class messages respond with data, not ACK/NAK - wait on response data
                 if (gpsState.hwVersion == UBX_HW_VERSION_UNKNOWN)
                 {
                     pollVersion();
-                    ptWaitTimeout((gpsState.hwVersion != UBX_HW_VERSION_UNKNOWN), GPS_CFG_CMD_TIMEOUT_MS);
                 }
 
                 pollGnssCapabilities();
-                ptWaitTimeout((gpsState.lastCapaUpdMs > gpsState.lastCapaPoolMs), GPS_CFG_CMD_TIMEOUT_MS);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes a bug where `gpsProcessNewSolutionData` was not called for 500ms every 5 seconds due to unnecessary blocking in the u-blox capability polling loop.

## Problem

In `gpsProtocolStateThread`, the periodic MON-VER and MON-GNSS polls (every `GPS_CAPA_INTERVAL` = 5s) waited on `_ack_state` for ACK/NAK:

```c
pollGnssCapabilities();
ptWaitTimeout((_ack_state == UBX_ACK_GOT_ACK || _ack_state == UBX_ACK_GOT_NAK), GPS_CFG_CMD_TIMEOUT_MS);
```

In the u-blox protocol, **MON-class messages respond with data, not ACK/NAK** (only CFG-class messages produce ACK/NAK). So the condition was never satisfied and `ptWaitTimeout` always hit the full 500ms (`GPS_CFG_CMD_TIMEOUT_MS`) timeout. During this window the protothread was blocked and could not loop back to call `gpsProcessNewSolutionData`.

At 10 Hz GPS, this means ~5 position fixes go unprocessed every 5 seconds.

## Fix

Remove the `ptWaitTimeout` calls entirely. The receiver thread parses MON-VER/MON-GNSS responses asynchronously regardless of whether the state thread waits, and nothing between the polls and the next loop iteration depends on the updated data. The `GPS_CAPA_INTERVAL` (5s) guard already prevents re-polling too frequently.

This matches ArduPilot's approach to capability polling — fire-and-forget, with responses handled asynchronously as they arrive.

## Testing

- SITL build compiles cleanly
- Code reviewed before PR
- Note: this was discovered by breadoven during testing of PR #11322 (position estimator refactor)

## Changes

- `src/main/io/gps_ublox.c` — Remove blocking `ptWaitTimeout` calls from periodic MON-VER and MON-GNSS polls in `gpsProtocolStateThread` main loop