### PR TITLE
fix(gps): clamp negative uBlox nano field before millis conversion

### DIFF
--- a/src/main/io/gps_ublox.c
+++ b/src/main/io/gps_ublox.c
@@ -635,7 +635,7 @@ static bool gpsParseFrameUBLOX(void)
             gpsSolDRV.time.hours = _buffer.timeutc.hour;
             gpsSolDRV.time.minutes = _buffer.timeutc.min;
             gpsSolDRV.time.seconds = _buffer.timeutc.sec;
-            gpsSolDRV.time.millis = _buffer.timeutc.nano / (1000*1000);
+            gpsSolDRV.time.millis = (uint16_t)(MAX(0, _buffer.timeutc.nano) / (1000*1000));
 
             gpsSolDRV.flags.validTime = true;
         } else {
@@ -674,7 +674,7 @@ static bool gpsParseFrameUBLOX(void)
             gpsSolDRV.time.hours = _buffer.pvt.hour;
             gpsSolDRV.time.minutes = _buffer.pvt.min;
             gpsSolDRV.time.seconds = _buffer.pvt.sec;
-            gpsSolDRV.time.millis = _buffer.pvt.nano / (1000*1000);
+            gpsSolDRV.time.millis = (uint16_t)(MAX(0, _buffer.pvt.nano) / (1000*1000));
 
             gpsSolDRV.flags.validTime = true;
         } else {


### PR DESCRIPTION
## Summary

The `nano` field in UBX-NAV-TIMEUTC and UBX-NAV-PVT messages is `int32_t` and legitimately goes negative near second boundaries (e.g. −50,000,000 ns). The previous code divided without clamping:

```c
gpsSolDRV.time.millis = _buffer.pvt.nano / (1000*1000);
```

A negative value such as −50,000,000 ns → −50 ms → wraps to 65,486 when assigned to `uint16_t`, setting the RTC approximately 64 seconds fast on first GPS lock. Once `rtcHasTime()` returns true the RTC cannot be corrected until reboot.

## Changes

- `src/main/io/gps_ublox.c`: clamp `nano` to zero before the millis division in both `MSG_TIMEUTC` and `MSG_PVT` handlers

```c
gpsSolDRV.time.millis = (uint16_t)(MAX(0, _buffer.pvt.nano) / (1000*1000));
```

## Testing

Build matrix — all targets clean, no warnings:

| Family | Target |
|--------|--------|
| SITL | SITL |
| F4 | MATEKF405 |
| F7 | MATEKF765SE |
| H7 | KAKUTEH7WING |
| AT32 | IFLIGHT_BLITZ_ATF435 |

Hardware test with negative nano values at second boundaries not yet performed (requires a uBlox receiver and GPS lock capture near a second boundary).