### PR TITLE
dshot beeper ignore list fix

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -345,7 +345,9 @@ void beeperUpdate(timeUs_t currentTimeUs)
     if (!beeperIsOn) {
 #ifdef USE_DSHOT
         if (isMotorProtocolDshot() && !areMotorsRunning() && beeperConfig()->dshot_beeper_enabled
-            && currentTimeUs - lastDshotBeeperCommandTimeUs > getDShotBeaconGuardDelayUs())
+            && currentTimeUs - lastDshotBeeperCommandTimeUs > getDShotBeaconGuardDelayUs()
+            && currentBeeperEntry->sequence[beeperPos] != 0                   // added beeper timeout so dshot does not beep on "off"
+            && !(getBeeperOffMask() & (1 << (currentBeeperEntry->mode - 1)))) // added beeper ignore to dshot beacon
         {
             lastDshotBeeperCommandTimeUs = currentTimeUs;
             sendDShotCommand(beeperConfig()->dshot_beeper_tone);


### PR DESCRIPTION
dshot beeper was implemented outside of the beeper ignore list.

it's been added in now along with a beeper off.