### PR TITLE
added changes to max7456.c to add setting speed and removing spi_mod_0 flag with defines from target.h file

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -293,7 +293,7 @@ static int max7456PrepareBuffer(uint8_t * buf, size_t bufsize, int bufPtr, uint8
     return bufPtr;
 }
 
-void max7456ApplyBusSpeed(void)
+static void max7456ApplyBusSpeed(void)
 {
 #if defined(MAX7456_SPI_SPEED)
     busSetSpeed(state.dev, MAX7456_SPI_SPEED);
@@ -304,19 +304,20 @@ void max7456ApplyBusSpeed(void)
 }
 
 // Used when standard DEVFLAGS_SPI_MODE_0 is omitted in common_hardware 
-void max7456SpiModeOverride(void)
+static void max7456SpiModeOverride(void)
 {
 #if defined(STM32H7) && defined(MAX7456_MANUAL_SPI_CONFIG)
-            SPI_TypeDef *maxSpiInstance = spiInstanceByDevice(state.dev->busdev.spi.spiBus);
-            if (!maxSpiInstance) return;
-            maxSpiInstance->CR1 &= ~SPI_CR1_SPE;
-            maxSpiInstance->CFG2 &= ~(SPI_CFG2_CPHA | SPI_CFG2_CPOL);
-
-            maxSpiInstance->CFG2 |= (SPI_CFG2_CPHA | SPI_CFG2_CPOL);
-            maxSpiInstance->CR1 |= SPI_CR1_SPE;
+    SPI_TypeDef *maxSpiInstance = spiInstanceByDevice(state.dev->busdev.spi.spiBus);
+    if (!maxSpiInstance){
+        return;
+    }
+    
+    maxSpiInstance->CR1 &= ~SPI_CR1_SPE;
+    maxSpiInstance->CFG2 &= ~(SPI_CFG2_CPHA | SPI_CFG2_CPOL);
+    maxSpiInstance->CFG2 |= (SPI_CFG2_CPHA | SPI_CFG2_CPOL);
+    maxSpiInstance->CR1 |= SPI_CR1_SPE;
 #endif
 }
-
 
 uint16_t max7456GetScreenSize(void)
 {
@@ -412,7 +413,6 @@ void max7456Init(const videoSystem_e videoSystem)
     }
 
     max7456ApplyBusSpeed();
-
     max7456SpiModeOverride(); 
 
     // force soft reset on Max7456

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -293,6 +293,31 @@ static int max7456PrepareBuffer(uint8_t * buf, size_t bufsize, int bufPtr, uint8
     return bufPtr;
 }
 
+void max7456ApplyBusSpeed(void)
+{
+#if defined(MAX7456_SPI_SPEED)
+    busSetSpeed(state.dev, MAX7456_SPI_SPEED);
+#else
+    // Default safe speed for MAX7456
+    busSetSpeed(state.dev, BUS_SPEED_STANDARD);
+#endif
+}
+
+// Used when standard DEVFLAGS_SPI_MODE_0 is omitted in common_hardware 
+void max7456SpiModeOverride(void)
+{
+#if defined(STM32H7) && defined(MAX7456_MANUAL_SPI_CONFIG)
+            SPI_TypeDef *maxSpiInstance = spiInstanceByDevice(state.dev->busdev.spi.spiBus);
+            if (!maxSpiInstance) return;
+            maxSpiInstance->CR1 &= ~SPI_CR1_SPE;
+            maxSpiInstance->CFG2 &= ~(SPI_CFG2_CPHA | SPI_CFG2_CPOL);
+
+            maxSpiInstance->CFG2 |= (SPI_CFG2_CPHA | SPI_CFG2_CPOL);
+            maxSpiInstance->CR1 |= SPI_CR1_SPE;
+#endif
+}
+
+
 uint16_t max7456GetScreenSize(void)
 {
     // Default to PAL while the display is not yet initialized. This
@@ -386,7 +411,9 @@ void max7456Init(const videoSystem_e videoSystem)
         return;
     }
 
-    busSetSpeed(state.dev, BUS_SPEED_STANDARD);
+    max7456ApplyBusSpeed();
+
+    max7456SpiModeOverride(); 
 
     // force soft reset on Max7456
     busWrite(state.dev, MAX7456ADD_VM0, MAX7456_RESET);

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -296,7 +296,8 @@ static int max7456PrepareBuffer(uint8_t * buf, size_t bufsize, int bufPtr, uint8
 static void max7456ApplyBusSpeed(void)
 {
 #if defined(MAX7456_SPI_SPEED)
-    busSetSpeed(state.dev, MAX7456_SPI_SPEED);
+    busSpeed_e speed = (MAX7456_SPI_SPEED <= BUS_SPEED_ULTRAFAST) ? MAX7456_SPI_SPEED : BUS_SPEED_STANDARD;
+    busSetSpeed(state.dev, speed);
 #else
     // Default safe speed for MAX7456
     busSetSpeed(state.dev, BUS_SPEED_STANDARD);
@@ -311,11 +312,9 @@ static void max7456SpiModeOverride(void)
     if (!maxSpiInstance){
         return;
     }
-    
+   
     maxSpiInstance->CR1 &= ~SPI_CR1_SPE;
-    maxSpiInstance->CFG2 &= ~(SPI_CFG2_CPHA | SPI_CFG2_CPOL);
     maxSpiInstance->CFG2 |= (SPI_CFG2_CPHA | SPI_CFG2_CPOL);
-    maxSpiInstance->CR1 |= SPI_CR1_SPE;
 #endif
 }
 

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -304,20 +304,6 @@ static void max7456ApplyBusSpeed(void)
 #endif
 }
 
-// Used when standard DEVFLAGS_SPI_MODE_0 is omitted in common_hardware 
-static void max7456SpiModeOverride(void)
-{
-#if defined(STM32H7) && defined(MAX7456_MANUAL_SPI_CONFIG)
-    SPI_TypeDef *maxSpiInstance = spiInstanceByDevice(state.dev->busdev.spi.spiBus);
-    if (!maxSpiInstance){
-        return;
-    }
-   
-    maxSpiInstance->CR1 &= ~SPI_CR1_SPE;
-    maxSpiInstance->CFG2 |= (SPI_CFG2_CPHA | SPI_CFG2_CPOL);
-#endif
-}
-
 uint16_t max7456GetScreenSize(void)
 {
     // Default to PAL while the display is not yet initialized. This
@@ -412,7 +398,6 @@ void max7456Init(const videoSystem_e videoSystem)
     }
 
     max7456ApplyBusSpeed();
-    max7456SpiModeOverride(); 
 
     // force soft reset on Max7456
     busWrite(state.dev, MAX7456ADD_VM0, MAX7456_RESET);


### PR DESCRIPTION
This PR introduces the ability to override default SPI parameters for the MAX7456 OSD chip. These changes are necessary to support specific STM32H7-based targets and custom hardware configurations where the standard DEVFLAGS_SPI_MODE_0 or BUS_SPEED_STANDARD are insufficient or incompatible with the hardware routing.