### PR TITLE
CI: fix pr-test-builds release creation

### DIFF
--- a/.github/workflows/pr-test-builds.yml
+++ b/.github/workflows/pr-test-builds.yml
@@ -81,7 +81,6 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           SHORT_SHA: ${{ steps.info.outputs.short_sha }}
           HEX_COUNT: ${{ steps.info.outputs.count }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           REPO: ${{ github.repository }}
         run: |
           PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
@@ -93,7 +92,6 @@ jobs:
           gh release create "pr-${PR_NUMBER}" hexes/*.hex \
             --repo iNavFlight/pr-test-builds \
             --prerelease \
-            --target "${HEAD_SHA}" \
             --title "PR #${PR_NUMBER} (${SHORT_SHA})" \
             --notes-file release-notes.md
 


### PR DESCRIPTION


The --target flag was passing the inav commit SHA to gh release create in iNavFlight/pr-test-builds. That SHA does not exist in that repo so GitHub rejected it with HTTP 422 "Release.target_commitish is invalid".

Remove --target so the release is anchored to the default branch (main) of pr-test-builds, which is the correct behaviour for a binary hosting repo.