### PR TITLE
fix: extend SBUS2 and UART inversion guards to include RP2350

### DIFF
--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -36,7 +36,7 @@
 #include "serial_uart_impl.h"
 
 static void usartConfigurePinInversion(uartPort_t *uartPort) {
-#if !defined(USE_UART_INVERTER) && !defined(STM32F7)
+#if !defined(USE_UART_INVERTER)
     UNUSED(uartPort);
 #else
     bool inverted = uartPort->port.options & SERIAL_INVERTED;

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -197,8 +197,8 @@
 #define USE_HEADTRACKER_SERIAL
 #define USE_HEADTRACKER_MSP
 
-#if defined(STM32F7) || defined(STM32H7)
-// needs bi-direction inverter, not available on F4 hardware.
+#if defined(STM32F7) || defined(STM32H7) || defined(RP2350)
+// needs bi-directional inverter; not available on F4 or AT32F43x hardware
 #define USE_TELEMETRY_SBUS2
 #endif
 


### PR DESCRIPTION
## Summary

- `USE_TELEMETRY_SBUS2` was gated to STM32F7/H7 only. RP2350 also has bi-directional UART inversion capability and is now included.
- AT32F43x was investigated: the USART CTRL2/CTRL3 register map has no RXINV/TXINV bits, so it cannot do hardware pin inversion and is intentionally excluded.
- Removes dead `!defined(STM32F7)` from `serial_uart.c`. That file is compiled only for STM32F4 via `stm32-stdperiph.cmake` (included exclusively by `stm32f4.cmake`), so `STM32F7` can never be defined in that translation unit. Confirmed by inspecting the MATEKF722 build directory — no `serial_uart.c.obj` present.

## Changes

- `src/main/target/common.h` — add `|| defined(RP2350)` to `USE_TELEMETRY_SBUS2` guard; improve comment to name both excluded platforms
- `src/main/drivers/serial_uart.c` — remove tautological `&& !defined(STM32F7)` from `usartConfigurePinInversion`

## Testing

- Built MATEKF405 (STM32F4), MATEKF722 (STM32F7), MATEKH743 (STM32H7) — all compile clean with no errors or warnings
- Hardware runtime testing of SBUS2 on RP2350 not yet performed (RP2350 UART driver still in development)

## Code Review

Reviewed with inav-code-review — no critical or important issues found.

Documentation not needed (preprocessor guard fix, no user-visible behaviour change on existing targets).