### PR TITLE
CI: publish PR test builds to iNavFlight/pr-test-builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,16 @@ jobs:
         with:
           name: targets
           path: targets.txt
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+      - name: Upload PR number
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: pr_number.txt
+          retention-days: 1
 
   build-SITL-Linux-arm64:
     runs-on: ubuntu-22.04-arm

--- a/.github/workflows/pr-test-builds.yml
+++ b/.github/workflows/pr-test-builds.yml
@@ -20,10 +20,11 @@ jobs:
     # Prevent concurrent runs for the same PR branch racing on the
     # release delete/create cycle.
     concurrency:
-      group: pr-test-build-${{ github.event.workflow_run.head_branch }}
+      group: pr-test-build-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
       cancel-in-progress: true
     permissions:
       actions: read          # to download artifacts from the triggering workflow run
+      issues: write          # github.rest.issues.* endpoints used to post PR comments
       pull-requests: write   # to post the PR comment
 
     steps:
@@ -93,6 +94,7 @@ jobs:
           gh release create "pr-${PR_NUMBER}" *.hex \
             --repo iNavFlight/pr-test-builds \
             --prerelease \
+            --target "${{ github.event.workflow_run.head_sha }}" \
             --title "PR #${PR_NUMBER} (${SHORT_SHA})" \
             --notes "${NOTES}"
 
@@ -104,7 +106,8 @@ jobs:
           HEX_COUNT: ${{ steps.info.outputs.count }}
         with:
           script: |
-            const prNumber = parseInt(process.env.PR_NUMBER);
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            if (isNaN(prNumber)) throw new Error(`Invalid PR number: ${process.env.PR_NUMBER}`);
             const shortSha  = process.env.SHORT_SHA;
             const count     = process.env.HEX_COUNT;
             const releaseUrl = `https://github.com/iNavFlight/pr-test-builds/releases/tag/pr-${prNumber}`;

--- a/.github/workflows/pr-test-builds.yml
+++ b/.github/workflows/pr-test-builds.yml
@@ -1,0 +1,151 @@
+name: PR Test Builds
+
+# Runs after "Build firmware" completes. Uses workflow_run (rather than
+# pull_request directly) so that secrets are available even for PRs from forks.
+#
+# Requires a repository secret PR_BUILDS_TOKEN with Contents: write access
+# to iNavFlight/pr-test-builds (fine-grained PAT or classic PAT with repo scope).
+on:
+  workflow_run:
+    workflows: ["Build firmware"]
+    types: [completed]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Only act on pull_request-triggered runs that succeeded.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    # Prevent concurrent runs for the same PR branch racing on the
+    # release delete/create cycle.
+    concurrency:
+      group: pr-test-build-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: true
+    permissions:
+      actions: read          # to download artifacts from the triggering workflow run
+      pull-requests: write   # to post the PR comment
+
+    steps:
+      - name: Download PR number
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: |
+          PR_NUM=$(tr -dc '0-9' < pr_number.txt)
+          if [ -z "$PR_NUM" ]; then
+            echo "::error::Invalid PR number in artifact"
+            exit 1
+          fi
+          echo "number=${PR_NUM}" >> $GITHUB_OUTPUT
+
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: matrix-inav-*
+          merge-multiple: true
+          path: hexes
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get build info
+        id: info
+        run: |
+          COUNT=$(find hexes -name '*.hex' -type f | wc -l)
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::No .hex files found in downloaded artifacts"
+            exit 1
+          fi
+          echo "count=${COUNT}" >> $GITHUB_OUTPUT
+          echo "short_sha=$(echo '${{ github.event.workflow_run.head_sha }}' | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      # Delete the previous release for this PR (if any) so assets are replaced
+      # cleanly on each new commit. --cleanup-tag removes the old tag so it is
+      # recreated fresh pointing to the new commit.
+      - name: Delete existing PR release
+        env:
+          GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
+        run: |
+          gh release delete "pr-${{ steps.pr.outputs.number }}" \
+            --repo iNavFlight/pr-test-builds --cleanup-tag --yes 2>/dev/null || true
+
+      - name: Create PR release
+        env:
+          GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          SHORT_SHA="${{ steps.info.outputs.short_sha }}"
+          COUNT="${{ steps.info.outputs.count }}"
+          PR_URL="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+
+          NOTES="Test build for [PR #${PR_NUMBER}](${PR_URL}) — commit \`${SHORT_SHA}\`
+
+**${COUNT} targets built.** Find your board's \`.hex\` file by name (e.g. \`MATEKF405SE.hex\`).
+
+> Development build for testing only. Use Full Chip Erase when flashing."
+
+          cd hexes
+          gh release create "pr-${PR_NUMBER}" *.hex \
+            --repo iNavFlight/pr-test-builds \
+            --prerelease \
+            --title "PR #${PR_NUMBER} (${SHORT_SHA})" \
+            --notes "${NOTES}"
+
+      - name: Post or update PR comment
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          SHORT_SHA: ${{ steps.info.outputs.short_sha }}
+          HEX_COUNT: ${{ steps.info.outputs.count }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            const shortSha  = process.env.SHORT_SHA;
+            const count     = process.env.HEX_COUNT;
+            const releaseUrl = `https://github.com/iNavFlight/pr-test-builds/releases/tag/pr-${prNumber}`;
+
+            const body = [
+              '<!-- pr-test-build -->',
+              '**Test firmware build ready** — commit `' + shortSha + '`',
+              '',
+              `[Download firmware for PR #${prNumber}](${releaseUrl})`,
+              '',
+              `${count} targets built. Find your board's \`.hex\` file by name on that page ` +
+              '(e.g. `MATEKF405SE.hex`). Files are individually downloadable — no GitHub login required.',
+              '',
+              '> Development build for testing only. Use Full Chip Erase when flashing.',
+            ].join('\n');
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: prNumber,
+              }
+            );
+
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('<!-- pr-test-build -->')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner:      context.repo.owner,
+                repo:       context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner:        context.repo.owner,
+                repo:         context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

Make it easier for people to test PRs.

Adds a workflow that publishes firmware from every CI-passing PR as individually named release assets on a dedicated [`iNavFlight/pr-test-builds`](https://github.com/iNavFlight/pr-test-builds) repository, and posts a comment on the PR with a direct download link.

This addresses two long-standing issues with the current approach of bundling everything into a single Actions artifact zip:
- Users could not find the firmware for their specific board without downloading and unzipping the entire bundle
- GitHub requires a login to download Actions artifacts, blocking community testers without a GitHub account

## Changes

- `.github/workflows/ci.yml` — adds two steps at the end of `upload-artifacts` to save the PR number as a short-lived artifact (no-op on push events)
- `.github/workflows/pr-test-builds.yml` — new `workflow_run`-triggered workflow that runs after CI completes; uses `workflow_run` rather than `pull_request` so secrets are available for fork PRs

## How it works

1. CI builds all targets as normal
2. `pr-test-builds.yml` triggers on CI completion, downloads the hex artifacts, creates/replaces a pre-release on `iNavFlight/pr-test-builds` tagged `pr-NNNN` with each `.hex` as an individual named asset
3. A comment is posted (or updated) on the PR with a link to the release page

Release assets on public repos are publicly downloadable without a GitHub login.

## Setup required before this is active

- Create the `iNavFlight/pr-test-builds` repository (public, empty)
- Create a fine-grained PAT with `Contents: write` on that repo
- Add it as a repository secret `PR_BUILDS_TOKEN` in `iNavFlight/inav`

## Testing

This is a GitHub Actions workflow change. Functional testing requires a live CI run after the `pr-test-builds` repo and `PR_BUILDS_TOKEN` secret are in place. The workflow logic (artifact download, release create, PR comment) has been reviewed for correctness.

## Code Review

Reviewed with inav-code-review agent. Issues addressed: missing `actions: read` permission, `process.env` pattern in github-script, PR number validation, concurrency group to prevent race conditions on rapid pushes, comment pagination for PRs with 30+ comments, hex count validation, and `--cleanup-tag` on release delete.