### PR TITLE
Update branch references from master to maintenance

### DIFF
--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -101,7 +101,7 @@ The main flow for a contributing is as follows:
 1. Login to github, go to the INAV repository and press `fork`.
 2. Then using the command line/terminal on your computer: `git clone <url to YOUR fork>`
 3. `cd inav`
-4. `git checkout master`
+4. `git checkout maintenance-10.x`
 5. `git checkout -b my-new-code`
 6. Make changes
 7. `git add <files that have changed>`
@@ -114,13 +114,13 @@ The primary thing to remember is that separate pull requests should be created f
 
 **Important:** Most contributions should target a maintenance branch, not `master`. See the branching section below for guidance on choosing the correct target branch.
 
-Later, you can get the changes from the INAV repo into your `master` branch by adding INAV as a git remote and merging from it as follows:
+Later, you can get the changes from the INAV repo into your version branch by adding INAV as a git remote and merging from it as follows:
 
 1. `git remote add upstream https://github.com/iNavFlight/inav.git`
-2. `git checkout master`
+2. `git checkout maintenance-10.x`
 3. `git fetch upstream`
-4. `git merge upstream/master`
-5. `git push origin master` is an optional step that will update your fork on github
+4. `git merge upstream/maintenance-10.x`
+5. `git push origin` is an optional step that will update your fork on github
 
 
 You can also perform the git commands using the git client inside Eclipse.  Refer to the Eclipse git manual.


### PR DESCRIPTION
Updated instructions to reflect the use of the maintenance branch instead of master for cloning and merging.