### PR TITLE
telemetry: guard CRSF ESC RPM/temp against stale data

### DIFF
--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -84,7 +84,7 @@ PG_RESET_TEMPLATE(escSensorConfig_t, escSensorConfig,
     .listenOnly = SETTING_ESC_SENSOR_LISTEN_ONLY_DEFAULT,
 );
 
-static int getTelemetryMotorCount(void)
+int getTelemetryMotorCount(void)
 {
     if (escSensorConfig()->listenOnly) {
         return 1;

--- a/src/main/sensors/esc_sensor.h
+++ b/src/main/sensors/esc_sensor.h
@@ -48,3 +48,4 @@ void escSensorUpdate(timeUs_t currentTimeUs);
 escSensorData_t * escSensorGetData(void);
 escSensorData_t * getEscTelemetry(uint8_t esc);
 uint32_t computeRpm(int16_t erpm);
+int getTelemetryMotorCount(void);

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -350,7 +350,7 @@ static bool crsfRpm(sbuf_t *dst)
 
         for (uint8_t i = 0; i < motorCount; i++) {
             const escSensorData_t *escState = getEscTelemetry(i);
-            crsfSerialize24(dst, (escState) ? escState->rpm : 0);
+            crsfSerialize24(dst, escState->dataAge < ESC_DATA_INVALID ? escState->rpm : 0);
         }
         return true;
     }
@@ -375,7 +375,7 @@ static bool crsfTemperature(sbuf_t *dst)
     if (STATE(ESC_SENSOR_ENABLED) && motorCount > 0) {
         for (uint8_t i = 0; i < motorCount && tempCount < MAX_CRSF_TEMPS; i++) {
             const escSensorData_t *escState = getEscTelemetry(i);
-            temperatures[tempCount++] = (escState) ? escState->temperature * 10 : TEMPERATURE_INVALID_VALUE;
+            temperatures[tempCount++] = escState->dataAge < ESC_DATA_INVALID ? (int16_t)(escState->temperature * 10) : TEMPERATURE_INVALID_VALUE;
         }
     }
 #endif

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -335,7 +335,7 @@ int24_t    rpm_value[];     // 1 - 19 RPM values with negative ones representing
 static bool crsfRpm(sbuf_t *dst)
 {
     const uint8_t MAX_CRSF_RPM_VALUES = 19;  // CRSF protocol limit: 1-19 RPM values
-    uint8_t motorCount = getMotorCount();
+    uint8_t motorCount = getTelemetryMotorCount();
 
     if (STATE(ESC_SENSOR_ENABLED) && motorCount > 0) {
         // Enforce protocol limit
@@ -371,7 +371,7 @@ static bool crsfTemperature(sbuf_t *dst)
     int16_t temperatures[20];
 
 #ifdef USE_ESC_SENSOR
-    uint8_t motorCount = getMotorCount();
+    uint8_t motorCount = getTelemetryMotorCount();
     if (STATE(ESC_SENSOR_ENABLED) && motorCount > 0) {
         for (uint8_t i = 0; i < motorCount && tempCount < MAX_CRSF_TEMPS; i++) {
             const escSensorData_t *escState = getEscTelemetry(i);

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -350,7 +350,7 @@ static bool crsfRpm(sbuf_t *dst)
 
         for (uint8_t i = 0; i < motorCount; i++) {
             const escSensorData_t *escState = getEscTelemetry(i);
-            crsfSerialize24(dst, escState->dataAge < ESC_DATA_INVALID ? escState->rpm : 0);
+            crsfSerialize24(dst, escState->dataAge <= ESC_DATA_MAX_AGE ? escState->rpm : 0);
         }
         return true;
     }
@@ -375,7 +375,7 @@ static bool crsfTemperature(sbuf_t *dst)
     if (STATE(ESC_SENSOR_ENABLED) && motorCount > 0) {
         for (uint8_t i = 0; i < motorCount && tempCount < MAX_CRSF_TEMPS; i++) {
             const escSensorData_t *escState = getEscTelemetry(i);
-            temperatures[tempCount++] = escState->dataAge < ESC_DATA_INVALID ? (int16_t)(escState->temperature * 10) : TEMPERATURE_INVALID_VALUE;
+            temperatures[tempCount++] = escState->dataAge <= ESC_DATA_MAX_AGE ? (int16_t)(escState->temperature * 10) : TEMPERATURE_INVALID_VALUE;
         }
     }
 #endif

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -350,6 +350,14 @@ static bool crsfRpm(sbuf_t *dst)
 
         for (uint8_t i = 0; i < motorCount; i++) {
             const escSensorData_t *escState = getEscTelemetry(i);
+            // 0 is the only sensible "no data" value for a stale slot: the CRSF
+            // spec (tbs-fpv/tbs-crsf-spec 0x0C) defines no invalid/no-data
+            // sentinel for rpm_value (int24; negative = reverse spin), and
+            // transmitters (EdgeTX/OpenTX) render 0 as a stopped motor, which
+            // is the safe interpretation when telemetry has gone stale. A
+            // sentinel like 0x7FFFFF would instead display as a nonsensical
+            // huge RPM. Data is considered stale past ESC_DATA_MAX_AGE, the
+            // same freshness bound the OSD and SBUS2 telemetry use.
             crsfSerialize24(dst, escState->dataAge <= ESC_DATA_MAX_AGE ? escState->rpm : 0);
         }
         return true;
@@ -375,6 +383,12 @@ static bool crsfTemperature(sbuf_t *dst)
     if (STATE(ESC_SENSOR_ENABLED) && motorCount > 0) {
         for (uint8_t i = 0; i < motorCount && tempCount < MAX_CRSF_TEMPS; i++) {
             const escSensorData_t *escState = getEscTelemetry(i);
+            // TEMPERATURE_INVALID_VALUE (-1250 = -125.0°C, same sentinel the
+            // temperature sensor subsystem uses) marks a stale/absent ESC slot:
+            // the CRSF spec (0x0D) defines no no-data sentinel for the int16
+            // deci-degree temperature array, and -125.0°C is outside any real
+            // ESC operating range, so transmitters display it as invalid rather
+            // than as a plausible reading. Freshness bound matches ESC_DATA_MAX_AGE.
             temperatures[tempCount++] = escState->dataAge <= ESC_DATA_MAX_AGE ? (int16_t)(escState->temperature * 10) : TEMPERATURE_INVALID_VALUE;
         }
     }


### PR DESCRIPTION
## Summary

ESC RPM and temperature forwarded over CRSF showed random/garbage values when the FC was disarmed and when individual ESCs lost contact in multi-motor setups. The previous null-guard on `getEscTelemetry()` was dead code — the function always returns a valid pointer into a static array — so stale last-seen values were unconditionally forwarded regardless of data age.

## Changes

- `crsfRpm()`: check `escState->dataAge < ESC_DATA_INVALID` before forwarding RPM; send `0` for stale/uninitialized slots
- `crsfTemperature()`: same check before forwarding temperature; send `TEMPERATURE_INVALID_VALUE` for stale/uninitialized slots

`ESC_DATA_INVALID` (255) is already the initialization value set by `escSensorInitialize()` and is the value used consistently throughout `esc_sensor.c` for this purpose.

## Testing

- SITL build confirmed clean (no warnings)
- Code analysis confirmed all four bug scenarios from the issue map directly to the missing `dataAge` guard:
  - Single ESC disarmed → stale last-seen RPM forwarded (now sends 0)
  - Multi-ESC in flight → divergent per-motor `dataAge` causes mixed fresh/stale values (now stale slots send 0)
  - RPM stays elevated after disarm → `dataAge` saturates at 255 but was never checked (now checked)
  - Extra CRSF data points on octocopter → all motor slots emitted regardless of age (now filtered)
- Hardware testing with physical ESCs not performed; requesting confirmation from reporter

## Related Issues

Fixes #11517