### PR TITLE
BLUEBERRYF405: add missing PWM beeper timer entry for PB9

### DIFF
--- a/src/main/target/BLUEBERRYF405/target.c
+++ b/src/main/target/BLUEBERRYF405/target.c
@@ -40,6 +40,7 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM4,  CH1,  PB6,  TIM_USE_OUTPUT_AUTO,   0, 0), // S11 D(1,0,2)
 
     DEF_TIM(TIM3,  CH4,  PB1,  TIM_USE_LED,    0, 0), // 2812LED  D(1,2,5)
+    DEF_TIM(TIM11, CH1,  PB9,  TIM_USE_BEEPER, 0, 0), // BEEPER PWM
 
     DEF_TIM(TIM5,  CH3,  PA2,  TIM_USE_ANY,    0, 0), // softserial1_TX (PA2 shared with UART2_TX)
 };


### PR DESCRIPTION
## Summary

- Adds the missing `DEF_TIM(TIM11, CH1, PB9, TIM_USE_BEEPER, 0, 0)` entry to `BLUEBERRYF405/target.c`
- Without this entry, `timerGetByTag()` returns NULL for the beeper pin and `beeperPwmInit()` silently leaves `beeperPwm = NULL`, so `beeper_pwm_mode = ON` produces no sound
- TIM11/CH1 is the correct assignment for PB9 on STM32F405 (confirmed against SKYSTARSF405WING reference target)

Fixes part of #11492 (`beeper_pwm_mode` regression in 9.x maintenance builds).

**Note:** A second root cause also exists for boards where the beeper timer entry is present but `timer_output_mode` is set to reassign that peripheral (e.g. MATEKH743 with `timer_output_mode 1 SERVOS`). That issue is in `timerHardwareOverride()` in `pwm_mapping.c` and is being handled separately.

## Test plan

- [x] Build BLUEBERRYF405 target cleanly
- [ ] Verify `beeper_pwm_mode = ON` produces tone on PB9 hardware
- [ ] Confirm GPIO (non-PWM) beeper mode unaffected