### PR TITLE
Fix int8_t overflow in AAF frequency selection for ICM-42688P/42686P

### DIFF
--- a/src/main/drivers/accgyro/accgyro_icm42605.c
+++ b/src/main/drivers/accgyro/accgyro_icm42605.c
@@ -422,7 +422,7 @@ static const aafConfig_t *getGyroAafConfig(icm42605Variant_e variant, const uint
         aafConfigs = aafLUT42605;
     }
     int i;
-    int8_t selectedFreq = aafConfigs[0].freq;
+    uint16_t selectedFreq = aafConfigs[0].freq;
     const aafConfig_t * candidate = &aafConfigs[0];
 
     // Choose closest supported LPF value


### PR DESCRIPTION
## Summary
`getGyroAafConfig()` in `src/main/drivers/accgyro/accgyro_icm42605.c` tracks the running "best candidate" Anti-Alias Filter (AAF) frequency in a local variable `selectedFreq` declared as `int8_t` (max value 127). The `aafLUT42688[]` table (used for ICM-42688P/42686P) contains `freq` values up to 1962, all stored as `uint16_t` in `aafConfig_t`. Any LUT value above 127 silently truncates on assignment to `selectedFreq`, corrupting the closest-frequency comparison and causing the wrong AAF register configuration to be selected.

This affects every board using the ICM-42688P/42686P gyro at INAV's default hardware LPF setting (`GYRO_LPF_256HZ`, set unconditionally in `gyro.c`): the function selects 303Hz instead of the correct 258Hz AAF cutoff.

## Changes
- Changed `selectedFreq` from `int8_t` to `uint16_t` in `getGyroAafConfig()`, matching the type of `aafConfig_t.freq` (the field it tracks) and `desiredFreq` (the value it's compared against).

## Testing
- Wrote a standalone test harness reproducing the exact struct/LUT/algorithm from the source file, confirming the bug: for `GYRO_LPF_256HZ` (default) on the 42688P table, the buggy code selects 303Hz instead of the correct 258Hz; also reproduced for `GYRO_LPF_188HZ` on both the 42688P and 42605 tables.
- Re-ran the same harness with the fix applied — all cases now select the correct closest-frequency LUT entry.
- Built the `AETH743Basic` target (uses ICM-42688P, confirmed via WHOAMI-detected `ICM42605_VARIANT_42688P` at runtime, exercising `aafLUT42688[]` directly) — build succeeds with zero warnings on the changed file.
- Verified via manual trace of C integer promotion rules that the `ABS()` macro (`src/main/common/maths.h`) has no signed/unsigned hazard now that `desiredFreq`, `selectedFreq`, and `aafConfigs[i].freq` are all `uint16_t` — both operands promote to signed `int` before subtraction on all INAV-supported 32-bit targets.

## Code Review
Reviewed with inav-code-review agent — approved, no issues found.

## Related
This is a long-standing pre-existing bug present on master, maintenance-9.x, maintenance-10.x, and release/9.1. Flagged by Qodo bot review on PR #11681 (a release/9.1 → maintenance-10.x branch-sync merge) and independently verified against the actual file content. Targeting `release/9.1` per current branch-basing guidance; this will flow up to maintenance-10.x via the normal release/9.1 → maintenance-10.x merge process.