### PR TITLE
fix lsm6dxx driver lack gyroAlign setting issue.

### DIFF
--- a/src/main/drivers/accgyro/accgyro_lsm6dxx.c
+++ b/src/main/drivers/accgyro/accgyro_lsm6dxx.c
@@ -222,6 +222,7 @@ bool lsm6dGyroDetect(gyroDev_t *gyro)
     gyro->initFn = lsm6dxxSpiGyroInit;
     gyro->readFn = lsm6dxxGyroRead;
     gyro->intStatusFn = gyroCheckDataReady;
+    gyro->gyroAlign = gyro->busDev->param;
     gyro->scale = 1.0f / 16.4f; // 2000 dps
     return true;
 


### PR DESCRIPTION
- Fixed LSM6DXX driver missing gyroAlign setting that was causing alignment issues with the gyroscope                                              

Thank you, feel free to leave comments.