### PR TITLE
Fixed wing nav: reset WP cross-track tracking state on re-engagement

### DIFF
--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -454,6 +454,13 @@ static void updatePositionHeadingController_FW(timeUs_t currentTimeUs, timeDelta
     }
 
     if (isWaypointNavTrackingActive()) {
+        /* Cross-track controller state. Scoped here, not in the control branch, so the
+         * else branch can re-seed it while the controller is disengaged. */
+        static float crossTrackErrorRate;
+        static timeUs_t previousCrossTrackErrorUpdateTime;
+        static float previousCrossTrackError = 0.0f;
+        static pt1Filter_t fwCrossTrackErrorRateFilterState;
+
         /* Calculate cross track error */
         posControl.wpDistance = calculateDistanceToDestination(&posControl.activeWaypoint.pos);
 
@@ -466,11 +473,6 @@ static void updatePositionHeadingController_FW(timeUs_t currentTimeUs, timeDelta
 
         /* If waypoint tracking enabled force craft toward and closely track along waypoint course line */
         if (navConfig()->fw.wp_tracking_accuracy && !needToCalculateCircularLoiter) {
-            static float crossTrackErrorRate;
-            static timeUs_t previousCrossTrackErrorUpdateTime;
-            static float previousCrossTrackError = 0.0f;
-            static pt1Filter_t fwCrossTrackErrorRateFilterState;
-
             if ((currentTimeUs - previousCrossTrackErrorUpdateTime) >= HZ2US(20) && fabsf(previousCrossTrackError - navCrossTrackError) > 10.0f) {
                 const float crossTrackErrorDtSec =  US2S(currentTimeUs - previousCrossTrackErrorUpdateTime);
                 if (fabsf(previousCrossTrackError - navCrossTrackError) < 500.0f) {
@@ -497,6 +499,13 @@ static void updatePositionHeadingController_FW(timeUs_t currentTimeUs, timeDelta
                 adjustmentFactor = constrainf(adjustmentFactor, -limit, limit);
                 virtualTargetBearing = wrap_36000(posControl.activeWaypoint.bearing - adjustmentFactor);
             }
+        } else {
+            /* Keep state synced to the current error while not steering, so the
+             * controller re-engages cleanly on the next leg (no stale-data kick). */
+            previousCrossTrackError = navCrossTrackError;
+            previousCrossTrackErrorUpdateTime = currentTimeUs;
+            crossTrackErrorRate = 0.0f;
+            pt1FilterReset(&fwCrossTrackErrorRateFilterState, 0.0f);
         }
     }
     /*


### PR DESCRIPTION
### What
Fixes a brief, unnecessary heading twitch when a fixed-wing aircraft rejoins a
waypoint course line after a turn or loiter, with `nav_fw_wp_tracking_accuracy`
(waypoint course tracking) enabled.

### Root cause
The cross-track controller in `updatePositionHeadingController_FW()` keeps its
rate/error state in function-local `static` variables (`previousCrossTrackError`,
`previousCrossTrackErrorUpdateTime`, `crossTrackErrorRate` and the rate filter)
that are never reset.

While the controller is disengaged — during a turn/loiter
(`needToCalculateCircularLoiter`) or when the feature is off — that state freezes.
On the next leg the first control sample is then computed against stale cross-track
data from the *previous* leg, producing a small heading kick as the aircraft
rejoins the new course line.

### Fix
Re-seed the controller state to the current cross-track error whenever it is not
actively steering, so on re-engagement the error delta starts near zero and the
rate filter starts clean.

- Moved the four state variables up one scope (still `static`) so the inactive
  branch can reset them.
- Added an `else` branch that syncs `previousCrossTrackError`/timestamp to the
  current value, zeroes the rate, and resets the rate filter.

No new settings, no parameter-group change, no MSP/protocol change. No behavioural
change when `nav_fw_wp_tracking_accuracy = 0`.

### Target branch
`maintenance-9.x` — backward-compatible bug fix per the branching guidelines.
Propagates to `maintenance-10.x` via the normal merge-forward flow.

### Testing
- [x] Builds cleanly (MATEKF722SE / F7); change is platform-independent C.
- [ ] In-flight verification on a WP mission with `nav_fw_wp_tracking_accuracy`
      enabled, checking clean leg re-capture after turns/loiter.

### Scope
Single focused fix in `navigation/navigation_fixedwing.c` (~14 added / 5 removed).
