### PR TITLE
Fix LED strip / ADC1 DMA conflict on DAKEFPVH743PRO

### DIFF
--- a/src/main/target/DAKEFPVH743PRO/target.c
+++ b/src/main/target/DAKEFPVH743PRO/target.c
@@ -55,7 +55,7 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM4,  CH4, PD15, TIM_USE_OUTPUT_AUTO, 0, 0),   // S4
     DEF_TIM(TIM15, CH1, PE5,   TIM_USE_ANY, 0, 0),  // CAMERA_CONTROL_PIN
     DEF_TIM(TIM15, CH2, PE6,   TIM_USE_ANY, 0, 0),  // GYRO_1_CLKIN_PIN
-    DEF_TIM(TIM3,  CH3, PB0,   TIM_USE_LED, 0, 8), // LED_2812
+    DEF_TIM(TIM3,  CH3, PB0,   TIM_USE_LED, 0, 9), // LED_2812 - moved off DMA2 Stream0 to avoid ADC1 DMA conflict
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);


### PR DESCRIPTION
## Summary
Fixes a DMA stream conflict between the LED strip and ADC1 (VBAT/current sensing) on DAKEFPVH743PRO.

## Problem
`TIM3 CH3` (LED strip) was assigned DMA option 8, which resolves to DMA2 Stream0 on STM32H743. ADC1 (used here for VBAT and current-meter sensing) is hardwired to the same DMA2 Stream0 in the driver. Driving the LED strip and reading VBAT/current at the same time contended for the same DMA stream.

## Changes
- `src/main/target/DAKEFPVH743PRO/target.c`: LED strip DMA option changed from 8 (DMA2 Stream0) to 9 (DMA2 Stream1), which is unclaimed on this target since ADC2/ADC3 are never enabled here.

This matches the identical fix already merged for the sibling `DAKEFPVH743_SLIM` target, and the pattern used by several other STM32H7 targets (MATEKH743, FOXEERH743, BLUEBERRYH743, etc.) that route the LED strip off DMA2 Stream0 for the same reason.

## Testing
- Build: DAKEFPVH743PRO builds cleanly, no new warnings, flash/RAM usage unchanged in any meaningful way.
- Hardware: Tested on physical DAKEFPVH743PRO hardware with LED strip and ADC (VBAT + current sensing) active simultaneously — no telemetry glitching, no LED corruption/flicker.
- Code review performed (inav-code-review agent) — no issues found, independently re-verified the DMA option → stream mapping and confirmed DMA2 Stream1 is free on this target.