### PR TITLE
Fix MSP-over-telemetry multi-frame request assembly

### DIFF
--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -101,7 +101,7 @@ The main flow for a contributing is as follows:
 1. Login to github, go to the INAV repository and press `fork`.
 2. Then using the command line/terminal on your computer: `git clone <url to YOUR fork>`
 3. `cd inav`
-4. `git checkout master`
+4. `git checkout maintenance-10.x`
 5. `git checkout -b my-new-code`
 6. Make changes
 7. `git add <files that have changed>`
@@ -114,13 +114,13 @@ The primary thing to remember is that separate pull requests should be created f
 
 **Important:** Most contributions should target a maintenance branch, not `master`. See the branching section below for guidance on choosing the correct target branch.
 
-Later, you can get the changes from the INAV repo into your `master` branch by adding INAV as a git remote and merging from it as follows:
+Later, you can get the changes from the INAV repo into your version branch by adding INAV as a git remote and merging from it as follows:
 
 1. `git remote add upstream https://github.com/iNavFlight/inav.git`
-2. `git checkout master`
+2. `git checkout maintenance-10.x`
 3. `git fetch upstream`
-4. `git merge upstream/master`
-5. `git push origin master` is an optional step that will update your fork on github
+4. `git merge upstream/maintenance-10.x`
+5. `git push origin` is an optional step that will update your fork on github
 
 
 You can also perform the git commands using the git client inside Eclipse.  Refer to the Eclipse git manual.

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -73,7 +73,7 @@ void initSharedMsp(void)
     mspPackage.responseBuffer = (uint8_t *)&mspTxBuffer;
     mspPackage.responsePacket = &mspTxPacket;
     mspPackage.responsePacket->buf.ptr = mspPackage.responseBuffer;
-    mspPackage.responsePacket->buf.end = mspPackage.responseBuffer + sizeof(mspTxBuffer);
+    mspPackage.responsePacket->buf.end = mspPackage.responseBuffer;
 }
 
 static void processMspPacket(void)


### PR DESCRIPTION
## Summary

One-line fix in `initSharedMsp()` to initialize the response buffer as empty, preventing the response-pending check in `handleMspFrame()` from permanently blocking multi-frame MSP request assembly.

## Root Cause

`initSharedMsp()` initialized the response buffer with `buf.end` pointing to the end of the full buffer:
```c
responsePacket->buf.end = responseBuffer + sizeof(mspTxBuffer);  // e.g. 512 bytes
```

The response-pending check in `handleMspFrame()` uses `sbufBytesRemaining()` (`end - ptr`) to detect unsent response data:
```c
if (sbufBytesRemaining(&mspPackage.responsePacket->buf) > 0) {
    mspStarted = 0;
}
```

After `initSharedMsp()` runs, `sbufBytesRemaining()` returns the full buffer size (512) rather than 0, because `ptr` and `end` span the entire buffer. The check misinterprets this as a pending response, resets `mspStarted` to 0, which triggers `initSharedMsp()` again on the next frame — creating a permanent cycle that drops every continuation frame.

## Fix

```diff
-    mspPackage.responsePacket->buf.end = mspPackage.responseBuffer + sizeof(mspTxBuffer);
+    mspPackage.responsePacket->buf.end = mspPackage.responseBuffer;
```

Initialize the response buffer as empty (`ptr == end`) so `sbufBytesRemaining()` returns 0 when no response is actually pending. This is safe because `processMspPacket()` already sets up the response buffer with full capacity before writing any response.

## Impact

All MSPv1/MSPv2 requests requiring more than one telemetry frame are silently dropped over SmartPort, CRSF, and FPort MSP passthrough. Only zero-payload single-frame requests (e.g. `MSP2_INAV_STATUS`) work because they complete in a single frame without needing continuation.

## Testing

Verified on MATEKF765 with SmartPort MSP passthrough using diagnostic logging in `handleMspFrame()`:
- **Before fix:** Every continuation frame was dropped — `sbufBytesRemaining()` returned 512 after each `initSharedMsp()` call, causing `mspStarted` to be reset before the continuation could be processed
- **After fix:** Multi-frame MSPv2 requests are correctly reassembled and dispatched to `mspFcProcessCommand()`