### PR TITLE
target/FLYINGRCF4WINGMINI_NOT_RECOMMENDED: add LED strip support

### DIFF
--- a/src/main/target/FLYINGRCF4WINGMINI_NOT_RECOMMENDED/target.c
+++ b/src/main/target/FLYINGRCF4WINGMINI_NOT_RECOMMENDED/target.c
@@ -34,7 +34,7 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM2,  CH4,  PB11, TIM_USE_OUTPUT_AUTO,   0, 0), // S5 D(1,7,3) UP173
     DEF_TIM(TIM2,  CH3,  PB10, TIM_USE_OUTPUT_AUTO,   0, 0), // S6 D(1,1,3) UP173
 
-    DEF_TIM(TIM3,  CH4,  PB1,  TIM_USE_OUTPUT_AUTO,    0, 0), // 2812LED  D(1,2,5)
+    DEF_TIM(TIM3,  CH4,  PB1,  TIM_USE_LED,    0, 0), // 2812LED  D(1,2,5)
 
     DEF_TIM(TIM5,  CH3,  PA2,  TIM_USE_ANY,    0, 0), //TX2  softserial1_Tx
 };

--- a/src/main/target/FLYINGRCF4WINGMINI_NOT_RECOMMENDED/target.h
+++ b/src/main/target/FLYINGRCF4WINGMINI_NOT_RECOMMENDED/target.h
@@ -95,6 +95,10 @@
 #define ADC_CHANNEL_1_PIN           PC4
 #define VBAT_ADC_CHANNEL            ADC_CHN_1
 
+// *************** LEDSTRIP ************************
+#define USE_LED_STRIP
+#define WS2811_PIN PB1
+
 // *************** others  ************************
 #define DEFAULT_FEATURES   (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX)
 #define VBAT_SCALE_DEFAULT      2100


### PR DESCRIPTION
This adds LED strip support for FLYINGRCF4WINGMINI_NOT_RECOMMENDED.

Problem:
The target does not define LED strip resources, so WS2812/WS2811 LEDs cannot be used on this board.

Solution:
- Enable LED strip support in target.h
- Define WS2811_PIN (PB1)
- Configure TIM3 CH4 for LED usage (TIM_USE_LED)

This matches the hardware capabilities of the board and enables LED strip functionality.

Tested:
- Successfully built FLYINGRCF4WINGMINI_NOT_RECOMMENDED
- Verified LED strip functionality on hardware

Fixes #11495