### PR TITLE
Position estimator GPS origin altitude improvement for poor initial GPS epv

### DIFF
--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -175,6 +175,7 @@ void onNewGPSData(void)
     static int32_t previousLon;
     static int32_t previousAlt;
     static bool isFirstGPSUpdate = true;
+    static bool originAltitudeCorrectionIsActive = true;
 
     gpsLocation_t newLLH;
     const timeUs_t currentTimeUs = micros();
@@ -219,6 +220,15 @@ void onNewGPSData(void)
         else if (shouldResetReferenceAltitude()) {
             /* If we were never armed - keep altitude at zero */
             geoSetOrigin(&posControl.gpsOrigin, &newLLH, GEO_ORIGIN_RESET_ALTITUDE);
+        }
+        else if (ARMING_FLAG(ARMED) && originAltitudeCorrectionIsActive) {
+            /* Continue updating gps origin altitude after arming if gps epv exceeds max limit
+             * correcting back to takeoff altitude using estimated altitude */
+            if (posEstimator.gps.epv >= positionEstimationConfig()->max_eph_epv) {
+                posControl.gpsOrigin.alt = newLLH.alt - posEstimator.est.pos.z;
+            } else {
+                originAltitudeCorrectionIsActive = false;
+            }
         }
 
         if (posControl.gpsOrigin.valid) {


### PR DESCRIPTION
PR improves handling of GPS origin altitude setting in position estimator. With the Baro providing a valid altitude estimation it is possible to arm with a poor GPS epv that exceeds the max epv limit resulting in a GPS origin altitude value being set that can be wildly inaccurate (10's meters out). When/if the GPS epv subsequently improves and falls below the max limit the GPS will start being used for altitude estimation causing a significant altitude error.

This PR mitigates the problem by continuing to set the GPS origin altitude after arming up until GPS epv falls below the max allowed limit at which point no further correction occurs until disarm (if altitude reset is used on disarming) or reboot. The GPS origin altitude is set relative to takeoff altitude by correcting with estimated altitude.

Tested OK by reducing max epv limit to value slightly below first fix value then waiting for it to improve ...