### PR TITLE
lucid: add more baros, enable led strip, align gyo orientations

### DIFF
--- a/src/main/target/TBS_LUCID_H7/target.c
+++ b/src/main/target/TBS_LUCID_H7/target.c
@@ -54,7 +54,8 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM15, CH1, PE5, TIM_USE_OUTPUT_AUTO, 0, 0),   // S11
     DEF_TIM(TIM15, CH2, PE6, TIM_USE_OUTPUT_AUTO, 0, 0),   // S12 DMA_NONE
 
-    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_LED, 0, 9),    // RGB_LED
+    DEF_TIM(TIM1,  CH1, PA8, TIM_USE_OUTPUT_AUTO | TIM_USE_LED, 0, 9),    // RGB_LED
+
     DEF_TIM(TIM2,  CH1, PA15, TIM_USE_BEEPER, 0, 0),  // BEEPER
 };
 

--- a/src/main/target/TBS_LUCID_H7/target.h
+++ b/src/main/target/TBS_LUCID_H7/target.h
@@ -101,8 +101,8 @@
 #define GYRO2_CS_PIN            PE11
 
 #define USE_IMU_MPU6000
-#define IMU_1_MPU6000_ALIGN       CW0_DEG_FLIP
-#define IMU_2_MPU6000_ALIGN       CW90_DEG_FLIP
+#define IMU_1_MPU6000_ALIGN       CW90_DEG_FLIP
+#define IMU_2_MPU6000_ALIGN       CW0_DEG_FLIP
 
 #define USE_IMU_ICM42605
 #define IMU_1_ICM42605_ALIGN      CW90_DEG_FLIP
@@ -124,6 +124,8 @@
 
 #define USE_BARO
 #define USE_BARO_DPS310
+#define USE_BARO_BMP388
+#define USE_BARO_BMP390
 #define BARO_I2C_BUS            BUS_I2C2
 
 #define USE_MAG

--- a/src/main/target/TBS_LUCID_H7_WING/target.c
+++ b/src/main/target/TBS_LUCID_H7_WING/target.c
@@ -55,6 +55,7 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM15, CH2, PE6, TIM_USE_OUTPUT_AUTO, 0, 0),   // S12 DMA_NONE
 
     DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_OUTPUT_AUTO, 0, 9),   // S13
+    DEF_TIM(TIM2,  CH1, PA15, TIM_USE_OUTPUT_AUTO | TIM_USE_LED, 0, 8),   // LED_STRIP
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/TBS_LUCID_H7_WING/target.h
+++ b/src/main/target/TBS_LUCID_H7_WING/target.h
@@ -100,7 +100,7 @@
 #define GYRO2_CS_PIN            PE11
 
 #define USE_IMU_MPU6000
-#define IMU_1_MPU6000_ALIGN       CW0_DEG_FLIP
+#define IMU_1_MPU6000_ALIGN       CW180_DEG_FLIP
 #define IMU_2_MPU6000_ALIGN       CW90_DEG_FLIP
 
 #define USE_IMU_ICM42605
@@ -124,6 +124,8 @@
 
 #define USE_BARO
 #define USE_BARO_DPS310
+#define USE_BARO_BMP388
+#define USE_BARO_BMP390
 #define BARO_I2C_BUS            BUS_I2C2
 
 #define USE_MAG
@@ -160,6 +162,9 @@
 #define USE_PINIOBOX
 #define PINIO1_PIN                  PD10 
 #define PINIO2_PIN                  PD11
+
+#define USE_LED_STRIP
+#define WS2811_PIN                  PA15
 
 #define DEFAULT_FEATURES            (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX)
 #define CURRENT_METER_SCALE         200

--- a/src/main/target/TBS_LUCID_H7_WING_MINI/target.c
+++ b/src/main/target/TBS_LUCID_H7_WING_MINI/target.c
@@ -47,6 +47,7 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM5, CH4, PA3, TIM_USE_OUTPUT_AUTO, 0, 5),   // S6
 
     DEF_TIM(TIM4, CH1, PD12, TIM_USE_OUTPUT_AUTO, 0, 6),  // S7
+    DEF_TIM(TIM2, CH1, PA15, TIM_USE_OUTPUT_AUTO | TIM_USE_LED, 0, 8),  // LED_STRIP
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/TBS_LUCID_H7_WING_MINI/target.h
+++ b/src/main/target/TBS_LUCID_H7_WING_MINI/target.h
@@ -100,7 +100,7 @@
 #define GYRO2_CS_PIN            PE11
 
 #define USE_IMU_MPU6000
-#define IMU_1_MPU6000_ALIGN       CW0_DEG_FLIP
+#define IMU_1_MPU6000_ALIGN       CW180_DEG_FLIP
 #define IMU_2_MPU6000_ALIGN       CW90_DEG_FLIP
 
 #define USE_IMU_ICM42605
@@ -124,6 +124,8 @@
 
 #define USE_BARO
 #define USE_BARO_DPS310
+#define USE_BARO_BMP388
+#define USE_BARO_BMP390
 #define BARO_I2C_BUS            BUS_I2C2
 
 #define USE_MAG
@@ -159,6 +161,9 @@
 #define USE_PINIO
 #define USE_PINIOBOX
 #define PINIO1_PIN                  PD10 
+
+#define USE_LED_STRIP
+#define WS2811_PIN                  PA15
 
 #define DEFAULT_FEATURES            (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX)
 #define CURRENT_METER_SCALE         250


### PR DESCRIPTION
DPS310 is becoming hard to source.
Give users the freedom to use the LED pin as output.
MPU6000 versions will be built for the first time, aligned orientation with ICM for simplicity. 