### PR TITLE
New target: SDMODELH7V2 (STM32H743)

### DIFF
--- a/src/main/target/SDMODELH7V2/CMakeLists.txt
+++ b/src/main/target/SDMODELH7V2/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32h743xi(SDMODELH7V2)

--- a/src/main/target/SDMODELH7V2/config.c
+++ b/src/main/target/SDMODELH7V2/config.c
@@ -30,6 +30,7 @@ void targetConfiguration(void)
 {
     pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
     pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+    pinioBoxConfigMutable()->permanentId[2] = findBoxByActiveBoxId(BOXARM)->permanentId;
 
     // UART2 is connected to an onboard Bluetooth module (not user-accessible)
     serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART2)].functionMask = FUNCTION_MSP;

--- a/src/main/target/SDMODELH7V2/config.c
+++ b/src/main/target/SDMODELH7V2/config.c
@@ -1,0 +1,37 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "fc/fc_msp_box.h"
+#include "fc/config.h"
+
+#include "io/piniobox.h"
+#include "drivers/serial.h"
+#include "io/serial.h"
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+
+    // UART2 is connected to an onboard Bluetooth module (not user-accessible)
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART2)].functionMask = FUNCTION_MSP;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART2)].msp_baudrateIndex = BAUD_115200;
+}

--- a/src/main/target/SDMODELH7V2/target.c
+++ b/src/main/target/SDMODELH7V2/target.c
@@ -40,7 +40,6 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM8, CH4, PC9,  TIM_USE_OUTPUT_AUTO, 0, 7),   // M8
 
     DEF_TIM(TIM4, CH1, PD12, TIM_USE_LED,         0, 14),  // LED strip
-    DEF_TIM(TIM1, CH1, PE9,  TIM_USE_ANY,         0, 12),  // Camera control
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/SDMODELH7V2/target.c
+++ b/src/main/target/SDMODELH7V2/target.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/pinio.h"
+#include "drivers/sensor.h"
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_OUTPUT_AUTO, 0, 0),   // M1
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_OUTPUT_AUTO, 0, 1),   // M2
+
+    DEF_TIM(TIM2, CH2, PB3,  TIM_USE_OUTPUT_AUTO, 0, 2),   // M3
+    DEF_TIM(TIM2, CH3, PB10, TIM_USE_OUTPUT_AUTO, 0, 3),   // M4
+
+    DEF_TIM(TIM5, CH1, PA0,  TIM_USE_OUTPUT_AUTO, 0, 4),   // M5
+    DEF_TIM(TIM5, CH3, PA2,  TIM_USE_OUTPUT_AUTO, 0, 5),   // M6
+
+    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_OUTPUT_AUTO, 0, 6),   // M7
+    DEF_TIM(TIM8, CH4, PC9,  TIM_USE_OUTPUT_AUTO, 0, 7),   // M8
+
+    DEF_TIM(TIM4, CH1, PD12, TIM_USE_LED,         0, 14),  // LED strip
+    DEF_TIM(TIM1, CH1, PE9,  TIM_USE_ANY,         0, 12),  // Camera control
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/SDMODELH7V2/target.h
+++ b/src/main/target/SDMODELH7V2/target.h
@@ -1,0 +1,178 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "SDH7V2"
+#define USBD_PRODUCT_STRING     "SDMODELH7V2"
+
+#define USE_TARGET_CONFIG
+
+// *************** LED / BEEPER **********************
+#define LED0                    PC2
+
+#define BEEPER                  PC13
+#define BEEPER_INVERTED
+
+// *************** SPI1 - SD Card ********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+// *************** SPI2 - OSD (MAX7456) **************
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          PB12
+
+// *************** SPI4 - IMU (MPU6000) **************
+#define USE_SPI_DEVICE_4
+#define SPI4_SCK_PIN            PE2
+#define SPI4_MISO_PIN           PE5
+#define SPI4_MOSI_PIN           PE6
+
+#define USE_IMU_MPU6000
+#define IMU_MPU6000_ALIGN       CW270_DEG
+#define MPU6000_SPI_BUS         BUS_SPI4
+#define MPU6000_CS_PIN          PE4
+#define MPU6000_EXTI_PIN        PE1
+
+// *************** I2C1 - Baro / Mag *****************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_IST8310
+#define USE_MAG_ALL
+
+#define TEMPERATURE_I2C_BUS     BUS_I2C1
+#define PITOT_I2C_BUS           BUS_I2C1
+
+#define USE_RANGEFINDER
+#define RANGEFINDER_I2C_BUS     BUS_I2C1
+
+// *************** SD Card (SPI) *********************
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+#define SDCARD_SPI_BUS          BUS_SPI1
+#define SDCARD_CS_PIN           PA4
+#define SDCARD_DETECT_PIN       PA3
+#define SDCARD_DETECT_INVERTED
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+// *************** UART ******************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PD5
+#define UART2_RX_PIN            PD6
+
+#define USE_UART3
+#define UART3_TX_PIN            PD8
+#define UART3_RX_PIN            PD9
+
+#define USE_UART4
+#define UART4_TX_PIN            PD1
+#define UART4_RX_PIN            PD0
+
+#define USE_UART6
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+// UART7 RX-only (ESC sensor); TX pin not routed but AF mapping requires a valid pin
+#define USE_UART7
+#define UART7_TX_PIN            PE8
+#define UART7_RX_PIN            PE7
+
+#define SERIAL_PORT_COUNT       7   // VCP, UART1-4, UART6, UART7
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART6
+
+// *************** ADC *******************************
+#define USE_ADC
+#define ADC_INSTANCE            ADC1
+
+#define ADC_CHANNEL_1_PIN       PC0
+#define ADC_CHANNEL_2_PIN       PC1
+#define ADC_CHANNEL_3_PIN       PC5
+
+#define VBAT_ADC_CHANNEL        ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL        ADC_CHN_3
+
+// BF DEFAULT_VOLTAGE_METER_SCALE=109, BF DEFAULT_CURRENT_METER_SCALE=168
+// INAV uses a different scaling formula; these values approximate the same
+// physical measurement. Users should calibrate via the configurator.
+#define VBAT_SCALE_DEFAULT      1090
+#define CURRENT_METER_SCALE     168
+
+// *************** USB detect ************************
+#define USB_DETECT_PIN          PA8
+
+// *************** PINIO *****************************
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN              PE13
+#define PINIO1_FLAGS            PINIO_FLAGS_INVERTED
+#define PINIO2_PIN              PB11
+#define PINIO2_FLAGS            PINIO_FLAGS_INVERTED
+
+// *************** LED STRIP *************************
+#define USE_LED_STRIP
+#define WS2811_PIN              PD12
+
+// *************** DEFAULT FEATURES ******************
+#define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX)
+
+// *************** SERIAL 4WAY ***********************
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+// *************** ESC SENSOR ************************
+#define USE_ESC_SENSOR
+
+// *************** DSHOT *****************************
+#define USE_DSHOT
+
+// *************** IO PORT MASK **********************
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         0xffff
+#define TARGET_IO_PORTE         0xffff
+
+#define MAX_PWM_OUTPUT_PORTS    8

--- a/src/main/target/SDMODELH7V2/target.h
+++ b/src/main/target/SDMODELH7V2/target.h
@@ -135,9 +135,6 @@
 #define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
 #define RSSI_ADC_CHANNEL        ADC_CHN_3
 
-// BF DEFAULT_VOLTAGE_METER_SCALE=109, BF DEFAULT_CURRENT_METER_SCALE=168
-// INAV uses a different scaling formula; these values approximate the same
-// physical measurement. Users should calibrate via the configurator.
 #define VBAT_SCALE_DEFAULT      1090
 #define CURRENT_METER_SCALE     168
 
@@ -147,10 +144,18 @@
 // *************** PINIO *****************************
 #define USE_PINIO
 #define USE_PINIOBOX
-#define PINIO1_PIN              PE13
+
+// VTX power
+#define PINIO1_PIN              PB11
 #define PINIO1_FLAGS            PINIO_FLAGS_INVERTED
-#define PINIO2_PIN              PB11
+
+// Cam pin
+#define PINIO2_PIN              PE9
 #define PINIO2_FLAGS            PINIO_FLAGS_INVERTED
+
+// Bluetooth (off on arm)
+#define PINIO3_PIN              PE13
+#define PINIO3_FLAGS            PINIO_FLAGS_INVERTED
 
 // *************** LED STRIP *************************
 #define USE_LED_STRIP


### PR DESCRIPTION
## Summary

Adds support for the SDMODEL SDH7 V2 flight controller (STM32H743).

## Hardware

| Component | Details |
|-----------|---------|
| MCU | STM32H743 |
| IMU | MPU6000 on SPI4, CW270 alignment |
| Baro | BMP280 + MS5611 on I2C1 |
| Mag | IST8310 on I2C1 |
| OSD | MAX7456 on SPI2 |
| Blackbox | SD card on SPI1 |
| UARTs | VCP + UART1-4, UART6, UART7 (RX-only, ESC sensor) |
| Motors | 8 outputs: TIM3 (M1-2), TIM2 (M3-4), TIM5 (M5-6), TIM8 (M7-8) |
| LED strip | PD12 (TIM4) |
| Camera control | PE9 (TIM1) |

## Changes

- `src/main/target/SDMODELH7V2/CMakeLists.txt`
- `src/main/target/SDMODELH7V2/target.h`
- `src/main/target/SDMODELH7V2/target.c`



