### PR TITLE
fix(pitotmeter): guard MS5525 i2c address writes with USE_I2C for SITL builds

### DIFF
--- a/src/main/drivers/pitotmeter/pitotmeter_ms5525.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_ms5525.c
@@ -172,10 +172,14 @@ bool ms5525Detect(pitotDev_t * pitot)
     }
 
     // Try primary address 0x76
+#ifdef USE_I2C
     pitot->busDev->busdev.i2c.address = MS5525_ADDR_1;
+#endif
     if (!deviceDetect(pitot->busDev)) {
         // Fallback to secondary 0x77
+#ifdef USE_I2C
         pitot->busDev->busdev.i2c.address = MS5525_ADDR_2;
+#endif
         if (!deviceDetect(pitot->busDev)) {
             busDeviceDeInit(pitot->busDev);
             return false;


### PR DESCRIPTION
## Summary

The MS5525 pitotmeter driver failed to compile for SITL targets because it directly accessed `pitot->busDev->busdev.i2c.address`, but the `i2c` union member in `busDevice_t.busdev` is conditionally compiled under `#ifdef USE_I2C`. The SITL target explicitly `#undef USE_I2C` (target.h), so the member does not exist in that build.

## Changes

- Wrapped the two `busdev.i2c.address` assignment lines in `pitotmeter_ms5525.c` with `#ifdef USE_I2C` / `#endif`, matching the pattern already used throughout `bus.h` and `bus.c`

## Testing

- SITL target compiled successfully with the fix applied (`ninja -j4` in `build_sitl/`)
- No behavioral change on hardware targets where `USE_I2C` is defined — the guards are compile-time only
- Note: full hardware I2C testing of the MS5525 sensor was not performed (no hardware available); the fix is a compile guard only and does not alter runtime logic

## Code Review

Reviewed for correctness and INAV coding standards — no issues found. The fix mirrors the existing `#ifdef USE_I2C` pattern used in `bus.c` and `bus.h` for all direct `busdev` union member accesses.