### PR TITLE
JHEMCUF435: enable UART2

### DIFF
--- a/src/main/target/JHEMCUF435/target.h
+++ b/src/main/target/JHEMCUF435/target.h
@@ -114,15 +114,11 @@
 #define UART1_RX_PIN            PA10
 #define UART1_TX_PIN            PA9
 
-// UART2 TX does not work due currently unknown software issue
-// Leaving this info here for future work.
-/*
 #define USE_UART2
 #define UART2_RX_AF             6
 #define UART2_TX_AF             8
 #define UART2_RX_PIN            PB0
 #define UART2_TX_PIN            PA8
-*/
 
 #define USE_UART3
 #define UART3_RX_PIN            PB11
@@ -149,7 +145,7 @@
 #define UART8_RX_PIN            PC3
 #define UART8_TX_PIN            PC2
 
-#define SERIAL_PORT_COUNT       8
+#define SERIAL_PORT_COUNT       9
 
 #define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_CRSF


### PR DESCRIPTION
# JHEMCUF435: enable UART2

## Summary

This PR enables UART2 on the `JHEMCUF435` target and updates `SERIAL_PORT_COUNT` accordingly.

UART2 was already documented in the target file, but it was left commented out with this note:

> UART2 TX does not work due currently unknown software issue

The target already contained the intended UART2 mapping:

- UART2 RX: `PB0`, `UART2_RX_AF 6`
- UART2 TX: `PA8`, `UART2_TX_AF 8`

This PR restores that mapping and increases `SERIAL_PORT_COUNT` from `8` to `9` because the target now exposes:

- USB VCP
- UART1
- UART2
- UART3
- UART4
- UART5
- UART6
- UART7
- UART8

## Rationale

The original UART2 comment appears to refer to an AT32F43x UART driver issue that has since been fixed.

Relevant history:

- [`51d98cffe`](https://github.com/iNavFlight/inav/commit/51d98cffe5642b5e149ed0694bf4e0322c5dff40) added support for specifying AT32 UART RX/TX alternate functions independently.
- In that implementation, the TX pin configuration accidentally used `uart->rx_af` instead of `uart->tx_af`.
- This was later fixed by [`a941b14a8`](https://github.com/iNavFlight/inav/commit/a941b14a8ca9a4610994f3d29b31ff2aca4928bd) / [PR #10840](https://github.com/iNavFlight/inav/pull/10840) (`f435 correct uart->tx_af`), changing the TX configuration to use the correct `uart->tx_af` value.
- `JHEMCUF435AIO` was then updated in [`9b43222ee`](https://github.com/iNavFlight/inav/commit/9b43222ee8ae699d4f858da016ec74b0b4909611) to use the same UART2 alternate-function mapping style:
  - `UART2_RX_AF 6`
  - `UART2_TX_AF 8`
  - `UART2_RX_PIN PB0`
  - `UART2_TX_PIN PA8`

Related target history:

- `JHEMCUF435` was added in [`5283cd7c9`](https://github.com/iNavFlight/inav/commit/5283cd7c93cd10403f11985d228aff748795468e), merged via [PR #10825](https://github.com/iNavFlight/inav/pull/10825). This is where the commented UART2 block and the “software issue” note were introduced.
- `JHEMCUF435AIO` was added via [PR #10740](https://github.com/iNavFlight/inav/pull/10740), and later received the UART2 AF update above.

Because the current AT32F43x serial driver now correctly applies `uart->tx_af` to TX pins, the earlier software limitation should no longer apply.


## Notes for reviewers

This PR only changes the `JHEMCUF435` target configuration. It does not modify common serial driver code.

The only remaining point to verify is hardware-level confirmation that the non-AIO `JHEMCUF435` board routes the TX2 pad to MCU pin `PA8`. The mapping itself matches the existing target comments and the related `JHEMCUF435AIO` configuration pattern.
