### PR TITLE
fix: make PLL2M dynamic to keep VCO=800MHz for any HSE frequency (closes #11594)

### DIFF
--- a/src/main/target/system_stm32h7xx.c
+++ b/src/main/target/system_stm32h7xx.c
@@ -501,7 +501,7 @@ void SystemClock_Config(void)
     RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_SDMMC;
     RCC_PeriphClkInit.PLL2.PLL2M = HSE_VALUE / 1000000 / 2;
     RCC_PeriphClkInit.PLL2.PLL2N = 400;
-    RCC_PeriphClkInit.PLL2.PLL2P = 2; // 200Mhz
+    RCC_PeriphClkInit.PLL2.PLL2P = 2; // 400Mhz
     RCC_PeriphClkInit.PLL2.PLL2Q = 3; // 266Mhz - 133Mhz can be derived from this for for QSPI if flash chip supports the speed.
     RCC_PeriphClkInit.PLL2.PLL2R = 4; // 200Mhz HAL LIBS REQUIRE 200MHZ SDMMC CLOCK, see HAL_SD_ConfigWideBusOperation, SDMMC_HSpeed_CLK_DIV, SDMMC_NSpeed_CLK_DIV
     RCC_PeriphClkInit.PLL2.PLL2RGE = RCC_PLL2VCIRANGE_0;

--- a/src/main/target/system_stm32h7xx.c
+++ b/src/main/target/system_stm32h7xx.c
@@ -499,9 +499,9 @@ void SystemClock_Config(void)
 
 #ifdef USE_SDCARD_SDIO
     RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_SDMMC;
-    RCC_PeriphClkInit.PLL2.PLL2M = 5;
-    RCC_PeriphClkInit.PLL2.PLL2N = 500;
-    RCC_PeriphClkInit.PLL2.PLL2P = 2; // 500Mhz
+    RCC_PeriphClkInit.PLL2.PLL2M = HSE_VALUE / 1000000 / 2;
+    RCC_PeriphClkInit.PLL2.PLL2N = 400;
+    RCC_PeriphClkInit.PLL2.PLL2P = 2; // 200Mhz
     RCC_PeriphClkInit.PLL2.PLL2Q = 3; // 266Mhz - 133Mhz can be derived from this for for QSPI if flash chip supports the speed.
     RCC_PeriphClkInit.PLL2.PLL2R = 4; // 200Mhz HAL LIBS REQUIRE 200MHZ SDMMC CLOCK, see HAL_SD_ConfigWideBusOperation, SDMMC_HSpeed_CLK_DIV, SDMMC_NSpeed_CLK_DIV
     RCC_PeriphClkInit.PLL2.PLL2RGE = RCC_PLL2VCIRANGE_0;


### PR DESCRIPTION
## Summary

PLL2M was hardcoded to 5, which assumes HSE = 8 MHz (giving VCO = 800 MHz).
On KakuteH7Wing (HSE = 16 MHz), VCO = 16/5 * 500 = 1600 MHz, far exceeding
the STM32H7 specification. This caused the SDMMC kernel clock (PLL2R = 4)
to run at 400 MHz instead of the expected 200 MHz.

## Fix

Compute PLL2M from HSE_VALUE (same formula as PLL1M) and reduce PLL2N
from 500 to 400, pinning VCO to 800 MHz for any HSE frequency:
- HSE=8:  M=4, N=400 → VCO=800 MHz
- HSE=16: M=8, N=400 → VCO=800 MHz


## Testing

**Build:** KAKUTEH7WING Release — 0 errors, 0 warnings
**SD card test 1 (detection):** PASS — card detected, filesystem Ready
**SD card test 2 (write):** 4 MB written in 60s at 68 KB/s, no errors

Closes #11594

## Risk

Low — only affects H7 targets with HSE ≠ 8 MHz (currently only
KAKUTEH7WING at 16 MHz). For all standard 8 MHz HSE targets the
VCO remains 800 MHz (M goes from 5 to 4, N from 500 to 400).