### PR TITLE
Fix SDIO blocking delays and state management issues

### DIFF
--- a/src/main/drivers/sdcard/sdcard_sdio.c
+++ b/src/main/drivers/sdcard/sdcard_sdio.c
@@ -461,12 +461,12 @@ static sdcardOperationStatus_e sdcardSdio_writeBlock(uint32_t blockIndex, uint8_
 
     if (SD_WriteBlocks_DMA(blockIndex, (uint32_t*) buffer, 512, block_count) != SD_OK) {
         /* Our write was rejected! Try a few times before giving up.
-         * This handles transient DMA/bus issues without full card reset.
+         * This handles transient DMA/bus issues without a full card reset.
+         * Returning busy without blocking: the blackbox/asyncfatfs flush re-issues
+         * this operation on the next PID loop, which paces the retries for us.
          */
         if (sdcard.operationRetries < SDCARD_MAX_OPERATION_RETRIES) {
             sdcard.operationRetries++;
-            // Brief delay before retry
-            delay(1);
             return SDCARD_OPERATION_BUSY;
         }
 
@@ -562,11 +562,11 @@ static bool sdcardSdio_readBlock(uint32_t blockIndex, uint8_t *buffer, sdcard_op
     } else {
         /* Read was rejected! Try a few times before giving up.
          * This handles transient DMA/bus issues without full card reset.
+         * Returning busy without blocking: the asyncfatfs read re-issues
+         * this operation on the next PID loop, which paces the retries for us.
          */
         if (sdcard.operationRetries < SDCARD_MAX_OPERATION_RETRIES) {
             sdcard.operationRetries++;
-            // Brief delay before retry
-            delay(1);
             return false;
         }
 

--- a/src/main/drivers/sdcard/sdcard_sdio.c
+++ b/src/main/drivers/sdcard/sdcard_sdio.c
@@ -457,7 +457,6 @@ static sdcardOperationStatus_e sdcardSdio_writeBlock(uint32_t blockIndex, uint8_
     sdcard.pendingOperation.callback = callback;
     sdcard.pendingOperation.callbackData = callbackData;
     sdcard.pendingOperation.chunkIndex = 1; // (for non-DMA transfers) we've sent chunk #0 already
-    sdcard.state = SDCARD_STATE_SENDING_WRITE;
 
     if (SD_WriteBlocks_DMA(blockIndex, (uint32_t*) buffer, 512, block_count) != SD_OK) {
         /* Our write was rejected! Try a few times before giving up.
@@ -480,6 +479,9 @@ static sdcardOperationStatus_e sdcardSdio_writeBlock(uint32_t blockIndex, uint8_
         }
         return SDCARD_OPERATION_FAILURE;
     }
+
+    // DMA started successfully - only set state after confirming operation will proceed
+    sdcard.state = SDCARD_STATE_SENDING_WRITE;
 
     // Success - reset retry counter
     sdcard.operationRetries = 0;


### PR DESCRIPTION
## Summary

Remove blocking `delay(1)` calls from SDIO retry paths and fix write-path state management. Blocking delays on the flight-control hot path cause ~3 ms CPU stalls during transient SD card DMA rejections, resulting in loop overruns and dropped gyro samples during active logging.

## Problem

**Blocking delay on hot path:**
The driver calls `delay(1)` when DMA operations are rejected before retrying. In INAV's cooperative scheduler, this stalls the entire flight-control loop, gyro sampling, and PID control — exactly when loop timing matters most (during active blackbox logging).

**State management bug:**
The write path sets `sdcard.state = SDCARD_STATE_SENDING_WRITE` *before* the DMA call. On rejection, state remains `SENDING_WRITE` instead of `READY`. The poll cycle then calls `SD_CheckWrite()` on a transfer that never started, potentially invoking callbacks for failed writes.

## Solution

**Remove blocking delays:** Both retry branches now return `SDCARD_OPERATION_BUSY`/`false` immediately. The asyncfatfs layer re-invokes on the next loop naturally, pacing retries without blocking.

**Fix state assignment:** Only set `sdcard.state = SDCARD_STATE_SENDING_WRITE` after confirming `SD_WriteBlocks_DMA()` succeeds. This mirrors the read-path pattern and ensures correct retry behavior.

## Testing

✅ **Build:** MATEKH743 (H7 SDIO target) compiles cleanly, no warnings
✅ **Code review:** Both commits approved
✅ **Backend audit:** No similar issues in other SD-card drivers

## Compliance

✅ **Retry-before-reset principle preserved** — still retries 3 times before reset
✅ **No new complexity** — pure removal of blocking calls
✅ **No behavior change** — only timing/reliability improvements

## Files Changed

- `src/main/drivers/sdcard/sdcard_sdio.c`

## Related

- Commit `146ff5616c` (introduced retry logic)
- Project: `claude/projects/active/fix-sdio-retry-blocking-delay/`