### PR TITLE
Improved virtual pitot calculation method

### DIFF
--- a/src/main/drivers/pitotmeter/pitotmeter_virtual.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_virtual.c
@@ -38,14 +38,13 @@
 #include "io/gps.h"
 
 #include "navigation/navigation.h"
-#include "navigation/navigation_private.h"
 
 #include "sensors/pitotmeter.h"
 
 #include "drivers/pitotmeter/pitotmeter.h"
 #include "drivers/pitotmeter/pitotmeter_virtual.h"
 
-#if defined(USE_WIND_ESTIMATOR) && defined(USE_PITOT_VIRTUAL) 
+#if defined(USE_WIND_ESTIMATOR) && defined(USE_PITOT_VIRTUAL)
 
 static bool virtualPitotStart(pitotDev_t *pitot)
 {
@@ -63,26 +62,22 @@ static void virtualPitotCalculate(pitotDev_t *pitot, float *pressure, float *tem
 {
     UNUSED(pitot);
     float airSpeed = 0.0f;
+
     if (pitotIsCalibrationComplete()) {
         if (isEstimatedWindSpeedValid() && STATE(GPS_FIX)) {
-            uint16_t windHeading; //centidegrees
-            float windSpeed = getEstimatedHorizontalWindSpeed(&windHeading); //cm/s
-            float horizontalWindSpeed = windSpeed * cos_approx(CENTIDEGREES_TO_RADIANS(windHeading - posControl.actualState.yaw)); //yaw int32_t centidegrees
-            airSpeed = posControl.actualState.velXY - horizontalWindSpeed; //float cm/s or gpsSol.groundSpeed int16_t cm/s
-            airSpeed = calc_length_pythagorean_2D(airSpeed,getEstimatedActualVelocity(Z)+getEstimatedWindSpeed(Z));
-        } 
+            airSpeed = getWindEstimatedVirtualAirspeed();
+        }
         else if (STATE(GPS_FIX))
         {
-            airSpeed = calc_length_pythagorean_3D(gpsSol.velNED[X],gpsSol.velNED[Y],gpsSol.velNED[Z]);
+            airSpeed = calc_length_pythagorean_3D(gpsSol.velNED[X], gpsSol.velNED[Y], gpsSol.velNED[Z]);
         }
         else {
             airSpeed = pidProfile()->fixedWingReferenceAirspeed; //float cm/s
         }
     }
-    if (pressure)
-        *pressure = sq(airSpeed) * SSL_AIR_DENSITY / 20000.0f + SSL_AIR_PRESSURE;
-    if (temperature)
-        *temperature = SSL_AIR_TEMPERATURE; // Temperature at standard sea level
+
+    if (pressure) *pressure = sq(airSpeed) * SSL_AIR_DENSITY / 20000.0f + SSL_AIR_PRESSURE;
+    if (temperature) *temperature = SSL_AIR_TEMPERATURE; // Temperature at standard sea level
 }
 
 bool virtualPitotDetect(pitotDev_t *pitot)

--- a/src/main/drivers/pitotmeter/pitotmeter_virtual.c
+++ b/src/main/drivers/pitotmeter/pitotmeter_virtual.c
@@ -45,7 +45,6 @@
 #include "drivers/pitotmeter/pitotmeter_virtual.h"
 
 #if defined(USE_WIND_ESTIMATOR) && defined(USE_PITOT_VIRTUAL)
-
 static bool virtualPitotStart(pitotDev_t *pitot)
 {
     UNUSED(pitot);
@@ -64,6 +63,7 @@ static void virtualPitotCalculate(pitotDev_t *pitot, float *pressure, float *tem
     float airSpeed = 0.0f;
 
     if (pitotIsCalibrationComplete()) {
+#if defined(USE_GPS)
         if (isEstimatedWindSpeedValid() && STATE(GPS_FIX)) {
             airSpeed = getWindEstimatedVirtualAirspeed();
         }
@@ -71,7 +71,9 @@ static void virtualPitotCalculate(pitotDev_t *pitot, float *pressure, float *tem
         {
             airSpeed = calc_length_pythagorean_3D(gpsSol.velNED[X], gpsSol.velNED[Y], gpsSol.velNED[Z]);
         }
-        else {
+        else
+#endif
+        {
             airSpeed = pidProfile()->fixedWingReferenceAirspeed; //float cm/s
         }
     }

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -45,8 +45,9 @@
 
 #include "scheduler/protothreads.h"
 
-#include "sensors/pitotmeter.h"
 #include "sensors/barometer.h"
+#include "flight/imu.h"
+#include "sensors/pitotmeter.h"
 #include "sensors/sensors.h"
 
 #include "io/gps.h"
@@ -368,6 +369,22 @@ bool pitotIsHealthy(void)
  *
  * @return virtual airspeed in cm/s, or 0 if GPS unavailable
  */
+
+float getWindEstimatedVirtualAirspeed(void)
+{
+    fpVector3_t windCorrectedVel;
+
+    // Correct nav velocities with estimated wind velocities in earth frame
+    for (uint8_t axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
+        windCorrectedVel.v[axis] = posControl.actualState.abs.vel.v[axis] - getEstimatedWindSpeed(axis);
+    }
+
+    // Transform to body frame to obtain virtual airspeed in the x direction
+    imuTransformVectorEarthToBody(&windCorrectedVel);
+
+    return windCorrectedVel.x;
+}
+
 static float getVirtualAirspeedEstimate(void)
 {
 #if defined(USE_GPS) && defined(USE_WIND_ESTIMATOR)
@@ -379,11 +396,7 @@ static float getVirtualAirspeedEstimate(void)
 
     // Use wind estimator if available (matches virtual pitot logic)
     if (isEstimatedWindSpeedValid()) {
-        uint16_t windHeading;  // centidegrees
-        float windSpeed = getEstimatedHorizontalWindSpeed(&windHeading);  // cm/s
-        float horizontalWindSpeed = windSpeed * cos_approx(CENTIDEGREES_TO_RADIANS(windHeading - posControl.actualState.yaw));
-        airSpeed = posControl.actualState.velXY - horizontalWindSpeed;
-        airSpeed = calc_length_pythagorean_2D(airSpeed, getEstimatedActualVelocity(Z) + getEstimatedWindSpeed(Z));
+        airSpeed = getWindEstimatedVirtualAirspeed();
     } else {
         // Fall back to raw GPS velocity if no wind estimator
         airSpeed = calc_length_pythagorean_3D(gpsSol.velNED[X], gpsSol.velNED[Y], gpsSol.velNED[Z]);

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -382,7 +382,7 @@ float getWindEstimatedVirtualAirspeed(void)
     // Transform to body frame to obtain virtual airspeed in the x direction
     imuTransformVectorEarthToBody(&windCorrectedVel);
 
-    return windCorrectedVel.x;
+    return fabsf(windCorrectedVel.x);
 }
 #endif
 static float getVirtualAirspeedEstimate(void)

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -372,17 +372,27 @@ bool pitotIsHealthy(void)
 #if defined(USE_GPS) && defined(USE_WIND_ESTIMATOR)
 float getWindEstimatedVirtualAirspeed(void)
 {
-    fpVector3_t windCorrectedVel;
+    static float virtualAirspeed = 0.0f;
+    static timeMs_t lastUpdateTimeMs = 0;
+    const timeMs_t currentTimeMs = millis();
 
-    // Correct nav velocities with estimated wind velocities in earth frame
-    for (uint8_t axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-        windCorrectedVel.v[axis] = posControl.actualState.abs.vel.v[axis] - getEstimatedWindSpeed(axis);
+    if (currentTimeMs - lastUpdateTimeMs > 100) {   // 10Hz update rate should be sufficient for virtual airspeed
+        lastUpdateTimeMs = currentTimeMs;
+
+        fpVector3_t windCorrectedVel;
+
+        // Correct nav velocities with estimated wind velocities in earth frame
+        for (uint8_t axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
+            windCorrectedVel.v[axis] = posControl.actualState.abs.vel.v[axis] - getEstimatedWindSpeed(axis);
+        }
+
+        // Transform to body frame to obtain virtual airspeed in the x direction
+        imuTransformVectorEarthToBody(&windCorrectedVel);
+
+        virtualAirspeed = fabsf(windCorrectedVel.x);
     }
 
-    // Transform to body frame to obtain virtual airspeed in the x direction
-    imuTransformVectorEarthToBody(&windCorrectedVel);
-
-    return fabsf(windCorrectedVel.x);
+    return virtualAirspeed;
 }
 #endif
 static float getVirtualAirspeedEstimate(void)

--- a/src/main/sensors/pitotmeter.c
+++ b/src/main/sensors/pitotmeter.c
@@ -369,7 +369,7 @@ bool pitotIsHealthy(void)
  *
  * @return virtual airspeed in cm/s, or 0 if GPS unavailable
  */
-
+#if defined(USE_GPS) && defined(USE_WIND_ESTIMATOR)
 float getWindEstimatedVirtualAirspeed(void)
 {
     fpVector3_t windCorrectedVel;
@@ -384,7 +384,7 @@ float getWindEstimatedVirtualAirspeed(void)
 
     return windCorrectedVel.x;
 }
-
+#endif
 static float getVirtualAirspeedEstimate(void)
 {
 #if defined(USE_GPS) && defined(USE_WIND_ESTIMATOR)

--- a/src/main/sensors/pitotmeter.h
+++ b/src/main/sensors/pitotmeter.h
@@ -73,5 +73,6 @@ bool pitotIsHealthy(void);
 bool pitotValidateAirspeed(void);
 bool pitotGetValidForAirspeed(void);
 bool pitotHasFailed(void);
+float getWindEstimatedVirtualAirspeed(void);
 
 #endif


### PR DESCRIPTION
Changes the method used to calculate virtual airspeed which currently becomes inaccurate as pitch increases. At very high pitch angles yaw can suddenly flip causing a large abrupt unrealistic change in virtual airspeed.

The new method calculates velocities in earth frame using Nav velocities and wind velocities then transforms the wind corrected velocities to body frame. Virtual airspeed is considered be the body frame x velocity.

Seems to work in HITL testing. The sudden jumps in virtual airspeed seen with the old method at high pitch angles are gone with the velocity changing consistently.