### PR TITLE
Remove outdated OLED display link from Display.md

### DIFF
--- a/docs/Display.md
+++ b/docs/Display.md
@@ -40,7 +40,6 @@ Links to displays:
  * [banggood.com](https://inavflight.com/shop/s/bg/969147) 0.96 Inch 4Pin IIC I2C Blue OLED Display Module For Arduino
  * [wide.hk](http://www.wide.hk/products.php?product=I2C-0.96%22-OLED-display-module-%28-compatible-Arduino-%29) I2C 0.96" OLED display module
  * [witespyquad.gostorego.com](http://witespyquad.gostorego.com/accessories/readytofly-1-oled-128x64-pid-tuning-display-i2c.html) ReadyToFlyQuads 1" OLED Display
- * [multiwiicopter.com](http://www.multiwiicopter.com/products/1-oled) PARIS 1" OLED 128x64 PID tuning screen AIR
 
 The banggood.com display is the cheapest at the time of writing and will correctly send I2C ACK signals.
 


### PR DESCRIPTION
Removed a link to a specific OLED display from the documentation. Resolves https://github.com/iNavFlight/inav/discussions/11660