### PR TITLE
DroneCAN: Add node table, CLI status, and MSP2 node query commands

### DIFF
--- a/docs/DroneCAN-Driver.md
+++ b/docs/DroneCAN-Driver.md
@@ -242,6 +242,38 @@ dronecanUpdate(micros());  // Called repeatedly
 
 ---
 
+### Node Table
+
+The driver maintains a table of detected DroneCAN nodes populated from incoming `NodeStatus` broadcasts.
+
+#### `dronecanNodeInfo_t` struct
+
+```c
+typedef struct dronecanNodeInfo_s {
+    uint8_t  nodeID;              // CAN node ID (1-127)
+    uint8_t  health;              // UAVCAN_PROTOCOL_NODESTATUS_HEALTH_*
+    uint8_t  mode;                // UAVCAN_PROTOCOL_NODESTATUS_MODE_*
+    uint32_t uptime_sec;          // Node uptime in seconds
+    uint16_t vendor_status_code;  // Vendor-specific status word
+    uint32_t last_seen_ms;        // FC millis() timestamp of last NodeStatus
+    uint8_t  name_len;            // Length of name (0 until GetNodeInfo implemented)
+    char     name[32];            // Node name, zero-padded
+} dronecanNodeInfo_t;
+```
+
+The table holds up to `DRONECAN_MAX_NODES` (32) entries, indexed by arrival order. Entries are never removed at runtime; the table persists from boot until power-off.
+
+#### Accessor Functions
+
+| Function | Returns |
+|----------|---------|
+| `dronecanGetNodeCount()` | Number of unique nodes seen (`uint8_t`) |
+| `dronecanGetNode(uint8_t index)` | Pointer to `dronecanNodeInfo_t` for entry `index`, or `NULL` if out of range |
+| `dronecanGetState()` | Current bus state (`dronecanState_e`) |
+| `dronecanGetBitrateKbps()` | Configured bitrate as a plain integer (e.g. 1000) |
+
+---
+
 ### Configuration
 
 #### Settings
@@ -305,8 +337,8 @@ The driver includes 7 built-in message handlers. Each handler decodes a message 
 
 #### `handle_NodeStatus()`
 **Receives:** `uavcan_protocol_NodeStatus` (from other nodes)
-**Processing:** Decodes and logs node health (OK/WARNING/ERROR/CRITICAL) and mode (OPERATIONAL/INITIALIZATION/MAINTENANCE/SOFTWARE_UPDATE/OFFLINE)
-**Status:** Logs health and mode status
+**Processing:** Decodes the message and upserts into the node table (`nodeTable[]`). If the source node ID is already in the table, health, mode, uptime, vendor status, and `last_seen_ms` are updated. If it is a new node and the table is not full, a new entry is appended and `activeNodeCount` is incremented. Node names are not available from NodeStatus broadcasts; they remain empty until `GetNodeInfo` service requests are implemented.
+**Status:** Node count accessible via `dronecanGetNodeCount()`; per-node detail via `dronecanGetNode()`
 
 ### Service Handlers
 
@@ -474,6 +506,46 @@ if (uavcan_equipment_gnss_Fix_decode(transfer, &gnssFix) == 0) {
     LOG_DEBUG(CAN, "GNSSFix decode failed");
 }
 ```
+
+---
+
+## MSP Commands
+
+Two MSP2 commands expose the node table to external tools (configurator, GCS, test scripts):
+
+### `MSP2_INAV_DRONECAN_NODES` (0x2042)
+
+**Direction:** Request (no payload) → Reply  
+**Handler location:** `mspFcProcessOutCommand()` in `fc_msp.c`  
+**Guard:** `#ifdef USE_DRONECAN`
+
+**Reply layout:**
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 1 | `nodeCount` |
+| 1 + N×30 | 1 | `nodeID` |
+| 2 + N×30 | 1 | `health` |
+| 3 + N×30 | 1 | `mode` |
+| 4 + N×30 | 4 | `uptime_sec` (little-endian) |
+| 8 + N×30 | 2 | `vendor_status_code` |
+| 10 + N×30 | 4 | `last_seen_ms` |
+| 14 + N×30 | 1 | `name_len` |
+| 15 + N×30 | 16 | `name` (zero-padded) |
+
+Total: 1 + nodeCount × 30 bytes.
+
+---
+
+### `MSP2_INAV_DRONECAN_NODE_INFO` (0x2043)
+
+**Direction:** Request (1 byte node ID) → Reply  
+**Handler location:** `mspFCProcessInOutCommand()` in `fc_msp.c`  
+**Guard:** `#ifdef USE_DRONECAN`
+
+**Request:** 1 byte — target `nodeID`
+
+**Reply layout:** same fields as above but with a 32-byte `name` field (46 bytes total). Returns an empty response if the requested node ID is not in the table.
 
 ---
 
@@ -837,6 +909,7 @@ void broadcastNodeStatus(void) {
 
 | Date | Version | Changes |
 |---|---|---|
+| 2026-04-30 | 1.2 | Added node table (`dronecanNodeInfo_t`), accessor functions, CLI status output, and MSP commands (0x2042/0x2043) |
 | 2026-02-18 | 1.1 | Added error recovery, graceful disable behavior, and safe initialization documentation |
 | 2026-02-16 | 1.0 | Initial version - handler-based architecture documentation |
 

--- a/docs/DroneCAN.md
+++ b/docs/DroneCAN.md
@@ -318,6 +318,40 @@ Connect the CAN bus lines between your flight controller and DroneCAN peripheral
     120R                          (pass-through)                              120R
 ```
 
+## Diagnostics
+
+### CLI Status
+
+The `status` CLI command includes a DroneCAN summary line showing the current bus state and how many nodes have been detected:
+
+```
+DroneCAN: nodeID=10, bitrate=1000 kbps, status=NORMAL, nodes=2
+```
+
+| Field | Description |
+|-------|-------------|
+| `nodeID` | This FC's CAN node ID |
+| `bitrate` | Configured CAN bus bitrate |
+| `status` | `INIT`, `NORMAL`, or `BUS_OFF` |
+| `nodes` | Number of unique nodes seen since boot |
+
+### MSP Commands
+
+Two MSP2 commands are available for querying detected DroneCAN nodes programmatically (e.g. from a GCS or configurator):
+
+| Command | Code | Description |
+|---------|------|-------------|
+| `MSP2_INAV_DRONECAN_NODES` | `0x2042` | Returns count and status of all detected nodes |
+| `MSP2_INAV_DRONECAN_NODE_INFO` | `0x2043` | Returns full detail for a single node by ID |
+
+**`MSP2_INAV_DRONECAN_NODES` response:** one byte node count followed by 30-byte records — nodeID, health, mode, uptime, vendor status code, last-seen timestamp, and name (currently empty; populated once `GetNodeInfo` service requests are implemented).
+
+**`MSP2_INAV_DRONECAN_NODE_INFO` request/response:** send a single-byte node ID; receive the same fields as above with a 32-byte name field. Returns an empty response if the node ID is not in the table.
+
+See `docs/development/msp/README.md` for the full MSP field layout.
+
+---
+
 ## Troubleshooting
 
 ### No data from DroneCAN devices

--- a/docs/DroneCAN.md
+++ b/docs/DroneCAN.md
@@ -344,9 +344,9 @@ Two MSP2 commands are available for querying detected DroneCAN nodes programmati
 | `MSP2_INAV_DRONECAN_NODES` | `0x2042` | Returns count and status of all detected nodes |
 | `MSP2_INAV_DRONECAN_NODE_INFO` | `0x2043` | Returns full detail for a single node by ID |
 
-**`MSP2_INAV_DRONECAN_NODES` response:** one byte node count followed by 30-byte records — nodeID, health, mode, uptime, vendor status code, last-seen timestamp, and name (currently empty; populated once `GetNodeInfo` service requests are implemented).
+**`MSP2_INAV_DRONECAN_NODES` response:** one byte node count followed by 7-byte records — nodeID(1), health(1), mode(1), last\_seen\_ms(4). Maximum payload is 1 + 32×7 = 225 bytes, well within the 512-byte MSP output buffer.
 
-**`MSP2_INAV_DRONECAN_NODE_INFO` request/response:** send a single-byte node ID; receive the same fields as above with a 32-byte name field. Returns an empty response if the node ID is not in the table.
+**`MSP2_INAV_DRONECAN_NODE_INFO` request/response:** send a single-byte node ID; receive full node detail — nodeID, health, mode, uptime\_sec, vendor\_status\_code, last\_seen\_ms, name\_len, and name (32 bytes). Returns `MSP_RESULT_ERROR` if the node ID is not in the table.
 
 See `docs/development/msp/README.md` for the full MSP field layout.
 

--- a/docs/development/msp/README.md
+++ b/docs/development/msp/README.md
@@ -4165,19 +4165,12 @@ When the MSP JSON specification changes, bump `msp_messages.json` version:
 **Request Payload:** **None**  
   
 **Reply Payload:**
-|Field|C Type|Size (Bytes)|Units|Description|
-|---|---|---|---|---|
-| `nodeCount` | `uint8_t` | 1 | - | Number of detected DroneCAN nodes |
-| `nodeID` | `uint8_t` | 1 | - | DroneCAN node ID (1-127) |
-| `health` | `uint8_t` | 1 | - | Node health: 0=OK, 1=WARNING, 2=ERROR, 3=CRITICAL |
-| `mode` | `uint8_t` | 1 | - | Node mode: 0=OPERATIONAL, 1=INITIALIZATION, 2=MAINTENANCE, 3=SOFTWARE_UPDATE, 7=OFFLINE |
-| `uptime_sec` | `uint32_t` | 4 | s | Node uptime in seconds |
-| `vendor_status_code` | `uint16_t` | 2 | - | Vendor-specific status code |
-| `last_seen_ms` | `uint32_t` | 4 | ms | FC millisecond timestamp when this node was last seen |
-| `name_len` | `uint8_t` | 1 | - | Length of node name string (0 if unknown) |
-| `name` | `char[16]` | 16 | - | Node name truncated to 16 bytes, zero-padded |
+|Field|C Type|Size (Bytes)|Description|
+|---|---|---|---|
+| `nodeCount` | `uint8_t` | 1 | Number of detected DroneCAN nodes |
+| `nodeData` | `dronecanNodeStatus_t[]` | array | Array of per-node status records, one per detected node. Each record: nodeID(1)+health(1)+mode(1)+last_seen_ms(4) = 7 bytes. Full detail available via MSP2_INAV_DRONECAN_NODE_INFO. |
 
-**Notes:** Requires `USE_DRONECAN`. Response is `nodeCount` followed by `nodeCount` records of 30 bytes each: nodeID(1)+health(1)+mode(1)+uptime_sec(4)+vendor_status_code(2)+last_seen_ms(4)+name_len(1)+name[16].
+**Notes:** Requires `USE_DRONECAN`. Response is `nodeCount` followed by `nodeCount` records of 7 bytes each: nodeID(1)+health(1)+mode(1)+last_seen_ms(4). Maximum payload 1 + (DRONECAN_MAX_NODES * 7) = 225 bytes. Full node detail including uptime, vendor status, and name is available via MSP2_INAV_DRONECAN_NODE_INFO.
 
 ## <a id="msp2_inav_dronecan_node_info"></a>`MSP2_INAV_DRONECAN_NODE_INFO (8259 / 0x2043)`
 **Description:** Returns full status detail for a single DroneCAN node by ID.  

--- a/docs/development/msp/README.md
+++ b/docs/development/msp/README.md
@@ -417,6 +417,8 @@ When the MSP JSON specification changes, bump `msp_messages.json` version:
 [8251 - MSP2_INAV_LOGIC_CONDITIONS_SINGLE](#msp2_inav_logic_conditions_single)  
 [8256 - MSP2_INAV_ESC_RPM](#msp2_inav_esc_rpm)  
 [8257 - MSP2_INAV_ESC_TELEM](#msp2_inav_esc_telem)  
+[8258 - MSP2_INAV_DRONECAN_NODES](#msp2_inav_dronecan_nodes)  
+[8259 - MSP2_INAV_DRONECAN_NODE_INFO](#msp2_inav_dronecan_node_info)  
 [8264 - MSP2_INAV_LED_STRIP_CONFIG_EX](#msp2_inav_led_strip_config_ex)  
 [8265 - MSP2_INAV_SET_LED_STRIP_CONFIG_EX](#msp2_inav_set_led_strip_config_ex)  
 [8266 - MSP2_INAV_FW_APPROACH](#msp2_inav_fw_approach)  
@@ -450,6 +452,7 @@ When the MSP JSON specification changes, bump `msp_messages.json` version:
 [8736 - MSP2_INAV_FULL_LOCAL_POSE](#msp2_inav_full_local_pose)  
 [8737 - MSP2_INAV_SET_WP_INDEX](#msp2_inav_set_wp_index)  
 [8739 - MSP2_INAV_SET_CRUISE_HEADING](#msp2_inav_set_cruise_heading)  
+[8752 - MSP2_INAV_SET_AUX_RC](#msp2_inav_set_aux_rc)  
 [12288 - MSP2_BETAFLIGHT_BIND](#msp2_betaflight_bind)  
 [12289 - MSP2_RX_BIND](#msp2_rx_bind)  
 
@@ -2311,7 +2314,7 @@ When the MSP JSON specification changes, bump `msp_messages.json` version:
 | `hdop` | `uint16_t` | 2 | HDOP * 100 | Horizontal Dilution of Precision (`gpsSol.hdop`) |
 | `eph` | `uint16_t` | 2 | cm | Estimated Horizontal Position Accuracy (`gpsSol.eph`) |
 | `epv` | `uint16_t` | 2 | cm | Estimated Vertical Position Accuracy (`gpsSol.epv`) |
-| `hwVersion` | `uint32_t` | 4 | Version code | GPS hardware version (`gpsState.hwVersion`). Values: 500=UBLOX5, 600=UBLOX6, 700=UBLOX7, 800=UBLOX8, 900=UBLOX9, 1000=UBLOX10, 0=UNKNOWN |
+| `hwVersion` | `uint8_t` | 1 | - | GPS hardware version bit-field: bits[7:6]=series (0b01=u-blox Neo/M), bits[5:0]=generation. E.g. 0x48=M8, 0x49=M9, 0x4A=M10, 0=unknown. |
 
 **Notes:** Requires `USE_GPS`.
 
@@ -4156,6 +4159,48 @@ When the MSP JSON specification changes, bump `msp_messages.json` version:
 
 **Notes:** Requires `USE_ESC_SENSOR`. See `escSensorData_t` in `sensors/esc_sensor.h` for the exact structure fields.
 
+## <a id="msp2_inav_dronecan_nodes"></a>`MSP2_INAV_DRONECAN_NODES (8258 / 0x2042)`
+**Description:** Returns the list of all detected DroneCAN nodes with their current status.  
+
+**Request Payload:** **None**  
+  
+**Reply Payload:**
+|Field|C Type|Size (Bytes)|Units|Description|
+|---|---|---|---|---|
+| `nodeCount` | `uint8_t` | 1 | - | Number of detected DroneCAN nodes |
+| `nodeID` | `uint8_t` | 1 | - | DroneCAN node ID (1-127) |
+| `health` | `uint8_t` | 1 | - | Node health: 0=OK, 1=WARNING, 2=ERROR, 3=CRITICAL |
+| `mode` | `uint8_t` | 1 | - | Node mode: 0=OPERATIONAL, 1=INITIALIZATION, 2=MAINTENANCE, 3=SOFTWARE_UPDATE, 7=OFFLINE |
+| `uptime_sec` | `uint32_t` | 4 | s | Node uptime in seconds |
+| `vendor_status_code` | `uint16_t` | 2 | - | Vendor-specific status code |
+| `last_seen_ms` | `uint32_t` | 4 | ms | FC millisecond timestamp when this node was last seen |
+| `name_len` | `uint8_t` | 1 | - | Length of node name string (0 if unknown) |
+| `name` | `char[16]` | 16 | - | Node name truncated to 16 bytes, zero-padded |
+
+**Notes:** Requires `USE_DRONECAN`. Response is `nodeCount` followed by `nodeCount` records of 30 bytes each: nodeID(1)+health(1)+mode(1)+uptime_sec(4)+vendor_status_code(2)+last_seen_ms(4)+name_len(1)+name[16].
+
+## <a id="msp2_inav_dronecan_node_info"></a>`MSP2_INAV_DRONECAN_NODE_INFO (8259 / 0x2043)`
+**Description:** Returns full status detail for a single DroneCAN node by ID.  
+  
+**Request Payload:**
+|Field|C Type|Size (Bytes)|Description|
+|---|---|---|---|
+| `nodeID` | `uint8_t` | 1 | DroneCAN node ID to query (1-127) |
+  
+**Reply Payload:**
+|Field|C Type|Size (Bytes)|Units|Description|
+|---|---|---|---|---|
+| `nodeID` | `uint8_t` | 1 | - | DroneCAN node ID |
+| `health` | `uint8_t` | 1 | - | Node health: 0=OK, 1=WARNING, 2=ERROR, 3=CRITICAL |
+| `mode` | `uint8_t` | 1 | - | Node mode: 0=OPERATIONAL, 1=INITIALIZATION, 2=MAINTENANCE, 3=SOFTWARE_UPDATE, 7=OFFLINE |
+| `uptime_sec` | `uint32_t` | 4 | s | Node uptime in seconds |
+| `vendor_status_code` | `uint16_t` | 2 | - | Vendor-specific status code |
+| `last_seen_ms` | `uint32_t` | 4 | ms | FC millisecond timestamp when this node was last seen |
+| `name_len` | `uint8_t` | 1 | - | Length of node name string (0 if unknown) |
+| `name` | `char[32]` | 32 | - | Node name up to 32 bytes, zero-padded |
+
+**Notes:** Requires `USE_DRONECAN`. Returns `MSP_RESULT_ERROR` if the requested node ID is not in the node table.
+
 ## <a id="msp2_inav_led_strip_config_ex"></a>`MSP2_INAV_LED_STRIP_CONFIG_EX (8264 / 0x2048)`
 **Description:** Retrieves the full configuration for each LED on the strip using the `ledConfig_t` structure. Supersedes `MSP_LED_STRIP_CONFIG`.  
 
@@ -4709,6 +4754,19 @@ When the MSP JSON specification changes, bump `msp_messages.json` version:
 **Reply Payload:** **None**  
 
 **Notes:** Returns error if the aircraft is not armed or `NAV_COURSE_HOLD_MODE` is not active. On success, sets both `posControl.cruise.course` and `posControl.cruise.previousCourse` to the normalised value, preventing spurious heading adjustments from `getCruiseHeadingAdjustment()` on the next control cycle.
+
+## <a id="msp2_inav_set_aux_rc"></a>`MSP2_INAV_SET_AUX_RC (8752 / 0x2230)`
+**Description:** Bandwidth-efficient auxiliary RC channel update. Sets CH13-CH32 with configurable resolution (2/4/8/16-bit) without affecting primary flight controls. Designed for extending channel count beyond native RC link capacity via MSP passthrough.  
+  
+**Request Payload:**
+|Field|C Type|Size (Bytes)|Units|Description|
+|---|---|---|---|---|
+| `definitionByte` | `uint8_t` | 1 | - | Packed start channel and resolution. Bits 7-3: start channel index (valid range 12-31 for CH13-CH32; 0-11 rejected as error). Bits 2-0: resolution mode (0=2-bit, 1=4-bit, 2=8-bit, 3=16-bit; 4-7 reserved/error). |
+| `channelData` | `uint8_t[]` | array | PWM (encoded) | Packed channel values, sequential from start channel. Number of channels is derived from data size and resolution. Value 0 means skip (no update). Sub-byte modes (2-bit, 4-bit) are packed MSB-first. 2-bit values 1-3 map to 1000/1500/2000us. 4-bit values 1-15 map to 1000 + (val-1)*1000/14 us. 8-bit values 1-255 map to 1000 + (val-1)*1000/254 us. 16-bit values are direct PWM, clamped to 750-2250us. |
+
+**Reply Payload:** **None**  
+
+**Notes:** CH1-CH12 (index 0-11) are protected and will return `MSP_RESULT_ERROR`. Payload size must be 2-49 bytes. Constraint: `startChannel + channelCount <= 32`. Values persist until overwritten; no timeout. Applied as a post-RX overlay in `calculateRxChannelsAndUpdateFailsafe()` after MSP RC Override but before failsafe. Does not require `USE_RX_MSP` or MSP-RC-OVERRIDE flight mode. Does not affect failsafe detection. When MSP is the primary RX provider, channels covered by `MSP_SET_RAW_RC` are automatically skipped. Channels in the `mspOverrideChannels` bitmask are skipped when MSP RC Override mode is active. Recommended to send with `MSP_FLAG_DONT_REPLY` (flags=0x01) to save bandwidth on telemetry passthrough links. 16-bit mode requires even number of data bytes and values are clamped to 750-2250us.
 
 ## <a id="msp2_betaflight_bind"></a>`MSP2_BETAFLIGHT_BIND (12288 / 0x3000)`
 **Description:** Initiates the receiver binding procedure for supported serial protocols (CRSF, SRXL2).  

--- a/docs/development/msp/msp_messages.json
+++ b/docs/development/msp/msp_messages.json
@@ -9818,69 +9818,29 @@
             "description": "Retrieves the full telemetry data structure reported by each ESC."
         },
         "MSP2_INAV_DRONECAN_NODES": {
-            "code": 8258,                                                                                         
-            "mspv": 2,                                                                      
-            "request": null,                                                                                      
-            "reply": {                                                                      
+            "code": 8258,
+            "mspv": 2,
+            "request": null,
+            "reply": {
                 "payload": [
-                    {                                                                                             
-                        "name": "nodeCount",
-                        "ctype": "uint8_t",                                                                       
-                        "desc": "Number of detected DroneCAN nodes",                        
-                        "units": ""
-                    },
-                    {                                                                                             
-                        "name": "nodeID",
-                        "ctype": "uint8_t",                                                                       
-                        "desc": "DroneCAN node ID (1-127)",                                 
-                        "units": ""
-                    },                                                                                            
                     {
-                        "name": "health",                                                                         
-                        "ctype": "uint8_t",                                                 
-                        "desc": "Node health: 0=OK, 1=WARNING, 2=ERROR, 3=CRITICAL",
-                        "units": ""                                                                               
-                    },
-                    {                                                                                             
-                        "name": "mode",                                                     
+                        "name": "nodeCount",
                         "ctype": "uint8_t",
-                        "desc": "Node mode: 0=OPERATIONAL, 1=INITIALIZATION, 2=MAINTENANCE, 3=SOFTWARE_UPDATE, 7=OFFLINE",                                                                                                       
+                        "desc": "Number of detected DroneCAN nodes",
                         "units": ""
-                    },                                                                                            
-                    {                                                                       
-                        "name": "uptime_sec",
-                        "ctype": "uint32_t",
-                        "desc": "Node uptime in seconds",
-                        "units": "s"                                                                              
                     },
-                    {                                                                                             
-                        "name": "vendor_status_code",                                       
-                        "ctype": "uint16_t",                                                                      
-                        "desc": "Vendor-specific status code",
-                        "units": ""                                                                               
-                    },                                                                      
-                    {                                                                                             
-                        "name": "last_seen_ms",
-                        "ctype": "uint32_t",                                                                      
-                        "desc": "FC millisecond timestamp when this node was last seen",    
-                        "units": "ms"                                                                             
-                    },
-                    {                                                                                             
-                        "name": "name_len",                                                 
-                        "ctype": "uint8_t",                                                                       
-                        "desc": "Length of node name string (0 if unknown)",
-                        "units": ""                                                                               
-                    },                                                                      
-                    {                                                                                             
-                        "name": "name",                                                     
-                        "ctype": "char[16]",
-                        "desc": "Node name truncated to 16 bytes, zero-padded",
-                        "units": ""                                                                               
+                    {
+                        "name": "nodeData",
+                        "desc": "Array of per-node status records, one per detected node. Each record: nodeID(1)+health(1)+mode(1)+last_seen_ms(4) = 7 bytes. Full detail available via MSP2_INAV_DRONECAN_NODE_INFO.",
+                        "ctype": "dronecanNodeStatus_t",
+                        "array": true,
+                        "array_size": 0,
+                        "units": ""
                     }
-                ]                                                                                                 
-            },                                                                              
+                ]
+            },
             "variable_len": true,
-            "notes": "Requires `USE_DRONECAN`. Response is `nodeCount` followed by `nodeCount` records of 30 bytes each: nodeID(1)+health(1)+mode(1)+uptime_sec(4)+vendor_status_code(2)+last_seen_ms(4)+name_len(1)+name[16].",    
+            "notes": "Requires `USE_DRONECAN`. Response is `nodeCount` followed by `nodeCount` records of 7 bytes each: nodeID(1)+health(1)+mode(1)+last_seen_ms(4). Maximum payload 1 + (DRONECAN_MAX_NODES * 7) = 225 bytes. Full node detail including uptime, vendor status, and name is available via MSP2_INAV_DRONECAN_NODE_INFO.",
             "description": "Returns the list of all detected DroneCAN nodes with their current status."
         },                                                                                                        
         "MSP2_INAV_DRONECAN_NODE_INFO": {                                                   

--- a/docs/development/msp/msp_messages.json
+++ b/docs/development/msp/msp_messages.json
@@ -9817,6 +9817,140 @@
             "notes": "Requires `USE_ESC_SENSOR`. See `escSensorData_t` in `sensors/esc_sensor.h` for the exact structure fields.",
             "description": "Retrieves the full telemetry data structure reported by each ESC."
         },
+        "MSP2_INAV_DRONECAN_NODES": {
+            "code": 8258,                                                                                         
+            "mspv": 2,                                                                      
+            "request": null,                                                                                      
+            "reply": {                                                                      
+                "payload": [
+                    {                                                                                             
+                        "name": "nodeCount",
+                        "ctype": "uint8_t",                                                                       
+                        "desc": "Number of detected DroneCAN nodes",                        
+                        "units": ""
+                    },
+                    {                                                                                             
+                        "name": "nodeID",
+                        "ctype": "uint8_t",                                                                       
+                        "desc": "DroneCAN node ID (1-127)",                                 
+                        "units": ""
+                    },                                                                                            
+                    {
+                        "name": "health",                                                                         
+                        "ctype": "uint8_t",                                                 
+                        "desc": "Node health: 0=OK, 1=WARNING, 2=ERROR, 3=CRITICAL",
+                        "units": ""                                                                               
+                    },
+                    {                                                                                             
+                        "name": "mode",                                                     
+                        "ctype": "uint8_t",
+                        "desc": "Node mode: 0=OPERATIONAL, 1=INITIALIZATION, 2=MAINTENANCE, 3=SOFTWARE_UPDATE, 7=OFFLINE",                                                                                                       
+                        "units": ""
+                    },                                                                                            
+                    {                                                                       
+                        "name": "uptime_sec",
+                        "ctype": "uint32_t",
+                        "desc": "Node uptime in seconds",
+                        "units": "s"                                                                              
+                    },
+                    {                                                                                             
+                        "name": "vendor_status_code",                                       
+                        "ctype": "uint16_t",                                                                      
+                        "desc": "Vendor-specific status code",
+                        "units": ""                                                                               
+                    },                                                                      
+                    {                                                                                             
+                        "name": "last_seen_ms",
+                        "ctype": "uint32_t",                                                                      
+                        "desc": "FC millisecond timestamp when this node was last seen",    
+                        "units": "ms"                                                                             
+                    },
+                    {                                                                                             
+                        "name": "name_len",                                                 
+                        "ctype": "uint8_t",                                                                       
+                        "desc": "Length of node name string (0 if unknown)",
+                        "units": ""                                                                               
+                    },                                                                      
+                    {                                                                                             
+                        "name": "name",                                                     
+                        "ctype": "char[16]",
+                        "desc": "Node name truncated to 16 bytes, zero-padded",
+                        "units": ""                                                                               
+                    }
+                ]                                                                                                 
+            },                                                                              
+            "variable_len": true,
+            "notes": "Requires `USE_DRONECAN`. Response is `nodeCount` followed by `nodeCount` records of 30 bytes each: nodeID(1)+health(1)+mode(1)+uptime_sec(4)+vendor_status_code(2)+last_seen_ms(4)+name_len(1)+name[16].",    
+            "description": "Returns the list of all detected DroneCAN nodes with their current status."
+        },                                                                                                        
+        "MSP2_INAV_DRONECAN_NODE_INFO": {                                                   
+            "code": 8259,                                                                                         
+            "mspv": 2,                                                                                            
+            "request": {
+                "payload": [                                                                                      
+                    {                                                                       
+                        "name": "nodeID",
+                        "ctype": "uint8_t",
+                        "desc": "DroneCAN node ID to query (1-127)",
+                        "units": ""                                                                               
+                    }
+                ]                                                                                                 
+            },                                                                              
+            "reply": {
+                "payload": [
+                    {
+                        "name": "nodeID",
+                        "ctype": "uint8_t",                                                                       
+                        "desc": "DroneCAN node ID",
+                        "units": ""                                                                               
+                    },                                                                      
+                    {
+                        "name": "health",
+                        "ctype": "uint8_t",
+                        "desc": "Node health: 0=OK, 1=WARNING, 2=ERROR, 3=CRITICAL",
+                        "units": ""
+                    },
+                    {
+                        "name": "mode",
+                        "ctype": "uint8_t",                                                                       
+                        "desc": "Node mode: 0=OPERATIONAL, 1=INITIALIZATION, 2=MAINTENANCE, 3=SOFTWARE_UPDATE, 7=OFFLINE",                                                                                                       
+                        "units": ""                                                         
+                    },                                                                                            
+                    {
+                        "name": "uptime_sec",                                                                     
+                        "ctype": "uint32_t",                                                
+                        "desc": "Node uptime in seconds",
+                        "units": "s"
+                    },
+                    {
+                        "name": "vendor_status_code",                                                             
+                        "ctype": "uint16_t",
+                        "desc": "Vendor-specific status code",                                                    
+                        "units": ""                                                         
+                    },
+                    {
+                        "name": "last_seen_ms",
+                        "ctype": "uint32_t",                                                                      
+                        "desc": "FC millisecond timestamp when this node was last seen",
+                        "units": "ms"                                                                             
+                    },                                                                      
+                    {
+                        "name": "name_len",
+                        "ctype": "uint8_t",                                                                       
+                        "desc": "Length of node name string (0 if unknown)",
+                        "units": ""                                                                               
+                    },                                                                      
+                    {
+                        "name": "name",
+                        "ctype": "char[32]",
+                        "desc": "Node name up to 32 bytes, zero-padded",                                          
+                        "units": ""
+                    }                                                                                             
+                ]                                                                           
+            },
+            "notes": "Requires `USE_DRONECAN`. Returns `MSP_RESULT_ERROR` if the requested node ID is not in the node table.",                                                                                                     
+            "description": "Returns full status detail for a single DroneCAN node by ID."
+        },                                        
         "MSP2_INAV_LED_STRIP_CONFIG_EX": {
             "code": 8264,
             "mspv": 2,

--- a/src/main/drivers/dronecan/dronecan.c
+++ b/src/main/drivers/dronecan/dronecan.c
@@ -40,7 +40,7 @@ PG_RESET_TEMPLATE(dronecanConfig_t, dronecanConfig,
 
 static dronecanState_e dronecanState = STATE_DRONECAN_INIT;
 static uint8_t activeNodeCount = 0;
-static uint8_t seenNodeIds[16] = {0};
+static dronecanNodeInfo_t nodeTable[DRONECAN_MAX_NODES];
 
 // NOTE: All canard handlers and senders are based on this reference: https://dronecan.github.io/Specification/7._List_of_standard_data_types/
 // Alternatively, you can look at the corresponding generated header file in the dsdlc_generated folder
@@ -56,53 +56,31 @@ void handle_NodeStatus(CanardInstance *ins, CanardRxTransfer *transfer) {
 		return;
 	}
 
-	// LOG_DEBUG(CAN, "Node Health ");
-
-	switch (nodeStatus.health) {
-	case UAVCAN_PROTOCOL_NODESTATUS_HEALTH_OK:
-		// LOG_DEBUG(CAN, "OK");
-		break;
-	case UAVCAN_PROTOCOL_NODESTATUS_HEALTH_WARNING:
-		// LOG_DEBUG(CAN, "WARNING");
-		break;
-	case UAVCAN_PROTOCOL_NODESTATUS_HEALTH_ERROR:
-		// LOG_DEBUG(CAN, "ERROR");
-		break;
-	case UAVCAN_PROTOCOL_NODESTATUS_HEALTH_CRITICAL:
-		// LOG_DEBUG(CAN, "CRITICAL");
-		break;
-	default:
-		// LOG_DEBUG(CAN, "UNKNOWN?");
-		break;
-	}
-
-	// LOG_DEBUG(CAN, "Node Mode ");
-
-	switch(nodeStatus.mode) {
-	case UAVCAN_PROTOCOL_NODESTATUS_MODE_OPERATIONAL:
-		// LOG_DEBUG(CAN, "OPERATIONAL");
-		break;
-	case UAVCAN_PROTOCOL_NODESTATUS_MODE_INITIALIZATION:
-		// LOG_DEBUG(CAN, "INITIALIZATION");
-		break;
-	case UAVCAN_PROTOCOL_NODESTATUS_MODE_MAINTENANCE:
-		// LOG_DEBUG(CAN, "MAINTENANCE");
-		break;
-	case UAVCAN_PROTOCOL_NODESTATUS_MODE_SOFTWARE_UPDATE:
-		// LOG_DEBUG(CAN, "SOFTWARE UPDATE");
-		break;
-	case UAVCAN_PROTOCOL_NODESTATUS_MODE_OFFLINE:
-		// LOG_DEBUG(CAN, "OFFLINE");
-		break;
-	default:
-		// LOG_DEBUG(CAN, "UNKNOWN?");
-		break;
-	}
-    uint8_t bit = 1 << (transfer->source_node_id % 8);
-    if(!(seenNodeIds[transfer->source_node_id/8] & bit)) { // If the bit corresponding to the node ID is not seen yet
-        seenNodeIds[transfer->source_node_id/8] |= bit;  // Set the bit corresponding to the node ID.
-        activeNodeCount++;
+	uint8_t nodeId = transfer->source_node_id;                                                                                                                                                                                                
+    for (uint8_t i = 0; i < activeNodeCount; i++) {
+        if (nodeTable[i].nodeID == nodeId) { 
+            // update health, mode, uptime, vendor_status_code, last_seen_ms                                                                                                                                                                                                 
+            nodeTable[i].health = nodeStatus.health;
+            nodeTable[i].mode = nodeStatus.mode;
+            nodeTable[i].uptime_sec = nodeStatus.uptime_sec;
+            nodeTable[i].vendor_status_code = nodeStatus.vendor_specific_status_code;
+            nodeTable[i].last_seen_ms = millis();                    
+            return;                                                                                                                                                                                                                           
+        }                                                                                       
+    }                                                                                                                                                                                                                                         
+    // new node                                                                                 
+    if (activeNodeCount < DRONECAN_MAX_NODES) {
+        nodeTable[activeNodeCount].nodeID = nodeId;
+        nodeTable[activeNodeCount].health = nodeStatus.health;
+        nodeTable[activeNodeCount].mode = nodeStatus.mode;
+        nodeTable[activeNodeCount].uptime_sec = nodeStatus.uptime_sec;
+        nodeTable[activeNodeCount].vendor_status_code = nodeStatus.vendor_specific_status_code;
+        nodeTable[activeNodeCount].name_len = 0;
+        nodeTable[activeNodeCount].name[0] = 0;
+        nodeTable[activeNodeCount].last_seen_ms = millis();     
+        activeNodeCount++;                                                                                                                                                               
     }
+
 }
 
 void handle_GNSSAuxiliary(CanardInstance *ins, CanardRxTransfer *transfer) {
@@ -557,4 +535,9 @@ uint32_t dronecanGetBitrateKbps(void)
     }
     return 0;
 }
+
+const dronecanNodeInfo_t *dronecanGetNode(uint8_t index) {                                                                                                                                                                                
+    if (index < activeNodeCount) return &nodeTable[index];                                  
+      return NULL;                                                                                                                                                                                                                          
+  }  
 #endif

--- a/src/main/drivers/dronecan/dronecan.c
+++ b/src/main/drivers/dronecan/dronecan.c
@@ -30,11 +30,6 @@
 CanardInstance canard;
 uint8_t memory_pool[1024];
 static struct uavcan_protocol_NodeStatus node_status;
-enum dronecanState_e {
-    STATE_DRONECAN_INIT,
-    STATE_DRONECAN_NORMAL,
-    STATE_DRONECAN_BUS_OFF
-};
 
 PG_REGISTER_WITH_RESET_TEMPLATE(dronecanConfig_t, dronecanConfig, PG_DRONECAN_CONFIG, 0);
 
@@ -42,6 +37,10 @@ PG_RESET_TEMPLATE(dronecanConfig_t, dronecanConfig,
     .nodeID = SETTING_DRONECAN_NODE_ID_DEFAULT,
     .bitRateKbps = SETTING_DRONECAN_BITRATE_KBPS_DEFAULT
 );
+
+static dronecanState_e dronecanState = STATE_DRONECAN_INIT;
+static uint8_t activeNodeCount = 0;
+static uint8_t seenNodeIds[16] = {0};
 
 // NOTE: All canard handlers and senders are based on this reference: https://dronecan.github.io/Specification/7._List_of_standard_data_types/
 // Alternatively, you can look at the corresponding generated header file in the dsdlc_generated folder
@@ -99,6 +98,11 @@ void handle_NodeStatus(CanardInstance *ins, CanardRxTransfer *transfer) {
 		// LOG_DEBUG(CAN, "UNKNOWN?");
 		break;
 	}
+    uint8_t bit = 1 << (transfer->source_node_id % 8);
+    if(!(seenNodeIds[transfer->source_node_id/8] & bit)) { // If the bit corresponding to the node ID is not seen yet
+        seenNodeIds[transfer->source_node_id/8] |= bit;  // Set the bit corresponding to the node ID.
+        activeNodeCount++;
+    }
 }
 
 void handle_GNSSAuxiliary(CanardInstance *ins, CanardRxTransfer *transfer) {
@@ -466,7 +470,6 @@ void dronecanUpdate(timeUs_t currentTimeUs)
     static timeUs_t busoffTimeUs = 0;
     CanardCANFrame rx_frame;
     int numMessagesToProcess = 0;
-    static enum dronecanState_e dronecanState = STATE_DRONECAN_INIT;
     canardProtocolStatus_t protocolStatus = {};
     uint64_t timestamp;
     int16_t rx_res;
@@ -522,5 +525,36 @@ void dronecanUpdate(timeUs_t currentTimeUs)
     
     }
     
+}
+
+dronecanState_e dronecanGetState(void)
+{
+    return dronecanState;
+}
+
+uint8_t dronecanGetNodeCount(void)
+{
+    return activeNodeCount;
+}
+
+uint32_t dronecanGetBitrateKbps(void)
+{
+    switch (dronecanConfig()->bitRateKbps){
+        case DRONECAN_BITRATE_125KBPS:
+            return 125;
+
+        case DRONECAN_BITRATE_250KBPS:
+            return 250;
+        
+        case DRONECAN_BITRATE_500KBPS:
+            return 500;
+
+        case DRONECAN_BITRATE_1000KBPS:
+            return 1000;
+        
+        case DRONECAN_BITRATE_COUNT:
+            return 0;
+    }
+    return 0;
 }
 #endif

--- a/src/main/drivers/dronecan/dronecan.c
+++ b/src/main/drivers/dronecan/dronecan.c
@@ -148,7 +148,7 @@ void handle_BatteryInfo(CanardInstance *ins, CanardRxTransfer *transfer) {
 
 // TODO: All the data in here is temporary for testing. If actually need to send valid data, edit accordingly.
 void handle_GetNodeInfo(CanardInstance *ins, CanardRxTransfer *transfer) {
-	printf("GetNodeInfo request from %d", transfer->source_node_id);
+	LOG_DEBUG(CAN, "GetNodeInfo request from %d", transfer->source_node_id);
 
 	uint8_t buffer[UAVCAN_PROTOCOL_GETNODEINFO_RESPONSE_MAX_SIZE];
 	struct uavcan_protocol_GetNodeInfoResponse pkt;
@@ -536,8 +536,8 @@ uint32_t dronecanGetBitrateKbps(void)
     return 0;
 }
 
-const dronecanNodeInfo_t *dronecanGetNode(uint8_t index) {                                                                                                                                                                                
-    if (index < activeNodeCount) return &nodeTable[index];                                  
-      return NULL;                                                                                                                                                                                                                          
-  }  
+const dronecanNodeInfo_t *dronecanGetNode(uint8_t index) {
+    if (index < activeNodeCount) return &nodeTable[index];
+    return NULL;
+}
 #endif

--- a/src/main/drivers/dronecan/dronecan.h
+++ b/src/main/drivers/dronecan/dronecan.h
@@ -17,17 +17,29 @@ typedef enum {
     STATE_DRONECAN_BUS_OFF
 } dronecanState_e;
 
+#define DRONECAN_MAX_NODES 32 // Reasonably expected number of devices on the bus.  If this is regularly hit, we could go higher but it consumes more ram.
+
 typedef struct dronecanConfig_s {
     uint8_t nodeID;
     dronecanBitrate_e bitRateKbps;
 } dronecanConfig_t;
 
+typedef struct dronecanNodeInfo_s {
+    uint8_t nodeID;
+    uint8_t health;
+    uint8_t mode;
+    uint32_t uptime_sec;
+    uint16_t vendor_status_code;
+    uint32_t last_seen_ms;
+    uint8_t name_len;
+    char name[32];
+} dronecanNodeInfo_t;
 
 void dronecanInit(void);
 void dronecanUpdate(timeUs_t currentTimeUs);
 dronecanState_e dronecanGetState(void);                                               
 uint8_t dronecanGetNodeCount(void);                                                                                                                                                                                                       
 uint32_t dronecanGetBitrateKbps(void);
-
+const dronecanNodeInfo_t *dronecanGetNode(uint8_t index);
 
 PG_DECLARE(dronecanConfig_t, dronecanConfig);

--- a/src/main/drivers/dronecan/dronecan.h
+++ b/src/main/drivers/dronecan/dronecan.h
@@ -3,9 +3,6 @@
 #include "common/time.h"
 #include "config/parameter_group.h"
 
-void dronecanInit(void);
-void dronecanUpdate(timeUs_t currentTimeUs);
-
 typedef enum {
     DRONECAN_BITRATE_125KBPS = 0,
     DRONECAN_BITRATE_250KBPS,
@@ -14,9 +11,23 @@ typedef enum {
     DRONECAN_BITRATE_COUNT
 } dronecanBitrate_e;
 
+typedef enum {
+    STATE_DRONECAN_INIT,
+    STATE_DRONECAN_NORMAL,
+    STATE_DRONECAN_BUS_OFF
+} dronecanState_e;
+
 typedef struct dronecanConfig_s {
     uint8_t nodeID;
     dronecanBitrate_e bitRateKbps;
 } dronecanConfig_t;
+
+
+void dronecanInit(void);
+void dronecanUpdate(timeUs_t currentTimeUs);
+dronecanState_e dronecanGetState(void);                                               
+uint8_t dronecanGetNodeCount(void);                                                                                                                                                                                                       
+uint32_t dronecanGetBitrateKbps(void);
+
 
 PG_DECLARE(dronecanConfig_t, dronecanConfig);

--- a/src/main/drivers/dronecan/dronecan.h
+++ b/src/main/drivers/dronecan/dronecan.h
@@ -35,6 +35,14 @@ typedef struct dronecanNodeInfo_s {
     char name[32];
 } dronecanNodeInfo_t;
 
+// Wire format for MSP2_INAV_DRONECAN_NODES records (7 bytes each, packed).
+typedef struct dronecanNodeStatus_s {
+    uint8_t nodeID;
+    uint8_t health;
+    uint8_t mode;
+    uint32_t last_seen_ms;
+} __attribute__((packed)) dronecanNodeStatus_t;
+
 void dronecanInit(void);
 void dronecanUpdate(timeUs_t currentTimeUs);
 dronecanState_e dronecanGetState(void);                                               

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -123,6 +123,9 @@ bool cliMode = false;
 #include "sensors/opflow.h"
 #include "sensors/sensors.h"
 #include "sensors/temperature.h"
+#ifdef USE_DRONECAN
+#include "drivers/dronecan/dronecan.h"
+#endif
 #ifdef USE_ESC_SENSOR
 #include "sensors/esc_sensor.h"
 #endif
@@ -4164,6 +4167,16 @@ static void cliStatus(char *cmdline)
         }
         cliPrintLinefeed();
     }
+#endif
+
+#ifdef USE_DRONECAN
+    static const char * const dronecanStateNames[] = {"INIT", "NORMAL", "BUS_OFF"};
+    cliPrintLinef("DroneCAN: nodeID=%d, bitrate=%u kbps, status=%s, nodes=%d",                                                                                                                                                  
+        dronecanConfig()->nodeID,                                                                                                                                                                                                     
+        (unsigned)dronecanGetBitrateKbps(),                                                                                                                                                                                                     
+        dronecanStateNames[dronecanGetState()],                                                                                                                                                                                       
+        dronecanGetNodeCount()                                                         
+    );
 #endif
 
 #ifdef USE_SDCARD

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -139,6 +139,10 @@
 #include "hardware_revision.h"
 #endif
 
+#ifdef USE_DRONECAN
+#include "drivers/dronecan/dronecan.h"
+#endif
+
 extern timeDelta_t cycleTime; // FIXME dependency on mw.c
 
 static const char * const flightControllerIdentifier = INAV_IDENTIFIER; // 4 UPPER CASE alpha numeric characters that identify the flight controller.
@@ -1763,6 +1767,29 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
             }
         }
         break;
+#endif
+
+#ifdef USE_DRONECAN
+    
+    case MSP2_INAV_DRONECAN_NODES:
+        {                                                                                                         
+            uint8_t count = dronecanGetNodeCount();                                         
+            sbufWriteU8(dst, count);                                                                              
+            for (uint8_t i = 0; i < count; i++) {
+                const dronecanNodeInfo_t *node = dronecanGetNode(i);                                              
+                sbufWriteU8(dst, node->nodeID);                                             
+                sbufWriteU8(dst, node->health);                                                                   
+                sbufWriteU8(dst, node->mode);                                               
+                sbufWriteU32(dst, node->uptime_sec);                                                              
+                sbufWriteU16(dst, node->vendor_status_code);                                
+                sbufWriteU32(dst, node->last_seen_ms);                                                            
+                sbufWriteU8(dst, node->name_len);
+                sbufWriteData(dst, node->name, 16);                                                               
+            }                                                                                                     
+        }
+        break;                                                                                                    
+                                                                                              
+     
 #endif
 
 #ifdef USE_EZ_TUNE
@@ -4254,6 +4281,33 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
         mspFcWaypointOutCommand(dst, src);
         *ret = MSP_RESULT_ACK;
         break;
+
+#ifdef USE_DRONECAN
+     case MSP2_INAV_DRONECAN_NODE_INFO:
+        {
+            if (sbufBytesRemaining(src) < 1) {
+                return MSP_RESULT_ERROR;                                                                          
+            }
+            uint8_t nodeId = sbufReadU8(src);                                                                     
+            uint8_t count = dronecanGetNodeCount();                                         
+            for (uint8_t i = 0; i < count; i++) {                                                                 
+                const dronecanNodeInfo_t *node = dronecanGetNode(i);
+                if (node->nodeID == nodeId) {                                                                     
+                    sbufWriteU8(dst, node->nodeID);                                                               
+                    sbufWriteU8(dst, node->health);
+                    sbufWriteU8(dst, node->mode);                                                                 
+                    sbufWriteU32(dst, node->uptime_sec);                                    
+                    sbufWriteU16(dst, node->vendor_status_code);
+                    sbufWriteU32(dst, node->last_seen_ms);
+                    sbufWriteU8(dst, node->name_len);
+                    sbufWriteData(dst, node->name, 32);
+                    return MSP_RESULT_ACK;
+                }
+            }
+            return MSP_RESULT_ERROR;
+        }
+        break;
+#endif
 
 #if defined(USE_FLASHFS)
     case MSP_DATAFLASH_READ:

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1770,26 +1770,21 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
 #endif
 
 #ifdef USE_DRONECAN
-    
     case MSP2_INAV_DRONECAN_NODES:
-        {                                                                                                         
-            uint8_t count = dronecanGetNodeCount();                                         
-            sbufWriteU8(dst, count);                                                                              
+        {
+            uint8_t count = dronecanGetNodeCount();
+            sbufWriteU8(dst, count);
             for (uint8_t i = 0; i < count; i++) {
-                const dronecanNodeInfo_t *node = dronecanGetNode(i);                                              
-                sbufWriteU8(dst, node->nodeID);                                             
-                sbufWriteU8(dst, node->health);                                                                   
-                sbufWriteU8(dst, node->mode);                                               
-                sbufWriteU32(dst, node->uptime_sec);                                                              
-                sbufWriteU16(dst, node->vendor_status_code);                                
-                sbufWriteU32(dst, node->last_seen_ms);                                                            
-                sbufWriteU8(dst, node->name_len);
-                sbufWriteData(dst, node->name, 16);                                                               
-            }                                                                                                     
+                const dronecanNodeInfo_t *node = dronecanGetNode(i);
+                sbufWriteDataSafe(dst, &(dronecanNodeStatus_t){
+                    .nodeID      = node->nodeID,
+                    .health      = node->health,
+                    .mode        = node->mode,
+                    .last_seen_ms = node->last_seen_ms,
+                }, sizeof(dronecanNodeStatus_t));
+            }
         }
-        break;                                                                                                    
-                                                                                              
-     
+        break;
 #endif
 
 #ifdef USE_EZ_TUNE
@@ -4283,28 +4278,39 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
         break;
 
 #ifdef USE_DRONECAN
-     case MSP2_INAV_DRONECAN_NODE_INFO:
+    case MSP2_INAV_DRONECAN_NODE_INFO:
         {
             if (sbufBytesRemaining(src) < 1) {
-                return MSP_RESULT_ERROR;                                                                          
+                *ret = MSP_RESULT_ERROR;
+                break;
             }
-            uint8_t nodeId = sbufReadU8(src);                                                                     
-            uint8_t count = dronecanGetNodeCount();                                         
-            for (uint8_t i = 0; i < count; i++) {                                                                 
+            uint8_t nodeId = sbufReadU8(src);
+            uint8_t count = dronecanGetNodeCount();
+            bool found = false;
+            for (uint8_t i = 0; i < count; i++) {
                 const dronecanNodeInfo_t *node = dronecanGetNode(i);
-                if (node->nodeID == nodeId) {                                                                     
-                    sbufWriteU8(dst, node->nodeID);                                                               
+                if (node->nodeID == nodeId) {
+                    found = true;
+                    if (sbufBytesRemaining(dst) < 46) {
+                        *ret = MSP_RESULT_ERROR;
+                        break;
+                    }
+                    sbufWriteU8(dst, node->nodeID);
                     sbufWriteU8(dst, node->health);
-                    sbufWriteU8(dst, node->mode);                                                                 
-                    sbufWriteU32(dst, node->uptime_sec);                                    
+                    sbufWriteU8(dst, node->mode);
+                    sbufWriteU32(dst, node->uptime_sec);
                     sbufWriteU16(dst, node->vendor_status_code);
                     sbufWriteU32(dst, node->last_seen_ms);
                     sbufWriteU8(dst, node->name_len);
-                    sbufWriteData(dst, node->name, 32);
-                    return MSP_RESULT_ACK;
+                    sbufWriteDataSafe(dst, node->name, 32);
+                    found = true;
+                    *ret = MSP_RESULT_ACK;
+                    break;
                 }
             }
-            return MSP_RESULT_ERROR;
+            if (!found) {
+                *ret = MSP_RESULT_ERROR;
+            }
         }
         break;
 #endif

--- a/src/main/msp/msp_protocol_v2_inav.h
+++ b/src/main/msp/msp_protocol_v2_inav.h
@@ -94,6 +94,9 @@
 #define MSP2_INAV_ESC_RPM                       0x2040
 #define MSP2_INAV_ESC_TELEM                     0x2041
 
+#define MSP2_INAV_DRONECAN_NODES                0x2042
+#define MSP2_INAV_DRONECAN_NODE_INFO            0x2043 
+
 #define MSP2_INAV_LED_STRIP_CONFIG_EX           0x2048
 #define MSP2_INAV_SET_LED_STRIP_CONFIG_EX       0x2049
 


### PR DESCRIPTION
## Summary

- **Add DroneCAN status to `status` CLI command** — shows nodeID, bitrate, bus state, and detected node count
- **Add node table infrastructure** — `dronecanNodeInfo_t` struct, `nodeTable[32]`, updated `handle_NodeStatus()` to upsert per-node data, and new accessors (`dronecanGetState()`, `dronecanGetNodeCount()`, `dronecanGetNode()`, `dronecanGetBitrateKbps()`)
- **Add `MSP2_INAV_DRONECAN_NODES` (0x2042)** — returns count and status of all detected DroneCAN nodes
- **Add `MSP2_INAV_DRONECAN_NODE_INFO` (0x2043)** — returns full detail for a single node by ID
- **Update MSP docs JSON and regenerate README** — new messages documented in `docs/development/msp/`
- **Update DroneCAN docs** — `DroneCAN.md` and `DroneCAN-Driver.md` updated to cover node table, CLI output, and MSP commands

These MSP commands are the prerequisite for DroneCAN support in the Configurator UI (feature-dronecan-configurator-tab).

## Test plan

- [x] Build cleanly for MATEKF765SE (zero errors, zero warnings)
- [x] Flash MATEKF765SE with DroneCAN battery monitor on bus
- [x] Verify `status` CLI shows correct nodeID, bitrate, and node count
- [x] Verify `MSP2_INAV_DRONECAN_NODES` returns the battery monitor node (health=OK, mode=OPERATIONAL)
- [x] Verify `MSP2_INAV_DRONECAN_NODE_INFO` returns correct data for node ID
- [x] Verify `MSP2_INAV_DRONECAN_NODE_INFO` returns empty response for unknown node ID
- [x] Verify targets without `USE_DRONECAN` build cleanly.