### PR TITLE
Add pinioBoxConfig_t to PG struct sizes reference database

### DIFF
--- a/cmake/pg_struct_sizes.reference.db
+++ b/cmake/pg_struct_sizes.reference.db
@@ -47,3 +47,4 @@ telemetryConfig_t               58 8
 timeConfig_t                     4 1
 vtxConfig_t                     55 4
 vtxSettingsConfig_t             12 2
+pinioBoxConfig_t                 4 1


### PR DESCRIPTION
## Summary

`pinioBoxConfig_t` was missing from `cmake/pg_struct_sizes.reference.db` despite the reference target (SPEEDYBEEF745AIO) having `USE_PINIO` and `USE_PINIOBOX` defined. It was simply omitted when the reference database was first generated.

- **Struct:** `uint8_t permanentId[PINIO_COUNT]` → 4 bytes
- **PG version:** 1 (from `PG_REGISTER_WITH_RESET_TEMPLATE(..., PG_PINIOBOX_CONFIG, 1)`)
- `pinioBoxConfig_t` has been present in INAV for ~8 years

## Changes

- `cmake/pg_struct_sizes.reference.db`: add `pinioBoxConfig_t 4 1`

## Test plan

- [ ] Confirm SPEEDYBEEF745AIO has `USE_PINIOBOX` in `target.h` ✓
- [ ] Confirm `PINIO_COUNT = 4` and PG version = 1 in source ✓
- [ ] Verify `validate-pg-for-release.sh` passes after this change