### PR TITLE
Add support for XTX XT25F128F nor flash chip

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -118,6 +118,9 @@ struct {
     {0x1C3017, 128, 256},
     // JEDEC_ID_SPANSION_S25FL116
     {0x014015, 32, 256 },
+    // JEDEC_ID_XTX_XT25F128F
+    // Datasheet: https://www.xtxtech.com/Products/info_productModel_XT25F128FSSIGT.html
+    {0x0B4018, 256, 256 },
     // End of list
     {0x000000, 0, 0}};
 


### PR DESCRIPTION
Added JEDEC ID and parameters for XTX XT25F128F flash chip.
Verified on SPEDIXF405 target.
Datasheet:https://www.xtxtech.com/Products/info_productModel_XT25F128FSSIGT.html
(Notice: Please view datasheets directly on our website. To prevent link expiration, we provide live online versions instead of static PDFs.)