### PR TITLE
Offset FW autoland loiter position perpendicular to runway

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -2462,7 +2462,27 @@ static navigationFSMEvent_t navOnEnteringState_NAV_STATE_FW_LANDING_LOITER(navig
         }
     }
 
-    fpVector3_t tmpPoint = posControl.fwLandState.landPos;
+    // Offset loiter position perpendicular to runway in the approach circuit direction (LEFT/RIGHT)
+    fpVector3_t tmpPoint;
+    int32_t refHeading = 0;
+    if (fwAutolandApproachConfig(posControl.fwLandState.approachSettingIdx)->landApproachHeading1 != 0) {
+        refHeading = ABS(DEGREES_TO_CENTIDEGREES(fwAutolandApproachConfig(posControl.fwLandState.approachSettingIdx)->landApproachHeading1));
+    } else if (fwAutolandApproachConfig(posControl.fwLandState.approachSettingIdx)->landApproachHeading2 != 0) {
+        refHeading = ABS(DEGREES_TO_CENTIDEGREES(fwAutolandApproachConfig(posControl.fwLandState.approachSettingIdx)->landApproachHeading2));
+    }
+
+    if (refHeading != 0) {
+        int32_t offsetDir;
+        if (fwAutolandApproachConfig(posControl.fwLandState.approachSettingIdx)->approachDirection == FW_AUTOLAND_APPROACH_DIRECTION_LEFT) {
+            offsetDir = wrap_36000(refHeading - 9000);
+        } else {
+            offsetDir = wrap_36000(refHeading + 9000);
+        }
+        calculateFarAwayPos(&tmpPoint, &posControl.fwLandState.landPos, offsetDir, navConfig()->fw.loiter_radius);
+    } else {
+        tmpPoint = posControl.fwLandState.landPos;
+    }
+
     tmpPoint.z = posControl.fwLandState.landAproachAltAgl;
     setDesiredPosition(&tmpPoint, posControl.fwLandState.landPosHeading, NAV_POS_UPDATE_XY | NAV_POS_UPDATE_Z | NAV_POS_UPDATE_HEADING);
 


### PR DESCRIPTION
### Untested - Don't merge yet

Loiter position improvements:

* This change is made to obey the rules of most flying club fields that don't allow flyover of the protection fence line
* The loiter position (`tmpPoint`) is now offset perpendicular to the runway in the direction of the approach circuit (LEFT or RIGHT), using either `landApproachHeading1` or `landApproachHeading2` from the approach configuration to determine the reference heading. If neither heading is set, the original landing position is used.
* The offset direction is calculated by adding or subtracting 90 degrees (in centidegrees) from the reference heading, depending on the approach direction, and the new loiter position is computed using `calculateFarAwayPos`.Shift the wind-check loiter circle away from the landing point by loiter_radius in the configured approach direction (LEFT/RIGHT), perpendicular to the runway heading. This places the loiter pattern on the same side as the base leg turn point, reducing the distance to the first approach waypoint after wind assessment.

<img width="1287" height="840" alt="image" src="https://github.com/user-attachments/assets/31c730a1-ac9e-4b44-90aa-260d5877faf0" />
