### PR TITLE
SOLOGOODF722 target

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -102,6 +102,7 @@ struct {
     // Puya PY25Q128HA
     // Datasheet: https://www.puyasemi.com/cpzx3/info_271_itemid_87.html
     {0x856018, 256, 256},
+    {0x852018, 256, 256},
     // Winbond W25Q256
     // Datasheet: https://www.winbond.com/resource-files/w25q256jv%20spi%20revb%2009202016.pdf
     {0xEF4019, 512, 256},

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -99,10 +99,10 @@ struct {
     // Winbond W25Q128_DTR
     // Datasheet: https://www.winbond.com/resource-files/w25q128jv%20dtr%20revb%2011042016.pdf
     {0xEF7018, 256, 256},
-    // Puya PY25Q128HA
+    // Puya PY25Q128
     // Datasheet: https://www.puyasemi.com/cpzx3/info_271_itemid_87.html
-    {0x856018, 256, 256},
-    {0x852018, 256, 256},
+    {0x856018, 256, 256}, // PY25Q128H
+    {0x852018, 256, 256}, // PY25Q128HA
     // Winbond W25Q256
     // Datasheet: https://www.winbond.com/resource-files/w25q256jv%20spi%20revb%2009202016.pdf
     {0xEF4019, 512, 256},

--- a/src/main/target/SOLOGOODF722/CMakeLists.txt
+++ b/src/main/target/SOLOGOODF722/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f722xe(SOLOGOODF722)

--- a/src/main/target/SOLOGOODF722/target.c
+++ b/src/main/target/SOLOGOODF722/target.c
@@ -1,0 +1,40 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_OUTPUT_AUTO, 0, 0), // S1
+    DEF_TIM(TIM8, CH4, PC9,  TIM_USE_OUTPUT_AUTO, 0, 0), // S2
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_OUTPUT_AUTO, 0, 1), // S3
+    DEF_TIM(TIM1, CH2, PA9,  TIM_USE_OUTPUT_AUTO, 0, 1), // S4
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_OUTPUT_AUTO, 0, 0), // S5
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_OUTPUT_AUTO, 0, 0), // S6
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_OUTPUT_AUTO, 0, 1), // S7
+    DEF_TIM(TIM3, CH1, PB4,  TIM_USE_OUTPUT_AUTO, 0, 0), // S8
+
+    DEF_TIM(TIM2, CH2, PB3, TIM_USE_LED, 0, 0), // 2812LED
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/SOLOGOODF722/target.h
+++ b/src/main/target/SOLOGOODF722/target.h
@@ -1,0 +1,170 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "SGF7"
+
+#define USBD_PRODUCT_STRING     "SOLOGOODF722"
+
+#define LED0                    PC15
+
+#define BEEPER                  PC13
+#define BEEPER_INVERTED
+
+// *************** Gyro & ACC **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_NSS_PIN            PA4
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+
+#define USE_IMU_MPU6000
+#define IMU_MPU6000_ALIGN       CW180_DEG
+#define MPU6000_CS_PIN          SPI1_NSS_PIN
+#define MPU6000_SPI_BUS         BUS_SPI1
+
+#define USE_IMU_BMI270
+#define IMU_BMI270_ALIGN        CW180_DEG
+#define BMI270_CS_PIN           SPI1_NSS_PIN
+#define BMI270_SPI_BUS          BUS_SPI1
+
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW180_DEG
+#define ICM42605_CS_PIN         SPI1_NSS_PIN
+#define ICM42605_SPI_BUS        BUS_SPI1
+
+// *************** I2C/Baro/Mag *********************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+
+#define DEFAULT_I2C_BUS         BUS_I2C1
+
+#define USE_BARO
+#define BARO_I2C_BUS            DEFAULT_I2C_BUS
+#define USE_BARO_DPS310
+
+#define USE_MAG
+#define MAG_I2C_BUS             DEFAULT_I2C_BUS
+#define USE_MAG_ALL
+
+#define TEMPERATURE_I2C_BUS     DEFAULT_I2C_BUS
+
+#define PITOT_I2C_BUS           DEFAULT_I2C_BUS
+
+#define USE_RANGEFINDER
+#define RANGEFINDER_I2C_BUS     DEFAULT_I2C_BUS
+
+// *************** FLASH **************************
+#define USE_SPI_DEVICE_3
+#define SPI3_NSS_PIN            PA15
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PB5
+
+#define M25P16_CS_PIN           SPI3_NSS_PIN
+#define M25P16_SPI_BUS          BUS_SPI3
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+
+// *************** OSD *****************************
+#define USE_SPI_DEVICE_2
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          SPI2_NSS_PIN
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN PB7
+#define UART1_TX_PIN PB6
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART5
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN PC12
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define SERIAL_PORT_COUNT       7
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC1
+#define ADC_CHANNEL_2_PIN           PC3
+
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+
+
+#define DEFAULT_FEATURES            (FEATURE_TX_PROF_SEL | FEATURE_CURRENT_METER | FEATURE_TELEMETRY | FEATURE_VBAT | FEATURE_OSD | FEATURE_BLACKBOX)
+// *************** PINIO ************************
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                      PC2
+#define PINIO2_PIN                      PC0
+
+// *************** LEDSTRIP ************************
+#define USE_LED_STRIP
+#define WS2811_PIN                  PB3
+
+// Others
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define CURRENT_METER_SCALE 250
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define MAX_PWM_OUTPUT_PORTS 8
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR


### PR DESCRIPTION
### Summary 

Added Sologood F722 target.
Added Puya PY25Q128HA flash jedecID used in SOLOGOOD F722 flight controller.

### Changes
src/main/drivers/flash_m25p16.c
src/main/target/SOLOGOODF722/CMakeLists.txt
src/main/target/SOLOGOODF722/target.h
src/main/target/SOLOGOODF722/target.c

### Notes

Tested UART1 (Walksnail Avatar OSD), UART2 (RX), UART6 and SPI (gps+magnitometer), S1-S6 (by spinning 4 motors, 2 servos), Gyroscope, Accelerometer, Barometer and blackbox flash.

Betaflight default CLI configuration:
```
# status  
MCU: STM32F722 CLK=216MHz, Vref=3.28V, Core temp=51degC  
STACK: 2048b (0x20010000)  
CONFIG: CONFIGURED (4117b / 16384b)  
  
DEVICES DETECTED: SPI=1, I2C=1 (0 errors)  
GYRO: (1) ICM42688P enabled locked dma  
ACC: ICM42688P  
BARO: DPS310  
GPS: NOT ENABLED  
OSD: MAX7456 (30 x 13)  
FLASH: JEDEC ID=0x00852018 16M  
...

# timer  
timer C08 AF3  
# pin C08: TIM8 CH3 (AF3)  
timer C09 AF3  
# pin C09: TIM8 CH4 (AF3)  
timer A08 AF1  
# pin A08: TIM1 CH1 (AF1)  
timer A09 AF1  
# pin A09: TIM1 CH2 (AF1)  
timer B00 AF2  
# pin B00: TIM3 CH3 (AF2)  
timer B01 AF2  
# pin B01: TIM3 CH4 (AF2)  
timer A10 AF1  
# pin A10: TIM1 CH3 (AF1)  
timer B04 AF2  
# pin B04: TIM3 CH1 (AF2)  
timer B03 AF1  
# pin B03: TIM2 CH2 (AF1)

# resource  
resource BEEPER 1 C13  
resource MOTOR 1 C08  
resource MOTOR 2 C09  
resource MOTOR 3 A08  
resource MOTOR 4 A09  
resource MOTOR 5 B00  
resource MOTOR 6 B01  
resource MOTOR 7 A10  
resource MOTOR 8 B04  
resource LED_STRIP 1 B03  
resource SERIAL_TX 1 B06  
resource SERIAL_TX 2 A02  
resource SERIAL_TX 3 B10  
resource SERIAL_TX 4 A00  
resource SERIAL_TX 5 C12  
resource SERIAL_TX 6 C06  
resource SERIAL_RX 1 B07  
resource SERIAL_RX 2 A03  
resource SERIAL_RX 3 B11  
resource SERIAL_RX 4 A01  
resource SERIAL_RX 5 D02  
resource SERIAL_RX 6 C07  
resource I2C_SCL 1 B08  
resource I2C_SDA 1 B09  
resource LED 1 C15  
resource SPI_SCK 1 A05  
resource SPI_SCK 2 B13  
resource SPI_SCK 3 C10  
resource SPI_SDI 1 A06  
resource SPI_SDI 2 B14  
resource SPI_SDI 3 C11  
resource SPI_SDO 1 A07  
resource SPI_SDO 2 B15  
resource SPI_SDO 3 B05  
resource ADC_BATT 1 C01  
resource ADC_CURR 1 C03  
resource PINIO 1 C02  
resource PINIO 2 C00  
resource FLASH_CS 1 A15  
resource OSD_CS 1 B12  
resource GYRO_EXTI 1 C04  
resource GYRO_CS 1 A04
```

Inav configurator CLI after flashing:
```
# flash_info  
Flash sectors=256, sectorSize=65536, pagesPerSector=256, pageSize=256, totalSize=16777216  
Paritions:  
0: FLASHFS 0 255  
FlashFS size=16777216, usedSize=0

# status  
INAV/SOLOGOODF722 9.0.1 Mar 4 2026 / 00:01:18 (bb1bd11a)  
GCC-13.2.1 20231009  
System Uptime: 98 seconds  
Current Time: 2026-03-05T12:32:46.260+00:00  
Voltage: 23.02V (6S battery - OK)  
CPU Clock=216MHz, GYRO=ICM42605, ACC=ICM42605, BARO=DPS310, MAG=QMC5883, PITOT=VIRTUAL  
STM32 system clocks:  
SYSCLK = 216 MHz  
HCLK = 216 MHz  
PCLK1 = 54 MHz  
PCLK2 = 108 MHz  
Sensor status: GYRO=OK, ACC=OK, MAG=OK, BARO=OK, RANGEFINDER=NONE, OPFLOW=NONE, GPS=OK  
Stack size: 6144, Stack address: 0x20010000, Heap available: 1820  
I2C Errors: 50, config size: 10939, max available config: 16384  
ADC channel usage:  
BATTERY : configured = ADC 1, used = ADC 1  
RSSI : configured = none, used = none  
CURRENT : configured = ADC 2, used = ADC 2  
AIRSPEED : configured = none, used = none  
System load: 15, cycle time: 508, PID rate: 1968, RX rate: 49, System rate: 9  
Arming disabled flags: CAL COMPASS RX CLI  
OSD: MAX7456 [30 x 16]  
VTX: not detected  
GPS: HW Version: UBLOX10 Proto: 34.09 Baud: 115200  
SATS: 0  
HDOP: 99.990  
EPH : 99.990 m  
EPV : 99.990 m  
GNSS Capabilities:  
GNSS Provider active/default  
GPS 1/1  
Galileo 0/1  
BeiDou 0/1  
Glonass 0/0  
Max concurrent: 3
```