### PR TITLE
Trackback flight controller lock up fix

### DIFF
--- a/src/main/navigation/rth_trackback.c
+++ b/src/main/navigation/rth_trackback.c
@@ -153,10 +153,11 @@ bool rthTrackBackSetNewPosition(void)
             rth_trackback.activePointIndex = NAV_RTH_TRACKBACK_POINTS - 1;
         }
 
-        calculateAndSetActiveWaypointToLocalPosition(getRthTrackBackPosition());
-
-        if (rth_trackback.activePointIndex - rth_trackback.WrapAroundCounter == 0) {
-            rth_trackback.WrapAroundCounter = rth_trackback.activePointIndex = -1;
+        // Last trackback point reached when activePointIndex = WrapAroundCounter so only set position when not equal
+        if (rth_trackback.activePointIndex != rth_trackback.WrapAroundCounter) {
+            calculateAndSetActiveWaypointToLocalPosition(getRthTrackBackPosition());
+        } else {
+            rth_trackback.activePointIndex = -1;  // if not already = -1 set to -1 to end trackback next iteration
         }
     } else {
         setDesiredPosition(getRthTrackBackPosition(), 0, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_Z | NAV_POS_UPDATE_BEARING);


### PR DESCRIPTION
Should provide a fix for https://github.com/iNavFlight/inav/issues/11392 and https://github.com/iNavFlight/inav/issues/11007.

Prevents a position being set when the trackback array index is < 0 which can cause the flight controller to lock up in some instances.

It's an issue if trackback is initiated when the trackback store hasn't completely filled initially and then runs back to the first trackback point set. Once the trackback point store has filled and is wrapping around the problem goes away. 

This issue affects all versions of INAV back to 6.0 when trackback was first introduced. It's not clear why it only seems to cause occasional FC lockups, likely just a result of undefined behaviour when trying to set a position with an invalid array index.

HITL testing shows the position is no longer set if the trackback array index is < 0.


