### PR TITLE
Bugfix: SDIO capacity shows incorrectly on F4 devices

### DIFF
--- a/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c
+++ b/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c
@@ -772,7 +772,7 @@ SD_Error_t SD_GetCardInfo(void)
         SD_CardInfo.CardCapacity  = (SD_CardInfo.SD_csd.DeviceSize + 1) ;
         SD_CardInfo.CardCapacity *= (1 << (SD_CardInfo.SD_csd.DeviceSizeMul + 2));
         SD_CardInfo.CardBlockSize = 1 << (SD_CardInfo.SD_csd.RdBlockLen);
-        SD_CardInfo.CardCapacity *= SD_CardInfo.CardBlockSize;
+        SD_CardInfo.CardCapacity = SD_CardInfo.CardCapacity * SD_CardInfo.CardBlockSize / 512; // In 512 byte blocks
     }
     else if (SD_CardType == SD_HIGH_CAPACITY) {
         // Byte 7


### PR DESCRIPTION
So I decided to make my own flight controller and believe I found a bug on F4 devices. It seemed weird to me to run SD cards in SPI mode since SDIO mode is faster, so I designed that into an STM32F405 board and it worked fine - except the capacity shows as 512 times larger than actual capacity. The same board has also been produced with an STM32H743 CPU which shows the correct capacity, so I decided to dig a bit deeper:

In the F7 and H7 HAL at [line 453](https://github.com/iNavFlight/inav/blob/master/src/main/drivers/sdcard/sdmmc_sdio_hal.c#L453), the capacity is divided with 512 before the SD_GetCardInfo function returns. The [equivalent calculation](https://github.com/iNavFlight/inav/blob/master/src/main/drivers/sdcard/sdcard_spi.c#L361) is performed in SPI mode as well.

However, [in the F4 HAL](https://github.com/iNavFlight/inav/blob/master/src/main/drivers/sdcard/sdmmc_sdio_f4xx.c#L775) it is not.

I've noticed that almost no F4 targets use SDIO (they all seem to be using SPI mode) so that may be the reason why this went unnoticed. The devices that do are the F7 and H7 series but on those platforms this doesn't manifest as they use a different version of the HAL.

When you adjust the F4 HAL to be equivalent to the F7/H7 HAL, the correct capacity is reported. I've tested this on the five boards I have and all of them work when making this change. The only officially supported target using the F4 SDIO HAL seems to be the PIXRACER so the affected user base is likely to be minimal by this change.