### PR TITLE
Add Loiter to LED control on mode flight

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -127,6 +127,7 @@ static const modeColorIndexes_t defaultModeColors[] = {
     [LED_MODE_ANGLE]       = {{ COLOR_CYAN,       COLOR_DARK_VIOLET, COLOR_YELLOW,    COLOR_DEEP_PINK, COLOR_BLUE, COLOR_ORANGE }},
     [LED_MODE_MAG]         = {{ COLOR_MINT_GREEN, COLOR_DARK_VIOLET, COLOR_ORANGE,    COLOR_DEEP_PINK, COLOR_BLUE, COLOR_ORANGE }},
     [LED_MODE_BARO]        = {{ COLOR_LIGHT_BLUE, COLOR_DARK_VIOLET, COLOR_RED,       COLOR_DEEP_PINK, COLOR_BLUE, COLOR_ORANGE }},
+    [LED_MODE_LOITER]      = {{ COLOR_YELLOW,     COLOR_DARK_VIOLET, COLOR_RED,       COLOR_DEEP_PINK, COLOR_BLUE, COLOR_ORANGE }},
 };
 
 static const specialColorIndexes_t defaultSpecialColors[] = {
@@ -423,6 +424,7 @@ static const struct {
     uint8_t ledMode;
 } flightModeToLed[] = {
     {HEADFREE_MODE, LED_MODE_HEADFREE},
+    {NAV_POSHOLD_MODE, LED_MODE_LOITER},
     {HEADING_MODE,  LED_MODE_MAG},
 #ifdef USE_BARO
     {NAV_ALTHOLD_MODE, LED_MODE_BARO},

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -23,7 +23,7 @@
 
 #define LED_MAX_STRIP_LENGTH           128
 #define LED_CONFIGURABLE_COLOR_COUNT   16
-#define LED_MODE_COUNT                  6
+#define LED_MODE_COUNT                  7
 #define LED_DIRECTION_COUNT             6
 #define LED_BASEFUNCTION_COUNT          8
 #define LED_OVERLAY_COUNT               7
@@ -79,6 +79,7 @@ typedef enum {
     LED_MODE_ANGLE,
     LED_MODE_MAG,
     LED_MODE_BARO,
+    LED_MODE_LOITER,
     LED_SPECIAL
 } ledModeIndex_e;
 


### PR DESCRIPTION
Adds Loiter as a flight mode, allowing control of the LEDs when this mode is activated.
<img width="1206" height="1044" alt="image" src="https://github.com/user-attachments/assets/81e4631b-faf7-408c-b20c-d781d8b2f966" />
