### PR TITLE
Please test on FRSKYPILOT.  Fix STM32F765xG linker scripts

### DIFF
--- a/src/main/target/link/stm32_flash_f765xg.ld
+++ b/src/main/target/link/stm32_flash_f765xg.ld
@@ -1,10 +1,10 @@
 /*
 *****************************************************************************
 **
-**  File        : stm32_flash_f745.ld
+**  File        : stm32_flash_f765xg.ld
 **
-**  Abstract    : Linker script for STM32F745VGTx Device with
-**                1024KByte FLASH, 320KByte RAM
+**  Abstract    : Linker script for STM32F765xGTx Device with
+**                1024KByte FLASH, 512KByte RAM
 **
 *****************************************************************************
 */
@@ -29,7 +29,7 @@ MEMORY
 {
     ITCM_RAM (rx)			: ORIGIN = 0x00000000, LENGTH = 16K
     ITCM_FLASH (rx)        	: ORIGIN = 0x00200000, LENGTH = 32K
-    /* config occupies the entire flash sector 1 for the ease of erasure, 32K on F74x */
+    /* config occupies the entire flash sector 1 for the ease of erasure, 32K on F7xx */
     ITCM_FLASH_CONFIG (r)  	: ORIGIN = 0x00208000, LENGTH = 32K
     ITCM_FLASH1 (rx)       	: ORIGIN = 0x00210000, LENGTH = 960K
 
@@ -37,12 +37,16 @@ MEMORY
     FLASH_CONFIG (r)  : ORIGIN = 0x08008000, LENGTH = 32K
     FLASH1 (rx)       : ORIGIN = 0x08010000, LENGTH = 960K
 
-    TCM (rwx)         : ORIGIN = 0x20000000, LENGTH = 64K
-    RAM (rwx)         : ORIGIN = 0x20010000, LENGTH = 256K
+    DTCM_RAM (rwx)    : ORIGIN = 0x20000000, LENGTH = 128K
+    SRAM1 (rwx)       : ORIGIN = 0x20020000, LENGTH = 368K
+    SRAM2 (rwx)       : ORIGIN = 0x2007C000, LENGTH = 16K
     MEMORY_B1 (rx)    : ORIGIN = 0x60000000, LENGTH = 0K
 }
-/* note CCM could be used for stack */
-REGION_ALIAS("STACKRAM", TCM)
-REGION_ALIAS("FASTRAM", TCM)
+/* STM32F765 DTCM is 128KB (0x20000000-0x2001FFFF); SRAM1 starts at 0x20020000.
+ * DMA cannot access DTCM on STM32F7 - all DMA buffers must be in SRAM1 or SRAM2.
+ * NOTE: F745 DTCM is only 64KB, so F745 SRAM1 starts at 0x20010000 (different!). */
+REGION_ALIAS("STACKRAM", DTCM_RAM)
+REGION_ALIAS("FASTRAM",  DTCM_RAM)
+REGION_ALIAS("RAM",      SRAM1)
 
 INCLUDE "stm32_flash_f7_split.ld"

--- a/src/main/target/link/stm32_flash_f765xg_bl.ld
+++ b/src/main/target/link/stm32_flash_f765xg_bl.ld
@@ -1,10 +1,10 @@
 /*
 *****************************************************************************
 **
-**  File        : stm32_flash_f745.ld
+**  File        : stm32_flash_f765xg_bl.ld
 **
-**  Abstract    : Linker script for STM32F745VGTx Device with
-**                1024KByte FLASH, 320KByte RAM
+**  Abstract    : Linker script for STM32F765xGTx Device with
+**                1024KByte FLASH, 512KByte RAM (bootloader)
 **
 *****************************************************************************
 */
@@ -29,7 +29,7 @@ MEMORY
 {
     ITCM_RAM (rx)               : ORIGIN = 0x00000000, LENGTH = 16K
     ITCM_FLASH (rx)             : ORIGIN = 0x00200000, LENGTH = 32K
-    /* config occupies the entire flash sector 1 for the ease of erasure, 32K on F74x */
+    /* config occupies the entire flash sector 1 for the ease of erasure, 32K on F7xx */
     ITCM_FLASH_CONFIG (r)       : ORIGIN = 0x00208000, LENGTH = 32K
     ITCM_FLASH1 (rx)            : ORIGIN = 0x00210000, LENGTH = 928K
 
@@ -37,13 +37,17 @@ MEMORY
     FIRMWARE (rx)               : ORIGIN = 0x08008000, LENGTH = 32K
     FLASH_CONFIG (r)            : ORIGIN = 0x08010000, LENGTH = 32K
 
-    TCM (rwx)                   : ORIGIN = 0x20000000, LENGTH = 64K
-    RAM (rwx)                   : ORIGIN = 0x20010000, LENGTH = 256K
+    DTCM_RAM (rwx)              : ORIGIN = 0x20000000, LENGTH = 128K
+    SRAM1 (rwx)                 : ORIGIN = 0x20020000, LENGTH = 368K
+    SRAM2 (rwx)                 : ORIGIN = 0x2007C000, LENGTH = 16K
     MEMORY_B1 (rx)              : ORIGIN = 0x60000000, LENGTH = 0K
 }
-/* note CCM could be used for stack */
-REGION_ALIAS("STACKRAM", TCM)
-REGION_ALIAS("FASTRAM", TCM)
+/* STM32F765 DTCM is 128KB (0x20000000-0x2001FFFF); SRAM1 starts at 0x20020000.
+ * DMA cannot access DTCM on STM32F7 - all DMA buffers must be in SRAM1 or SRAM2.
+ * NOTE: F745 DTCM is only 64KB, so F745 SRAM1 starts at 0x20010000 (different!). */
+REGION_ALIAS("STACKRAM", DTCM_RAM)
+REGION_ALIAS("FASTRAM",  DTCM_RAM)
+REGION_ALIAS("RAM",      SRAM1)
 
 __firmware_start = ORIGIN(FIRMWARE);
 

--- a/src/main/target/link/stm32_flash_f765xg_for_bl.ld
+++ b/src/main/target/link/stm32_flash_f765xg_for_bl.ld
@@ -1,10 +1,10 @@
 /*
 *****************************************************************************
 **
-**  File        : stm32_flash_f745.ld
+**  File        : stm32_flash_f765xg_for_bl.ld
 **
-**  Abstract    : Linker script for STM32F745VGTx Device with
-**                1024KByte FLASH, 320KByte RAM
+**  Abstract    : Linker script for STM32F765xGTx Device with
+**                1024KByte FLASH, 512KByte RAM (bootloader-aware)
 **
 *****************************************************************************
 */
@@ -29,7 +29,7 @@ MEMORY
 {
     ITCM_RAM (rx)               : ORIGIN = 0x00000000, LENGTH = 16K
     ITCM_FLASH (rx)             : ORIGIN = 0x00200000, LENGTH = 32K
-    /* config occupies the entire flash sector 1 for the ease of erasure, 32K on F74x */
+    /* config occupies the entire flash sector 1 for the ease of erasure, 32K on F7xx */
     ITCM_FLASH_CONFIG (r)       : ORIGIN = 0x00208000, LENGTH = 32K
     ITCM_FLASH1 (rx)            : ORIGIN = 0x00210000, LENGTH = 960K
 
@@ -37,13 +37,17 @@ MEMORY
     FLASH_CONFIG (r)            : ORIGIN = 0x08010000, LENGTH = 32K
     FLASH1 (rx)                 : ORIGIN = 0x08018000, LENGTH = 928K
 
-    TCM (rwx)                   : ORIGIN = 0x20000000, LENGTH = 64K
-    RAM (rwx)                   : ORIGIN = 0x20010000, LENGTH = 256K
+    DTCM_RAM (rwx)              : ORIGIN = 0x20000000, LENGTH = 128K
+    SRAM1 (rwx)                 : ORIGIN = 0x20020000, LENGTH = 368K
+    SRAM2 (rwx)                 : ORIGIN = 0x2007C000, LENGTH = 16K
     MEMORY_B1 (rx)              : ORIGIN = 0x60000000, LENGTH = 0K
 }
-/* note CCM could be used for stack */
-REGION_ALIAS("STACKRAM", TCM)
-REGION_ALIAS("FASTRAM", TCM)
+/* STM32F765 DTCM is 128KB (0x20000000-0x2001FFFF); SRAM1 starts at 0x20020000.
+ * DMA cannot access DTCM on STM32F7 - all DMA buffers must be in SRAM1 or SRAM2.
+ * NOTE: F745 DTCM is only 64KB, so F745 SRAM1 starts at 0x20010000 (different!). */
+REGION_ALIAS("STACKRAM", DTCM_RAM)
+REGION_ALIAS("FASTRAM",  DTCM_RAM)
+REGION_ALIAS("RAM",      SRAM1)
 
 __firmware_start = ORIGIN(FLASH);
 


### PR DESCRIPTION
## Problem

The three `stm32_flash_f765xg*.ld` linker scripts were copy-pasted from the STM32F745 linker without updating the memory map for the F765's larger DTCM.

| Chip | DTCM size | DTCM range | SRAM1 start |
|------|-----------|------------|-------------|
| STM32F745xG | 64 KB | 0x20000000–0x2000FFFF | **0x20010000** |
| STM32F765xG | 128 KB | 0x20000000–0x2001FFFF | **0x20020000** |

The F765xG linker scripts kept the F745 values (`TCM = 64K`, `RAM at 0x20010000`). On STM32F765 hardware, 0x20010000 is the start of the second 64 KB of DTCM — not SRAM1. This means:

- Only the first 64 KB of the 128 KB DTCM was mapped (the other 64 KB was unused)
- The `RAM` region (containing `.bss`, `.data`, and DMA buffers) was placed in DTCM address space rather than in SRAM1

The correct `stm32_flash_f765xi.ld` scripts (used by MATEKF765, MATEKF765SE) already have the correct addresses at 0x20020000 and serve as the reference.

## Fix

All three xG linker script variants are corrected:

- `stm32_flash_f765xg.ld`
- `stm32_flash_f765xg_bl.ld`
- `stm32_flash_f765xg_for_bl.ld`

Changes in each file:
- `DTCM_RAM`: 64 KB → **128 KB** (full F765 DTCM)
- `SRAM1` origin: 0x20010000 → **0x20020000** (correct F765 SRAM1 start)
- Added `SRAM2` region (16 KB at 0x2007C000) matching xi scripts
- Updated `REGION_ALIAS("RAM")` to point to `SRAM1`
- Corrected stale file headers (still said "STM32F745VGTx" / "320KByte RAM")
- Updated flash config comment from "32K on F74x" to "32K on F7xx"

## Affected Targets

- **FRSKYPILOT**
- **FRSKYPILOT_LED**

Targets using `target_stm32f765xi()` (MATEKF765, MATEKF765SE) are **not affected** — their linker scripts already have the correct addresses.

## Testing

**Build test:** FRSKYPILOT builds cleanly. Post-fix memory report:
- `DTCM_RAM`: 21,156 B / 128 KB (16%) — stack and FASTRAM variables
- `SRAM1`: 95,404 B / 368 KB (25%) — `.bss`, `.data`, DMA buffers

Previously, those 95 KB were mapped starting at 0x20010000 (inside F765 DTCM) rather than SRAM1.

**Hardware test:** Not performed — no physical FRSKYPILOT hardware available.