### PR TITLE
Add support for AllPower AP25Q128HD flash chip

### DIFF
--- a/docs/Blackbox.md
+++ b/docs/Blackbox.md
@@ -121,6 +121,7 @@ These chips are also supported:
 * Micron N25Q0128 - 128 Mbit / 16 MByte
 * Winbond W25Q128 - 128 Mbit / 16 MByte
 * Puya PY25Q128HA - 128 Mbit / 16 MByte
+* ALLPOWER AP25Q128 - 128 Mbit / 16 MByte
 * Winbond W25N01  - 1 Gbit / 128 MByte
 * Winbond W25N02  - 2 Gbit / 256 MByte
 

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -118,6 +118,9 @@ struct {
     {0x1C3017, 128, 256},
     // JEDEC_ID_SPANSION_S25FL116
     {0x014015, 32, 256 },
+    // ALLPOWER_AP25Q128
+    // Datasheet: https://github.com/LoyalLinjy/AP25Q128HD/blob/main/AP25Q128HD.pdf
+    {0x852018, 256, 256},
     // End of list
     {0x000000, 0, 0}};
 


### PR DESCRIPTION
Add support for AllPower AP25Q128HD flash chip
The AllPower AP25Q128HD is a W25Q128-compatible 128Mbit (16MB) SPI NOR flash
chip. This PR adds detection support by including its JEDEC ID in the flash
configuration table.

Changes:
- Added AP25Q128HD JEDEC ID (0x852018) to m25p16FlashConfig[] array
- Updated Blackbox documentation with AP25Q128HD in supported chips list

The chip uses the same SPI command set as other supported flash chips,
so no driver modifications are required beyond adding the JEDEC ID for
auto-detection during initialization.