### PR TITLE
AEDROXH7: fix LED strip DMA conflict with motor outputs

### DIFF
--- a/src/main/target/AEDROXH7/target.c
+++ b/src/main/target/AEDROXH7/target.c
@@ -42,8 +42,8 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM1, CH3, PE13, TIM_USE_OUTPUT_AUTO, 0, 6),  // M7
     DEF_TIM(TIM1, CH4, PE14, TIM_USE_OUTPUT_AUTO, 0, 7),  // M8
 
-    // LED strip: TIM2_CH1 on PA5 (AF1) — separate timer from motors
-    DEF_TIM(TIM2, CH1, PA5,  TIM_USE_LED,         0, 0),  // LED strip
+    // LED strip: TIM2_CH1 on PA5 (AF1) — dmavar=8 selects DMA2 S0, clear of motor streams 0-7
+    DEF_TIM(TIM2, CH1, PA5,  TIM_USE_LED,         0, 8),  // LED strip
 
     // Beeper PWM: TIM3_CH2 on PA7 (AF2)
     DEF_TIM(TIM3, CH2, PA7,  TIM_USE_BEEPER,      0, 0),  // Beeper


### PR DESCRIPTION
## Problem

The LED strip entry in `target.c` used `dmavar=0`:

```c
DEF_TIM(TIM2, CH1, PA5, TIM_USE_LED, 0, 0),  // LED strip
```

On STM32H7, `dmavar` is a flat index into a 16-entry list of all DMA streams (DMA1 S0–S7 at indices 0–7, DMA2 S0–S7 at indices 8–15). Index `0` selects **DMA1 Stream 0**, which is already claimed by M1 (TIM8_CH2, also `dmavar=0`).

When DSHOT is active, motor DMA streams are allocated before the LED strip initialises. By the time `ws2811LedStripInit()` runs, DMA1 S0 is already owned, causing `ledConfigureDMA()` to silently return `false` — the LED strip never initialises.

This explains why the issue was not caught during initial testing: if tested without DSHOT active, DMA1 S0 is still free when the LED strip initialises and everything appears to work.

## Fix

Change `dmavar` from `0` to `8` (DMA2 Stream 0), moving the LED strip off the motor DMA bank:

```c
DEF_TIM(TIM2, CH1, PA5, TIM_USE_LED, 0, 8),  // LED strip
```

This matches the pattern used by other H7 targets (MATEKH743, MAMBAH743, FOXEERH743, BROTHERHOBBYH743 all use `dmavar=8` or `9` for their LED strip entries).

## Testing

Verified on hardware with DSHOT active — LED strip operates correctly after this fix.