### PR TITLE
GPS: fix hwVersion field size from uint32_t to uint8_t

### DIFF
--- a/docs/development/msp/msp_messages.json
+++ b/docs/development/msp/msp_messages.json
@@ -4914,9 +4914,9 @@
                 },
                 {
                     "name": "hwVersion",
-                    "ctype": "uint32_t",
-                    "desc": "GPS hardware version (`gpsState.hwVersion`). Values: 500=UBLOX5, 600=UBLOX6, 700=UBLOX7, 800=UBLOX8, 900=UBLOX9, 1000=UBLOX10, 0=UNKNOWN",
-                    "units": "Version code"
+                    "ctype": "uint8_t",
+                    "desc": "GPS hardware version bit-field: bits[7:6]=series (0b01=u-blox Neo/M), bits[5:0]=generation. E.g. 0x48=M8, 0x49=M9, 0x4A=M10, 0=unknown.",
+                    "units": ""
                 }
             ]
         },

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1009,7 +1009,7 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
         sbufWriteU16(dst, gpsSol.hdop);
         sbufWriteU16(dst, gpsSol.eph);
         sbufWriteU16(dst, gpsSol.epv);
-        sbufWriteU32(dst, gpsState.hwVersion);
+        sbufWriteU8(dst, gpsState.hwVersion);
         break;
 #endif
     case MSP2_ADSB_VEHICLE_LIST:

--- a/src/main/io/gps_private.h
+++ b/src/main/io/gps_private.h
@@ -42,7 +42,7 @@ typedef struct {
     const serialConfig_t * serialConfig;
     serialPort_t *  gpsPort;                // Serial GPS only
 
-    uint32_t        hwVersion;
+    uint8_t         hwVersion;          // See UBX_HW_VERSION_* in gps_ublox.h
     uint8_t         swVersionMajor;
     uint8_t         swVersionMinor;
 

--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -556,7 +556,7 @@ static void gpsDecodeProtocolVersion(const char *proto, size_t bufferLength)
     }
 }
 
-static uint32_t gpsDecodeHardwareVersion(const char * szBuf, unsigned nBufSize)
+static uint8_t gpsDecodeHardwareVersion(const char * szBuf, unsigned nBufSize)
 {
     // ublox_5   hwVersion 00040005
     if (strncmp(szBuf, "00040005", nBufSize) == 0) {

--- a/src/main/io/gps_ublox.h
+++ b/src/main/io/gps_ublox.h
@@ -62,13 +62,25 @@ STATIC_ASSERT(MAX_UBLOX_PAYLOAD_SIZE >= 256, ubx_size_too_small);
 #define UBX_VALID_GPS_TIME(valid) (valid & 1 << 1)
 #define UBX_VALID_GPS_DATE_TIME(valid) (UBX_VALID_GPS_DATE(valid) && UBX_VALID_GPS_TIME(valid))
 
-#define UBX_HW_VERSION_UNKNOWN  0
-#define UBX_HW_VERSION_UBLOX5   500
-#define UBX_HW_VERSION_UBLOX6   600
-#define UBX_HW_VERSION_UBLOX7   700
-#define UBX_HW_VERSION_UBLOX8   800
-#define UBX_HW_VERSION_UBLOX9   900
-#define UBX_HW_VERSION_UBLOX10  1000
+/*
+ * hwVersion encoding (fits in uint8_t):
+ *   bits [7:6]  series:  0b00=unknown, 0b01=u-blox Neo/M series
+ *   bits [5:0]  generation within series (e.g. 8=M8, 9=M9, 10=M10)
+ *
+ * This leaves 0b10 and 0b11 available for future series (e.g. u-blox F9,
+ * other manufacturers).
+ */
+#define UBX_HW_SERIES_MASK          0xC0
+#define UBX_HW_GEN_MASK             0x3F
+#define UBX_HW_SERIES_UBLOX_NM      0x40    // 0b01 << 6: u-blox Neo/M series
+
+#define UBX_HW_VERSION_UNKNOWN      0
+#define UBX_HW_VERSION_UBLOX5       (UBX_HW_SERIES_UBLOX_NM | 5)   // 0x45
+#define UBX_HW_VERSION_UBLOX6       (UBX_HW_SERIES_UBLOX_NM | 6)   // 0x46
+#define UBX_HW_VERSION_UBLOX7       (UBX_HW_SERIES_UBLOX_NM | 7)   // 0x47
+#define UBX_HW_VERSION_UBLOX8       (UBX_HW_SERIES_UBLOX_NM | 8)   // 0x48
+#define UBX_HW_VERSION_UBLOX9       (UBX_HW_SERIES_UBLOX_NM | 9)   // 0x49
+#define UBX_HW_VERSION_UBLOX10      (UBX_HW_SERIES_UBLOX_NM | 10)  // 0x4A
 
 #define UBLOX_CFG_MSGOUT_NAV_POSLLH_UART1   0x2091002a // U1
 #define UBLOX_CFG_MSGOUT_NAV_SAT_UART1      0x20910016 // U1


### PR DESCRIPTION
## Summary

Follow-up to #11262. Changes `gpsState.hwVersion` from `uint32_t` to `uint8_t` and introduces a structured bit-field encoding for the hardware version byte sent via `MSP_GPSSTATISTICS`:

- **bits [7:6]** = series (`0b01` = u-blox Neo/M series)
- **bits [5:0]** = generation within series (e.g. 8=M8, 9=M9, 10=M10)

Concrete values: M8=`0x48`, M9=`0x49`, M10=`0x4A`

The encoding reserves series values `0b10` and `0b11` for future chip families (u-blox F9, other manufacturers).

**Files changed:**
- `src/main/io/gps_ublox.h` — new `UBX_HW_SERIES_*` macros + updated `UBX_HW_VERSION_*` constants
- `src/main/io/gps_private.h` — `uint32_t hwVersion` → `uint8_t hwVersion`
- `src/main/fc/fc_msp.c` — `sbufWriteU32` → `sbufWriteU8`
- `src/main/io/gps_ublox.c` — decode function return type `uint32_t` → `uint8_t`

## Test plan

- [x] Firmware builds without errors or warnings
- [x] Tested with M9 receiver — hwVersion reported as `0x49`, M9-precision preset auto-detected
- [x] Tested with M10 receiver — hwVersion reported as `0x4A`, M10 preset auto-detected
- [x] Companion configurator PR: iNavFlight/inav-configurator#XXXX