### PR TITLE
Bump firmware version to 9.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
 endif()
 
 
-project(INAV VERSION 9.0.1)
+project(INAV VERSION 9.1.0)
 
 
 enable_language(ASM)


### PR DESCRIPTION
## Summary

- Bumps `CMakeLists.txt` version from `9.0.1` to `9.1.0` in preparation for the 9.1.0-RC1 release.

## Test plan

- [ ] Verify `project(INAV VERSION 9.1.0)` in `CMakeLists.txt`
- [ ] Confirm build system picks up the new version string