### PR TITLE
cmake/sitl: use CheckLinkerFlag instead of GCC version check for --no-warn-rwx-segments

### DIFF
--- a/cmake/sitl.cmake
+++ b/cmake/sitl.cmake
@@ -64,7 +64,9 @@ if(NOT MACOSX)
         -Wno-error=maybe-uninitialized
         -fsingle-precision-constant
     )
-    if (CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 12.0)
+    include(CheckLinkerFlag)
+    check_linker_flag(C "-Wl,--no-warn-rwx-segments" LINKER_SUPPORTS_NO_RWX_WARNING)
+    if(LINKER_SUPPORTS_NO_RWX_WARNING)
         set(SITL_LINK_OPTIONS ${SITL_LINK_OPTIONS} "-Wl,--no-warn-rwx-segments")
     endif()
 else()

--- a/cmake/sitl.cmake
+++ b/cmake/sitl.cmake
@@ -64,8 +64,10 @@ if(NOT MACOSX)
         -Wno-error=maybe-uninitialized
         -fsingle-precision-constant
     )
-    include(CheckLinkerFlag)
-    check_linker_flag(C "-Wl,--no-warn-rwx-segments" LINKER_SUPPORTS_NO_RWX_WARNING)
+    include(CheckLinkerFlag OPTIONAL)
+    if(COMMAND check_linker_flag)
+        check_linker_flag(C "-Wl,--no-warn-rwx-segments" LINKER_SUPPORTS_NO_RWX_WARNING)
+    endif()
     if(LINKER_SUPPORTS_NO_RWX_WARNING)
         set(SITL_LINK_OPTIONS ${SITL_LINK_OPTIONS} "-Wl,--no-warn-rwx-segments")
     endif()


### PR DESCRIPTION
## Summary

Replace the fragile GCC version check for `--no-warn-rwx-segments` in `cmake/sitl.cmake` with a proper `CheckLinkerFlag` capability probe.

## Changes

- Remove `CMAKE_COMPILER_IS_GNUCC + VERSION_LESS 12.0` heuristic
- Add `include(CheckLinkerFlag)` and `check_linker_flag()` probe
- The probe directly tests whether the linker accepts the flag, rather than guessing from the compiler version

`check_linker_flag()` has been available since CMake 3.18; SITL already requires CMake 3.22+, so there is no minimum version concern.

## Testing

- Built SITL successfully after the change
- On this system the probe correctly detected that `--no-warn-rwx-segments` is not supported (ld < 2.39) and skipped the flag — build completed cleanly with no linker warnings or errors
- On systems with ld ≥ 2.39 the probe will pass and the flag will be applied as before