### PR TITLE
Add LSM6DSV16X/LSM6DSK320X support to LSM6DXX accgyro driver

### DIFF
--- a/src/main/drivers/accgyro/accgyro_lsm6dxx.c
+++ b/src/main/drivers/accgyro/accgyro_lsm6dxx.c
@@ -49,8 +49,18 @@ typedef struct __attribute__ ((__packed__)) lsm6DContextData_s {
 #define LSM6DSO_CHIP_ID 0x6C
 #define LSM6DSL_CHIP_ID 0x6A
 #define LSM6DS3_CHIP_ID 0x69
+// "Gen V" chips - reorganized register map vs. the DSO/DSL/DS3 above, see lsm6dxxConfigGenV()
+#define LSM6DSV16X_CHIP_ID 0x70
+#define LSM6DSK320X_CHIP_ID 0x75
 
+// Single physical instance assumed: set once by lsm6dxxDetect() and read by lsm6dxxConfig()/
+// lsm6dxxIsGenV() afterward for the same instance - gyro detect always runs before config.
 static uint8_t lsm6dID = 0x6C;
+
+static inline bool lsm6dxxIsGenV(void)
+{
+    return lsm6dID == LSM6DSV16X_CHIP_ID || lsm6dID == LSM6DSK320X_CHIP_ID;
+}
 
 static void lsm6dxxWriteRegister(const  busDevice_t *dev, lsm6dxxRegister_e registerID, uint8_t value, unsigned delayMs)
 {
@@ -85,8 +95,88 @@ static uint8_t getLsmDlpfBandwidth(gyroDev_t *gyro)
     return 0;
 }
 
+// LPF1 bandwidth options for the Gen V chips, at the fixed 7.68kHz LPF1+LPF2 table row this
+// driver uses. Values cross-checked against atbetaflight's accgyro_spi_lsm6dsv16x.c, which
+// uses this same mapping on real hardware.
+static uint8_t getLsmVDlpfBandwidth(gyroDev_t *gyro)
+{
+    switch (gyro->lpf) {
+        case GYRO_HARDWARE_LPF_NORMAL:
+            return LSM6DXX_VAL_CTRL6_C_V_LPF1_BW_288HZ;
+        case GYRO_HARDWARE_LPF_OPTION_1:
+            return LSM6DXX_VAL_CTRL6_C_V_LPF1_BW_157HZ;
+        case GYRO_HARDWARE_LPF_OPTION_2:
+            return LSM6DXX_VAL_CTRL6_C_V_LPF1_BW_215HZ;
+        case GYRO_HARDWARE_LPF_EXPERIMENTAL:
+            return LSM6DXX_VAL_CTRL6_C_V_LPF1_BW_455HZ;
+    }
+    return LSM6DXX_VAL_CTRL6_C_V_LPF1_BW_288HZ;
+}
+
+// Configuration for LSM6DSV16X / LSM6DSK320X ("Gen V" chips - see lsm6dxxIsGenV()). These
+// reorganized CTRL1_XL/CTRL2_G to hold ODR + operating mode only (full scale moved to
+// CTRL6_C/CTRL8_XL) with a different ODR bit encoding, so they need their own config sequence
+// rather than sharing the legacy DSO/DSL/DS3 one below. Sequence and register values are
+// cross-checked against the LSM6DSV16X and LSM6DSK320X datasheets and atbetaflight's
+// accgyro_spi_lsm6dsv16x.c (hardware-validated there for LSM6DSV16X).
+static void lsm6dxxConfigGenV(gyroDev_t *gyro)
+{
+    busDevice_t * dev = gyro->busDev;
+
+    busSetSpeed(dev, BUS_SPEED_INITIALIZATION);
+
+    // Software reset, then wait for the device to clear the bit itself
+    lsm6dxxWriteRegister(dev, LSM6DXX_REG_CTRL3_C, LSM6DXX_MASK_CTRL3_C_RESET, 0);
+    uint8_t ctrl3 = LSM6DXX_MASK_CTRL3_C_RESET;
+    unsigned attemptsRemaining = 10;
+    while ((ctrl3 & LSM6DXX_MASK_CTRL3_C_RESET) && attemptsRemaining--) {
+        delay(1);
+        if (!busRead(dev, LSM6DXX_REG_CTRL3_C, &ctrl3)) {
+            break; // bus read failed - fall through to config once attempts are exhausted below
+        }
+    }
+
+    // Auto-increment addresses for burst reads; hold output registers stable across a burst read
+    lsm6dxxWriteRegister(dev, LSM6DXX_REG_CTRL3_C, LSM6DXX_VAL_CTRL3_C_IF_INC | LSM6DXX_VAL_CTRL3_C_BDU, 0);
+
+    // Selects the high-accuracy ODR table used by the CTRL1_XL/CTRL2_G writes below
+    lsm6dxxWriteRegister(dev, LSM6DXX_REG_HAODR_CFG, LSM6DXX_VAL_HAODR_CFG_MODE1, 0);
+
+    // Accelerometer: high-accuracy mode, 1kHz ODR, +-16g full scale
+    lsm6dxxWriteRegister(dev, LSM6DXX_REG_CTRL1_XL,
+        (LSM6DXX_VAL_CTRL1_XL_V_OPMODE_HIGH_ACCURACY << 4) | LSM6DXX_VAL_CTRL1_XL_V_ODR_1000HZ_HAODR1, 0);
+    lsm6dxxWriteRegister(dev, LSM6DXX_REG_CTRL8_XL, LSM6DXX_VAL_CTRL8_XL_V_FS_16G, 0);
+
+    // Gyroscope: high-accuracy mode, 8kHz ODR, +-2000dps full scale, LPF1 bandwidth per user setting
+    lsm6dxxWriteRegister(dev, LSM6DXX_REG_CTRL2_G,
+        (LSM6DXX_VAL_CTRL2_G_V_OPMODE_HIGH_ACCURACY << 4) | LSM6DXX_VAL_CTRL2_G_V_ODR_8000HZ_HAODR1, 0);
+    // LSM6DSK320X requires bit 3 of this register set to 1 ("must be set to 1 for correct operation of
+    // the device" per its datasheet) - it isn't part of the FS_G field there like it is on LSM6DSV16X
+    lsm6dxxWriteRegister(dev, LSM6DXX_REG_CTRL6_C,
+        (getLsmVDlpfBandwidth(gyro) << 4) | LSM6DXX_VAL_CTRL6_C_V_FS_G_2000DPS
+        | (lsm6dID == LSM6DSK320X_CHIP_ID ? LSM6DXX_VAL_CTRL6_C_V_DSK320X_RESERVED_BIT3 : 0), 0);
+    lsm6dxxWriteRegister(dev, LSM6DXX_REG_CTRL7_G, LSM6DXX_VAL_CTRL7_G_V_LPF1_EN, 0);
+
+    // Data-ready interrupt is a pulse (no read required to clear it), routed to pin 1
+    lsm6dxxWriteRegister(dev, LSM6DXX_REG_CTRL4_C, LSM6DXX_VAL_CTRL4_C_V_DRDY_PULSED, 0);
+    lsm6dxxWriteRegister(dev, LSM6DXX_REG_INT1_CTRL, LSM6DXX_VAL_INT1_CTRL, 0);
+
+    // Datasheet section 4.1 (Mechanical characteristics): 70mdps/LSB at +-2000dps full scale.
+    // This differs from the 1/16.4 constant the legacy DSO/DSL/DS3 path below uses - that
+    // existing value is left untouched since it's out of scope here and already shipped.
+    gyro->scale = 0.070f;
+    gyro->sampleRateIntervalUs = 125; // 8kHz gyro ODR configured above
+
+    busSetSpeed(dev, BUS_SPEED_FAST);
+}
+
 static void lsm6dxxConfig(gyroDev_t *gyro)
-{ 
+{
+    if (lsm6dxxIsGenV()) {
+        lsm6dxxConfigGenV(gyro);
+        return;
+    }
+
     busDevice_t * dev = gyro->busDev;
     const gyroFilterAndRateConfig_t * config = mpuChooseGyroConfig(gyro->lpf, 1000000 / gyro->requestedSampleIntervalUs);
     gyro->sampleRateIntervalUs = 1000000 / config->gyroRateHz;
@@ -153,7 +243,9 @@ static bool lsm6dxxDetect(busDevice_t * dev)
 
         switch (tmp) {
             case LSM6DSO_CHIP_ID:
-            case LSM6DSL_CHIP_ID: 
+            case LSM6DSL_CHIP_ID:
+            case LSM6DSV16X_CHIP_ID:
+            case LSM6DSK320X_CHIP_ID:
                  lsm6dID = tmp;
                 // Compatible chip detected
                 return true;

--- a/src/main/drivers/accgyro/accgyro_lsm6dxx.h
+++ b/src/main/drivers/accgyro/accgyro_lsm6dxx.h
@@ -51,6 +51,7 @@ typedef enum {
     LSM6DXX_REG_OUTY_H_A = 0x2B,   // acc Y axis MSB
     LSM6DXX_REG_OUTZ_L_A = 0x2C,   // acc Z axis LSB
     LSM6DXX_REG_OUTZ_H_A = 0x2D,   // acc Z axis MSB
+    LSM6DXX_REG_HAODR_CFG = 0x62,  // high-accuracy ODR mode select (LSM6DSV16X/LSM6DSK320X only)
 } lsm6dxxRegister_e;
   
 // LSM6DXX register configuration values
@@ -68,7 +69,7 @@ typedef enum {
     LSM6DXX_VAL_CTRL1_XL_LPF2 = 0x01,         // accelerometer output from LPF2
     LSM6DXX_VAL_CTRL2_G_ODR6664 = 0x0A,       // gyro 6664hz output data rate
     LSM6DXX_VAL_CTRL2_G_2000DPS = 0x03,       // gyro 2000dps scale
-    // LSM6DXX_VAL_CTRL3_C_BDU = BIT(6),         // (bit 6) output registers are not updated until MSB and LSB have been read (prevents MSB from being updated while burst reading LSB/MSB)
+    LSM6DXX_VAL_CTRL3_C_BDU = BIT(6),          // (bit 6) output registers are not updated until MSB and LSB have been read (prevents MSB from being updated while burst reading LSB/MSB)
     LSM6DXX_VAL_CTRL3_C_H_LACTIVE = 0,        // (bit 5) interrupt pins active high
     LSM6DXX_VAL_CTRL3_C_PP_OD = 0,            // (bit 4) interrupt pins push/pull
     LSM6DXX_VAL_CTRL3_C_SIM = 0,              // (bit 3) SPI 4-wire interface mode
@@ -87,6 +88,30 @@ typedef enum {
     LSM6DXX_VAL_CTRL7_G_HPM_G_260 = 0x02,     // (bits 5:4) gyro HPF cutoff 260mHz
     LSM6DXX_VAL_CTRL7_G_HPM_G_1040 = 0x03,    // (bits 5:4) gyro HPF cutoff 1.04Hz
     LSM6DXX_VAL_CTRL9_XL_I3C_DISABLE = BIT(1),// (bit 1) disable I3C interface
+
+    // LSM6DSV16X/LSM6DSK320X ("Gen V") register field values. This generation moved ODR/mode
+    // into CTRL1_XL/CTRL2_G bits[6:4]+[3:0] (full scale is no longer here - see CTRL6_C/CTRL8_XL
+    // below) and uses a completely different ODR encoding from the legacy LSM6DSO/DSL/DS3 chips
+    // above, so none of the _ODR*/_*DPS/_*G values above apply to these two chips.
+    LSM6DXX_VAL_CTRL1_XL_V_OPMODE_HIGH_ACCURACY = 0x01, // (bits 6:4) accel high-accuracy ODR mode
+    LSM6DXX_VAL_CTRL1_XL_V_ODR_1000HZ_HAODR1 = 0x09,    // (bits 3:0) 1kHz accel ODR, HAODR mode 1
+    LSM6DXX_VAL_CTRL2_G_V_OPMODE_HIGH_ACCURACY = 0x01,  // (bits 6:4) gyro high-accuracy ODR mode
+    LSM6DXX_VAL_CTRL2_G_V_ODR_8000HZ_HAODR1 = 0x0C,     // (bits 3:0) 8kHz gyro ODR, HAODR mode 1 (0x0B is 4kHz - off by one row)
+    LSM6DXX_VAL_HAODR_CFG_MODE1 = 0x01,                 // (bits 1:0) selects the ODR tables above
+    LSM6DXX_VAL_CTRL6_C_V_FS_G_2000DPS = 0x04,          // (bits 3:0) gyro full-scale +-2000dps
+                                                         // (LSM6DSV16X: 4-bit FS_G field, 0100 = 2000dps; on
+                                                         // LSM6DSK320X, bit 3 of this value is instead a separate
+                                                         // reserved bit the datasheet says "must be set to 1 for
+                                                         // correct operation" - FS_G there is bits[2:0] only, where
+                                                         // 100 also happens to mean 2000dps - see LSM6DXX_VAL_CTRL6_C_V_DSK320X_RESERVED_BIT3)
+    LSM6DXX_VAL_CTRL6_C_V_DSK320X_RESERVED_BIT3 = BIT(3), // must be 1 on LSM6DSK320X only, see above
+    LSM6DXX_VAL_CTRL6_C_V_LPF1_BW_288HZ = 0x00,         // (bits 6:4) gyro LPF1 bandwidth ~288Hz
+    LSM6DXX_VAL_CTRL6_C_V_LPF1_BW_215HZ = 0x01,         // (bits 6:4) gyro LPF1 bandwidth ~215Hz
+    LSM6DXX_VAL_CTRL6_C_V_LPF1_BW_157HZ = 0x02,         // (bits 6:4) gyro LPF1 bandwidth ~157Hz
+    LSM6DXX_VAL_CTRL6_C_V_LPF1_BW_455HZ = 0x03,         // (bits 6:4) gyro LPF1 bandwidth ~455Hz
+    LSM6DXX_VAL_CTRL7_G_V_LPF1_EN = BIT(0),             // (bit 0) enable gyro LPF1
+    LSM6DXX_VAL_CTRL8_XL_V_FS_16G = 0x03,               // (bits 1:0) accel full-scale +-16g
+    LSM6DXX_VAL_CTRL4_C_V_DRDY_PULSED = BIT(1),         // (bit 1) data-ready interrupt is a pulse, not a level
 } lsm6dxxConfigValues_e;
 
 // LSM6DXX register configuration bit masks

--- a/src/main/target/DAKEFPVF405/target.h
+++ b/src/main/target/DAKEFPVF405/target.h
@@ -72,7 +72,13 @@
 #define BMI270_SPI_BUS          BUS_SPI1
 #define BMI270_CS_PIN           PA4
 
+#define USE_IMU_LSM6DXX
+#define IMU_LSM6DXX_ALIGN       CW90_DEG
+#define LSM6DXX_SPI_BUS         BUS_SPI1
+#define LSM6DXX_CS_PIN          PA4
+
 // ICM42688P driver handled by USE_IMU_ICM42605 above (shares WHO_AM_I detection)
+// LSM6DSV16X / LSM6DSK320X driver handled by USE_IMU_LSM6DXX above (shares WHO_AM_I detection)
 
 //Baro
 #define USE_BARO


### PR DESCRIPTION
## Summary
Adds driver support for two IMU chips not previously recognized by INAV's `accgyro_lsm6dxx.c`: LSM6DSV16X and LSM6DSK320X. These chips reorganize `CTRL1_XL`/`CTRL2_G` to hold ODR + operating mode only (full scale moved to `CTRL6_C`/`CTRL8_XL`) with a different ODR bit encoding than the existing LSM6DSO/DSL/DS3 chips this driver already supports, so they get their own configuration sequence (`lsm6dxxConfigGenV()`) reached via an early-return branch in `lsm6dxxConfig()`, gated on `WHO_AM_I`. The pre-existing legacy code path is untouched.

Also wires `DAKEFPVF405/target.h` to the driver (`USE_IMU_LSM6DXX` + CS/bus/alignment, sharing the same physical pin as the board's existing gyro options per its manufacturer's public config), since that's the hardware testbed used to validate this change and its Betaflight-equivalent config lists both new chips as populated options.

## Changes
- `src/main/drivers/accgyro/accgyro_lsm6dxx.c` / `.h`: new `lsm6dxxConfigGenV()` config path, `WHO_AM_I` detection for the two new chip IDs (`0x70`, `0x75`), new register-value constants for the Gen V register layout
- `src/main/target/DAKEFPVF405/target.h`: adds `USE_IMU_LSM6DXX` alongside the board's existing gyro options

## Testing
- Register values cross-checked directly against the ST datasheets for both chips, and independently cross-validated against atbetaflight's hardware-validated `accgyro_spi_lsm6dsv16x.c` reference driver
- Compile-tested cleanly on an existing target already using this driver (`BLUEBERRYF435WING`), confirming no regression to already-shipped boards
- Hardware-validated on two physical DAKEFPVF405 units, one per new chip:
  - Correct chip detection (`GYRO=LSM6DXX, ACC=LSM6DXX`, status OK)
  - At-rest accelerometer magnitude ~0.99-1.0g, gyro ~0dps
  - Live dynamic response to physical handling (multi-g accel spikes, hundreds-of-dps gyro spikes) with clean settle-back to rest
  - `CW90_DEG` board-alignment orientation confirmed correct via physical roll and pitch tests (sign and magnitude both verified against the documented axis convention in `imu.c`)
- Code-reviewed with a focus on register-level correctness given this feeds attitude estimation; two real bugs were caught and fixed before this PR (see below)

## Design note: legacy chips are unaffected
Detection dispatches on an exact `WHO_AM_I` hardware match (a fixed silicon value, not something a legacy chip could produce), and the entire new config path is behind a single early return that's unreachable unless `WHO_AM_I` already matched one of the two new chip IDs. The pre-existing legacy LSM6DSO/DSL/DS3 code path is verified byte-for-byte unmodified.

## Related Issues
N/A - proactively added driver support after finding these chips listed as gyro options in a target's manufacturer config with no existing INAV driver.