### PR TITLE
Add SOLOGOODF722 target (with config.c for PINIO user boxes)

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -99,9 +99,10 @@ struct {
     // Winbond W25Q128_DTR
     // Datasheet: https://www.winbond.com/resource-files/w25q128jv%20dtr%20revb%2011042016.pdf
     {0xEF7018, 256, 256},
-    // Puya PY25Q128HA
+    // Puya PY25Q128
     // Datasheet: https://www.puyasemi.com/cpzx3/info_271_itemid_87.html
-    {0x856018, 256, 256},
+    {0x856018, 256, 256}, // PY25Q128H
+    {0x852018, 256, 256}, // PY25Q128HA
     // Winbond W25Q256
     // Datasheet: https://www.winbond.com/resource-files/w25q256jv%20spi%20revb%2009202016.pdf
     {0xEF4019, 512, 256},

--- a/src/main/target/SOLOGOODF722/CMakeLists.txt
+++ b/src/main/target/SOLOGOODF722/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f722xe(SOLOGOODF722)

--- a/src/main/target/SOLOGOODF722/config.c
+++ b/src/main/target/SOLOGOODF722/config.c
@@ -1,0 +1,28 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include "platform.h"
+#include "fc/fc_msp_box.h"
+#include "fc/config.h"
+#include "io/piniobox.h"
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+}

--- a/src/main/target/SOLOGOODF722/target.c
+++ b/src/main/target/SOLOGOODF722/target.c
@@ -1,0 +1,40 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "platform.h"
+#include "drivers/io.h"
+
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_OUTPUT_AUTO, 0, 0), // S1
+    DEF_TIM(TIM8, CH4, PC9,  TIM_USE_OUTPUT_AUTO, 0, 0), // S2
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_OUTPUT_AUTO, 0, 1), // S3
+    DEF_TIM(TIM1, CH2, PA9,  TIM_USE_OUTPUT_AUTO, 0, 1), // S4
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_OUTPUT_AUTO, 0, 0), // S5
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_OUTPUT_AUTO, 0, 0), // S6
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_OUTPUT_AUTO, 0, 1), // S7
+    DEF_TIM(TIM3, CH1, PB4,  TIM_USE_OUTPUT_AUTO, 0, 0), // S8
+
+    DEF_TIM(TIM2, CH2, PB3, TIM_USE_LED, 0, 0), // 2812LED
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/SOLOGOODF722/target.h
+++ b/src/main/target/SOLOGOODF722/target.h
@@ -1,0 +1,170 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "SGF7"
+
+#define USBD_PRODUCT_STRING     "SOLOGOODF722"
+
+#define LED0                    PC15
+
+#define BEEPER                  PC13
+#define BEEPER_INVERTED
+
+// *************** Gyro & ACC **********************
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+
+#define SPI1_NSS_PIN            PA4
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+
+#define USE_IMU_MPU6000
+#define IMU_MPU6000_ALIGN       CW180_DEG
+#define MPU6000_CS_PIN          SPI1_NSS_PIN
+#define MPU6000_SPI_BUS         BUS_SPI1
+
+#define USE_IMU_BMI270
+#define IMU_BMI270_ALIGN        CW180_DEG
+#define BMI270_CS_PIN           SPI1_NSS_PIN
+#define BMI270_SPI_BUS          BUS_SPI1
+
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW180_DEG
+#define ICM42605_CS_PIN         SPI1_NSS_PIN
+#define ICM42605_SPI_BUS        BUS_SPI1
+
+// *************** I2C/Baro/Mag *********************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+
+#define DEFAULT_I2C_BUS         BUS_I2C1
+
+#define USE_BARO
+#define BARO_I2C_BUS            DEFAULT_I2C_BUS
+#define USE_BARO_DPS310
+
+#define USE_MAG
+#define MAG_I2C_BUS             DEFAULT_I2C_BUS
+#define USE_MAG_ALL
+
+#define TEMPERATURE_I2C_BUS     DEFAULT_I2C_BUS
+
+#define PITOT_I2C_BUS           DEFAULT_I2C_BUS
+
+#define USE_RANGEFINDER
+#define RANGEFINDER_I2C_BUS     DEFAULT_I2C_BUS
+
+// *************** FLASH **************************
+#define USE_SPI_DEVICE_3
+#define SPI3_NSS_PIN            PA15
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PB5
+
+#define M25P16_CS_PIN           SPI3_NSS_PIN
+#define M25P16_SPI_BUS          BUS_SPI3
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+
+// *************** OSD *****************************
+#define USE_SPI_DEVICE_2
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          SPI2_NSS_PIN
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN PB7
+#define UART1_TX_PIN PB6
+
+#define USE_UART2
+#define UART2_RX_PIN            PA3
+#define UART2_TX_PIN            PA2
+
+#define USE_UART3
+#define UART3_RX_PIN            PB11
+#define UART3_TX_PIN            PB10
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART5
+#define UART5_RX_PIN            PD2
+#define UART5_TX_PIN PC12
+
+#define USE_UART6
+#define UART6_RX_PIN            PC7
+#define UART6_TX_PIN            PC6
+
+#define SERIAL_PORT_COUNT       7
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC1
+#define ADC_CHANNEL_2_PIN           PC3
+
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+
+
+#define DEFAULT_FEATURES            (FEATURE_TX_PROF_SEL | FEATURE_CURRENT_METER | FEATURE_TELEMETRY | FEATURE_VBAT | FEATURE_OSD | FEATURE_BLACKBOX)
+// *************** PINIO ************************
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                      PC2
+#define PINIO2_PIN                      PC0
+
+// *************** LEDSTRIP ************************
+#define USE_LED_STRIP
+#define WS2811_PIN                  PB3
+
+// Others
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define CURRENT_METER_SCALE 250
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define MAX_PWM_OUTPUT_PORTS 8
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR


### PR DESCRIPTION
## Summary

Finishes #11394 (adds the SOLOGOODF722 flight controller target) by adding the
`config.c` file requested in review but never supplied by the original PR author.

Credit for the target and flash chip support goes entirely to the author of
#11394 (Valerii Chebanov) — the 3 commits here are cherry-picked unchanged
from that PR. This PR adds one new commit on top: `config.c`, per
sensei-hacker's 2026-05-18 review comment on #11394 asking for the target's
two PINIO pins to be made available as user-assignable boxes.

## Changes

- `src/main/drivers/flash_m25p16.c` — corrects the label on the existing
  `0x856018` JEDEC ID entry (was mislabeled "PY25Q128HA", now "PY25Q128H")
  and adds the actual PY25Q128HA entry (`0x852018`) used by this target's
  flash chip. (From #11394.)
- `src/main/target/SOLOGOODF722/{CMakeLists.txt,target.c,target.h}` — new
  hardware target. (From #11394.)
- `src/main/target/SOLOGOODF722/config.c` — new. Implements
  `targetConfiguration()` to assign the target's two PINIO pins to
  `BOX_PERMANENT_ID_USER1`/`USER2`, matching the pattern used by other
  targets (e.g. `AOCODARCH7DUAL`).

## Testing

- Built the `SOLOGOODF722` target successfully (RelWithDebInfo): no compiler
  or linker errors/warnings. Flash usage ~467KB, RAM ~129KB, no overflow.
- Verified `config.c`'s `pinioBoxConfigMutable()` and
  `BOX_PERMANENT_ID_USER1/2` resolve correctly via `io/piniobox.h` and
  `fc/fc_msp_box.h`.
- Verified all motor/LED timer channels in `target.c` map to distinct
  DMA controller/stream pairs (no DMA contention), including the
  `dmaopt=1` override needed to avoid a DMA2 Stream6 collision between
  TIM1_CH1 and TIM1_CH2.

