### PR TITLE
Update DAKEFPVF405 PINIO

### DIFF
--- a/src/main/target/DAKEFPVF405/config.c
+++ b/src/main/target/DAKEFPVF405/config.c
@@ -28,4 +28,5 @@
 void targetConfiguration(void)
 {
     pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
 }

--- a/src/main/target/DAKEFPVF405/target.h
+++ b/src/main/target/DAKEFPVF405/target.h
@@ -101,8 +101,8 @@
 #define MAX7456_CS_PIN          PB12
 
 // CAMERA_CONTROL
-// PA8 is currently inert (no INAV driver consumes CAMERA_CONTROL_PIN yet). Candidate for
-// migration to a PWM-capable PINIO once that lands in 10.0.
+// PA8 has no consuming driver prior to 10.0. From 10.0 forward this will be set up as a
+// PWM-capable PINIO pin instead -- see the October 2026 migration project.
 #define CAMERA_CONTROL_PIN      PA8
 
 // Serial ports

--- a/src/main/target/DAKEFPVF405/target.h
+++ b/src/main/target/DAKEFPVF405/target.h
@@ -72,12 +72,9 @@
 #define BMI270_SPI_BUS          BUS_SPI1
 #define BMI270_CS_PIN           PA4
 
-#define USE_IMU_ICM42688P
-#define IMU_ICM42688P_ALIGN     CW90_DEG
-#define ICM42688P_CS_PIN        PA4
-#define ICM42688P_SPI_BUS       BUS_SPI1
+// ICM42688P driver handled by USE_IMU_ICM42605 above (shares WHO_AM_I detection)
 
-//Baro 
+//Baro
 #define USE_BARO
 #define USE_BARO_BMP280
 #define BMP280_SPI_BUS          BUS_SPI2

--- a/src/main/target/DAKEFPVF405/target.h
+++ b/src/main/target/DAKEFPVF405/target.h
@@ -101,6 +101,8 @@
 #define MAX7456_CS_PIN          PB12
 
 // CAMERA_CONTROL
+// PA8 is currently inert (no INAV driver consumes CAMERA_CONTROL_PIN yet). Candidate for
+// migration to a PWM-capable PINIO once that lands in 10.0.
 #define CAMERA_CONTROL_PIN      PA8
 
 // Serial ports

--- a/src/main/target/DAKEFPVF405/target.h
+++ b/src/main/target/DAKEFPVF405/target.h
@@ -72,6 +72,11 @@
 #define BMI270_SPI_BUS          BUS_SPI1
 #define BMI270_CS_PIN           PA4
 
+#define USE_IMU_ICM42688P
+#define IMU_ICM42688P_ALIGN     CW90_DEG
+#define ICM42688P_CS_PIN        PA4
+#define ICM42688P_SPI_BUS       BUS_SPI1
+
 //Baro 
 #define USE_BARO
 #define USE_BARO_BMP280
@@ -94,6 +99,9 @@
 #define USE_MAX7456
 #define MAX7456_SPI_BUS         BUS_SPI2
 #define MAX7456_CS_PIN          PB12
+
+// CAMERA_CONTROL
+#define CAMERA_CONTROL_PIN      PA8
 
 // Serial ports
 #define USE_VCP
@@ -171,3 +179,5 @@
 #define USE_PINIOBOX
 #define PINIO1_PIN                  PC5
 #define PINIO1_FLAGS                PINIO_FLAGS_INVERTED
+#define PINIO2_PIN                  PB4
+#define PINIO2_FLAGS                PINIO_FLAGS_INVERTED


### PR DESCRIPTION
## Changes

- Added `PINIO2_PIN`/`PINIO2_FLAGS` (`PB4`, inverted) alongside the
  existing `PINIO1`, and set `pinioBoxConfigMutable()->permanentId[1] =
  BOX_PERMANENT_ID_USER2` in `config.c` to match.
- Added `CAMERA_CONTROL_PIN` (`PA8`), matching the convention used by
  sibling Dake targets. This pin has no consuming driver in INAV prior to
  10.0; commented accordingly, and noted as a migration candidate once
  10.0's planned PWM-capable PINIO support lands.
- Confirmed `ICM42688P`   requires no additional target.h changes: the existing
  `USE_IMU_ICM42605` driver already recognizes ICM42688P's `WHO_AM_I` ID
  and handles detection on the same SPI1/PA4 bus. Added a one-line
  comment noting this so it isn't mistaken for missing support.
- Everything else in the current Betaflight config (motor/servo/LED


**Not included:** `LSM6DSV16X` and `LSM6DSK320X`  gyro options. will be added after support for those is added and tested in INAV

