### PR TITLE
Add missing getCurrentControlProfile implementation

### DIFF
--- a/src/main/fc/control_profile.c
+++ b/src/main/fc/control_profile.c
@@ -101,3 +101,13 @@ void changeControlProfile(uint8_t profileIndex)
     setControlProfile(profileIndex);
     activateControlConfig();
 }
+
+uint8_t getCurrentControlProfile(void) {
+  for (uint8_t index = 0; index < MAX_CONTROL_PROFILE_COUNT; index++) {
+    if (currentControlProfile == controlProfiles(index)) {
+      return index;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
control_profile.h defines a getCurrentControlProfile, but it was never implemented in control_profile.c, leading to issues for anyone wanting to use this function. This PR adds a simple implementation of said function.

The function iterares over index = 0, index < MAX_CONTROL_PROFILE_COUNT and checks if currentControlProfile == controlProfiles(index) for each index, until it finds a match.
If not match is found, it returns 0 instead. 

I'm not sure if returning 0 is the best choice here, since it makes it impossible to tell if the index is genuinely just 0 or if something went wrong. I didn't want to return an arbitrary sentinel value like -1 without first checking in with you though since I'm not sure if there's an established convention or anything like that.