### PR TITLE
Add new target: AEDROXH7 (Airbot Systems AEDROX H7)

### DIFF
--- a/src/main/target/AEDROXH7/CMakeLists.txt
+++ b/src/main/target/AEDROXH7/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32h743xi(AEDROXH7)

--- a/src/main/target/AEDROXH7/config.c
+++ b/src/main/target/AEDROXH7/config.c
@@ -1,0 +1,52 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "config/config_master.h"
+
+#include "fc/fc_msp_box.h"
+#include "fc/config.h"
+
+#include "io/serial.h"
+#include "io/piniobox.h"
+
+void targetConfiguration(void)
+{
+    // GPS on UART2
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART2)].functionMask = FUNCTION_GPS;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART2)].gps_baudrateIndex = BAUD_115200;
+
+    // ESC telemetry on UART7 (RX only)
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART7)].functionMask = FUNCTION_ESCSERIAL;
+
+    // HD OSD via MSP DisplayPort on UART8
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART8)].functionMask = FUNCTION_MSP;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART8)].msp_baudrateIndex = BAUD_115200;
+
+    // PINIO boxes: USER1-4 mapped to switch boxes
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+    pinioBoxConfigMutable()->permanentId[2] = BOX_PERMANENT_ID_USER3;
+    pinioBoxConfigMutable()->permanentId[3] = BOX_PERMANENT_ID_USER4;
+
+    // Enable PWM drive for passive beeper on PA7 / TIM3_CH2
+    beeperConfigMutable()->pwmMode = true;
+}

--- a/src/main/target/AEDROXH7/target.c
+++ b/src/main/target/AEDROXH7/target.c
@@ -1,0 +1,52 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/pinio.h"
+#include "drivers/sensor.h"
+
+// ICM42688P: DEVHW_ICM42605 driver detects both via WHO_AM_I
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688, DEVHW_ICM42605, ICM42605_SPI_BUS, ICM42605_CS_PIN, ICM42605_EXTI_PIN, 0, DEVFLAGS_NONE, IMU_ICM42605_ALIGN);
+
+timerHardware_t timerHardware[] = {
+    // Motors M1-M4: TIM8 (CH mapping follows board silkscreen, not channel order)
+    DEF_TIM(TIM8, CH2, PC7, TIM_USE_OUTPUT_AUTO, 0, 0),   // M1
+    DEF_TIM(TIM8, CH1, PC6, TIM_USE_OUTPUT_AUTO, 0, 1),   // M2
+    DEF_TIM(TIM8, CH4, PC9, TIM_USE_OUTPUT_AUTO, 0, 2),   // M3
+    DEF_TIM(TIM8, CH3, PC8, TIM_USE_OUTPUT_AUTO, 0, 3),   // M4
+
+    // Motors M5-M8: TIM1 on PE9/PE11/PE13/PE14 (AF1)
+    DEF_TIM(TIM1, CH1, PE9,  TIM_USE_OUTPUT_AUTO, 0, 4),  // M5
+    DEF_TIM(TIM1, CH2, PE11, TIM_USE_OUTPUT_AUTO, 0, 5),  // M6
+    DEF_TIM(TIM1, CH3, PE13, TIM_USE_OUTPUT_AUTO, 0, 6),  // M7
+    DEF_TIM(TIM1, CH4, PE14, TIM_USE_OUTPUT_AUTO, 0, 7),  // M8
+
+    // LED strip: TIM2_CH1 on PA5 (AF1) — separate timer from motors
+    DEF_TIM(TIM2, CH1, PA5,  TIM_USE_LED,         0, 0),  // LED strip
+
+    // Beeper PWM: TIM3_CH2 on PA7 (AF2)
+    DEF_TIM(TIM3, CH2, PA7,  TIM_USE_BEEPER,      0, 0),  // Beeper
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/AEDROXH7/target.h
+++ b/src/main/target/AEDROXH7/target.h
@@ -115,10 +115,11 @@
 #define UART3_RX_PIN            PD9
 
 // *************** CAN Bus *************************
-// TODO: verify CAN syntax for INAV and confirm transceiver standby pin (if any)
+// CAN not yet tested
 #define USE_DRONECAN
 #define CAN1_RX                 PD0
 #define CAN1_TX                 PD1
+#define CAN1_STANDBY            PD3
 
 #define USE_UART7
 #define UART7_TX_PIN            PE8

--- a/src/main/target/AEDROXH7/target.h
+++ b/src/main/target/AEDROXH7/target.h
@@ -114,10 +114,11 @@
 #define UART3_TX_PIN            PD8
 #define UART3_RX_PIN            PD9
 
-// PD0/PD1 are also CAN1_RX/TX; CAN not used on this board
-#define USE_UART4
-#define UART4_TX_PIN            PD1
-#define UART4_RX_PIN            PD0
+// *************** CAN Bus *************************
+// TODO: verify CAN syntax for INAV and confirm transceiver standby pin (if any)
+#define USE_DRONECAN
+#define CAN1_RX                 PD0
+#define CAN1_TX                 PD1
 
 #define USE_UART7
 #define UART7_TX_PIN            PE8
@@ -127,7 +128,7 @@
 #define UART8_TX_PIN            PE1
 #define UART8_RX_PIN            PE0
 
-#define SERIAL_PORT_COUNT       7
+#define SERIAL_PORT_COUNT       6   // VCP + UART1-3 + UART7 + UART8
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_CRSF

--- a/src/main/target/AEDROXH7/target.h
+++ b/src/main/target/AEDROXH7/target.h
@@ -1,0 +1,177 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "AEDH"
+#define USBD_PRODUCT_STRING     "AEDROXH7"
+
+#define USE_TARGET_CONFIG
+
+// *************** LEDs ***************************
+#define LED0                    PE5
+#define LED1                    PE2
+
+// *************** Beeper *************************
+#define BEEPER                  PA7
+#define BEEPER_INVERTED
+#define BEEPER_PWM_FREQUENCY    2500
+
+// *************** SPI1 - OSD (MAX7456) ***********
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PB3
+#define SPI1_MISO_PIN           PB4
+#define SPI1_MOSI_PIN           PB5
+
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI1
+#define MAX7456_CS_PIN          PE4
+
+// *************** SPI2 - Gyro (ICM42688P) ********
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS
+
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW90_DEG
+#define ICM42605_SPI_BUS        BUS_SPI2
+#define ICM42605_CS_PIN         PB12
+#define ICM42605_EXTI_PIN       PC4
+
+// *************** SPI3 - Flash (W25N01G) *********
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PB2
+#define SPI3_NSS_PIN            PA15
+// PB2 requires AF7 for SPI3 MOSI — AF6 is the default and incorrect for this pin
+#define SPI3_SCK_AF             GPIO_AF6_SPI3
+#define SPI3_MISO_AF            GPIO_AF6_SPI3
+#define SPI3_MOSI_AF            GPIO_AF7_SPI3
+
+#define USE_BLACKBOX
+#define USE_FLASHFS
+#define USE_FLASH_W25N01G
+#define W25N01G_SPI_BUS         BUS_SPI3
+#define W25N01G_CS_PIN          PA15
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+// *************** I2C1 - Magnetometer ************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+// *************** I2C2 - Barometer (DPS310) ******
+#define USE_I2C_DEVICE_2
+#define I2C2_SCL                PB10
+#define I2C2_SDA                PB11
+
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C2
+#define USE_BARO_ALL
+
+#define TEMPERATURE_I2C_BUS     BUS_I2C2
+#define PITOT_I2C_BUS           BUS_I2C1
+#define RANGEFINDER_I2C_BUS     BUS_I2C1
+#define USE_RANGEFINDER
+
+// *************** UARTs **************************
+// UART5 not wired; UART6 pins PC6/PC7 used as motor outputs
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PD5
+#define UART2_RX_PIN            PD6
+
+#define USE_UART3
+#define UART3_TX_PIN            PD8
+#define UART3_RX_PIN            PD9
+
+// PD0/PD1 are also CAN1_RX/TX; CAN not used on this board
+#define USE_UART4
+#define UART4_TX_PIN            PD1
+#define UART4_RX_PIN            PD0
+
+#define USE_UART7
+#define UART7_TX_PIN            PE8
+#define UART7_RX_PIN            PE7
+
+#define USE_UART8
+#define UART8_TX_PIN            PE1
+#define UART8_RX_PIN            PE0
+
+#define SERIAL_PORT_COUNT       7
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART3
+
+// *************** ADC ****************************
+#define USE_ADC
+#define ADC_INSTANCE            ADC1
+
+#define ADC_CHANNEL_1_PIN       PC0
+#define ADC_CHANNEL_2_PIN       PC1
+#define ADC_CHANNEL_3_PIN       PC5
+
+#define VBAT_ADC_CHANNEL        ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL ADC_CHN_2
+#define RSSI_ADC_CHANNEL        ADC_CHN_3
+
+// *************** LED Strip **********************
+#define USE_LED_STRIP
+#define WS2811_PIN              PA5
+
+// *************** PINIO **************************
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN              PA2
+#define PINIO2_PIN              PA3
+#define PINIO3_PIN              PB1
+#define PINIO3_FLAGS            PINIO_FLAGS_INVERTED
+#define PINIO4_PIN              PD15
+
+// *************** Features ***********************
+#define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX)
+#define CURRENT_METER_SCALE     250
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define USE_ESC_SENSOR
+
+// *************** IO Port Masks ******************
+#define TARGET_IO_PORTA         (0xffff & ~(BIT(13) | BIT(14)))
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         0xffff
+#define TARGET_IO_PORTE         0xffff
+
+// *************** PWM Outputs ********************
+#define MAX_PWM_OUTPUT_PORTS    8
+#define USE_DSHOT


### PR DESCRIPTION
## Summary

Adds INAV firmware support for the Airbot Systems AEDROX H7 flight controller (STM32H743), translated from the official Betaflight configuration.

## Hardware

- **MCU:** STM32H743
- **Gyro:** ICM42688P on SPI2 (CW90°)
- **Baro:** DPS310 on I2C2
- **Mag:** Hardware present on I2C1 — enabled (was commented out in BF config)
- **Flash:** W25N01G 1Gbit NAND on SPI3 — default blackbox storage
- **OSD:** MAX7456 analog on SPI1 + HD MSP DisplayPort on UART8
- **Motors:** 8 outputs — M1–M4 on TIM8 (PC6–PC9), M5–M8 on TIM1 (PE9/PE11/PE13/PE14)
- **UARTs:** 1, 2, 3, 7 (RX only), 8 + VCP
- **CAN:** DroneCAN on PD0/PD1

## Default UART roles (config.c)

| UART | Role |
|------|------|
| UART2 | GPS |
| UART3 | SerialRX (CRSF) |
| UART7 | ESC telemetry (RX only) |
| UART8 | MSP DisplayPort (HD OSD) |

## Notes

- SPI3 MOSI on PB2 requires explicit `GPIO_AF7_SPI3` override — same pattern as JHEMCUH743HD
- ICM42688P registered as `DEVHW_ICM42605`; driver distinguishes via WHO_AM_I at runtime
- TIM8 channel order for M1–M4 follows board silkscreen (M1=PC7=TIM8_CH2, M2=PC6=TIM8_CH1), not sequential channel numbering

## Testing

- Built successfully for `AEDROXH7` target — zero warnings, zero errors
- Flashed via DFU and booted successfully on hardware
- UART1 verified functional on hardware

## Code Review

Reviewed with inav-code-review agent — critical issues addressed (USE_BARO_ALL, trimmed config.c includes, comment placement).