### PR TITLE
FW autotrim: replace servo_autotrim_iterm_rate_limit setting with hardcoded constant

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -6052,16 +6052,6 @@ When feature SERIALRX is enabled, this allows connection to several receivers wh
 
 ---
 
-### servo_autotrim_iterm_rate_limit
-
-Maximum I-term rate of change (units/sec) for autotrim to be applied. Prevents trim updates during maneuver transitions when I-term is changing rapidly. Only applies when using `feature FW_AUTOTRIM`.
-
-| Default | Min | Max |
-| --- | --- | --- |
-| 2 | 0 | 50 |
-
----
-
 ### servo_autotrim_rotation_limit
 
 Servo midpoints are only updated when total aircraft rotation is less than this threshold [deg/s]. Only applies when using `feature FW_AUTOTRIM`.

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1361,11 +1361,6 @@ groups:
         default_value: 15
         min: 1
         max: 60
-      - name: servo_autotrim_iterm_rate_limit
-        description: "Maximum I-term rate of change (units/sec) for autotrim to be applied. Prevents trim updates during maneuver transitions when I-term is changing rapidly. Only applies when using `feature FW_AUTOTRIM`."
-        default_value: 2
-        min: 0
-        max: 50
 
   - name: PG_CONTROL_PROFILES
     type: controlConfig_t

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -608,6 +608,7 @@ void processServoAutotrimMode(void)
 #define SERVO_AUTOTRIM_CENTER_MAX       1700
 #define SERVO_AUTOTRIM_UPDATE_SIZE      5
 #define SERVO_AUTOTRIM_ATTITUDE_LIMIT   50       // 5 degrees
+#define SERVO_AUTOTRIM_ITERM_RATE_LIMIT 30  // ~90th percentile during stable cruise (blackbox-derived)
 
 void processContinuousServoAutotrim(const float dT)
 {
@@ -646,7 +647,7 @@ void processContinuousServoAutotrim(const float dT)
                 for (int axis = FD_ROLL; axis <= FD_PITCH; axis++) {
                     // For each stabilized axis, add 5 units of I-term to all associated servo midpoints
                     const float axisIterm = getAxisIterm(axis);
-                    const bool itermIsStable = itermRateOfChange[axis] < servoConfig()->servo_autotrim_iterm_rate_limit;
+                    const bool itermIsStable = itermRateOfChange[axis] < SERVO_AUTOTRIM_ITERM_RATE_LIMIT;
 
                     if (fabsf(axisIterm) > SERVO_AUTOTRIM_UPDATE_SIZE && itermIsStable) {
                         const int8_t ItermUpdate = axisIterm > 0.0f ? SERVO_AUTOTRIM_UPDATE_SIZE : -SERVO_AUTOTRIM_UPDATE_SIZE;

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -171,7 +171,6 @@ typedef struct servoConfig_s {
     uint8_t tri_unarmed_servo;              // send tail servo correction pulses even when unarmed
     uint8_t servo_autotrim_rotation_limit;  // Max rotation for servo midpoints to be updated
     uint8_t servo_autotrim_iterm_threshold; // How much of the Iterm is carried over to the servo midpoints on each update
-    uint8_t servo_autotrim_iterm_rate_limit; // Max I-term rate of change (units/sec) to apply autotrim
 } servoConfig_t;
 
 PG_DECLARE(servoConfig_t, servoConfig);


### PR DESCRIPTION
## Summary

Removes the `servo_autotrim_iterm_rate_limit` CLI setting introduced in #11215 and replaces it with the hardcoded constant `SERVO_AUTOTRIM_ITERM_RATE_LIMIT 30`.

Blackbox analysis of real flight i-term data shows:
- Median rate during stable cruise: 4–9 units/s
- 90th percentile: ~30 units/s
- The `planeIsFlyingStraight` gyro guard already rejects most unsettled post-maneuver windows, the rate check also protects against turbulence-driven i-term spikes during otherwise-quiet cruise

A value of 30 (the ~90th percentile) gives appropriate protection without exposing a tuning knob that pilots cannot meaningfully calibrate.

## Changes

- `src/main/flight/servos.c`: Add `#define SERVO_AUTOTRIM_ITERM_RATE_LIMIT 30` grouped with the other autotrim defines; replace `servoConfig()->servo_autotrim_iterm_rate_limit` with the constant
- `src/main/flight/servos.h`: Remove `uint8_t servo_autotrim_iterm_rate_limit` from `servoConfig_t`
- `src/main/fc/settings.yaml`: Remove the `servo_autotrim_iterm_rate_limit` setting entry

No PG version bump required because the tunable setting was for testing only and never released. Also field was at the end of `servoConfig_t`, so existing EEPROM blocks may load safely  anyway.

Thanks @error414  !
