### PR TITLE
drivers: wait for DMA EN bit to clear before reconfiguring DShot DMA (F7/H7)

### DIFF
--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -536,12 +536,8 @@ void impl_timerPWMPrepareDMA(TCH_t * tch, uint32_t dmaBufferElementCount)
         __NOP();
     }
     if (LL_DMA_IsEnabledStream(dmaBase, streamLL)) {
-        // EN did not clear within the timeout (~140-230 us at 216 MHz). Any in-progress
-        // transfer has long since completed or been aborted, so no data corruption risk
-        // remains - but we cannot safely reconfigure the DMA registers this cycle.
-        // Skip this frame (ESC holds its last command) and mark the channel IDLE so
-        // StartDMA passes over it. EN will almost certainly have cleared by the next
-        // PrepareDMA call (~1-2 ms later), allowing normal operation to resume.
+        // EN did not clear - cannot reconfigure this cycle. Skip frame (ESC holds
+        // last command); EN should clear before the next call.
         tch->dmaState = TCH_DMA_IDLE;
         return;
     }

--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -528,6 +528,19 @@ void impl_timerPWMPrepareDMA(TCH_t * tch, uint32_t dmaBufferElementCount)
         DMA_CLEAR_FLAG(tch->dma, DMA_IT_TCIF);
     }
 
+    // Wait for EN bit to actually clear before reconfiguring DMA registers.
+    // Per STM32F7 RM: writes to DMA_SxNDTR and DMA_SxM0AR are ignored while EN=1.
+    // The EN bit does not clear synchronously - hardware may still be completing an
+    // in-progress burst when software writes 0 to EN.
+    uint32_t timeout = 10000;
+    while (LL_DMA_IsEnabledStream(dmaBase, streamLL) && timeout--) {
+        __NOP();
+    }
+    if (LL_DMA_IsEnabledStream(dmaBase, streamLL)) {
+        // EN did not clear - skip reconfiguration to avoid silent data corruption.
+        return;
+    }
+
     LL_DMA_SetDataLength(dmaBase, streamLL, dmaBufferElementCount);
     LL_DMA_ConfigAddresses(dmaBase, streamLL, (uint32_t)tch->dmaBuffer, (uint32_t)impl_timerCCR(tch), LL_DMA_DIRECTION_MEMORY_TO_PERIPH);
     LL_DMA_EnableIT_TC(dmaBase, streamLL);

--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -536,8 +536,12 @@ void impl_timerPWMPrepareDMA(TCH_t * tch, uint32_t dmaBufferElementCount)
         __NOP();
     }
     if (LL_DMA_IsEnabledStream(dmaBase, streamLL)) {
-        // EN did not clear - hardware fault. Set channel idle so it is skipped
-        // on the next StartDMA call rather than being left in an ambiguous state.
+        // EN did not clear within the timeout (~140-230 us at 216 MHz). Any in-progress
+        // transfer has long since completed or been aborted, so no data corruption risk
+        // remains - but we cannot safely reconfigure the DMA registers this cycle.
+        // Skip this frame (ESC holds its last command) and mark the channel IDLE so
+        // StartDMA passes over it. EN will almost certainly have cleared by the next
+        // PrepareDMA call (~1-2 ms later), allowing normal operation to resume.
         tch->dmaState = TCH_DMA_IDLE;
         return;
     }

--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -532,12 +532,13 @@ void impl_timerPWMPrepareDMA(TCH_t * tch, uint32_t dmaBufferElementCount)
     // Per STM32F7 RM: writes to DMA_SxNDTR and DMA_SxM0AR are ignored while EN=1.
     // The EN bit does not clear synchronously - hardware may still be completing an
     // in-progress burst when software writes 0 to EN.
-    uint32_t timeout = 10000;
-    while (LL_DMA_IsEnabledStream(dmaBase, streamLL) && timeout--) {
+    for (uint32_t timeout = 10000; timeout && LL_DMA_IsEnabledStream(dmaBase, streamLL); timeout--) {
         __NOP();
     }
     if (LL_DMA_IsEnabledStream(dmaBase, streamLL)) {
-        // EN did not clear - skip reconfiguration to avoid silent data corruption.
+        // EN did not clear - hardware fault. Set channel idle so it is skipped
+        // on the next StartDMA call rather than being left in an ambiguous state.
+        tch->dmaState = TCH_DMA_IDLE;
         return;
     }
 


### PR DESCRIPTION
Brings a fix already done on H7 over to F7. It may be the cause of some mystery lock ups on F765.
F765 are more likely to hit it because of the caching structure.


## Problem
In `timer_impl_hal.c` :

`impl_timerPWMPrepareDMA()` calls `LL_DMA_DisableStream()` then immediately calls `LL_DMA_SetDataLength()` and `LL_DMA_ConfigAddresses()` with no wait between them.



Per STM32F7 Reference Manual (RM0410, Section 8.3.5):

> The stream can be disabled by resetting the EN bit. [...] Note that it takes a certain number of AHB clock cycles before the stream is effectively disabled. __So it is recommended to check the EN bit = 0 before re-enabling the stream.
> Writing to the SxNDTR register when the stream is enabled (bit EN = 1 in the DMA_SxCR register) has no effect on the DMA stream operation.

In the race window between `LL_DMA_DisableStream()` and EN actually clearing, the writes to `DMA_SxNDTR` (count) and `DMA_SxM0AR` (address) are silently discarded by hardware. The subsequent `LL_DMA_EnableStream()` then fires DMA with the previous transfer's stale count and address, producing garbled Shot frames.

## Why This Manifests on F765 More Than F745

The race window is only ~5–18 ns (1–4 AHB cycles at 216 MHz). On **STM32F745** (4 KB I-Cache), frequent cache misses in the interrupt handler may add enough pipeline stalls that EN clears naturally before `LL_DMA_SetDataLength()` is reached. On **STM32F765** (16 KB I-Cache), the hot path fits entirely in cache and executes without stalls, consistently landing within the race window.

The race condition exists on all F7/H7 targets; the cache difference may makes it more reproducible on F765.

## Fix

Add a bounded spin-wait for EN to clear after `LL_DMA_DisableStream()`, before any DMA register writes. If EN has not cleared after the timeout (indicating a hardware fault), skip reconfiguration entirely rather than proceeding with stale register values — a skipped DShot cycle holds last good motor values, which is far preferable to a corrupted frame.

## Files Changed

- `src/main/drivers/timer_impl_hal.c` — add EN-bit wait in `impl_timerPWMPrepareDMA()`

## Testing

**Build test:** MATEKF765 and FRSKYPILOT targets build cleanly with this change.

**Hardware test:** Not performed by me — no physical STM32F765 hardware available. The fix is a straightforward application of the RM guidance; the logic is equivalent to the wait loops used in `stm32f7xx_hal_dma.c`.

Reports of intermittent F765 lockups at arm time (when DShot DMA starts for the first time) are potentially consistent with this race condition.