### PR TITLE
Add BMI270 support to COREWINGF405WINGV2

### DIFF
--- a/src/main/target/COREWINGF405WINGV2/target.h
+++ b/src/main/target/COREWINGF405WINGV2/target.h
@@ -102,6 +102,10 @@
 #define ICM42605_CS_PIN         PA4
 #define ICM42605_SPI_BUS        BUS_SPI1
 
+#define USE_IMU_BMI270
+#define IMU_BMI270_ALIGN        CW270_DEG
+#define BMI270_CS_PIN           PA4
+#define BMI270_SPI_BUS          BUS_SPI1
 
 // Baro
 #define USE_BARO


### PR DESCRIPTION
## Summary

A new board revision of the CoreWing F405 Wing V2 ships with a BMI270 IMU instead of the ICM42688 (covered by `USE_IMU_ICM42605`). Users with the new revision have no working IMU with the current firmware.

Adding BMI270 defines on the same SPI1/CS pin (PA4) allows a single firmware image to serve both hardware revisions. INAV's boot-time auto-probe walks all `USE_IMU_*` defines and identifies the correct chip by its WHO_AM_I/CHIP_ID register — no conditional compilation required.

## Changes

- `src/main/target/COREWINGF405WINGV2/target.h`: Add `USE_IMU_BMI270` block (SPI1, CS PA4, CW270_DEG) alongside the existing ICM42605 block

## Testing

- Target builds cleanly on release/9.1: 610 KB / 896 KB flash (68%), no errors or warnings
- Pattern verified against DAKEFPVF722 which uses the identical dual ICM42605+BMI270 on SPI1/PA4 in production
- **Hardware testing required**: a user with the new-revision board (BMI270 variant) should confirm IMU detection at boot. Existing ICM42688 boards are unaffected.

## Notes

- No changes to driver code — BMI270 driver already present in firmware
- Existing ICM42688 boards: auto-probe finds ICM42605 match first, BMI270 probe returns false (different CHIP_ID register/value), no behaviour change