### PR TITLE
drivers: fix DMA request disable ordering in timer IRQ handlers and stop functions

### DIFF
--- a/src/main/drivers/timer_impl_hal.c
+++ b/src/main/drivers/timer_impl_hal.c
@@ -330,8 +330,8 @@ static void impl_timerDMA_IRQHandler(DMA_t descriptor)
             tch->dmaState = TCH_DMA_IDLE;
         }
 
-        LL_DMA_DisableStream(tch->dma->dma, lookupDMALLStreamTable[DMATAG_GET_STREAM(tch->timHw->dmaTag)]);
         LL_TIM_DisableDMAReq_CCx(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex]);
+        LL_DMA_DisableStream(tch->dma->dma, lookupDMALLStreamTable[DMATAG_GET_STREAM(tch->timHw->dmaTag)]);
 
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
     }

--- a/src/main/drivers/timer_impl_stdperiph.c
+++ b/src/main/drivers/timer_impl_stdperiph.c
@@ -279,8 +279,8 @@ static void impl_timerDMA_IRQHandler(DMA_t descriptor)
 
         tch->dmaState = TCH_DMA_IDLE;
 
-        DMA_Cmd(tch->dma->ref, DISABLE);
         TIM_DMACmd(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], DISABLE);
+        DMA_Cmd(tch->dma->ref, DISABLE);
 
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
     }
@@ -518,8 +518,8 @@ void impl_timerPWMPrepareDMA(TCH_t * tch, uint32_t dmaBufferElementCount)
     // Clear the flag as well, so even if DMA transfer finishes while within ATOMIC_BLOCK
     // the resulting IRQ won't mess up the DMA state
     ATOMIC_BLOCK(NVIC_PRIO_MAX) {
-        DMA_Cmd(tch->dma->ref, DISABLE);
         TIM_DMACmd(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], DISABLE);
+        DMA_Cmd(tch->dma->ref, DISABLE);
         DMA_CLEAR_FLAG(tch->dma, DMA_IT_TCIF);
     }
 
@@ -561,8 +561,8 @@ void impl_timerPWMStartDMA(TCH_t * tch)
 
 void impl_timerPWMStopDMA(TCH_t * tch)
 {
-    DMA_Cmd(tch->dma->ref, DISABLE);
     TIM_DMACmd(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], DISABLE);
+    DMA_Cmd(tch->dma->ref, DISABLE);
     tch->dmaState = TCH_DMA_IDLE;
     TIM_Cmd(tch->timHw->tim, ENABLE);
 }

--- a/src/main/drivers/timer_impl_stdperiph_at32.c
+++ b/src/main/drivers/timer_impl_stdperiph_at32.c
@@ -409,8 +409,8 @@ void impl_timerPWMStartDMA(TCH_t * tch)
 
 void impl_timerPWMStopDMA(TCH_t * tch)
 {
-    dma_channel_enable(tch->dma->ref,FALSE);
     tmr_dma_request_enable(tch->timHw->tim, lookupDMASourceTable[tch->timHw->channelIndex], FALSE);
+    dma_channel_enable(tch->dma->ref,FALSE);
     tch->dmaState = TCH_DMA_IDLE;
     tmr_counter_enable(tch->timHw->tim, TRUE);
 }


### PR DESCRIPTION
## Summary

Fixes incorrect DMA stream disable ordering in `timer_impl_stdperiph.c`, `timer_impl_stdperiph_at32.c`, and `timer_impl_hal.c`.

STM32 Reference Manual (RM0090 §10.3.17) requires disabling the **timer DMA request first**, then the **DMA stream**. Five locations had this backwards, creating a race window where the timer peripheral could issue a DMA request to an already-disabled stream via the hardware DMA request line (which bypasses CPU interrupts and operates even inside an ATOMIC_BLOCK).

## Changes

**timer_impl_stdperiph.c** (3 sites):
- `impl_timerPWMStopDMA` — swapped disable order
- `impl_timerPWMPrepareDMA` — swapped disable order inside ATOMIC_BLOCK
- DMA TC IRQ handler — swapped disable order

**timer_impl_stdperiph_at32.c** (1 site):
- `impl_timerPWMStopDMA` — swapped `dma_channel_enable`/`tmr_dma_request_enable` order

**timer_impl_hal.c** (1 site):
- DMA TC IRQ handler — swapped `LL_DMA_DisableStream`/`LL_TIM_DisableDMAReq_CCx` order

The correct ordering was already present in `impl_timerPWMSetDMACircular` (both stdperiph files, added in #11260) and `impl_timerPWMStopDMA` (HAL file), which serve as the reference implementation.

## Testing

- Built AIKONF4V3 (STM32F4/stdperiph) — clean build, no warnings in changed files
- Built MATEKF405 (STM32F4/stdperiph) — clean build
- Flashed AIKONF4V3 and verified FC boots and responds normally
- Ran 3000-iteration disarmed DShot DMA stress test before and after — stable latency, zero MSP timeouts in both runs; no regressions observed

## Code Review

Reviewed for ISR safety, ordering correctness against RM0090 §10.3.17, and consistency with reference implementations.