### PR TITLE
New target: SPEDIXH743

### DIFF
--- a/src/main/target/SPEDIXH743/CMakeLists.txt
+++ b/src/main/target/SPEDIXH743/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32h743xi(SPEDIXH743)

--- a/src/main/target/SPEDIXH743/config.c
+++ b/src/main/target/SPEDIXH743/config.c
@@ -1,0 +1,28 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include "platform.h"
+
+#include "fc/fc_msp_box.h"
+#include "io/piniobox.h"
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1; // PINIO1: VTX power switch
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2; // PINIO2: Camera switch
+}

--- a/src/main/target/SPEDIXH743/target.c
+++ b/src/main/target/SPEDIXH743/target.c
@@ -1,0 +1,56 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/pinio.h"
+#include "drivers/sensor.h"
+
+// Gyro 1: ICM42688P on SPI1, tag=0
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688_1, DEVHW_ICM42605, ICM42605_1_SPI_BUS, ICM42605_1_CS_PIN, NONE, 0, DEVFLAGS_NONE, IMU_ICM42605_ALIGN);
+// Gyro 2: ICM42688P on SPI4, tag=1
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688_2, DEVHW_ICM42605, ICM42605_2_SPI_BUS, ICM42605_2_CS_PIN, NONE, 1, DEVFLAGS_NONE, IMU_ICM42605_2_ALIGN);
+
+timerHardware_t timerHardware[] = {
+    // ---- Motors (TIM1 x4) ----
+    DEF_TIM(TIM1,  CH1,  PE9,  TIM_USE_OUTPUT_AUTO, 0, 0),  // M1
+    DEF_TIM(TIM1,  CH2,  PE11, TIM_USE_OUTPUT_AUTO, 0, 1),  // M2
+    DEF_TIM(TIM1,  CH3,  PE13, TIM_USE_OUTPUT_AUTO, 0, 2),  // M3
+    DEF_TIM(TIM1,  CH4,  PE14, TIM_USE_OUTPUT_AUTO, 0, 3),  // M4
+
+    // ---- Motors (TIM8 x2) ----
+    DEF_TIM(TIM8,  CH3,  PC8,  TIM_USE_OUTPUT_AUTO, 0, 4),  // M5
+    DEF_TIM(TIM8,  CH4,  PC9,  TIM_USE_OUTPUT_AUTO, 0, 5),  // M6
+
+    // ---- Motors (TIM3 x2) ----
+    DEF_TIM(TIM3,  CH1,  PA6,  TIM_USE_OUTPUT_AUTO, 0, 6),  // M7
+    DEF_TIM(TIM3,  CH2,  PA7,  TIM_USE_OUTPUT_AUTO, 0, 7),  // M8
+
+    // ---- LED Strip (TIM5 CH1) ----
+    DEF_TIM(TIM5,  CH1,  PA0,  TIM_USE_LED, 0, 8),          // WS2812 LED Strip
+
+    // ---- Camera Control (PA1 / TIM15_CH1N) ----
+    DEF_TIM(TIM15, CH1N, PA1,  TIM_USE_ANY, 0, 0),
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/SPEDIXH743/target.h
+++ b/src/main/target/SPEDIXH743/target.h
@@ -143,10 +143,10 @@
 
 // *************** ADC **********************************
 #define USE_ADC
-#define ADC_INSTANCE            ADC1
+#define ADC_INSTANCE                ADC3    // PC-port pins require ADC3 on H743
 
-#define ADC_CHANNEL_1_PIN       PC1     // VBAT
-#define ADC_CHANNEL_2_PIN       PC2     // Current
+#define ADC_CHANNEL_1_PIN           PC1     // VBat    — ADC123_INP11 (works on ADC3)
+#define ADC_CHANNEL_2_PIN           PC2     // Current — ADC3_INP0
 
 #define VBAT_ADC_CHANNEL            ADC_CHN_1
 #define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2

--- a/src/main/target/SPEDIXH743/target.h
+++ b/src/main/target/SPEDIXH743/target.h
@@ -85,13 +85,17 @@
 #define I2C1_SCL                PB8
 #define I2C1_SDA                PB9
 
+#define USE_I2C_DEVICE_2
+#define I2C2_SCL                PB10
+#define I2C2_SDA                PB11
+
 #define USE_BARO
 #define BARO_I2C_BUS            BUS_I2C1
 #define USE_BARO_BMP280
 #define USE_BARO_DPS310
 
 #define USE_MAG
-#define MAG_I2C_BUS             BUS_I2C1
+#define MAG_I2C_BUS             BUS_I2C2
 #define USE_MAG_ALL
 
 #define TEMPERATURE_I2C_BUS     BUS_I2C1
@@ -151,7 +155,7 @@
 #define VBAT_ADC_CHANNEL            ADC_CHN_1
 #define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
 
-#define VBAT_SCALE_DEFAULT      110
+#define VBAT_SCALE_DEFAULT      1100
 
 // *************** PINIO ********************************
 #define USE_PINIO

--- a/src/main/target/SPEDIXH743/target.h
+++ b/src/main/target/SPEDIXH743/target.h
@@ -1,0 +1,183 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "SPX7"
+#define USBD_PRODUCT_STRING     "SPEDIXH743"
+
+#define USE_TARGET_CONFIG
+
+// *************** Indicators ***************************
+#define LED0                    PC4
+#define LED1                    PC5
+
+#define BEEPER                  PD14
+#define BEEPER_INVERTED
+
+// *************** IMU generic **************************
+#define USE_DUAL_GYRO
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS
+
+#define USE_IMU_ICM42605
+
+// *************** SPI1 — Gyro 1 (ICM42688P) ************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PB3
+#define SPI1_MISO_PIN           PB4
+#define SPI1_MOSI_PIN           PB5
+
+#define ICM42605_1_SPI_BUS      BUS_SPI1
+#define ICM42605_1_CS_PIN       PA15
+#define IMU_ICM42605_ALIGN      CW0_DEG
+
+// *************** SPI4 — Gyro 2 (ICM42688P) ************
+#define USE_SPI_DEVICE_4
+#define SPI4_SCK_PIN            PE2
+#define SPI4_MISO_PIN           PE5
+#define SPI4_MOSI_PIN           PE6
+
+#define ICM42605_2_SPI_BUS      BUS_SPI4
+#define ICM42605_2_CS_PIN       PE3
+#define IMU_ICM42605_2_ALIGN    CW0_DEG
+
+// *************** SPI2 — OSD (MAX7456) *****************
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          PB12
+
+// *************** SPI3 — Flash (M25P16 blackbox) *******
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PC12
+
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_SPI_BUS          BUS_SPI3
+#define M25P16_CS_PIN           PA8
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+// *************** I2C — Baro (BMP280/DPS310) ***********
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_DPS310
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+#define TEMPERATURE_I2C_BUS     BUS_I2C1
+#define PITOT_I2C_BUS           BUS_I2C1
+#define RANGEFINDER_I2C_BUS     BUS_I2C1
+#define USE_RANGEFINDER
+
+// *************** UART *********************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PB7
+
+#define USE_UART2
+#define UART2_TX_PIN            PD5
+#define UART2_RX_PIN            PD6
+
+#define USE_UART3
+#define UART3_TX_PIN            PD8
+#define UART3_RX_PIN            PD9
+
+#define USE_UART4
+#define UART4_TX_PIN            PD1
+#define UART4_RX_PIN            PD0
+
+#define USE_UART5
+#define UART5_TX_PIN            PB6
+#define UART5_RX_PIN            PD2
+
+#define USE_UART6
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+#define USE_UART7
+#define UART7_TX_PIN            PE8
+#define UART7_RX_PIN            PE7
+
+#define USE_UART8
+#define UART8_TX_PIN            PE1
+#define UART8_RX_PIN            PE0
+
+// VCP + 8 UARTs
+#define SERIAL_PORT_COUNT       9
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART6
+
+// *************** ADC **********************************
+#define USE_ADC
+#define ADC_INSTANCE            ADC1
+
+#define ADC_CHANNEL_1_PIN       PC1     // VBAT
+#define ADC_CHANNEL_2_PIN       PC2     // Current
+
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+
+#define VBAT_SCALE_DEFAULT      110
+
+// *************** PINIO ********************************
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN              PA2     // VTX power switch
+#define PINIO2_PIN              PA3     // Camera switch
+
+// *************** LED STRIP ****************************
+#define USE_LED_STRIP
+#define WS2811_PIN              PA0
+
+// *************** Features / defaults ******************
+#define DEFAULT_FEATURES            (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX)
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define USE_DSHOT
+#define USE_DSHOT_DMAR
+#define USE_ESC_SENSOR
+
+#define MAX_PWM_OUTPUT_PORTS    8
+
+// *************** Pin availability *********************
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         0xffff
+#define TARGET_IO_PORTE         0xffff


### PR DESCRIPTION
## Summary

Adds a new target for the Spedix H743, an STM32H743-based flight controller with dual ICM42688P gyros.

## Hardware

- **MCU:** STM32H743
- **Gyros:** 2× ICM42688P — Gyro1 on SPI1 (CS: PA15, EXTI: PD7), Gyro2 on SPI4 (CS: PE3, EXTI: PE4)
- **OSD:** MAX7456 on SPI2
- **Blackbox:** M25P16 on SPI3
- **Baro:** BMP280 / DPS310 on I2C1
- **Motors:** 8× (TIM1×4, TIM8×2, TIM3×2)
- **UARTs:** 8 (+ VCP)
- **ADC:** VBat (PC1), Current (PC2)
- **PINIO:** VTX power switch (PA2), Camera switch (PA3)
- **LED strip:** WS2812 on PA0 (TIM5_CH1)

## Changes

- `src/main/target/SPEDIXH743/target.h` — pin definitions, feature enables, UART/SPI/I2C/ADC config
- `src/main/target/SPEDIXH743/target.c` — timer hardware table, BUSDEV SPI registrations for both gyros
- `src/main/target/SPEDIXH743/config.c` — PINIO box assignments (USER1/USER2)
- `src/main/target/SPEDIXH743/CMakeLists.txt` — build system registration

## Notes

- Both gyros use `DEVHW_ICM42605` (the ICM42605 driver is compatible with the ICM42688P)
- Gyros use polling mode (`NONE` irqPin) via `USE_TARGET_IMU_HARDWARE_DESCRIPTORS`
- The board has GYRO_CLKIN pins (PA5, PB0) but INAV does not implement GYRO_CLKIN; those pins are left as unconfigured GPIO and are not declared in the timer table

## Testing

- Built successfully against `maintenance-9.x` with zero warnings
- Flash usage: 35% of 1,792 KB — well within limits
- No hardware available for on-FC testing; requesting testing from anyone with this FC

## Code Review

Reviewed prior to PR — no critical issues. Dead `CAMERA_CONTROL_PIN` define (Betaflight-ism not used in INAV) was caught and removed during review.

## Documentation

No end-user documentation needed for a new target.