### PR TITLE
Fix hard faults when handling large MSP responses over CRSF

### DIFF
--- a/src/main/telemetry/crsf.h
+++ b/src/main/telemetry/crsf.h
@@ -20,8 +20,8 @@
 #include "common/time.h"
 #include "rx/crsf.h"
 
-#define CRSF_MSP_RX_BUF_SIZE 128
-#define CRSF_MSP_TX_BUF_SIZE 128
+#define CRSF_MSP_RX_BUF_SIZE 512
+#define CRSF_MSP_TX_BUF_SIZE 512
 
 void initCrsfTelemetry(void);
 bool checkCrsfTelemetryState(void);

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -68,12 +68,12 @@ void initSharedMsp(void)
     mspPackage.requestBuffer = (uint8_t *)&mspRxBuffer;
     mspPackage.requestPacket = &mspRxPacket;
     mspPackage.requestPacket->buf.ptr = mspPackage.requestBuffer;
-    mspPackage.requestPacket->buf.end = mspPackage.requestBuffer;
+    mspPackage.requestPacket->buf.end = mspPackage.requestBuffer + sizeof(mspRxBuffer);
 
     mspPackage.responseBuffer = (uint8_t *)&mspTxBuffer;
     mspPackage.responsePacket = &mspTxPacket;
     mspPackage.responsePacket->buf.ptr = mspPackage.responseBuffer;
-    mspPackage.responsePacket->buf.end = mspPackage.responseBuffer;
+    mspPackage.responsePacket->buf.end = mspPackage.responseBuffer + sizeof(mspTxBuffer);
 }
 
 static void processMspPacket(void)

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -80,7 +80,8 @@ static void processMspPacket(void)
 {
     mspPackage.responsePacket->cmd = 0;
     mspPackage.responsePacket->result = 0;
-    mspPackage.responsePacket->buf.end = mspPackage.responseBuffer;
+    mspPackage.responsePacket->buf.ptr = mspPackage.responseBuffer;
+    mspPackage.responsePacket->buf.end = mspPackage.responseBuffer + sizeof(mspTxBuffer);
 
     mspPostProcessFnPtr mspPostProcessFn = NULL;
     if (mspFcProcessCommand(mspPackage.requestPacket, mspPackage.responsePacket, &mspPostProcessFn) == MSP_RESULT_ERROR) {
@@ -231,7 +232,7 @@ bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)
         sbufWriteU8(payloadBuf, (seq++ & TELEMETRY_MSP_SEQ_MASK) | (lastRequestVersion << TELEMETRY_MSP_VER_SHIFT)); // header without 'start' flag
     }
 
-    const uint8_t bufferBytesRemaining = sbufBytesRemaining(txBuf);
+    const uint16_t bufferBytesRemaining = sbufBytesRemaining(txBuf);
     const uint8_t payloadBytesRemaining = sbufBytesRemaining(payloadBuf);
     uint8_t frame[payloadBytesRemaining];
 

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -217,7 +217,7 @@ bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)
         }
         sbufWriteU8(payloadBuf, status);
 
-        const uint8_t size = sbufBytesRemaining(txBuf);
+        const uint16_t size = sbufBytesRemaining(txBuf);
         if (lastRequestVersion == 1) { // MSPv1
             sbufWriteU8(payloadBuf, size);
             sbufWriteU8(payloadBuf, mspPackage.responsePacket->cmd);


### PR DESCRIPTION
### Description

Resolves hard faults and connection hangs when the INAV Configurator requests large datasets (e.g., Mixer configuration on the Mixer tab) via an ELRS WiFi TCP connection.

### System Architecture

```mermaid
graph LR
    A["INAV<br/>Configurator<br/>(TCP Client)"] -->|MSP Request| B["ELRS WiFi<br/>TCP Server<br/>:5761"]
    B -->|MSP in CRSF Req| C
    C -->|MSP in CRSF Res| B
    B -->|MSP Response| A

    subgraph FC["INAV Flight Controller"]
        C["CRSF<br/>Handler"] -->|MSP Request| D["MSP<br/>Handler"]
        D -->|MSP Response| C
    end
```

### Root Cause

The original MSP-over-CRSF implementation assumed small payloads. When requesting large datasets (like the 432-byte Mixer config), this caused:

1. Buffer overflows in `CRSF_MSP_RX_BUF_SIZE` (128 bytes), leading to hard faults.
2. `uint8_t` overflows in `size` and `bufferBytesRemaining`, corrupting MSP headers and packet tracking.
3. Incorrect buffer boundary initialization in `initSharedMsp()`.

### Investigation

* CRSF Packet captures: Confirmed the ELRS receiver correctly fragments, sequences, and forwards complete MSP frames via the CRSF tunnel.
* Direct UART test: Forwarding TCP packets directly to the FC's MSP UART works perfectly, isolating the bug to INAV's MSP-over-CRSF handling.

### Fixes & Memory Impact

* Increased `CRSF_MSP_RX_BUF_SIZE` and `CRSF_MSP_TX_BUF_SIZE` to 512 bytes (safely accommodates max known payloads).
* Widened `size` and `bufferBytesRemaining` from `uint8_t` to `uint16_t`.
* Fixed buffer boundaries in `initSharedMsp()` and pointer resets in `processMspPacket()`.
* Memory Impact: Adds 768 bytes total SRAM usage (~0.3% on AT32F435). A negligible tradeoff for wireless configuration stability.

### Expected Behavior & Verification

* Behavior: All Configurator tabs load reliably over ELRS WiFi TCP without freezing. Enables in-field wireless tuning. *(Note: CLI uses a raw text protocol unsupported by ELRS tunneling).*
* Verification: Tested on `NEUTRONRCF435MINI` with an ESP8285 ELRS RX (v3.6.2). `MSP2_INAV_SERVO_MIXER` loads successfully with a valid CRC.
