### PR TITLE
FW nav: fix WP JUMP target skipped by stale turn-smoothing flag

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -4228,6 +4228,7 @@ void calculateAndSetActiveWaypointToLocalPosition(const fpVector3_t *pos)
         posControl.activeWaypoint.bearing = calculateBearingToDestination(pos);
     }
     posControl.activeWaypoint.nextTurnAngle = -1;     // no turn angle set (-1), will be set by WP mode as required
+    posControl.flags.wpTurnSmoothingActive = false;   // a freshly activated WP (e.g. JUMP target) must not inherit the previous WP's smoothing-reached state
 
     posControl.activeWaypoint.pos = *pos;
 


### PR DESCRIPTION
### What
Fixes a long-standing bug where a WP mission JUMP lands on **target+1** instead of
the intended target waypoint. Intermittent in general, but **~100% reproducible**
with `nav_fw_wp_turn_smoothing = CUT`, especially on specific mission layouts.

### Root cause
`isWaypointReached()` reads the shared `wpTurnSmoothingActive` flag, which is owned
and recomputed by the FW position controller. A JUMP defers setup of its target
waypoint by one navigation loop; in that gap the controller re-arms the flag from
the **previous** waypoint's geometry. On the next loop the freshly activated target
inherits that stale flag and, in CUT mode, is marked "reached" on its very first
loop (and can cascade the following WP via the bearing-miss check). The active
waypoint counter advances past the target.

This matches blackbox evidence: the correct target WP is active for exactly one
50 Hz nav tick (~20 ms) before being skipped.

### Fix
Reset `wpTurnSmoothingActive` when a new active waypoint is set, so a freshly
activated waypoint cannot inherit the previous waypoint's smoothing-reached state.
One line in `calculateAndSetActiveWaypointToLocalPosition()`, next to the existing
`nextTurnAngle` reset.

Turn smoothing itself is unchanged — the controller recomputes the flag every
position update from the new waypoint's geometry, so smoothed turns still work.

### Testing
- HITL on MATEKF765, `nav_fw_wp_turn_smoothing = CUT`.
- Before: 100% skip of the JUMP target (jumped to target+1, penduluming between WPs).
- After: JUMP executes correctly to the target; turns remain smoothed (no regression).

### Notes
- No parameter-group change → no PG version bump.
- No `settings.yaml` change → no CLI docs regeneration needed.
- Single-line, no API/MSP impact.