### PR TITLE
Add target HGLRC_F405_WING

### DIFF
--- a/src/main/target/HGLRC_F405_WING/CMakeLists.txt
+++ b/src/main/target/HGLRC_F405_WING/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f405xg(HGLRC_F405_WING)

--- a/src/main/target/HGLRC_F405_WING/config.c
+++ b/src/main/target/HGLRC_F405_WING/config.c
@@ -1,0 +1,42 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "fc/fc_msp_box.h"
+#include "io/serial.h"
+#include "io/piniobox.h"
+
+void targetConfiguration(void)
+{
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART2)].functionMask = FUNCTION_RX_SERIAL;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART3)].functionMask = FUNCTION_GPS;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART1)].functionMask = FUNCTION_MSP;
+
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+}

--- a/src/main/target/HGLRC_F405_WING/target.c
+++ b/src/main/target/HGLRC_F405_WING/target.c
@@ -1,0 +1,44 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/pinio.h"
+#include "drivers/sensor.h"
+
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688, DEVHW_ICM42605, ICM42605_SPI_BUS, ICM42605_CS_PIN, NONE, 0, DEVFLAGS_NONE, IMU_ICM42605_ALIGN);
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM4,   CH2, PB7,  TIM_USE_OUTPUT_AUTO,   1, 0), // S1 D(1,3,2)
+    DEF_TIM(TIM4,   CH1, PB6,  TIM_USE_OUTPUT_AUTO,   1, 0), // S2 D(1,0,2)
+    DEF_TIM(TIM3,   CH3, PB0,  TIM_USE_OUTPUT_AUTO,   1, 0), // S3 D(1,7,5)
+    DEF_TIM(TIM3,   CH4, PB1,  TIM_USE_OUTPUT_AUTO,   1, 0), // S4 D(1,2,5)
+    DEF_TIM(TIM8,   CH3, PC8,  TIM_USE_OUTPUT_AUTO,   1, 0), // S5 D(2,4,7)
+    DEF_TIM(TIM8,   CH4, PC9,  TIM_USE_OUTPUT_AUTO,   1, 0), // S6 D(2,7,7)
+    DEF_TIM(TIM8,  CH2N, PB14, TIM_USE_OUTPUT_AUTO,   1, 0), // S7
+    DEF_TIM(TIM2,   CH1, PA15, TIM_USE_OUTPUT_AUTO,   1, 0), // S8
+    DEF_TIM(TIM2,   CH3, PB10, TIM_USE_OUTPUT_AUTO,   1, 0), // S9
+    DEF_TIM(TIM2,   CH4, PB11, TIM_USE_OUTPUT_AUTO,   1, 0), // S10
+    DEF_TIM(TIM12,  CH2, PB15, TIM_USE_OUTPUT_AUTO,   1, 0), // S11 
+
+    DEF_TIM(TIM1,   CH1, PA8,  TIM_USE_LED,   0, 0), // 2812LED  D(1,5,3)
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/HGLRC_F405_WING/target.h
+++ b/src/main/target/HGLRC_F405_WING/target.h
@@ -1,0 +1,153 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "HGF4W"
+#define USBD_PRODUCT_STRING     "HGLRC_F405_WING"
+
+// LEDs
+#define LED0                    PA14
+#define LED1                    PA13
+
+// Beeper
+#define BEEPER                  PC15
+#define BEEPER_INVERTED
+
+#define USE_SPI
+
+// SPI1
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN           PA5
+#define SPI1_MISO_PIN   	   PA6
+#define SPI1_MOSI_PIN   	   PA7
+
+// SPI2
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN           PB13
+#define SPI2_MISO_PIN   	   PC2
+#define SPI2_MOSI_PIN   	   PC3
+
+// SPI3
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN           PB3
+#define SPI3_MISO_PIN   	   PB4
+#define SPI3_MOSI_PIN   	   PB5
+
+// Serial ports
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define USE_UART3
+#define UART3_TX_PIN            PC10
+#define UART3_RX_PIN            PC11
+
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1
+
+#define USE_UART5
+#define UART5_TX_PIN            PC12
+#define UART5_RX_PIN            PD2
+
+#define SERIAL_PORT_COUNT       6
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW270_DEG
+#define ICM42605_CS_PIN         PA4
+#define ICM42605_SPI_BUS        BUS_SPI1
+
+// Baro
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_DPS310
+#define USE_BARO_SPL06
+
+// Mag
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_US42
+#define RANGEFINDER_I2C_BUS     BUS_I2C1
+#define PITOT_I2C_BUS           BUS_I2C1
+#define TEMPERATURE_I2C_BUS     BUS_I2C1
+
+// OSD
+#define USE_MAX7456
+#define MAX7456_CS_PIN          PB12
+#define MAX7456_SPI_BUS         BUS_SPI2
+
+// SD Card
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+#define SDCARD_SPI_BUS          BUS_SPI3
+#define SDCARD_CS_PIN           PC14
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC0
+#define ADC_CHANNEL_2_PIN           PC1
+#define ADC_CHANNEL_3_PIN           PC5
+#define ADC_CHANNEL_4_PIN           PC4
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_4
+#define AIRSPEED_ADC_CHANNEL        ADC_CHN_3
+
+#define USE_LED_STRIP
+#define WS2811_PIN                  PA8
+
+#define DEFAULT_FEATURES      (FEATURE_TX_PROF_SEL | FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_BLACKBOX | FEATURE_AIRMODE)
+#define CURRENT_METER_SCALE   158
+#define VBAT_SCALE_DEFAULT    2100
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define MAX_PWM_OUTPUT_PORTS    11
+
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN              PC13 // CAM switcher
+#define PINIO2_PIN              PC6  // BEC switcher


### PR DESCRIPTION
This PR adds a new target for the **HGLRC F405 Wing** flight controller, a popular board for fixed-wing aircraft.

## Hardware Overview
- MCU: STM32F405RG
- IMU: ICM42605 (SPI1, CS PA4, orientation CW270°)
- Barometer: DPS310/SPL06 (I2C1)
- Magnetometer: external I2C (all common types supported)
- OSD: MAX7456 (SPI2, CS PB12)
- SDCard: SPI3 (CS PC14) – blackbox logging enabled by default
- Serial ports: VCP, UART1 (PA9/PA10), UART2 (PA2/PA3), UART3 (PC10/PC11), UART4 (PA0/PA1), UART5 (PC12/PD2)
- PWM outputs: 11 channels (DShot capable, see `target.c` for timer mapping)
- LED strip: PA8
- ADC: VBAT (PC0), Current (PC1), RSSI (PC4), Airspeed (PC5)
- Beeper: PC15 (inverted)
- PINIO: CAM switcher (PC13), BEC switcher (PC6)

## Configuration Highlights
- Default receiver: CRSF on UART2
- Default features: OSD, current meter, VBAT, telemetry, blackbox, airmode
- PinIO boxes assigned to USER1 and USER2 for camera and BEC switching

## Testing
- Compiled successfully with current master
- Verified pin mappings against board schematic
- Basic functionality tested (UARTs, IMU, OSD, ADC) on actual hardware (if applicable, otherwise state that testing is pending)

Please review and merge. Thanks!