### PR TITLE
fix warning / errors from GCC 16

### DIFF
--- a/lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c
+++ b/lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c
@@ -506,8 +506,6 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTy
   */
 HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep)
 {
-  static __IO uint32_t debug = 0;
-
   /* Read DEPCTLn register */
   if (ep->is_in == 1)
   {
@@ -517,10 +515,6 @@ HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB
         ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP));
     }
 
-
-    debug  |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
-        ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP));
-
    USBx_DEVICE->DEACHMSK |= USB_OTG_DAINTMSK_IEPM & ((1 << (ep->num)));
   }
   else
@@ -528,11 +522,6 @@ HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB
     if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_USBAEP) == 0)
     {
       USBx_OUTEP(ep->num)->DOEPCTL |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
-        ((ep->num) << 22 ) | (USB_OTG_DOEPCTL_USBAEP));
-
-      debug = (uint32_t)(((uint32_t )USBx) + USB_OTG_OUT_ENDPOINT_BASE + (0)*USB_OTG_EP_REG_SIZE);
-      debug = (uint32_t )&USBx_OUTEP(ep->num)->DOEPCTL;
-      debug |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
         ((ep->num) << 22 ) | (USB_OTG_DOEPCTL_USBAEP));
     }
 

--- a/src/main/io/serial_4way_avrootloader.c
+++ b/src/main/io/serial_4way_avrootloader.c
@@ -195,7 +195,7 @@ uint8_t BL_ConnectEx(uint8_32_u *pDeviceInfo)
 
     //DeviceInfo.dword=0; is set before
     uint8_t BootInfo[9];
-    uint8_t BootMsg[BootMsgLen-1] = "471";
+    uint8_t BootMsg[BootMsgLen-1] = {'4','7','1'};
     // x * 0 + 9
 #if defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
     uint8_t BootInit[] = {0,0,0,0,0,0,0,0,0,0,0,0,0x0D,'B','L','H','e','l','i',0xF4,0x7D};

--- a/src/main/rx/fport.c
+++ b/src/main/rx/fport.c
@@ -149,8 +149,6 @@ static serialPort_t *fportPort;
 
 static void reportFrameError(uint8_t errorReason) {
     UNUSED(errorReason);
-    static volatile uint16_t frameErrors = 0;
-    frameErrors++;
 }
 
 // Receive ISR callback

--- a/src/main/target/SITL/sim/xplane.c
+++ b/src/main/target/SITL/sim/xplane.c
@@ -169,7 +169,7 @@ typedef enum
     DREF_XITL_BATTERY_CURRENT,
     DREF_XITL_RSSI,
     DREF_XITL_FAILSAFE,
-    
+
     DREF_LAST
 } dref_t;
 
@@ -560,8 +560,8 @@ static void exchangeDataWithXPlane(void)
     }
 
     gpsFakeSet(
-        fixType, 
-        numSats, 
+        fixType,
+        numSats,
         (int32_t)roundf(lattitude * 10000000),
         (int32_t)roundf(longitude * 10000000),
         (int32_t)roundf(elevation * 100),
@@ -687,7 +687,7 @@ static void* listenWorker(void* arg)
                 // calibration of the accelerometer
                 ENABLE_STATE(ACCELEROMETER_CALIBRATED);
                 connectionState = CONNECTED;
-                
+
                 break;
             }
             case CONNECTED:

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -236,7 +236,7 @@ void hottPrepareGPSResponse(HOTT_GPS_MSG_t *hottGPSMessage)
 
 #ifdef USE_GPS_FIX_ESTIMATION
     if (!(STATE(GPS_FIX) || STATE(GPS_ESTIMATED_FIX)))
-#else            
+#else
     if (!(STATE(GPS_FIX)))
 #endif
          {
@@ -339,8 +339,6 @@ void hottPrepareEAMResponse(HOTT_EAM_MSG_t *hottEAMMessage)
 
 static void hottSerialWrite(uint8_t c)
 {
-    static uint8_t serialWrites = 0;
-    serialWrites++;
     serialWrite(hottPort, c);
 }
 

--- a/src/main/telemetry/jetiexbus.c
+++ b/src/main/telemetry/jetiexbus.c
@@ -447,7 +447,7 @@ int32_t getSensorValue(uint8_t sensor)
 
     case EX_TRIP_DISTANCE:
         return getTotalTravelDistance() / 10;
-    
+
     case EX_DEBUG0:
         return debug[0];
     case EX_DEBUG1:
@@ -548,7 +548,6 @@ void checkJetiExBusTelemetryState(void)
 
 void NOINLINE handleJetiExBusTelemetry(void)
 {
-    static uint16_t framesLost = 0; // only for debug
     static uint8_t item = 0;
     uint32_t timeDiff;
 
@@ -564,7 +563,6 @@ void NOINLINE handleJetiExBusTelemetry(void)
 
         if (timeDiff > 3000) {   // include reserved time
             jetiExBusRequestState = EXBUS_STATE_ZERO;
-            framesLost++;
             return;
         }
 


### PR DESCRIPTION
GCC 16 reveals a number of warnings and errors (real and promoted from warnings) for:

* unused variables
* set but unused variables
* misuse of `char*` to initialise `uint8_t []`
