### PR TITLE
NEW_HARDWARE_POLICY.md: Use Discord rather than email

### DIFF
--- a/docs/policies/NEW_HARDWARE_POLICY.md
+++ b/docs/policies/NEW_HARDWARE_POLICY.md
@@ -67,7 +67,7 @@ If one of the core developers has the hardware in possession they may opt in and
 
 1. Requester is advised to open a feature request to add support for certain hardware to INAV by following [this link](https://github.com/iNavFlight/inav/issues/new/choose)
 
-2. After opening a feature request, Requester is advised to contact the core development team by [email](mailto:coredev@inavflight.com) mentioning the open feature request and communicate with developer team via email to arrange hardware and specifications delivery.
+2. After opening a feature request, Requester is advised to contact the core development team via [Discord](https://discord.gg/peg2hhbYwN) mentioning the open feature request and communicate with developer team via email to arrange hardware and specifications delivery.
 
 
 ## See also


### PR DESCRIPTION
### **User description**
Updated contact method for hardware feature requests.


___

### **PR Type**
Documentation


___

### **Description**
- Updates hardware feature request contact method from email to Discord

- Directs users to Discord server for initial developer team communication

- Maintains email for hardware specifications delivery arrangement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Feature Request"] -- "Contact via" --> B["Discord"]
  B -- "Arrange delivery via" --> C["Email"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NEW_HARDWARE_POLICY.md</strong><dd><code>Replace email with Discord for hardware requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/policies/NEW_HARDWARE_POLICY.md

<ul><li>Changed primary contact method from email to Discord for hardware <br>feature requests<br> <li> Updated link to point to Discord server instead of email address<br> <li> Kept email as secondary communication channel for hardware <br>specifications delivery</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav/pull/11333/files#diff-789721b31f04b0baea805c610f79c812b1e6f865ed4aea21b962708874a2061b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

