### PR TITLE
CI: fix YAML syntax error in pr-test-builds workflow

### DIFF
--- a/.github/workflows/pr-test-builds.yml
+++ b/.github/workflows/pr-test-builds.yml
@@ -78,25 +78,24 @@ jobs:
       - name: Create PR release
         env:
           GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          SHORT_SHA: ${{ steps.info.outputs.short_sha }}
+          HEX_COUNT: ${{ steps.info.outputs.count }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
         run: |
-          PR_NUMBER="${{ steps.pr.outputs.number }}"
-          SHORT_SHA="${{ steps.info.outputs.short_sha }}"
-          COUNT="${{ steps.info.outputs.count }}"
-          PR_URL="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
-
-          NOTES="Test build for [PR #${PR_NUMBER}](${PR_URL}) — commit \`${SHORT_SHA}\`
-
-**${COUNT} targets built.** Find your board's \`.hex\` file by name (e.g. \`MATEKF405SE.hex\`).
-
-> Development build for testing only. Use Full Chip Erase when flashing."
-
-          cd hexes
-          gh release create "pr-${PR_NUMBER}" *.hex \
+          PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+          printf '%s\n\n%s\n\n%s\n' \
+            "Test build for [PR #${PR_NUMBER}](${PR_URL}) — commit \`${SHORT_SHA}\`" \
+            "**${HEX_COUNT} targets built.** Find your board's \`.hex\` file by name (e.g. \`MATEKF405SE.hex\`)." \
+            "> Development build for testing only. Use Full Chip Erase when flashing." \
+            > release-notes.md
+          gh release create "pr-${PR_NUMBER}" hexes/*.hex \
             --repo iNavFlight/pr-test-builds \
             --prerelease \
-            --target "${{ github.event.workflow_run.head_sha }}" \
+            --target "${HEAD_SHA}" \
             --title "PR #${PR_NUMBER} (${SHORT_SHA})" \
-            --notes "${NOTES}"
+            --notes-file release-notes.md
 
       - name: Post or update PR comment
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

Fixes a YAML parse error introduced in #11381 that caused the `pr-test-builds` workflow to fail on every run with "workflow file issue".

## Root cause

The `NOTES` variable assignment in the "Create PR release" step spanned multiple lines, and the continuation lines (`**...`, `>...`) had zero indentation. YAML block scalars require all non-blank content lines to be at least as indented as the block's base level. Lines at column 0 inside a 10-space-indented block scalar are a parse error.

## Fix

Replace the multi-line `NOTES` variable + `--notes` with `printf` writing to a temp file + `--notes-file`. This avoids multi-line strings in the YAML block scalar entirely. The `${{ }}` expressions are also moved into `env:` vars rather than inline in the shell script.

## Testing

PR #11383 had all CI checks pass before this fix was available — it can be used to verify the workflow runs correctly once this is merged.