### PR TITLE
Improve OSD Glide Slope implementation

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -4872,6 +4872,26 @@ Value under which the OSD axis g force indicators will blink (g)
 
 ---
 
+### osd_glide_sample_rate
+
+Glide slope sampling rate in Hz (1-4 Hz). Higher rates give more responsive glide slope calculations but use more CPU.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 2 | 1 | 4 |
+
+---
+
+### osd_glide_sample_time_frame
+
+Glide slope sampling time frame in seconds (5-60 seconds). Longer frames provide more stable glide slope estimates.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 10 | 5 | 60 |
+
+---
+
 ### osd_highlight_djis_missing_font_symbols
 
 Show question marks where there is no symbol in the DJI font to represent the INAV OSD element's symbol. When off, blank spaces will be used. Only relevent for DJICOMPAT modes.

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3909,6 +3909,20 @@ groups:
         field: osd_switch_indicators_align_left
         type: bool
         default_value: ON
+      - name: osd_glide_sample_rate
+        description: "Glide slope sampling rate in Hz (1-4 Hz). Higher rates give more responsive glide slope calculations but use more CPU."
+        field: glide_sample_rate
+        type: uint8_t
+        min: 1
+        max: 4
+        default_value: 2
+      - name: osd_glide_sample_time_frame
+        description: "Glide slope sampling time frame in seconds (5-60 seconds). Longer frames provide more stable glide slope estimates."
+        field: glide_sample_time_frame
+        type: uint8_t
+        min: 5
+        max: 60
+        default_value: 10
 
   - name: PG_OSD_COMMON_CONFIG
     type: osdCommonConfig_t

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -345,7 +345,9 @@ void beeperUpdate(timeUs_t currentTimeUs)
     if (!beeperIsOn) {
 #ifdef USE_DSHOT
         if (isMotorProtocolDshot() && !areMotorsRunning() && beeperConfig()->dshot_beeper_enabled
-            && currentTimeUs - lastDshotBeeperCommandTimeUs > getDShotBeaconGuardDelayUs())
+            && currentTimeUs - lastDshotBeeperCommandTimeUs > getDShotBeaconGuardDelayUs()
+            && currentBeeperEntry->sequence[beeperPos] != 0                   // added beeper timeout so dshot does not beep on "off"
+            && !(getBeeperOffMask() & (1 << (currentBeeperEntry->mode - 1)))) // added beeper ignore to dshot beacon
         {
             lastDshotBeeperCommandTimeUs = currentTimeUs;
             sendDShotCommand(beeperConfig()->dshot_beeper_tone);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2081,6 +2081,7 @@ static bool osdDrawSingleElement(uint8_t item)
             static glidePositionSample_t glideBuffer[20]; // Need to add semi-dynamic allocation based on glideSampleRate and glideSampleTimeFrame later to allow for changing this in settings
             static uint8_t glideBufferIndex = 0;
             static uint8_t samplesSinceLastClear = 0;
+            static timeMs_t glideLastSampleTime = 0;
             const timeMs_t currentTime = millis();
             const uint16_t sampleIntervalMs = 1000 / glideSampleRate; 
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1875,11 +1875,11 @@ static uint16_t ensureGlideBufferAllocated(uint16_t requiredSize)
 }
 
 static bool isDataValidForGlideRatio() {
-    // Check if we have been ascending for more than 5 seconds, which would indicate that the glide ratio is not valid
+    // Check if we have been ascending for more than 4 seconds, which would indicate that the glide ratio is not valid
     static timeMs_t lastDescentTime = 0;
     if (getEstimatedActualVelocity(Z) < 0) {  // Descending
         lastDescentTime = millis();
-    } else if (millis() - lastDescentTime > 5000) {  // Ascending for more than 5 seconds
+    } else if (millis() - lastDescentTime > 4000) {  // Ascending for more than 4 seconds
         return false;
     }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -191,6 +191,15 @@ typedef struct statistic_s {
     int32_t flightStartMWh;
 } statistic_t;
 
+typedef struct glidePositionSample_s {
+    uint32_t distance_cm;    // Total travel distance
+    int32_t altitude_cm;     // Altitude
+} glidePositionSample_t;
+
+static uint8_t glideSampleRate = 2;         // 2Hz
+static uint8_t glideSampleTimeFrame = 10;   // seconds
+static uint8_t minimumSampleCount = 5;      // Minimum number of samples in the timeframe to consider the glide slope valid
+
 static statistic_t stats;
 
 static timeUs_t resumeRefreshAt = 0;
@@ -2065,14 +2074,37 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_GLIDESLOPE:
         {
-            float horizontalSpeed = gpsSol.groundSpeed;
-            float sinkRate = -getEstimatedActualVelocity(Z);
-            static pt1Filter_t gsFilterState;
-            const timeMs_t currentTimeMs = millis();
-            static timeMs_t gsUpdatedTimeMs;
-            float glideSlope = horizontalSpeed / sinkRate;
-            glideSlope = pt1FilterApply4(&gsFilterState, isnormal(glideSlope) ? glideSlope : 200, 0.5, MS2S(currentTimeMs - gsUpdatedTimeMs));
-            gsUpdatedTimeMs = currentTimeMs;
+            // float horizontalSpeed = gpsSol.groundSpeed;
+            // float sinkRate = -getEstimatedActualVelocity(Z);
+            // static pt1Filter_t gsFilterState;
+            // const timeMs_t currentTimeMs = millis();
+            // static timeMs_t gsUpdatedTimeMs;
+            // float glideSlope = horizontalSpeed / sinkRate;
+            // glideSlope = pt1FilterApply4(&gsFilterState, isnormal(glideSlope) ? glideSlope : 200, 0.5, MS2S(currentTimeMs - gsUpdatedTimeMs));
+            // gsUpdatedTimeMs = currentTimeMs;
+
+            static uint8_t bufferSize = glideSampleRate * glideSampleTimeFrame;
+            static glidePositionSample_t glideBuffer[bufferSize] = 0;
+            static uint16_t glideBufferIndex = 0;
+            static timeMs_t glideLastSampleTime = 0;
+            static uint8_t samplesSinceLastClear = 0;
+            const timeMs_t currentTime = millis();
+
+            static float glideSlope = 0.0f;
+            
+            if (currentTime - glideLastSampleTime >= glideSampleRate) {
+                // Record a new sample
+                glideLastSampleTime = currentTime;
+                glideBuffer[glideBufferIndex].distance_cm = getTotalTravelDistance();
+                glideBuffer[glideBufferIndex].altitude_cm = osdGetAltitude();
+                glideBufferIndex = (glideBufferIndex + 1) % bufferSize;
+                (samplesSinceLastClear < bufferSize) ? samplesSinceLastClear++ : 0;
+
+                if (samplesSinceLastClear >= minimumSampleCount) {
+                    // Calculate glide slope using the samples
+
+                }
+            }
 
             buff[0] = SYM_GLIDESLOPE;
             if (glideSlope > 0.0f && glideSlope < 100.0f) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2098,7 +2098,9 @@ static bool osdDrawSingleElement(uint8_t item)
                 glideBuffer[glideBufferIndex].distance_cm = getTotalTravelDistance();
                 glideBuffer[glideBufferIndex].altitude_cm = osdGetAltitude();
                 glideBufferIndex = (glideBufferIndex + 1) % bufferSize;
-                (samplesSinceLastClear < bufferSize) ? samplesSinceLastClear++ : 0;
+                if (samplesSinceLastClear < bufferSize) {
+                    samplesSinceLastClear++;
+                }
 
                 if (samplesSinceLastClear >= minimumSampleCount) {
                     // Calculate glide slope using the samples

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2179,7 +2179,7 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_GLIDESLOPE:
         {
             // Note: the element was originally named "Glide Slope" but actually shows the glide ratio 
-            // The original naming is conserved in places to retain compatibility 
+            // The original naming is conserved in places to retain compatibility but otherwise the code refers to it as glide ratio
             
             uint8_t sampleRate = osdConfig()->glide_sample_rate;
             uint8_t timeFrame = osdConfig()->glide_sample_time_frame;
@@ -2190,7 +2190,9 @@ static bool osdDrawSingleElement(uint8_t item)
             if (bufferSize == 0) {
                 // Allocation failed, display error
                 buff[0] = SYM_GLIDESLOPE;
-                buff[1] = buff[2] = buff[3] = '-';
+                buff[1] = 'E';
+                buff[2] = 'R';
+                buff[3] = 'R';
                 buff[4] = '\0';
                 break;
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2074,15 +2074,9 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_GLIDESLOPE:
         {
-            // float horizontalSpeed = gpsSol.groundSpeed;
-            // float sinkRate = -getEstimatedActualVelocity(Z);
-            // static pt1Filter_t gsFilterState;
-            // const timeMs_t currentTimeMs = millis();
-            // static timeMs_t gsUpdatedTimeMs;
-            // float glideSlope = horizontalSpeed / sinkRate;
-            // glideSlope = pt1FilterApply4(&gsFilterState, isnormal(glideSlope) ? glideSlope : 200, 0.5, MS2S(currentTimeMs - gsUpdatedTimeMs));
-            // gsUpdatedTimeMs = currentTimeMs;
-
+            // Note: the element was originally named "Glide Slope" but actually shows the glide ratio 
+            // The original naming is conserved in places to retain compatibility 
+            
             static uint8_t bufferSize = glideSampleRate * glideSampleTimeFrame;
             static glidePositionSample_t glideBuffer[20]; // Need to add semi-dynamic allocation based on glideSampleRate and glideSampleTimeFrame later to allow for changing this in settings
             static uint8_t glideBufferIndex = 0;
@@ -2090,7 +2084,7 @@ static bool osdDrawSingleElement(uint8_t item)
             const timeMs_t currentTime = millis();
             const uint16_t sampleIntervalMs = 1000 / glideSampleRate; 
 
-            static float glideSlope = 0.0f;
+            static float glideRatio = 0.0f;
             
             if (currentTime - glideLastSampleTime >= sampleIntervalMs) {
                 // Record a new sample
@@ -2103,14 +2097,14 @@ static bool osdDrawSingleElement(uint8_t item)
                 }
 
                 if (samplesSinceLastClear >= minimumSampleCount) {
-                    // Calculate glide slope using the samples
-
+                    // Calculate glide ratio using the samples
+                    glideRatio = calculateGlideRatioFromBuffer(glideBuffer, bufferSize);
                 }
             }
 
             buff[0] = SYM_GLIDESLOPE;
-            if (glideSlope > 0.0f && glideSlope < 100.0f) {
-                osdFormatCentiNumber(buff + 1, glideSlope * 100.0f, 0, 2, 0, 3, false);
+            if (glideRatio > 0.0f && glideRatio < 100.0f) {
+                osdFormatCentiNumber(buff + 1, glideRatio * 100.0f, 0, 2, 0, 3, false);
             } else {
                 buff[1] = buff[2] = buff[3] = '-';
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -198,7 +198,6 @@ typedef struct glidePositionSample_s {
     int32_t altitude_cm;     // Altitude
 } glidePositionSample_t;
 
-static const uint8_t minimumSampleCount = 5;      // Minimum number of samples in the timeframe to consider the glide slope valid
 
 // Lazy-allocated glide buffer
 static glidePositionSample_t *glideBuffer = NULL;
@@ -2185,6 +2184,7 @@ static bool osdDrawSingleElement(uint8_t item)
             uint8_t sampleRate = osdConfig()->glide_sample_rate;
             uint8_t timeFrame = osdConfig()->glide_sample_time_frame;
             const uint16_t requiredBufferSize = sampleRate * timeFrame;
+            const uint8_t minimumSampleCount = requiredBufferSize / 4;  // Require at least a quarter of the buffer to be filled with valid samples before showing a glide ratio
             uint16_t bufferSize = ensureGlideBufferAllocated(requiredBufferSize);
             
             if (bufferSize == 0) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -196,9 +196,9 @@ typedef struct glidePositionSample_s {
     int32_t altitude_cm;     // Altitude
 } glidePositionSample_t;
 
-static uint8_t glideSampleRate = 2;         // 2Hz
-static uint8_t glideSampleTimeFrame = 10;   // seconds
-static uint8_t minimumSampleCount = 5;      // Minimum number of samples in the timeframe to consider the glide slope valid
+static const uint8_t glideSampleRate = 2;         // 2Hz
+static const uint8_t glideSampleTimeFrame = 10;   // seconds
+static const uint8_t minimumSampleCount = 5;      // Minimum number of samples in the timeframe to consider the glide slope valid
 
 static statistic_t stats;
 
@@ -2077,7 +2077,7 @@ static bool osdDrawSingleElement(uint8_t item)
             // Note: the element was originally named "Glide Slope" but actually shows the glide ratio 
             // The original naming is conserved in places to retain compatibility 
             
-            static uint8_t bufferSize = glideSampleRate * glideSampleTimeFrame;
+            const uint8_t bufferSize = glideSampleRate * glideSampleTimeFrame;
             static glidePositionSample_t glideBuffer[20]; // Need to add semi-dynamic allocation based on glideSampleRate and glideSampleTimeFrame later to allow for changing this in settings
             static uint8_t glideBufferIndex = 0;
             static uint8_t samplesSinceLastClear = 0;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -204,6 +204,11 @@ static glidePositionSample_t *glideBuffer = NULL;
 static uint16_t glideBufferAllocatedSize = 0;
 static uint16_t glideBufferCurrentSize = 0;
 
+// Calculated glide ratio (distance per unit altitude descent)
+// Available for use by multiple OSD elements
+static float currentGlideRatio = 0.0f;
+static bool useGlideElement = false; // Whether any glide element is enabled, used to determine whether glide ratio calculation needs to be performed
+
 static statistic_t stats;
 
 static timeUs_t resumeRefreshAt = 0;
@@ -1941,6 +1946,69 @@ static float calculateGlideRatioFromBuffer(const glidePositionSample_t *buffer, 
     return 0.0f;  // Out of reasonable range
 }
 
+// Update glide ratio calculation
+// Called regularly to maintain glide ratio buffer regardless of OSD element visibility
+// This ensures glide ratio is available for all OSD elements that need it
+static void updateGlideRatioCalculation(void) {
+    uint8_t sampleRate = osdConfig()->glide_sample_rate;
+    uint8_t timeFrame = osdConfig()->glide_sample_time_frame;
+    const uint16_t requiredBufferSize = sampleRate * timeFrame;
+    const uint8_t minimumSampleCount = requiredBufferSize / 4;
+    
+    uint16_t bufferSize = ensureGlideBufferAllocated(requiredBufferSize);
+    
+    if (bufferSize == 0) {
+        // Allocation failed
+        currentGlideRatio = 0.0f;
+        return;
+    }
+    
+    static uint8_t glideBufferIndex = 0;
+    static timeMs_t glideLastSampleTime = 0;
+    static uint8_t samplesSinceLastClear = 0;
+    const timeMs_t currentTime = millis();
+    const uint16_t sampleIntervalMs = 1000 / sampleRate;
+
+    if (currentTime - glideLastSampleTime >= sampleIntervalMs) {
+        // Record a new sample
+        glideLastSampleTime = currentTime;
+        if (!isDataValidForGlideRatio()) {
+            // Conditions not valid for glide ratio, reset buffer
+            for (uint16_t i = 0; i < bufferSize; i++) {
+                glideBuffer[i].distance_cm = 0;
+                glideBuffer[i].altitude_cm = 0;
+            }
+            currentGlideRatio = 0.0f;
+            samplesSinceLastClear = 0;
+            glideBufferIndex = 0;
+        }
+        else {
+            glideBuffer[glideBufferIndex].distance_cm = getTotalTravelDistance();
+            glideBuffer[glideBufferIndex].altitude_cm = osdGetAltitude();
+            glideBufferIndex = (glideBufferIndex + 1) % bufferSize;
+
+            if (samplesSinceLastClear < bufferSize) {
+                samplesSinceLastClear++;
+            }
+
+            if (samplesSinceLastClear >= minimumSampleCount) {
+                // Calculate glide ratio using only the valid samples collected
+                currentGlideRatio = calculateGlideRatioFromBuffer(glideBuffer, samplesSinceLastClear);
+            }
+            else {
+                currentGlideRatio = 0.0f;  // Not enough samples yet
+            }
+        }
+    }
+}
+
+static void enableGlideRatioCalculation(void) {
+    if (!useGlideElement) {
+        useGlideElement = true;
+        updateGlideRatioCalculation();  // Start calculation immediately when element is enabled
+    }
+}
+
 static bool osdDrawSingleElement(uint8_t item)
 {
     uint16_t pos = osdLayoutsConfig()->item_pos[currentLayout][item];
@@ -2178,67 +2246,10 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_GLIDESLOPE:
         {
-            // Note: the element was originally named "Glide Slope" but actually shows the glide ratio 
-            // The original naming is conserved in places to retain compatibility but otherwise the code refers to it as glide ratio
-            
-            uint8_t sampleRate = osdConfig()->glide_sample_rate;
-            uint8_t timeFrame = osdConfig()->glide_sample_time_frame;
-            const uint16_t requiredBufferSize = sampleRate * timeFrame;
-            const uint8_t minimumSampleCount = requiredBufferSize / 4;  // Require at least a quarter of the buffer to be filled with valid samples before showing a glide ratio
-            uint16_t bufferSize = ensureGlideBufferAllocated(requiredBufferSize);
-            
-            if (bufferSize == 0) {
-                // Allocation failed, display error
-                buff[0] = SYM_GLIDESLOPE;
-                buff[1] = 'E';
-                buff[2] = 'R';
-                buff[3] = 'R';
-                buff[4] = '\0';
-                break;
-            }
-            
-            static uint8_t glideBufferIndex = 0;
-            static timeMs_t glideLastSampleTime = 0;
-            static uint8_t samplesSinceLastClear = 0;
-            const timeMs_t currentTime = millis();
-            const uint16_t sampleIntervalMs = 1000 / sampleRate;
-            static float glideRatio = 0.0f;
-
-            if (currentTime - glideLastSampleTime >= sampleIntervalMs) {
-                // Record a new sample
-                glideLastSampleTime = currentTime;
-                if (!isDataValidForGlideRatio()) {
-                    // Conditions not valid for glide ratio, reset buffer
-                    for (uint16_t i = 0; i < bufferSize; i++) {
-                        glideBuffer[i].distance_cm = 0;
-                        glideBuffer[i].altitude_cm = 0;
-                    }
-                    glideRatio = 0.0f;
-                    samplesSinceLastClear = 0;
-                    glideBufferIndex = 0;
-                }
-                else {
-                    glideBuffer[glideBufferIndex].distance_cm = getTotalTravelDistance();
-                    glideBuffer[glideBufferIndex].altitude_cm = osdGetAltitude();
-                    glideBufferIndex = (glideBufferIndex + 1) % bufferSize;
-
-                    if (samplesSinceLastClear < bufferSize) {
-                        samplesSinceLastClear++;
-                    }
-
-                    if (samplesSinceLastClear >= minimumSampleCount) {
-                        // Calculate glide ratio using only the valid samples collected
-                        glideRatio = calculateGlideRatioFromBuffer(glideBuffer, samplesSinceLastClear);
-                    }
-                    else {
-                        glideRatio = 0.0f;  // Not enough samples yet
-                    }
-                }
-            }
-
+            enableGlideRatioCalculation();  // Ensure glide ratio calculation is running if this element is enabled
             buff[0] = SYM_GLIDESLOPE;
-            if (glideRatio > 0.0f && glideRatio < 100.0f) {
-                osdFormatCentiNumber(buff + 1, glideRatio * 100.0f, 0, 2, 0, 3, false);
+            if (currentGlideRatio > 0.0f && currentGlideRatio < 100.0f) {
+                osdFormatCentiNumber(buff + 1, currentGlideRatio * 100.0f, 0, 2, 0, 3, false);
             } else {
                 buff[1] = buff[2] = buff[3] = '-';
             }
@@ -6024,6 +6035,10 @@ static bool osdIsPageDownStickCommandHeld(void)
 static void osdRefresh(timeUs_t currentTimeUs)
 {
     osdFilterData(currentTimeUs);
+    
+    if (useGlideElement) {
+        updateGlideRatioCalculation();
+    }
 
 #ifdef USE_CMS
     if (IS_RC_MODE_ACTIVE(BOXOSD) && (!cmsInMenu) && !(osdConfig()->osd_failsafe_switch_layout && FLIGHT_MODE(FAILSAFE_MODE))) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3368,7 +3368,7 @@ static bool osdDrawSingleElement(uint8_t item)
             int32_t altitude = osdGetAltitude();
             buff[0] = SYM_GLIDE_DIST;
             if (currentGlideRatio <= 0.0f || altitude <= 0) {
-                tfp_sprintf(buff, "%s%c", "---", SYM_BLANK);
+                tfp_sprintf(buff + 1, "%s%c", "---", SYM_BLANK);
                 buff[5] = '\0';
                 break;
             }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1874,6 +1874,23 @@ static uint16_t ensureGlideBufferAllocated(uint16_t requiredSize)
     return requiredSize;
 }
 
+static bool isDataValidForGlideRatio() {
+    // Check if we have been ascending for more than 5 seconds, which would indicate that the glide ratio is not valid
+    static timeMs_t lastDescentTime = 0;
+    if (getEstimatedActualVelocity(Z) < 0) {  // Descending
+        lastDescentTime = millis();
+    } else if (millis() - lastDescentTime > 5000) {  // Ascending for more than 5 seconds
+        return false;
+    }
+
+    // Check if the throttle is above a certain threshold, which would indicate that we are under power and the glide ratio is not valid
+    if (getThrottlePercent(true) > 10) { 
+        return false;
+    }
+
+    return true;
+}
+
 
 // Linear regression: calculate glide ratio from position samples
 // Returns glide ratio (horizontal distance per 1 unit vertical descent)
@@ -2182,23 +2199,40 @@ static bool osdDrawSingleElement(uint8_t item)
             
             static uint8_t glideBufferIndex = 0;
             static timeMs_t glideLastSampleTime = 0;
+            static uint8_t samplesSinceLastClear = 0;
             const timeMs_t currentTime = millis();
             const uint16_t sampleIntervalMs = 1000 / sampleRate;
             static float glideRatio = 0.0f;
-            
+
             if (currentTime - glideLastSampleTime >= sampleIntervalMs) {
                 // Record a new sample
-                glideLastSampleTime = currentTime;
-                glideBuffer[glideBufferIndex].distance_cm = getTotalTravelDistance();
-                glideBuffer[glideBufferIndex].altitude_cm = osdGetAltitude();
-                glideBufferIndex = (glideBufferIndex + 1) % bufferSize;
-                if (glideBufferCurrentSize < bufferSize) {
-                    glideBufferCurrentSize++;
-                }
 
-                if (glideBufferCurrentSize >= minimumSampleCount) {
-                    // Calculate glide ratio using the samples
-                    glideRatio = calculateGlideRatioFromBuffer(glideBuffer, glideBufferCurrentSize);
+                if (!isDataValidForGlideRatio()) {
+                    // Conditions not valid for glide ratio, reset buffer
+                    for (uint16_t i = 0; i < bufferSize; i++) {
+                        glideBuffer[i].distance_cm = 0;
+                        glideBuffer[i].altitude_cm = 0;
+                    }
+                    glideRatio = 0.0f;
+                    samplesSinceLastClear = 0;
+                }
+                else {
+                    glideLastSampleTime = currentTime;
+                    glideBuffer[glideBufferIndex].distance_cm = getTotalTravelDistance();
+                    glideBuffer[glideBufferIndex].altitude_cm = osdGetAltitude();
+                    glideBufferIndex = (glideBufferIndex + 1) % bufferSize;
+
+                    if (samplesSinceLastClear < bufferSize) {
+                        samplesSinceLastClear++;
+                    }
+
+                    if (samplesSinceLastClear >= minimumSampleCount) {
+                        // Calculate glide ratio using the samples
+                        glideRatio = calculateGlideRatioFromBuffer(glideBuffer, bufferSize);
+                    }
+                    else {
+                        glideRatio = 0.0f;  // Not enough samples yet
+                    }
                 }
             }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1877,7 +1877,7 @@ static bool isDataValidForGlideRatio(void) {
     static timeMs_t lastDescentTime = 0;
     if (getEstimatedActualVelocity(Z) < 0) {  // Descending
         lastDescentTime = millis();
-    } else if (millis() - lastDescentTime > 4000) {  // Ascending for more than 4 seconds
+    } else if (millis() - lastDescentTime > 4000) {  // Not descending for more than 4 seconds
         return false;
     }
 
@@ -2213,6 +2213,7 @@ static bool osdDrawSingleElement(uint8_t item)
                     }
                     glideRatio = 0.0f;
                     samplesSinceLastClear = 0;
+                    glideBufferIndex = 0;
                 }
                 else {
                     glideBuffer[glideBufferIndex].distance_cm = getTotalTravelDistance();
@@ -2224,8 +2225,8 @@ static bool osdDrawSingleElement(uint8_t item)
                     }
 
                     if (samplesSinceLastClear >= minimumSampleCount) {
-                        // Calculate glide ratio using the samples
-                        glideRatio = calculateGlideRatioFromBuffer(glideBuffer, bufferSize);
+                        // Calculate glide ratio using only the valid samples collected
+                        glideRatio = calculateGlideRatioFromBuffer(glideBuffer, samplesSinceLastClear);
                     }
                     else {
                         glideRatio = 0.0f;  // Not enough samples yet

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1837,6 +1837,59 @@ static bool osdElementEnabled(uint8_t elementID, bool onlyCurrentLayout) {
     return elementEnabled;
 }
 
+
+// Linear regression: calculate glide ratio from position samples
+// Returns glide ratio (horizontal distance per 1 unit vertical descent)
+// Returns 0 if insufficient data or invalid conditions
+static float calculateGlideRatioFromBuffer(const glidePositionSample_t *buffer, uint8_t sampleCount)
+{
+    // Least-squares linear regression: y = mx + b
+    // where x = horizontal distance, y = altitude
+    // We need: sumX, sumY, sumX², sumXY, and n (sample count)
+    
+    float sumX = 0.0f;      // sum of distances
+    float sumY = 0.0f;      // sum of altitudes  
+    float sumXY = 0.0f;     // sum of (distance * altitude)
+    float sumX2 = 0.0f;     // sum of (distance²)
+    
+    for (uint8_t i = 0; i < sampleCount; i++) {
+        float x = (float)buffer[i].distance_cm;
+        float y = (float)buffer[i].altitude_cm;
+        
+        sumX += x;
+        sumY += y;
+        sumXY += x * y;
+        sumX2 += x * x;
+    }
+    
+    // Slope formula: m = (n·Σxy - Σx·Σy) / (n·Σx² - (Σx)²)
+    float n = (float)sampleCount;
+    float numerator = n * sumXY - sumX * sumY;
+    float denominator = n * sumX2 - sumX * sumX;
+    
+    // Avoid division by zero or degenerate cases
+    if (fabsf(denominator) < 1e-6f) {
+        return 0.0f;  // Not enough variation in distance
+    }
+    
+    float slope = numerator / denominator;  // altitude_change / distance_change
+    
+    // For descent, slope should be negative
+    if (slope >= 0.0f) {
+        return 0.0f;  // Not descending
+    }
+    
+    // Glide ratio = distance / |altitude_change| = 1 / |slope|
+    float glideRatio = -1.0f / slope;
+    
+    // Sanity check: reasonable glide ratios are 1-100
+    if (glideRatio > 0.1f && glideRatio < 100.0f) {
+        return glideRatio;
+    }
+    
+    return 0.0f;  // Out of reasonable range
+}
+
 static bool osdDrawSingleElement(uint8_t item)
 {
     uint16_t pos = osdLayoutsConfig()->item_pos[currentLayout][item];
@@ -6500,6 +6553,7 @@ void osdEraseCustomItem(uint8_t item){
     }
 
 }
+
 
 #endif // OSD
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2084,9 +2084,8 @@ static bool osdDrawSingleElement(uint8_t item)
             // gsUpdatedTimeMs = currentTimeMs;
 
             static uint8_t bufferSize = glideSampleRate * glideSampleTimeFrame;
-            static glidePositionSample_t glideBuffer[bufferSize] = 0;
-            static uint16_t glideBufferIndex = 0;
-            static timeMs_t glideLastSampleTime = 0;
+            static glidePositionSample_t glideBuffer[20]; // Need to add semi-dynamic allocation based on glideSampleRate and glideSampleTimeFrame later to allow for changing this in settings
+            static uint8_t glideBufferIndex = 0;
             static uint8_t samplesSinceLastClear = 0;
             const timeMs_t currentTime = millis();
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1959,6 +1959,7 @@ static void updateGlideRatioCalculation(void) {
     const uint16_t requiredBufferSize = sampleRate * timeFrame;
     const uint8_t minimumSampleCount = requiredBufferSize / 4;
     
+    static uint16_t previousBufferSize = 0;
     uint16_t bufferSize = ensureGlideBufferAllocated(requiredBufferSize);
     
     if (bufferSize == 0) {
@@ -1972,6 +1973,14 @@ static void updateGlideRatioCalculation(void) {
     static uint8_t samplesSinceLastClear = 0;
     const timeMs_t currentTime = millis();
     const uint16_t sampleIntervalMs = 1000 / sampleRate;
+
+    // Reset sampling state if buffer size changed
+    if (bufferSize != previousBufferSize) {
+        previousBufferSize = bufferSize;
+        glideBufferIndex = 0;
+        samplesSinceLastClear = 0;
+        glideLastSampleTime = 0;  // Reset to take sample immediately after resize
+    }
 
     if (currentTime - glideLastSampleTime >= sampleIntervalMs) {
         // Record a new sample

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1874,7 +1874,7 @@ static uint16_t ensureGlideBufferAllocated(uint16_t requiredSize)
     return requiredSize;
 }
 
-static bool isDataValidForGlideRatio() {
+static bool isDataValidForGlideRatio(void) {
     // Check if we have been ascending for more than 4 seconds, which would indicate that the glide ratio is not valid
     static timeMs_t lastDescentTime = 0;
     if (getEstimatedActualVelocity(Z) < 0) {  // Descending

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -198,8 +198,6 @@ typedef struct glidePositionSample_s {
     int32_t altitude_cm;     // Altitude
 } glidePositionSample_t;
 
-static const uint8_t glideSampleRate = 2;         // 2Hz
-static const uint8_t glideSampleTimeFrame = 10;   // seconds
 static const uint8_t minimumSampleCount = 5;      // Minimum number of samples in the timeframe to consider the glide slope valid
 
 // Lazy-allocated glide buffer

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1849,6 +1849,15 @@ static uint16_t ensureGlideBufferAllocated(uint16_t requiredSize)
     if (requiredSize > MAX_GLIDE_BUFFER_SIZE) {
         requiredSize = MAX_GLIDE_BUFFER_SIZE;
     }
+
+    if (requiredSize == 0) {
+        // Free buffer if no longer needed
+        free(glideBuffer);
+        glideBuffer = NULL;
+        glideBufferAllocatedSize = 0;
+        glideBufferCurrentSize = 0;
+        return 0;
+    }
     
     // If already allocated with correct size, return it
     if (glideBuffer != NULL && glideBufferAllocatedSize == requiredSize) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1326,21 +1326,16 @@ static inline int32_t osdGetAltitudeMsl(void)
 }
 
 uint16_t osdGetRemainingGlideTime(void) {
-    float value = getEstimatedActualVelocity(Z);
-    static pt1Filter_t glideTimeFilterState;
-    const  timeMs_t curTimeMs = millis();
-    static timeMs_t glideTimeUpdatedMs;
-
-    value = pt1FilterApply4(&glideTimeFilterState, isnormal(value) ? value : 0, 0.5, MS2S(curTimeMs - glideTimeUpdatedMs));
-    glideTimeUpdatedMs = curTimeMs;
-
-    if (value < 0) {
-        value = osdGetAltitude() / abs((int)value);
-    } else {
-        value = 0;
+    // Use glide ratio if available and valid
+    uint16_t glideTime = 0;
+    if (currentGlideRatio > 0.0f) {
+        int32_t altitude = osdGetAltitude();
+        int16_t groundSpeed = gpsSol.groundSpeed;
+        if (altitude > 0 && groundSpeed > 0) {
+           glideTime = (uint16_t)((float)altitude * currentGlideRatio / groundSpeed);
+        }
     }
-
-    return (uint16_t)roundf(value);
+    return glideTime;
 }
 
 static bool osdIsHeadingValid(void)
@@ -3330,6 +3325,7 @@ static bool osdDrawSingleElement(uint8_t item)
         }
     case OSD_GLIDE_TIME_REMAINING:
         {
+            enableGlideRatioCalculation();
             uint16_t glideTime = osdGetRemainingGlideTime();
             buff[0] = SYM_GLIDE_MINS;
             if (glideTime > 0) {
@@ -3350,14 +3346,18 @@ static bool osdDrawSingleElement(uint8_t item)
         }
     case OSD_GLIDE_RANGE:
         {
-            uint16_t glideSeconds = osdGetRemainingGlideTime();
+            enableGlideRatioCalculation();
+            int32_t altitude = osdGetAltitude();
             buff[0] = SYM_GLIDE_DIST;
-            if (glideSeconds > 0) {
-                uint32_t glideRangeCM = glideSeconds * gpsSol.groundSpeed;
-                osdFormatDistanceSymbol(buff + 1, glideRangeCM, 0, 3);
-            } else {
-                tfp_sprintf(buff + 1, "%s%c", "---", SYM_BLANK);
+            if (currentGlideRatio <= 0.0f || altitude <= 0) {
+                tfp_sprintf(buff, "%s%c", "---", SYM_BLANK);
                 buff[5] = '\0';
+                break;
+            }
+            else
+            {
+                int32_t glideRangeCm = (int32_t)(currentGlideRatio * altitude);
+                osdFormatDistanceSymbol(buff + 1, glideRangeCm, 0, 3);
             }
             break;
         }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2206,7 +2206,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
             if (currentTime - glideLastSampleTime >= sampleIntervalMs) {
                 // Record a new sample
-
+                glideLastSampleTime = currentTime;
                 if (!isDataValidForGlideRatio()) {
                     // Conditions not valid for glide ratio, reset buffer
                     for (uint16_t i = 0; i < bufferSize; i++) {
@@ -2217,7 +2217,6 @@ static bool osdDrawSingleElement(uint8_t item)
                     samplesSinceLastClear = 0;
                 }
                 else {
-                    glideLastSampleTime = currentTime;
                     glideBuffer[glideBufferIndex].distance_cm = getTotalTravelDistance();
                     glideBuffer[glideBufferIndex].altitude_cm = osdGetAltitude();
                     glideBufferIndex = (glideBufferIndex + 1) % bufferSize;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -191,6 +191,8 @@ typedef struct statistic_s {
     int32_t flightStartMWh;
 } statistic_t;
 
+#define MAX_GLIDE_BUFFER_SIZE 240  // Maximum samples: 4 Hz * 60 seconds
+
 typedef struct glidePositionSample_s {
     uint32_t distance_cm;    // Total travel distance
     int32_t altitude_cm;     // Altitude
@@ -199,6 +201,11 @@ typedef struct glidePositionSample_s {
 static const uint8_t glideSampleRate = 2;         // 2Hz
 static const uint8_t glideSampleTimeFrame = 10;   // seconds
 static const uint8_t minimumSampleCount = 5;      // Minimum number of samples in the timeframe to consider the glide slope valid
+
+// Lazy-allocated glide buffer
+static glidePositionSample_t *glideBuffer = NULL;
+static uint16_t glideBufferAllocatedSize = 0;
+static uint16_t glideBufferCurrentSize = 0;
 
 static statistic_t stats;
 
@@ -1837,6 +1844,36 @@ static bool osdElementEnabled(uint8_t elementID, bool onlyCurrentLayout) {
     return elementEnabled;
 }
 
+// Manage lazy allocation and reallocation of glide buffer
+// Returns the current buffer size, or 0 if allocation failed
+static uint16_t ensureGlideBufferAllocated(uint16_t requiredSize)
+{
+    // Clamp to maximum size
+    if (requiredSize > MAX_GLIDE_BUFFER_SIZE) {
+        requiredSize = MAX_GLIDE_BUFFER_SIZE;
+    }
+    
+    // If already allocated with correct size, return it
+    if (glideBuffer != NULL && glideBufferAllocatedSize == requiredSize) {
+        return requiredSize;
+    }
+    
+    // Need to allocate or reallocate
+    glidePositionSample_t *newBuffer = (glidePositionSample_t *)realloc(glideBuffer, requiredSize * sizeof(glidePositionSample_t));
+    
+    if (newBuffer == NULL) {
+        return 0;  // Allocation failed, keep old buffer
+    }
+    
+    glideBuffer = newBuffer;
+    glideBufferAllocatedSize = requiredSize;
+    
+    // Reset sample tracking when buffer changes size
+    glideBufferCurrentSize = 0;
+    
+    return requiredSize;
+}
+
 
 // Linear regression: calculate glide ratio from position samples
 // Returns glide ratio (horizontal distance per 1 unit vertical descent)
@@ -2130,14 +2167,23 @@ static bool osdDrawSingleElement(uint8_t item)
             // Note: the element was originally named "Glide Slope" but actually shows the glide ratio 
             // The original naming is conserved in places to retain compatibility 
             
-            const uint8_t bufferSize = glideSampleRate * glideSampleTimeFrame;
-            static glidePositionSample_t glideBuffer[20]; // Need to add semi-dynamic allocation based on glideSampleRate and glideSampleTimeFrame later to allow for changing this in settings
+            uint8_t sampleRate = osdConfig()->glide_sample_rate;
+            uint8_t timeFrame = osdConfig()->glide_sample_time_frame;
+            const uint16_t requiredBufferSize = sampleRate * timeFrame;
+            uint16_t bufferSize = ensureGlideBufferAllocated(requiredBufferSize);
+            
+            if (bufferSize == 0) {
+                // Allocation failed, display error
+                buff[0] = SYM_GLIDESLOPE;
+                buff[1] = buff[2] = buff[3] = '-';
+                buff[4] = '\0';
+                break;
+            }
+            
             static uint8_t glideBufferIndex = 0;
-            static uint8_t samplesSinceLastClear = 0;
             static timeMs_t glideLastSampleTime = 0;
             const timeMs_t currentTime = millis();
-            const uint16_t sampleIntervalMs = 1000 / glideSampleRate; 
-
+            const uint16_t sampleIntervalMs = 1000 / sampleRate;
             static float glideRatio = 0.0f;
             
             if (currentTime - glideLastSampleTime >= sampleIntervalMs) {
@@ -2146,13 +2192,13 @@ static bool osdDrawSingleElement(uint8_t item)
                 glideBuffer[glideBufferIndex].distance_cm = getTotalTravelDistance();
                 glideBuffer[glideBufferIndex].altitude_cm = osdGetAltitude();
                 glideBufferIndex = (glideBufferIndex + 1) % bufferSize;
-                if (samplesSinceLastClear < bufferSize) {
-                    samplesSinceLastClear++;
+                if (glideBufferCurrentSize < bufferSize) {
+                    glideBufferCurrentSize++;
                 }
 
-                if (samplesSinceLastClear >= minimumSampleCount) {
+                if (glideBufferCurrentSize >= minimumSampleCount) {
                     // Calculate glide ratio using the samples
-                    glideRatio = calculateGlideRatioFromBuffer(glideBuffer, bufferSize);
+                    glideRatio = calculateGlideRatioFromBuffer(glideBuffer, glideBufferCurrentSize);
                 }
             }
 
@@ -4494,7 +4540,9 @@ PG_RESET_TEMPLATE(osdConfig_t, osdConfig,
     .stats_page_auto_swap_time = SETTING_OSD_STATS_PAGE_AUTO_SWAP_TIME_DEFAULT,
     .stats_show_metric_efficiency = SETTING_OSD_STATS_SHOW_METRIC_EFFICIENCY_DEFAULT,
 
-    .radar_peers_display_time = SETTING_OSD_RADAR_PEERS_DISPLAY_TIME_DEFAULT
+    .radar_peers_display_time = SETTING_OSD_RADAR_PEERS_DISPLAY_TIME_DEFAULT,
+    .glide_sample_rate = SETTING_OSD_GLIDE_SAMPLE_RATE_DEFAULT,
+    .glide_sample_time_frame = SETTING_OSD_GLIDE_SAMPLE_TIME_FRAME_DEFAULT
 );
 
 void pgResetFn_osdLayoutsConfig(osdLayoutsConfig_t *osdLayoutsConfig)

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1945,8 +1945,8 @@ static float calculateGlideRatioFromBuffer(const glidePositionSample_t *buffer, 
 // Called regularly to maintain glide ratio buffer regardless of OSD element visibility
 // This ensures glide ratio is available for all OSD elements that need it
 static void updateGlideRatioCalculation(void) {
-    uint8_t sampleRate = osdConfig()->glide_sample_rate;
-    uint8_t timeFrame = osdConfig()->glide_sample_time_frame;
+    uint8_t sampleRate = osdConfig()->glide_sample_rate > 0 ? osdConfig()->glide_sample_rate : 1;  // Default to 1 sample/sec if misconfigured
+    uint8_t timeFrame = osdConfig()->glide_sample_time_frame > 0 ? osdConfig()->glide_sample_time_frame : 5;  // Default to 5 seconds if misconfigured
     const uint16_t requiredBufferSize = sampleRate * timeFrame;
     const uint8_t minimumSampleCount = requiredBufferSize / 4;
     

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2088,10 +2088,11 @@ static bool osdDrawSingleElement(uint8_t item)
             static uint8_t glideBufferIndex = 0;
             static uint8_t samplesSinceLastClear = 0;
             const timeMs_t currentTime = millis();
+            const uint16_t sampleIntervalMs = 1000 / glideSampleRate; 
 
             static float glideSlope = 0.0f;
             
-            if (currentTime - glideLastSampleTime >= glideSampleRate) {
+            if (currentTime - glideLastSampleTime >= sampleIntervalMs) {
                 // Record a new sample
                 glideLastSampleTime = currentTime;
                 glideBuffer[glideBufferIndex].distance_cm = getTotalTravelDistance();

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -540,6 +540,8 @@ typedef struct osdConfig_s {
     uint8_t geozoneDistanceWarning;                     // Distance to fence or action
     bool geozoneDistanceType;                            // Shows a countdown timer or distance to fence/action
 #endif
+    uint8_t  glide_sample_rate;                         // Glide slope sampling rate in Hz (default 2)
+    uint8_t  glide_sample_time_frame;                   // Glide slope sampling time frame in seconds (default 10)
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);


### PR DESCRIPTION
This PR refactors the original instantaneous velocity based OSD Glide Slope implementation to instead use absolute altitude and total travel distance sampling and a linear regression model to calculate a more reliable and stable glide slope.

This leads to a more stable and consistent reading of glide related OSD elements.

This is a remake of my older PR (#11520) which tried to achieve the same results via filtering on the instantaneous velocity inputs, but that proved insufficient so I went with this approach instead.

For reference, there are two new variables added to the CLI settings:
- name: osd_glide_sample_rate
        description: "Glide slope sampling rate in Hz (1-4 Hz). Higher rates give more responsive glide slope calculations but use more CPU."
        field: glide_sample_rate
        type: uint8_t
        min: 1
        max: 4
        default_value: 2
- name: osd_glide_sample_time_frame
        description: "Glide slope sampling time frame in seconds (5-60 seconds). Longer frames provide more stable glide slope estimates."
        field: glide_sample_time_frame
        type: uint8_t
        min: 5
        max: 60
        default_value: 10
        
These values are ultimately user preference, especially the time frame. 
Longer time frame = more stable glide slope but slower to react to changes in conditions.
Shorter time frame = more unstable glide slope but faster to react to changes in conditions
