### PR TITLE
CI: build only affected target for single-target PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,69 @@ on:
 
 
 jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      single_target: ${{ steps.check.outputs.single_target }}
+      target_names: ${{ steps.check.outputs.target_names }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect single-target PR
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "single_target=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          if [ -z "$CHANGED" ]; then
+            echo "single_target=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Fail fast if any changed file is outside src/main/target/<dir>/
+          NON_TARGET=$(echo "$CHANGED" | grep -Ev '^src/main/target/[^/]+/.+' | head -1)
+          if [ -n "$NON_TARGET" ]; then
+            echo "Non-target file changed: $NON_TARGET — full build required"
+            echo "single_target=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Count how many distinct target directories were touched
+          TARGET_DIRS=$(echo "$CHANGED" | sed -n 's|^src/main/target/\([^/]*\)/.*|\1|p' | sort -u)
+          DIR_COUNT=$(echo "$TARGET_DIRS" | wc -l)
+          if [ "$DIR_COUNT" != "1" ]; then
+            echo "$DIR_COUNT target directories changed — full build required"
+            echo "single_target=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          TARGET_DIR="$TARGET_DIRS"
+          CMAKE="src/main/target/${TARGET_DIR}/CMakeLists.txt"
+          if [ ! -f "$CMAKE" ]; then
+            echo "No CMakeLists.txt for $TARGET_DIR — full build required"
+            echo "single_target=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          TARGET_NAMES=$(grep -oP '(?<=\()[^)]+' "$CMAKE" | tr '\n' ' ' | xargs)
+          if [ -z "$TARGET_NAMES" ]; then
+            echo "No target names in CMakeLists.txt — full build required"
+            echo "single_target=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Single-target PR: building $TARGET_NAMES"
+          echo "single_target=true" >> $GITHUB_OUTPUT
+          echo "target_names=$TARGET_NAMES" >> $GITHUB_OUTPUT
+
   build:
+    needs: [detect]
+    if: needs.detect.outputs.single_target != 'true'
     runs-on: ubuntu-latest
     strategy:
         matrix:
@@ -66,9 +128,42 @@ jobs:
           path: ./build/*.hex
           retention-days: 1
 
+  build-single-target:
+    needs: [detect]
+    if: needs.detect.outputs.single_target == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get -y install ninja-build
+      - name: Setup environment
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+        run: |
+          COMMIT_ID=${{ github.event.pull_request.head.sha }}
+          COMMIT_ID=${COMMIT_ID:-${{ github.sha }}}
+          BUILD_SUFFIX=ci-$(date '+%Y%m%d')-$(git rev-parse --short ${COMMIT_ID})
+          VERSION=$(grep project CMakeLists.txt|awk -F VERSION '{ gsub(/[ \t)]/, "", $2); print $2 }')
+          echo "BUILD_SUFFIX=${BUILD_SUFFIX}" >> $GITHUB_ENV
+          echo "BUILD_NAME=inav-${VERSION}-${BUILD_SUFFIX}" >> $GITHUB_ENV
+          echo "NUM_CORES=$(grep processor /proc/cpuinfo  | wc -l)" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          path: downloads
+          key: ${{ runner.os }}-downloads-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('**/cmake/*')}}
+      - name: Build targets (${{ needs.detect.outputs.target_names }})
+        run: mkdir -p build && cd build && cmake -DWARNINGS_AS_ERRORS=ON -DBUILD_SUFFIX=${{ env.BUILD_SUFFIX }} -DMAIN_COMPILE_OPTIONS=-pipe -G Ninja .. && ninja -j${{ env.NUM_CORES }} ${{ needs.detect.outputs.target_names }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: matrix-${{ env.BUILD_NAME }}.single
+          path: ./build/*.hex
+          retention-days: 1
+
   upload-artifacts:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, build-single-target]
+    if: always() && !cancelled() && (needs.build.result == 'success' || needs.build-single-target.result == 'success')
     steps:
       - uses: actions/checkout@v4
       - name: Setup environment


### PR DESCRIPTION
## Summary

Many pull requests only add or modify a single flight controller target — all changed files are within one `src/main/target/<TARGET>/` directory. In those cases it is wasteful to spin up 15 CI runners and rebuild all ~150 targets.

This adds a fast `detect` job that runs before the build. If every changed file in the PR is inside exactly one `src/main/target/<DIR>/` sub-directory, the target names are read directly from that directory's `CMakeLists.txt` and a single `build-single-target` job runs `ninja <targets>` on one runner instead of the usual 15-job matrix.

Any PR that touches files outside a single target directory falls through to the existing full matrix build unchanged. Push events and `workflow_call` (nightly builds) always do a full build.

## Changes

- New `detect` job: diffs PR against base branch, outputs `single_target=true/false` and `target_names`
- `build` matrix job: skipped when `single_target == 'true'`
- New `build-single-target` job: runs `ninja <target_names>` on a single runner
- `upload-artifacts` updated to accept output from either build path

## Testing

- Logic validated locally against several target CMakeLists.txt files (single-target pattern `target_stm32xxx(NAME)` extracts correctly)
- Full-build path is structurally unchanged; the `if: needs.detect.outputs.single_target != 'true'` condition passes through for all non-PR and multi-target scenarios
- For a PR like #11279 (only touches `src/main/target/BLUEBERRYH743/`), this would build only `BLUEBERRYH743` instead of all targets

## Related Issues

Reduces CI time and runner cost for the common case of single-target additions/fixes.