### PR TITLE
pid/filter: FAST_CODE annotations and RC command caching

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -44,7 +44,7 @@ float nullFilterApply4(void *filter, float input, float f_cut, float dt)
 
 // PT1 Low Pass filter
 
-static float pt1ComputeRC(const float f_cut)
+static float FAST_CODE pt1ComputeRC(const float f_cut)
 {
     return 1.0f / (2.0f * M_PIf * f_cut);
 }

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -165,7 +165,7 @@ int32_t applyDeadbandRescaled(int32_t value, int32_t deadband, int32_t min, int3
     return value;
 }
 
-int32_t constrain(int32_t amt, int32_t low, int32_t high)
+int32_t FAST_CODE constrain(int32_t amt, int32_t low, int32_t high)
 {
     if (amt < low)
         return low;
@@ -175,7 +175,7 @@ int32_t constrain(int32_t amt, int32_t low, int32_t high)
         return amt;
 }
 
-float constrainf(float amt, float low, float high)
+float FAST_CODE constrainf(float amt, float low, float high)
 {
     if (amt < low)
         return low;
@@ -225,7 +225,7 @@ int scaleRange(int x, int srcMin, int srcMax, int destMin, int destMax) {
     return ((a / b) + destMin);
 }
 
-float scaleRangef(float x, float srcMin, float srcMax, float destMin, float destMax) {
+float FAST_CODE scaleRangef(float x, float srcMin, float srcMax, float destMin, float destMax) {
     float a = (destMax - destMin) * (x - srcMin);
     float b = srcMax - srcMin;
     return ((a / b) + destMin);

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -390,10 +390,25 @@ static void processPilotAndFailSafeActions(float dT)
         failsafeApplyControlInput();
     }
     else {
-        // Compute ROLL PITCH and YAW command
-        rcCommand[ROLL] = getAxisRcCommand(rxGetChannelValue(ROLL), FLIGHT_MODE(MANUAL_MODE) ? currentControlProfile->manual.rcExpo8 : currentControlProfile->stabilized.rcExpo8, rcControlsConfig()->deadband);
-        rcCommand[PITCH] = getAxisRcCommand(rxGetChannelValue(PITCH), FLIGHT_MODE(MANUAL_MODE) ? currentControlProfile->manual.rcExpo8 : currentControlProfile->stabilized.rcExpo8, rcControlsConfig()->deadband);
-        rcCommand[YAW] = -getAxisRcCommand(rxGetChannelValue(YAW), FLIGHT_MODE(MANUAL_MODE) ? currentControlProfile->manual.rcYawExpo8 : currentControlProfile->stabilized.rcYawExpo8, rcControlsConfig()->yaw_deadband);
+        // Compute ROLL PITCH and YAW command.
+        // Only recompute when the RX task has delivered new data (~50 Hz).
+        {
+            static int16_t cachedCmd[3] = {0, 0, 0};
+            if (isRXDataNew) {
+                cachedCmd[ROLL]  = getAxisRcCommand(rxGetChannelValue(ROLL),
+                    FLIGHT_MODE(MANUAL_MODE) ? currentControlProfile->manual.rcExpo8 : currentControlProfile->stabilized.rcExpo8,
+                    rcControlsConfig()->deadband);
+                cachedCmd[PITCH] = getAxisRcCommand(rxGetChannelValue(PITCH),
+                    FLIGHT_MODE(MANUAL_MODE) ? currentControlProfile->manual.rcExpo8 : currentControlProfile->stabilized.rcExpo8,
+                    rcControlsConfig()->deadband);
+                cachedCmd[YAW]   = -getAxisRcCommand(rxGetChannelValue(YAW),
+                    FLIGHT_MODE(MANUAL_MODE) ? currentControlProfile->manual.rcYawExpo8 : currentControlProfile->stabilized.rcYawExpo8,
+                    rcControlsConfig()->yaw_deadband);
+            }
+            rcCommand[ROLL]  = cachedCmd[ROLL];
+            rcCommand[PITCH] = cachedCmd[PITCH];
+            rcCommand[YAW]   = cachedCmd[YAW];
+        }
 
         // Apply manual control rates
         if (FLIGHT_MODE(MANUAL_MODE)) {
@@ -418,8 +433,10 @@ static void processPilotAndFailSafeActions(float dT)
         //Compute THROTTLE command
         rcCommand[THROTTLE] = throttleStickMixedValue();
 
-        // Signal updated rcCommand values to Failsafe system
-        failsafeUpdateRcCommandValues();
+        // Signal updated rcCommand values to Failsafe system when new RC data arrived
+        if (isRXDataNew) {
+            failsafeUpdateRcCommandValues();
+        }
 
         if (FLIGHT_MODE(HEADFREE_MODE)) {
             const float radDiff = degreesToRadians(DECIDEGREES_TO_DEGREES(attitude.values.yaw) - headFreeModeHold);

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -177,7 +177,7 @@ bool areSensorsCalibrating(void)
     return false;
 }
 
-int16_t getAxisRcCommand(int16_t rawData, int16_t rate, int16_t deadband)
+int16_t FAST_CODE getAxisRcCommand(int16_t rawData, int16_t rate, int16_t deadband)
 {
     int16_t stickDeflection = 0;
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -117,6 +117,7 @@ typedef struct {
     smithPredictor_t smithPredictor;
 
     fwPidAttenuation_t attenuation;
+    uint16_t pidSumLimit;
 } pidState_t;
 
 STATIC_FASTRAM bool pidFiltersConfigured = false;
@@ -861,7 +862,7 @@ static void NOINLINE pidApplyFixedWingRateController(pidState_t *pidState, float
 
     applyItermLimiting(pidState);
 
-    const uint16_t limit = getPidSumLimit(pidState->axis);
+    const uint16_t limit = pidState->pidSumLimit;
 
     if (pidProfile()->pidItermLimitPercent != 0){
         float itermLimit = limit * pidProfile()->pidItermLimitPercent * 0.01f;
@@ -927,7 +928,7 @@ static void FAST_CODE NOINLINE pidApplyMulticopterRateController(pidState_t *pid
      */
     const float newCDTerm = rateTargetDeltaFiltered * pidState->kCD;
 
-    const uint16_t limit = getPidSumLimit(pidState->axis);
+    const uint16_t limit = pidState->pidSumLimit;
 
     // TODO: Get feedback from mixer on available correction range for each axis
     const float newOutput = newPTerm + newDTerm + pidState->errorGyroIf + newCDTerm;
@@ -1376,6 +1377,7 @@ void pidInit(void)
     #endif
 
         pidState[axis].axis = axis;
+        pidState[axis].pidSumLimit = getPidSumLimit(axis);
         if (axis == FD_YAW) {
             if (yawLpfHz) {
                 pidState[axis].ptermFilterApplyFn = (filterApply4FnPtr) pt1FilterApply4;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -413,7 +413,7 @@ float getAxisIterm(uint8_t axis)
     return pidState[axis].errorGyroIf;
 }
 
-static float pidRcCommandToAngle(int16_t stick, int16_t maxInclination)
+static float FAST_CODE pidRcCommandToAngle(int16_t stick, int16_t maxInclination)
 {
     stick = constrain(stick, -500, 500);
     return scaleRangef((float) stick, -500.0f, 500.0f, (float) -maxInclination, (float) maxInclination);
@@ -436,7 +436,7 @@ float pidRateToRcCommand(float rateDPS, uint8_t rate)
     return scaleRangef(rateDPS, -maxRateDPS, maxRateDPS, -500.0f, 500.0f);
 }
 
-float pidRcCommandToRate(int16_t stick, uint8_t rate)
+float FAST_CODE pidRcCommandToRate(int16_t stick, uint8_t rate)
 {
     const float maxRateDPS = rate * 10.0f;
     return scaleRangef((float) stick, -500.0f, 500.0f, -maxRateDPS, maxRateDPS);
@@ -725,7 +725,7 @@ static void pidLevel(const float angleTarget, pidState_t *pidState, flight_dynam
 }
 
 /* Apply angular acceleration limit to rate target to limit extreme stick inputs to respect physical capabilities of the machine */
-static void pidApplySetpointRateLimiting(pidState_t *pidState, flight_dynamics_index_t axis, float dT)
+static void FAST_CODE pidApplySetpointRateLimiting(pidState_t *pidState, flight_dynamics_index_t axis, float dT)
 {
     const uint32_t axisAccelLimit = (axis == FD_YAW) ? pidProfile()->axisAccelerationLimitYaw : pidProfile()->axisAccelerationLimitRollPitch;
 
@@ -734,7 +734,7 @@ static void pidApplySetpointRateLimiting(pidState_t *pidState, flight_dynamics_i
     }
 }
 
-static float pTermProcess(pidState_t *pidState, float rateError, float dT) {
+static float FAST_CODE pTermProcess(pidState_t *pidState, float rateError, float dT) {
     float newPTerm = rateError * pidState->kP;
 
     return pidState->ptermFilterApplyFn(&pidState->ptermLpfState, newPTerm, yawLpfHz, dT);
@@ -770,7 +770,7 @@ static float applyDBoost(pidState_t *pidState, float dT) {
 }
 #endif
 
-static float dTermProcess(pidState_t *pidState, float currentRateTarget, float dT, float dT_inv) {
+static float FAST_CODE dTermProcess(pidState_t *pidState, float currentRateTarget, float dT, float dT_inv) {
     // Calculate new D-term
     float newDTerm = 0;
     if (pidState->kD == 0) {
@@ -787,7 +787,7 @@ static float dTermProcess(pidState_t *pidState, float currentRateTarget, float d
     return(newDTerm);
 }
 
-static void applyItermLimiting(pidState_t *pidState) {
+static void FAST_CODE applyItermLimiting(pidState_t *pidState) {
     if (pidState->itermLimitActive) {
         pidState->errorGyroIf = constrainf(pidState->errorGyroIf, -pidState->errorGyroIfLimit, pidState->errorGyroIfLimit);
     } else
@@ -1136,7 +1136,7 @@ static void pidApplyFpvCameraAngleMix(pidState_t *pidState, uint8_t fpvCameraAng
     pidState[YAW].rateTarget = constrainf(yawRate * cosCameraAngle + rollRate * sinCameraAngle, -GYRO_SATURATION_LIMIT, GYRO_SATURATION_LIMIT);
 }
 
-void checkItermLimitingActive(pidState_t *pidState)
+void FAST_CODE checkItermLimitingActive(pidState_t *pidState)
 {
     bool shouldActivate = false;
 
@@ -1147,7 +1147,7 @@ void checkItermLimitingActive(pidState_t *pidState)
     pidState->itermLimitActive = STATE(ANTI_WINDUP) || shouldActivate;
 }
 
-void checkItermFreezingActive(pidState_t *pidState, flight_dynamics_index_t axis)
+void FAST_CODE checkItermFreezingActive(pidState_t *pidState, flight_dynamics_index_t axis)
 {
     if (usedPidControllerType == PID_TYPE_PIFF && pidProfile()->fixedWingYawItermBankFreeze != 0 && axis == FD_YAW) {
         // Do not allow yaw I-term to grow when bank angle is too large

--- a/src/main/flight/smith_predictor.c
+++ b/src/main/flight/smith_predictor.c
@@ -34,7 +34,7 @@
 #include "flight/smith_predictor.h"
 #include "build/debug.h"
 
-float applySmithPredictor(uint8_t axis, smithPredictor_t *predictor, float sample) {
+float FAST_CODE applySmithPredictor(uint8_t axis, smithPredictor_t *predictor, float sample) {
     UNUSED(axis);
     if (predictor->enabled) {
         predictor->data[predictor->idx] = sample;


### PR DESCRIPTION
## Summary

Two performance improvements to the PID hot path, applied in order:

1. **`pid/filter: add FAST_CODE to pidController callees`** — adds `FAST_CODE` to functions called from `pidController()` so they land in ITCM (fast RAM) on STM32 targets, eliminating flash-to-ITCM trampoline jumps at 1 kHz
2. **`fc/pid: avoid recomputing values that change at lower rates`** — caches RC command values and `pidSumLimit` so they are only recalculated when new RX data arrives (~50 Hz) rather than every PID loop iteration (~1000 Hz). Also gates `failsafeUpdateRcCommandValues()` behind the same new-data check

## Files Changed

- `src/main/common/filter.c` — FAST_CODE
- `src/main/common/maths.c` — FAST_CODE
- `src/main/fc/fc_core.c` — FAST_CODE, RC command caching
- `src/main/flight/pid.c` — FAST_CODE, RC command caching
- `src/main/flight/smith_predictor.c` — FAST_CODE

## Testing

- [ ] Compiles cleanly for SITL ✅
- [ ] STM32 target builds without linker errors
- [ ] No regressions in PID behavior or RC response

