### PR TITLE
Fix MSP_RESULT_NO_REPLY ignored in MSP-over-telemetry passthrough

### DIFF
--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -76,7 +76,7 @@ void initSharedMsp(void)
     mspPackage.responsePacket->buf.end = mspPackage.responseBuffer + sizeof(mspTxBuffer);
 }
 
-static void processMspPacket(void)
+static bool processMspPacket(void)
 {
     mspPackage.responsePacket->cmd = 0;
     mspPackage.responsePacket->result = 0;
@@ -84,14 +84,20 @@ static void processMspPacket(void)
     mspPackage.responsePacket->buf.end = mspPackage.responseBuffer + sizeof(mspTxBuffer);
 
     mspPostProcessFnPtr mspPostProcessFn = NULL;
-    if (mspFcProcessCommand(mspPackage.requestPacket, mspPackage.responsePacket, &mspPostProcessFn) == MSP_RESULT_ERROR) {
+    const mspResult_e status = mspFcProcessCommand(mspPackage.requestPacket, mspPackage.responsePacket, &mspPostProcessFn);
+    if (status == MSP_RESULT_ERROR) {
         sbufWriteU8(&mspPackage.responsePacket->buf, TELEMETRY_MSP_ERROR);
     }
     if (mspPostProcessFn) {
         mspPostProcessFn(NULL);
     }
 
+    if (status == MSP_RESULT_NO_REPLY) {
+        return false;
+    }
+
     sbufSwitchToReader(&mspPackage.responsePacket->buf, mspPackage.responseBuffer);
+    return true;
 }
 
 void sendMspErrorResponse(uint8_t error, int16_t cmd)
@@ -194,8 +200,7 @@ bool handleMspFrame(uint8_t *const frameStart, const int payloadLength)
     sbufAdvance(&mspPackage.requestFrame, payloadExpecting);
     sbufWriteData(&requestPacket->buf, payload, payloadExpecting);
     sbufSwitchToReader(&requestPacket->buf, mspPackage.requestBuffer);
-    processMspPacket();
-    return true;
+    return processMspPacket();
 }
 
 bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)


### PR DESCRIPTION
### Problem

`processMspPacket()` in msp_shared.c ignores the `MSP_RESULT_NO_REPLY` return value from `mspFcProcessCommand()`. When a client sends an MSPv2 command with the `MSP_FLAG_DONT_REPLY` flag (bit 0 of the flags byte), the FC correctly evaluates the result as `MSP_RESULT_NO_REPLY`, but `processMspPacket()` unconditionally calls `sbufSwitchToReader()` on the response buffer — causing a reply to be sent anyway.

This wastes bandwidth on half-duplex telemetry links (SmartPort, CRSF, FPort) and violates the MSPv2 protocol contract. In constrained passthrough scenarios (e.g. Lua scripts sending fire-and-forget SET commands), the unnecessary reply frames can cause congestion and slow down subsequent requests.

### Root Cause

The serial MSP path in msp_serial.c already handles this correctly:

```c
if (status != MSP_RESULT_NO_REPLY) {
    // ... send reply
}
```

The telemetry passthrough path in msp_shared.c was missing this check — the return value of `mspFcProcessCommand()` was discarded.

### Fix

Store the return value of `mspFcProcessCommand()` and check for `MSP_RESULT_NO_REPLY`. When the result is NO_REPLY, set the response buffer to empty (`buf.ptr = buf.end`) instead of calling `sbufSwitchToReader()`, so no reply is transmitted.

### Affected Paths

- SmartPort MSP passthrough
- CRSF MSP passthrough
- FPort MSP passthrough