### PR TITLE
fix: prevent LTO from breaking settingGet/settingGetIndex round-trip

### DIFF
--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -124,13 +124,19 @@ const setting_t *settingFind(const char *name)
 	return NULL;
 }
 
-// noinline: LTO inlines these with divergent settingsTable base addresses,
-// breaking the settingGetIndex -> settingGet round-trip.
+// Under release builds (LTO enabled), inlining settingGet and settingGetIndex
+// at their call sites in fc_msp.c produces wrong results for the
+// settingGetIndex(ptr)->settingGet(index) round-trip, causing MSPV2_SETTING
+// to return incorrect byte counts for some uint16_t settings.
+// Use the raw attribute rather than NOINLINE because NOINLINE expands to
+// nothing on non-F7/H7 targets (common.h:29), but LTO is enabled for all
+// release targets and the bug affects all of them.
 __attribute__((noinline)) const setting_t *settingGet(unsigned index)
 {
 	return index < SETTINGS_TABLE_COUNT ? &settingsTable[index] : NULL;
 }
 
+// noinline: same reason as settingGet above
 __attribute__((noinline)) unsigned settingGetIndex(const setting_t *val)
 {
 	return val - settingsTable;
@@ -217,7 +223,9 @@ size_t settingGetValueSize(const setting_t *val)
 	return 0; // Unreachable
 }
 
-pgn_t settingGetPgn(const setting_t *val)
+// noinline: same reason as settingGet above; also does pointer arithmetic
+// against settingsTable and is called from settingGetValuePointer.
+__attribute__((noinline)) pgn_t settingGetPgn(const setting_t *val)
 {
 	uint16_t pos = val - (const setting_t *)settingsTable;
 	uint16_t acc = 0;

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -124,12 +124,14 @@ const setting_t *settingFind(const char *name)
 	return NULL;
 }
 
-const setting_t *settingGet(unsigned index)
+// noinline: LTO inlines these with divergent settingsTable base addresses,
+// breaking the settingGetIndex -> settingGet round-trip.
+__attribute__((noinline)) const setting_t *settingGet(unsigned index)
 {
 	return index < SETTINGS_TABLE_COUNT ? &settingsTable[index] : NULL;
 }
 
-unsigned settingGetIndex(const setting_t *val)
+__attribute__((noinline)) unsigned settingGetIndex(const setting_t *val)
 {
 	return val - settingsTable;
 }


### PR DESCRIPTION
## Summary

Under `INTERPROCEDURAL_OPTIMIZATION` (LTO), the compiler inlines `settingGet` and `settingGetIndex` at their respective call sites with potentially divergent views of `settingsTable`'s base address. The result is that `settingGetIndex(ptr)` returns index X, but `settingGet(X)` does not return the same entry — breaking the round-trip.

**Symptom:** `MSPV2_SETTING` returns the wrong value size (e.g. 1 byte) for some settings, while `MSP2_COMMON_SETTING_INFO` for the same setting name correctly returns the expected size and value. SITL builds are not affected because SITL is excluded from LTO.

**Fix:** Mark `settingGet` and `settingGetIndex` as `noinline`, forcing LTO to use a single, consistent reference to `settingsTable` across all call sites.

## Changes

- `src/main/fc/settings.c`: add `__attribute__((noinline))` to `settingGet` and `settingGetIndex`

## Testing

- SITL build compiles cleanly with the change applied