### PR TITLE
Fix BEEPER timer sibling pad mislabeling and expose them as PINIO

### DIFF
--- a/src/main/drivers/pinio.c
+++ b/src/main/drivers/pinio.c
@@ -154,7 +154,17 @@ void pinioInit(void)
         }
         if (pinioInitTimerPWM(runtimeCount, io, timHw, false)) {
             runtimeCount++;
+            continue;
         }
+
+        // GPIO fallback: pad's timer is already running at a fixed frequency
+        // for another purpose (e.g. BEEPER), so PWM duty control isn't available.
+        IOInit(io, OWNER_PINIO, RESOURCE_OUTPUT, RESOURCE_INDEX(runtimeCount));
+        IOConfigGPIO(io, IOCFG_OUT_PP);
+        pinioRuntime[runtimeCount].inverted = false;
+        pinioRuntime[runtimeCount].io = io;
+        IOLo(io);
+        runtimeCount++;
     }
 
     pinioRuntimeCount = runtimeCount;

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -231,9 +231,12 @@ static void timerHardwareOverride(timerHardware_t * timer, bool isCanonicalBeepe
             break;
         case OUTPUT_MODE_BEEPER:
             // Other channels of this timer share its period register, so they can't
-            // be repurposed as motor/servo/LED/PINIO either — leave them flagless.
-            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_SERVO|TIM_USE_LED|TIM_USE_PINIO|TIM_USE_BEEPER);
+            // be repurposed as motor/servo/LED either. They can still drive a GPIO-only
+            // PINIO (binary on/off, no PWM), since that doesn't need the timer's period.
+            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_SERVO|TIM_USE_LED|TIM_USE_BEEPER);
+            timer->usageFlags |= TIM_USE_PINIO;
             if (isCanonicalBeeperPad) {
+                timer->usageFlags &= ~TIM_USE_PINIO;
                 timer->usageFlags |= TIM_USE_BEEPER;
             }
             break;

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -211,7 +211,7 @@ static bool checkPwmTimerConflicts(const timerHardware_t *timHw)
     return false;
 }
 
-static void timerHardwareOverride(timerHardware_t * timer) {
+static void timerHardwareOverride(timerHardware_t * timer, bool isCanonicalBeeperPad) {
     switch (timerOverrides(timer2id(timer->tim))->outputMode) {
         case OUTPUT_MODE_MOTORS:
             timer->usageFlags &= ~(TIM_USE_SERVO|TIM_USE_LED|TIM_USE_BEEPER);
@@ -230,8 +230,12 @@ static void timerHardwareOverride(timerHardware_t * timer) {
             timer->usageFlags |= TIM_USE_PINIO;
             break;
         case OUTPUT_MODE_BEEPER:
-            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_SERVO|TIM_USE_LED|TIM_USE_PINIO);
-            timer->usageFlags |= TIM_USE_BEEPER;
+            // Other channels of this timer share its period register, so they can't
+            // be repurposed as motor/servo/LED/PINIO either — leave them flagless.
+            timer->usageFlags &= ~(TIM_USE_MOTOR|TIM_USE_SERVO|TIM_USE_LED|TIM_USE_PINIO|TIM_USE_BEEPER);
+            if (isCanonicalBeeperPad) {
+                timer->usageFlags |= TIM_USE_BEEPER;
+            }
             break;
     }
 }
@@ -319,8 +323,16 @@ void pwmBuildTimerOutputList(timMotorServoHardware_t *timOutputs)
     uint8_t servoCount = anyServo ? (uint8_t)(1 + maxServo - minServo) : 0;
 
     // Apply all timerOverrides upfront so flag state is stable for both passes
+    bool beeperClaimed[HARDWARE_TIMER_DEFINITION_COUNT] = { false };
     for (int idx = 0; idx < timerHardwareCount; idx++) {
-        timerHardwareOverride(&timerHardware[idx]);
+        timerHardware_t *timHw = &timerHardware[idx];
+        uint8_t timId = timer2id(timHw->tim);
+        bool isCanonicalBeeperPad = false;
+        if (timerOverrides(timId)->outputMode == OUTPUT_MODE_BEEPER && !beeperClaimed[timId]) {
+            beeperClaimed[timId] = true;
+            isCanonicalBeeperPad = true;
+        }
+        timerHardwareOverride(timHw, isCanonicalBeeperPad);
     }
 
     // Assign outputs in priority order: dedicated first, then auto.


### PR DESCRIPTION
## Summary
Follows up on #11675 (unified buzzer output). When a timer is set to BEEPER output mode, only the timer's first channel is actually wired up as the beeper (`beeperInit()` picks the first match); the other channels on that same physical timer share its period register and can't independently do anything else. Previously those sibling channels kept whatever usage flags they already had, so the Configurator's Mixer tab labeled every pad on that timer "Buzzer" even though only one pad actually functioned as one.

## Changes
- `pwm_mapping.c`: `timerHardwareOverride()` now only applies `TIM_USE_BEEPER` to the canonical (first-match) pad on a BEEPER-mode timer. Sibling pads get their motor/servo/LED/beeper flags cleared so they're no longer mislabeled.
- `pinio.c` / `pwm_mapping.c`: since sibling pads can't do PWM (the timer's period is fixed for an audible tone) but can still be driven as simple on/off outputs, they're now flagged `TIM_USE_PINIO` instead of being left completely unusable. Added a GPIO-only fallback to `pinioInit()`'s Pass 2 (mirroring the existing fallback in Pass 1) for pads that fail PWM setup for this reason.
- Existing `PINIO_COUNT` (4) and MSP labeling caps are respected automatically — on boards that already have 4 target-defined PINIO pins, the new sibling pads are correctly inert with no phantom labels in the Configurator.

## Testing
- Build-verified (BROTHERHOBBYH743, KAKUTEF7): clean compile and link, no new warnings.
- Hardware-verified on a BrotherHobby H743: confirmed via MSP that only the canonical beeper pad reports `TIM_USE_BEEPER`/BEEPER label, and manually confirmed the buzzer works correctly when moved to different pads on the same timer bank.
- Code-reviewed (embedded-C correctness, IO ownership/resource-index correctness, struct-field parity with the existing Pass 1 GPIO fallback pattern): approved.

## Related Issues
Follow-up to #11675