### PR TITLE
add TBS_LUCID_H7_V3 target

### DIFF
--- a/src/main/target/TBS_LUCID_H7_V3/CMakeLists.txt
+++ b/src/main/target/TBS_LUCID_H7_V3/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32h743xi(TBS_LUCID_H7_V3)

--- a/src/main/target/TBS_LUCID_H7_V3/config.c
+++ b/src/main/target/TBS_LUCID_H7_V3/config.c
@@ -1,0 +1,42 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "fc/config.h"
+#include "fc/fc_msp_box.h"
+
+#include "io/piniobox.h"
+
+#include "drivers/pwm_mapping.h"
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+    pinioBoxConfigMutable()->permanentId[2] = BOX_PERMANENT_ID_USER3;
+    beeperConfigMutable()->pwmMode = true;
+}

--- a/src/main/target/TBS_LUCID_H7_V3/target.c
+++ b/src/main/target/TBS_LUCID_H7_V3/target.c
@@ -1,0 +1,64 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/sensor.h"
+
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro1_mpu6000,  DEVHW_MPU6000,  GYRO1_SPI_BUS,   GYRO1_CS_PIN,   GYRO1_EXTI_PIN,   0,  DEVFLAGS_NONE,  IMU_1_MPU6000_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro1_icm42688,  DEVHW_ICM42605,  GYRO1_SPI_BUS,   GYRO1_CS_PIN,   GYRO1_EXTI_PIN,   0,  DEVFLAGS_NONE,  IMU_1_ICM42605_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro1_icm45686,  DEVHW_ICM45686,  GYRO1_SPI_BUS,   GYRO1_CS_PIN,   GYRO1_EXTI_PIN,   0,  DEVFLAGS_NONE,  IMU_1_ICM42605_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro2_mpu6000,  DEVHW_MPU6000,  GYRO2_SPI_BUS,   GYRO2_CS_PIN,   GYRO2_EXTI_PIN,   1,  DEVFLAGS_NONE,  IMU_2_MPU6000_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro2_icm42688,  DEVHW_ICM42605,  GYRO2_SPI_BUS,   GYRO2_CS_PIN,   GYRO2_EXTI_PIN,   1,  DEVFLAGS_NONE,  IMU_2_ICM42605_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro2_icm45686,  DEVHW_ICM45686,  GYRO2_SPI_BUS,   GYRO2_CS_PIN,   GYRO2_EXTI_PIN,   1,  DEVFLAGS_NONE,  IMU_2_ICM42605_ALIGN);
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM5, CH1, PA0, TIM_USE_OUTPUT_AUTO, 0, 2),   // S1
+    DEF_TIM(TIM5, CH2, PA1, TIM_USE_OUTPUT_AUTO, 0, 3),   // S2
+    DEF_TIM(TIM5, CH3, PA2, TIM_USE_OUTPUT_AUTO, 0, 4),   // S3
+    DEF_TIM(TIM5, CH4, PA3, TIM_USE_OUTPUT_AUTO, 0, 5),   // S4
+
+    DEF_TIM(TIM4, CH1, PD12, TIM_USE_OUTPUT_AUTO, 0, 6),   // S5
+    DEF_TIM(TIM4, CH2, PD13, TIM_USE_OUTPUT_AUTO, 0, 7),   // S6
+    DEF_TIM(TIM4, CH3, PD14, TIM_USE_OUTPUT_AUTO, 0, 0),   // S7
+    DEF_TIM(TIM4, CH4, PD15, TIM_USE_OUTPUT_AUTO, 0, 0),   // S8 DMA_NONE
+
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_OUTPUT_AUTO, 0, 0),   // S9
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_OUTPUT_AUTO, 0, 1),   // S10
+
+    DEF_TIM(TIM15, CH1, PE5, TIM_USE_OUTPUT_AUTO, 0, 0),   // S11
+    DEF_TIM(TIM15, CH2, PE6, TIM_USE_OUTPUT_AUTO, 0, 0),   // S12 DMA_NONE
+
+    DEF_TIM(TIM1,  CH1, PA8, TIM_USE_OUTPUT_AUTO | TIM_USE_LED, 0, 9),    // RGB_LED
+
+    DEF_TIM(TIM2,  CH1, PA15, TIM_USE_BEEPER, 0, 0),  // BEEPER
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/TBS_LUCID_H7_V3/target.c
+++ b/src/main/target/TBS_LUCID_H7_V3/target.c
@@ -1,0 +1,64 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/sensor.h"
+
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro1_mpu6000,  DEVHW_MPU6000,  GYRO1_SPI_BUS,   GYRO1_CS_PIN,   GYRO1_EXTI_PIN,   0,  DEVFLAGS_NONE,  IMU_1_MPU6000_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro1_icm42688,  DEVHW_ICM42605,  GYRO1_SPI_BUS,   GYRO1_CS_PIN,   GYRO1_EXTI_PIN,   0,  DEVFLAGS_NONE,  IMU_1_ICM42605_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro1_icm45686,  DEVHW_ICM45686,  GYRO1_SPI_BUS,   GYRO1_CS_PIN,   GYRO1_EXTI_PIN,   0,  DEVFLAGS_NONE,  IMU_1_ICM42605_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro2_mpu6000,  DEVHW_MPU6000,  GYRO2_SPI_BUS,   GYRO2_CS_PIN,   GYRO2_EXTI_PIN,   1,  DEVFLAGS_NONE,  IMU_2_MPU6000_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro2_icm42688,  DEVHW_ICM42605,  GYRO2_SPI_BUS,   GYRO2_CS_PIN,   GYRO2_EXTI_PIN,   1,  DEVFLAGS_NONE,  IMU_2_ICM42605_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_gyro2_icm45686,  DEVHW_ICM45686,  GYRO2_SPI_BUS,   GYRO2_CS_PIN,   GYRO2_EXTI_PIN,   1,  DEVFLAGS_NONE,  IMU_2_ICM42605_ALIGN);
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM5, CH1, PA0, TIM_USE_OUTPUT_AUTO, 0, 0),   // S1
+    DEF_TIM(TIM5, CH2, PA1, TIM_USE_OUTPUT_AUTO, 0, 1),   // S2
+    DEF_TIM(TIM5, CH3, PA2, TIM_USE_OUTPUT_AUTO, 0, 2),   // S3
+    DEF_TIM(TIM5, CH4, PA3, TIM_USE_OUTPUT_AUTO, 0, 3),   // S4
+
+    DEF_TIM(TIM4, CH1, PD12, TIM_USE_OUTPUT_AUTO, 0, 4),   // S5
+    DEF_TIM(TIM4, CH2, PD13, TIM_USE_OUTPUT_AUTO, 0, 5),   // S6
+    DEF_TIM(TIM4, CH3, PD14, TIM_USE_OUTPUT_AUTO, 0, 6),   // S7
+    DEF_TIM(TIM4, CH4, PD15, TIM_USE_OUTPUT_AUTO, 0, 0),   // S8 DMA_NONE
+
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_OUTPUT_AUTO, 0, 11),  // S9
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_OUTPUT_AUTO, 0, 12),  // S10
+
+    DEF_TIM(TIM15, CH1, PE5, TIM_USE_OUTPUT_AUTO, 0, 13),  // S11
+    DEF_TIM(TIM15, CH2, PE6, TIM_USE_OUTPUT_AUTO, 0, 0),   // S12 DMA_NONE
+
+    DEF_TIM(TIM1,  CH1, PA8, TIM_USE_OUTPUT_AUTO | TIM_USE_LED, 0, 14),    // RGB_LED
+
+    DEF_TIM(TIM2,  CH1, PA15, TIM_USE_BEEPER, 0, 0),  // BEEPER
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/TBS_LUCID_H7_V3/target.h
+++ b/src/main/target/TBS_LUCID_H7_V3/target.h
@@ -1,0 +1,183 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "LH7V3"
+
+#define USBD_PRODUCT_STRING     "TBS_LUCID_H7_V3"
+
+#define USE_TARGET_CONFIG
+
+#define LED0                    PE3
+#define LED1                    PE4
+
+#define BEEPER                  PA15
+#define BEEPER_INVERTED
+#define BEEPER_PWM_FREQUENCY    2500
+
+#define USE_VCP
+
+#define USE_UART2
+#define UART2_TX_PIN            PD5
+#define UART2_RX_PIN            PD6
+
+#define USE_UART3
+#define UART3_TX_PIN            PD8
+#define UART3_RX_PIN            PD9
+
+#define USE_UART4
+#define UART4_TX_PIN            PB9
+#define UART4_RX_PIN            PB8
+
+#define USE_UART5
+#define UART5_TX_PIN            PB13
+#define UART5_RX_PIN            PB12
+
+#define USE_UART6
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+#define USE_UART7
+#define UART7_TX_PIN            PE8
+#define UART7_RX_PIN            PE7
+
+#define USE_UART8
+#define UART8_TX_PIN            PE1
+#define UART8_RX_PIN            PE0
+
+#define SERIAL_PORT_COUNT       8
+
+#define USE_DRONECAN
+#define CAN1_RX                 PD0
+#define CAN1_TX                 PD1
+#define CAN1_STANDBY            PD3
+
+#define USE_SPI
+
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PD7
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+#define USE_SPI_DEVICE_4
+#define SPI4_SCK_PIN            PE12
+#define SPI4_MISO_PIN           PE13
+#define SPI4_MOSI_PIN           PE14
+
+#define USE_DUAL_GYRO
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS
+
+#define GYRO1_SPI_BUS           BUS_SPI1
+#define GYRO1_CS_PIN            PC15
+#define GYRO1_EXTI_PIN          PB2
+#define GYRO2_SPI_BUS           BUS_SPI4
+#define GYRO2_CS_PIN            PE11
+#define GYRO2_EXTI_PIN          PE15
+
+#define USE_IMU_MPU6000
+#define IMU_1_MPU6000_ALIGN       CW90_DEG_FLIP
+#define IMU_2_MPU6000_ALIGN       CW0_DEG_FLIP
+
+#define USE_IMU_ICM42605
+#define USE_IMU_ICM45686
+#define IMU_1_ICM42605_ALIGN      CW90_DEG_FLIP
+#define IMU_2_ICM42605_ALIGN      CW0_DEG_FLIP
+
+#define USE_I2C
+
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+
+#define USE_I2C_DEVICE_2
+#define I2C2_SCL                PB10
+#define I2C2_SDA                PB11
+
+#define USE_BARO
+#define USE_BARO_DPS310
+#define USE_BARO_BMP388
+#define USE_BARO_BMP390
+#define BARO_I2C_BUS            BUS_I2C2
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+#define TEMPERATURE_I2C_BUS     BUS_I2C2
+#define PITOT_I2C_BUS           BUS_I2C2
+
+#define USE_RANGEFINDER
+#define RANGEFINDER_I2C_BUS     BUS_I2C1
+
+#define USE_SDCARD
+#define USE_SDCARD_SDIO
+#define SDCARD_SDIO_DEVICE      SDIODEV_1
+#define SDCARD_SDIO_4BIT
+
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+
+#define ADC_CHANNEL_1_PIN           PC0
+#define ADC_CHANNEL_2_PIN           PC1
+#define ADC_CHANNEL_3_PIN           PC5
+#define ADC_CHANNEL_4_PIN           PC4
+#define ADC_CHANNEL_5_PIN           PA4
+#define ADC_CHANNEL_6_PIN           PA7
+
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_3
+#define AIRSPEED_ADC_CHANNEL        ADC_CHN_4
+
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                  PD10
+#define PINIO2_PIN                  PD11
+#define PINIO3_PIN                  PC13
+
+#define USE_LED_STRIP
+#define WS2811_PIN                  PA8
+
+#define DEFAULT_FEATURES            (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX)
+#define CURRENT_METER_SCALE         250
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+#define TARGET_IO_PORTA (0xffff & ~(BIT(14) | BIT(13)))
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0xffff
+#define TARGET_IO_PORTE 0xffff
+
+#define MAX_PWM_OUTPUT_PORTS        15
+#define USE_DSHOT
+#define USE_ESC_SENSOR

--- a/src/main/target/TBS_LUCID_H7_V3/target.h
+++ b/src/main/target/TBS_LUCID_H7_V3/target.h
@@ -1,0 +1,183 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "LH7V3"
+
+#define USBD_PRODUCT_STRING     "TBS_LUCID_H7_V3"
+
+#define USE_TARGET_CONFIG
+
+#define LED0                    PE3
+#define LED1                    PE4
+
+#define BEEPER                  PA15
+#define BEEPER_INVERTED
+#define BEEPER_PWM_FREQUENCY    2500
+
+#define USE_VCP
+
+#define USE_UART2
+#define UART2_TX_PIN            PD5
+#define UART2_RX_PIN            PD6
+
+#define USE_UART3
+#define UART3_TX_PIN            PD8
+#define UART3_RX_PIN            PD9
+
+#define USE_UART4
+#define UART4_TX_PIN            PB9
+#define UART4_RX_PIN            PB8
+
+#define USE_UART5
+#define UART5_TX_PIN            PB13
+#define UART5_RX_PIN            PB12
+
+#define USE_UART6
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+#define USE_UART7
+#define UART7_TX_PIN            PE8
+#define UART7_RX_PIN            PE7
+
+#define USE_UART8
+#define UART8_TX_PIN            PE1
+#define UART8_RX_PIN            PE0
+
+#define SERIAL_PORT_COUNT       8
+
+#define USE_DRONECAN
+#define CAN1_RX                 PD0
+#define CAN1_TX                 PD1
+#define CAN1_STANDBY            PD3
+
+#define USE_SPI
+
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PD7
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN           PB4
+#define SPI3_MOSI_PIN           PB5
+
+#define USE_SPI_DEVICE_4
+#define SPI4_SCK_PIN            PE12
+#define SPI4_MISO_PIN           PE13
+#define SPI4_MOSI_PIN           PE14
+
+#define USE_DUAL_GYRO
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS
+
+#define GYRO1_SPI_BUS           BUS_SPI1
+#define GYRO1_CS_PIN            PC15
+#define GYRO1_EXTI_PIN          PB2
+#define GYRO2_SPI_BUS           BUS_SPI4
+#define GYRO2_CS_PIN            PE11
+#define GYRO2_EXTI_PIN          PE15
+
+#define USE_IMU_MPU6000
+#define IMU_1_MPU6000_ALIGN       CW90_DEG_FLIP
+#define IMU_2_MPU6000_ALIGN       CW0_DEG_FLIP
+
+#define USE_IMU_ICM42605
+#define USE_IMU_ICM45686
+#define IMU_1_ICM42605_ALIGN      CW90_DEG_FLIP
+#define IMU_2_ICM42605_ALIGN      CW0_DEG_FLIP
+
+#define USE_I2C
+
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB6
+#define I2C1_SDA                PB7
+
+#define USE_I2C_DEVICE_2
+#define I2C2_SCL                PB10
+#define I2C2_SDA                PB11
+
+#define USE_BARO
+#define USE_BARO_DPS310
+#define USE_BARO_BMP388
+#define USE_BARO_BMP390
+#define BARO_I2C_BUS            BUS_I2C2
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+#define TEMPERATURE_I2C_BUS     BUS_I2C2
+#define PITOT_I2C_BUS           BUS_I2C2
+
+#define USE_RANGEFINDER
+#define RANGEFINDER_I2C_BUS     BUS_I2C1
+
+#define USE_SDCARD
+#define USE_SDCARD_SDIO
+#define SDCARD_SDIO_DEVICE      SDIODEV_1
+#define SDCARD_SDIO_4BIT
+
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+
+#define ADC_CHANNEL_1_PIN           PC0
+#define ADC_CHANNEL_2_PIN           PC1
+#define ADC_CHANNEL_3_PIN           PC5
+#define ADC_CHANNEL_4_PIN           PC4
+#define ADC_CHANNEL_5_PIN           PA4
+#define ADC_CHANNEL_6_PIN           PA7
+
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+#define RSSI_ADC_CHANNEL            ADC_CHN_3
+#define AIRSPEED_ADC_CHANNEL        ADC_CHN_4
+
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                  PD10
+#define PINIO2_PIN                  PD11
+#define PINIO3_PIN                  PC13
+
+#define USE_LED_STRIP
+#define WS2811_PIN                  PA8
+
+#define DEFAULT_FEATURES            (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TX_PROF_SEL | FEATURE_BLACKBOX | FEATURE_LED_STRIP)
+#define CURRENT_METER_SCALE         250
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+#define TARGET_IO_PORTA (0xffff & ~(BIT(14) | BIT(13)))
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0xffff
+#define TARGET_IO_PORTE 0xffff
+
+#define MAX_PWM_OUTPUT_PORTS        15
+#define USE_DSHOT
+#define USE_ESC_SENSOR


### PR DESCRIPTION
This pull requests adds support for ``TBS_LUCID_H7_V3``

 * [x] Samples received
 * [x] Flash firmware
 * [x] Calibrate
 * [x] Orientation matches
 * [x] Gyro working
 * [x] Accel working
 * [x] Voltage correct
 * [x] Current correct
 * [x] Baro working
 * [x] Mag I2C Bus
 * [x] Additional I2C2 Buses (Airspeed/other accessories)
 * [x] UART2
 * [x] UART3
 * [x] UART4
 * [x] UART5
 * [x] UART6
 * [x] UART7
 * [x] UART8
 * [x] Analog Camera working
 * [x] Video Out working
 * [x] OSD working
 * [x] LEDs working
 * [x] Buzzer working
 * [x] Motor outputs
 * [x] DShot support on m1-4
 * [x] Servo outputs
 * [x] Blackbox
 * [x] PINIO1
 * [x] PINIO2
 * [x] PINIO3
