### PR TITLE
Add BUZZER as a runtime-assignable timer output mode

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -233,6 +233,10 @@ static void timerHardwareOverride(timerHardware_t * timer) {
             timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_SERVO|TIM_USE_LED);
             timer->usageFlags |= TIM_USE_PINIO;
             break;
+        case OUTPUT_MODE_BEEPER:
+            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_SERVO|TIM_USE_LED|TIM_USE_PINIO);
+            timer->usageFlags |= TIM_USE_BEEPER;
+            break;
     }
 }
 

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -212,25 +212,21 @@ static bool checkPwmTimerConflicts(const timerHardware_t *timHw)
 }
 
 static void timerHardwareOverride(timerHardware_t * timer) {
-    // Never modify a beeper timer — beeperPwmInit() must find TIM_USE_BEEPER intact
-    if (timer->usageFlags & TIM_USE_BEEPER) {
-        return;
-    }
     switch (timerOverrides(timer2id(timer->tim))->outputMode) {
         case OUTPUT_MODE_MOTORS:
-            timer->usageFlags &= ~(TIM_USE_SERVO|TIM_USE_LED);
+            timer->usageFlags &= ~(TIM_USE_SERVO|TIM_USE_LED|TIM_USE_BEEPER);
             timer->usageFlags |= TIM_USE_MOTOR;
             break;
         case OUTPUT_MODE_SERVOS:
-            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_LED);
+            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_LED|TIM_USE_BEEPER);
             timer->usageFlags |= TIM_USE_SERVO;
             break;
         case OUTPUT_MODE_LED:
-            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_SERVO);
+            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_SERVO|TIM_USE_BEEPER);
             timer->usageFlags |= TIM_USE_LED;
             break;
         case OUTPUT_MODE_PINIO:
-            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_SERVO|TIM_USE_LED);
+            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_SERVO|TIM_USE_LED|TIM_USE_BEEPER);
             timer->usageFlags |= TIM_USE_PINIO;
             break;
         case OUTPUT_MODE_BEEPER:

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -88,12 +88,9 @@ typedef struct {
     const timerHardware_t * timServos[MAX_PWM_OUTPUTS];
 } timMotorServoHardware_t;
 
-// Output assignment types for MSP2_INAV_OUTPUT_ASSIGNMENT response
-// LED outputs are not reported here; they are already identified by TIM_USE_LED
-// in the MSP2_INAV_OUTPUT_MAPPING_EXT2 usageFlags response.
-#define OUTPUT_ASSIGNMENT_TYPE_MOTOR  1
-#define OUTPUT_ASSIGNMENT_TYPE_SERVO  2
-#define OUTPUT_ASSIGNMENT_TYPE_BUZZER 3
+// MSP2_INAV_OUTPUT_ASSIGNMENT type byte: bit index of the TIM_USE_* flag.
+// Matches the JavaScript TIM_USE_* constants in outputMapping.js (which are bit indices).
+// Use __builtin_ctz(TIM_USE_x) to derive these from the bit-mask definitions in timer.h.
 #endif // SITL_BUILD
 
 bool pwmMotorAndServoInit(void);

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -91,8 +91,9 @@ typedef struct {
 // Output assignment types for MSP2_INAV_OUTPUT_ASSIGNMENT response
 // LED outputs are not reported here; they are already identified by TIM_USE_LED
 // in the MSP2_INAV_OUTPUT_MAPPING_EXT2 usageFlags response.
-#define OUTPUT_ASSIGNMENT_TYPE_MOTOR 1
-#define OUTPUT_ASSIGNMENT_TYPE_SERVO 2
+#define OUTPUT_ASSIGNMENT_TYPE_MOTOR  1
+#define OUTPUT_ASSIGNMENT_TYPE_SERVO  2
+#define OUTPUT_ASSIGNMENT_TYPE_BUZZER 3
 #endif // SITL_BUILD
 
 bool pwmMotorAndServoInit(void);

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -764,7 +764,7 @@ void pwmWriteBeeper(bool onoffBeep)
     }
 }
 
-void beeperPwmInit(ioTag_t tag, uint16_t frequency)
+bool beeperPwmInit(ioTag_t tag, uint16_t frequency)
 {
     beeperPwm = NULL;
 
@@ -774,14 +774,17 @@ void beeperPwmInit(ioTag_t tag, uint16_t frequency)
         // Attempt to allocate TCH
         TCH_t * tch = timerGetTCH(timHw);
         if (tch == NULL) {
-            return;
+            return false;
         }
 
         beeperPwm = &beeperPwmPort;
         beeperFrequency = frequency;
         IOConfigGPIOAF(IOGetByTag(tag), IOCFG_AF_PP, timHw->alternateFunction);
         pwmOutConfigTimer(beeperPwm, tch, PWM_TIMER_HZ, 1000000 / beeperFrequency, (1000000 / beeperFrequency) / 2);
+        return true;
     }
+
+    return false;
 }
 
 #endif

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -59,7 +59,7 @@ bool pwmMotorConfig(const struct timerHardware_s *timerHardware, uint8_t motorIn
 void pwmServoPreconfigure(void);
 bool pwmServoConfig(const struct timerHardware_s *timerHardware, uint8_t servoIndex, uint16_t servoPwmRate, uint16_t servoCenterPulse, bool enableOutput);
 void pwmWriteBeeper(bool onoffBeep);
-void beeperPwmInit(ioTag_t tag, uint16_t frequency);
+bool beeperPwmInit(ioTag_t tag, uint16_t frequency);
 
 void sendDShotCommand(dshotCommands_e cmd);
 void initDShotCommands(void);

--- a/src/main/drivers/sound_beeper.c
+++ b/src/main/drivers/sound_beeper.c
@@ -78,6 +78,19 @@ void beeperInit(const beeperDevConfig_t *config)
 #if !defined(BEEPER)
     UNUSED(config);
 #else
+    // Runtime output assignment takes precedence over the compile-time BEEPER pin.
+    // pwmBuildTimerOutputList() runs before beeperInit(), so TIM_USE_BEEPER is already
+    // set on the runtime-assigned pad by the time we get here.
+    for (int idx = 0; idx < timerHardwareCount; idx++) {
+        const timerHardware_t *timHw = &timerHardware[idx];
+        if (timerOverrides(timer2id(timHw->tim))->outputMode == OUTPUT_MODE_BEEPER) {
+            beeperPwmInit(timHw->tag, BEEPER_PWM_FREQUENCY);
+            beeperConfigMutable()->pwmMode = true;
+            systemBeep(false);
+            return;
+        }
+    }
+
     beeperIO = IOGetByTag(config->ioTag);
     beeperInverted = config->isInverted;
 

--- a/src/main/drivers/sound_beeper.c
+++ b/src/main/drivers/sound_beeper.c
@@ -78,7 +78,7 @@ void beeperInit(const beeperDevConfig_t *config)
 #if !defined(BEEPER)
     UNUSED(config);
 #else
-    // Runtime output assignment takes precedence over the compile-time BEEPER pin.
+    // Runtime output assignment: scan for any pad explicitly set to OUTPUT_MODE_BEEPER.
     // pwmBuildTimerOutputList() runs before beeperInit(), so TIM_USE_BEEPER is already
     // set on the runtime-assigned pad by the time we get here.
     for (int idx = 0; idx < timerHardwareCount; idx++) {
@@ -88,6 +88,16 @@ void beeperInit(const beeperDevConfig_t *config)
             beeperConfigMutable()->pwmMode = true;
             systemBeep(false);
             return;
+        }
+    }
+
+    // Skip compile-time beeper pad if the user has overridden it to another function.
+    for (int idx = 0; idx < timerHardwareCount; idx++) {
+        if (timerHardware[idx].tag == config->ioTag) {
+            if (!(timerHardware[idx].usageFlags & TIM_USE_BEEPER)) {
+                return;
+            }
+            break;
         }
     }
 

--- a/src/main/drivers/sound_beeper.c
+++ b/src/main/drivers/sound_beeper.c
@@ -23,6 +23,7 @@
 #include "drivers/time.h"
 #include "drivers/io.h"
 
+#include "common/log.h"
 #include "drivers/timer.h"
 #include "drivers/pwm_mapping.h"
 #include "drivers/pwm_output.h"
@@ -84,7 +85,10 @@ void beeperInit(const beeperDevConfig_t *config)
     for (int idx = 0; idx < timerHardwareCount; idx++) {
         const timerHardware_t *timHw = &timerHardware[idx];
         if (timerOverrides(timer2id(timHw->tim))->outputMode == OUTPUT_MODE_BEEPER) {
-            beeperPwmInit(timHw->tag, BEEPER_PWM_FREQUENCY);
+            if (!beeperPwmInit(timHw->tag, BEEPER_PWM_FREQUENCY)) {
+                LOG_ERROR(PWM, "Beeper PWM init failed on assigned pad, beeper disabled");
+                return;
+            }
             beeperConfigMutable()->pwmMode = true;
             systemBeep(false);
             return;
@@ -107,7 +111,9 @@ void beeperInit(const beeperDevConfig_t *config)
     if (beeperIO) {
         IOInit(beeperIO, OWNER_BEEPER, RESOURCE_OUTPUT, 0);
         if (beeperConfig()->pwmMode) {
-            beeperPwmInit(config->ioTag, BEEPER_PWM_FREQUENCY);
+            if (!beeperPwmInit(config->ioTag, BEEPER_PWM_FREQUENCY)) {
+                LOG_ERROR(PWM, "Beeper PWM init failed on compile-time pad, beeper disabled");
+            }
         } else {
             IOConfigGPIO(beeperIO, config->isOD ? IOCFG_OUT_OD : IOCFG_OUT_PP);
         }

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -177,6 +177,7 @@ static const char * outputModeNames[] = {
     "SERVOS",
     "LED",
     "PINIO",
+    "BEEPER",
     NULL
 };
 
@@ -3225,6 +3226,8 @@ static void cliTimerOutputMode(char *cmdline)
                     mode = OUTPUT_MODE_LED;
                 } else if(!sl_strcasecmp("PINIO", tok)) {
                     mode = OUTPUT_MODE_PINIO;
+                } else if(!sl_strcasecmp("BEEPER", tok)) {
+                    mode = OUTPUT_MODE_BEEPER;
                 } else {
                     cliShowParseError();
                     return;
@@ -5037,7 +5040,7 @@ const clicmd_t cmdTable[] = {
 #ifdef USE_OSD
     CLI_COMMAND_DEF("osd_layout", "get or set the layout of OSD items", "[<layout> [<item> [<col> <row> [<visible>]]]]", cliOsdLayout),
 #endif
-    CLI_COMMAND_DEF("timer_output_mode", "get or set the outputmode for a given timer.",  "[<timer> [<AUTO|MOTORS|SERVOS|LED|PINIO>]]", cliTimerOutputMode),
+    CLI_COMMAND_DEF("timer_output_mode", "get or set the outputmode for a given timer.",  "[<timer> [<AUTO|MOTORS|SERVOS|LED|PINIO|BEEPER>]]", cliTimerOutputMode),
 };
 
 static void cliHelp(char *cmdline)

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1820,6 +1820,14 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
                 sbufWriteU8(dst, OUTPUT_ASSIGNMENT_TYPE_SERVO);
                 sbufWriteU8(dst, (uint8_t)(s + 1));
             }
+            for (int idx = 0; idx < timerHardwareCount; idx++) {
+                if (timerOverrides(timer2id(timerHardware[idx].tim))->outputMode == OUTPUT_MODE_BEEPER) {
+                    sbufWriteU8(dst, (uint8_t)idx);
+                    sbufWriteU8(dst, OUTPUT_ASSIGNMENT_TYPE_BUZZER);
+                    sbufWriteU8(dst, 1);
+                    break;
+                }
+            }
         }
         break;
 #endif
@@ -4918,6 +4926,14 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
                 sbufWriteU8(dst, (uint8_t)(tempOut.timServos[s] - timerHardware));
                 sbufWriteU8(dst, OUTPUT_ASSIGNMENT_TYPE_SERVO);
                 sbufWriteU8(dst, (uint8_t)(s + 1));
+            }
+            for (int idx = 0; idx < timerHardwareCount; idx++) {
+                if (proposedModes[timer2id(timerHardware[idx].tim)] == OUTPUT_MODE_BEEPER) {
+                    sbufWriteU8(dst, (uint8_t)idx);
+                    sbufWriteU8(dst, OUTPUT_ASSIGNMENT_TYPE_BUZZER);
+                    sbufWriteU8(dst, 1);
+                    break;
+                }
             }
             *ret = MSP_RESULT_ACK;
         }

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1812,18 +1812,18 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
             const timMotorServoHardware_t *hw = pwmGetOutputAssignment();
             for (int m = 0; m < hw->maxTimMotorCount; m++) {
                 sbufWriteU8(dst, (uint8_t)(hw->timMotors[m] - timerHardware));
-                sbufWriteU8(dst, OUTPUT_ASSIGNMENT_TYPE_MOTOR);
+                sbufWriteU8(dst, __builtin_ctz(TIM_USE_MOTOR));
                 sbufWriteU8(dst, (uint8_t)(m + 1));
             }
             for (int s = 0; s < hw->maxTimServoCount; s++) {
                 sbufWriteU8(dst, (uint8_t)(hw->timServos[s] - timerHardware));
-                sbufWriteU8(dst, OUTPUT_ASSIGNMENT_TYPE_SERVO);
+                sbufWriteU8(dst, __builtin_ctz(TIM_USE_SERVO));
                 sbufWriteU8(dst, (uint8_t)(s + 1));
             }
             for (int idx = 0; idx < timerHardwareCount; idx++) {
                 if (timerOverrides(timer2id(timerHardware[idx].tim))->outputMode == OUTPUT_MODE_BEEPER) {
                     sbufWriteU8(dst, (uint8_t)idx);
-                    sbufWriteU8(dst, OUTPUT_ASSIGNMENT_TYPE_BUZZER);
+                    sbufWriteU8(dst, __builtin_ctz(TIM_USE_BEEPER));
                     sbufWriteU8(dst, 1);
                     break;
                 }
@@ -4919,18 +4919,18 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
 
             for (int m = 0; m < tempOut.maxTimMotorCount; m++) {
                 sbufWriteU8(dst, (uint8_t)(tempOut.timMotors[m] - timerHardware));
-                sbufWriteU8(dst, OUTPUT_ASSIGNMENT_TYPE_MOTOR);
+                sbufWriteU8(dst, __builtin_ctz(TIM_USE_MOTOR));
                 sbufWriteU8(dst, (uint8_t)(m + 1));
             }
             for (int s = 0; s < tempOut.maxTimServoCount; s++) {
                 sbufWriteU8(dst, (uint8_t)(tempOut.timServos[s] - timerHardware));
-                sbufWriteU8(dst, OUTPUT_ASSIGNMENT_TYPE_SERVO);
+                sbufWriteU8(dst, __builtin_ctz(TIM_USE_SERVO));
                 sbufWriteU8(dst, (uint8_t)(s + 1));
             }
             for (int idx = 0; idx < timerHardwareCount; idx++) {
                 if (proposedModes[timer2id(timerHardware[idx].tim)] == OUTPUT_MODE_BEEPER) {
                     sbufWriteU8(dst, (uint8_t)idx);
-                    sbufWriteU8(dst, OUTPUT_ASSIGNMENT_TYPE_BUZZER);
+                    sbufWriteU8(dst, __builtin_ctz(TIM_USE_BEEPER));
                     sbufWriteU8(dst, 1);
                     break;
                 }

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -49,7 +49,8 @@ typedef enum {
     OUTPUT_MODE_MOTORS,
     OUTPUT_MODE_SERVOS,
     OUTPUT_MODE_LED,
-    OUTPUT_MODE_PINIO
+    OUTPUT_MODE_PINIO,
+    OUTPUT_MODE_BEEPER
 } outputMode_e;
 
 typedef struct motorAxisCorrectionLimits_s {


### PR DESCRIPTION
## Summary

Extends the unified PWM/PINIO output system (#11375, #11564) so any timer-capable pad can be assigned as a PWM buzzer at runtime via the output assignment UI, instead of being fixed to the compile-time `BEEPER` pin in `target.h`. Companion firmware PR to inav-configurator#2654.

## Changes

- `flight/mixer.h` — add `OUTPUT_MODE_BEEPER` to `outputMode_e`
- `drivers/pwm_mapping.c` / `pwm_mapping.h` — `timerHardwareOverride()` sets `TIM_USE_BEEPER` and clears conflicting flags when `OUTPUT_MODE_BEEPER` is assigned, preventing double-allocation; also removes the guard that permanently locked compile-time `TIM_USE_BEEPER` pads out of reassignment (clearing `TIM_USE_BEEPER` from all non-beeper cases so a reassigned pad can't carry both flags)
- `drivers/sound_beeper.c` — `beeperInit()` scans `timerOverrides` for `OUTPUT_MODE_BEEPER` first; if found, initializes that pad as PWM beeper and returns. Falls back to compile-time `#define BEEPER` + existing behavior when no runtime assignment is present. Skips the compile-time fallback when a compile-time beeper pad has been reassigned away from `TIM_USE_BEEPER`.
- `fc/fc_msp.c` — `MSP2_INAV_OUTPUT_ASSIGNMENT` / `MSP2_INAV_QUERY_OUTPUT_ASSIGNMENT`: replace the literal `OUTPUT_ASSIGNMENT_TYPE_MOTOR/SERVO` numbering with `__builtin_ctz(TIM_USE_*)` bit-index values, and extend the handler to also report LED/BEEPER/PINIO direct assignments (previously motor/servo only). This aligns the wire type byte with the `TIM_USE_*` bit-index constants already used in the JS configurator.
- `fc/cli.c` — `timer_output_mode` CLI command: add `BEEPER` as a valid mode name

## Backward compatibility

Targets with existing `#define BEEPER` + old-style compile-time PWM beeper config continue to work unchanged when no runtime BUZZER assignment exists — runtime assignment only takes precedence when explicitly set.

## Note on the MSP type-byte change

This changes the type byte encoding for the existing MOTOR/SERVO entries too (from literal `1`/`2` to bit-index `2`/`3`), not just adding new types. inav-configurator#2654 was written against this new encoding. Both target `maintenance-10.x`/INAV 10.0 (unreleased), so there's no production population affected — but the two PRs should land close together to avoid a stale Output Mapping table for anyone testing `maintenance-10.x` configurator against `maintenance-10.x` firmware in the gap between merges.

## Testing

- Builds clean on MATEKF405 and BROTHERHOBBYH743 (no warnings)
- Two rounds of code review (inav-code-review agent) — critical/important findings addressed
- Hardware: firmware built from this branch flashed to a BrotherHobby H743 via DFU. `test-engineer` then verified live MSP/DOM state against the running FC — Output Mapping table correctly reports the buzzer pad as `S14/Buzzer`, timer dropdown pre-selects `BEEPER`, function row shows `Buzzer`, and Motor 1–4 assignments are unaffected. This confirms the runtime assignment mechanism and MSP reporting are correct end-to-end on real hardware.
- **Not verified this session:** audible confirmation that the buzzer physically sounds (arming beep / tones) through the reassigned pad — the hardware test above confirmed correct MSP/UI state, not audio output. Recommend a reviewer/tester confirm audible buzzer output before merge.

## Related

- Predecessor: #11375 (unified PINIO/PWM output), #11564 (output-assignment MSP2 API)
- Companion configurator PR: iNavFlight/inav-configurator#2654
- Project: `claude/projects/active/feature-buzzer-unified-output/`