### PR TITLE
Fix MSP_GPSSTATISTICS hwVersion documentation: uint32_t -> uint8_t

### DIFF
--- a/docs/development/msp/msp_messages.json
+++ b/docs/development/msp/msp_messages.json
@@ -4920,9 +4920,9 @@
                     },
                     {
                         "name": "hwVersion",
-                        "ctype": "uint32_t",
-                        "desc": "GPS hardware version (`gpsState.hwVersion`). Values: 500=UBLOX5, 600=UBLOX6, 700=UBLOX7, 800=UBLOX8, 900=UBLOX9, 1000=UBLOX10, 0=UNKNOWN",
-                        "units": "Version code"
+                        "ctype": "uint8_t",
+                        "desc": "GPS hardware version bit-field: bits[7:6]=series (0b01=u-blox Neo/M), bits[5:0]=generation. E.g. 0x48=M8, 0x49=M9, 0x4A=M10, 0=unknown.",
+                        "units": ""
                     }
                 ]
             },


### PR DESCRIPTION
## Summary

Fixes the `hwVersion` field type in `MSP_GPSSTATISTICS` (code 166) in `msp_messages.json`.

The merged firmware sends `hwVersion` as `sbufWriteU8` (1 byte, bit-field encoding), but the documentation still had the old `uint32_t` (4 bytes) description from before PR #11510.

**Corrected entry:**
- Type: `uint8_t` (was `uint32_t`)
- Description: bit-field encoding — bits[7:6]=series (0b01=u-blox Neo/M), bits[5:0]=generation. E.g. 0x48=M8, 0x49=M9, 0x4A=M10, 0=unknown.

This commit was pushed to the merge branch after PR #11512 was already merged.