### PR TITLE
Fix SITL system load metric permanently pinned at 100%, blocking arming

### DIFF
--- a/docs/SITL/SITL.md
+++ b/docs/SITL/SITL.md
@@ -16,6 +16,8 @@ Currently supported are
 
 INAV SITL communicates for sensor data and control directly with the corresponding simulator, see the documentation of the individual simulators and the Configurator or the command line options.
 
+SITL system load is calculated from scheduler busy time and excludes intentional host sleeps used to avoid pegging a CPU core.
+
 AS SITL is still an inav software, but running on PC, it is possible to use HITL interface for communication.
 
 [INAV-X-Plane-HITL](https://github.com/RomanLut/INAV-X-Plane-HITL) or [INAV-X-Plane-XITL](https://github.com/Scavanger/INAV-X-Plane-XITL) plugin can be used with SITL.

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -43,6 +43,11 @@ STATIC_FASTRAM uint32_t totalWaitingTasksSamples;
 
 FASTRAM uint16_t averageSystemLoadPercent = 0;
 
+#if defined(SITL_BUILD)
+STATIC_FASTRAM timeUs_t sitlLoadWindowStartUs;
+STATIC_FASTRAM timeUs_t sitlLoadBusyTimeUs;
+#endif
+
 
 STATIC_FASTRAM int taskQueuePos = 0;
 STATIC_FASTRAM int taskQueueSize = 0;
@@ -125,12 +130,28 @@ void taskSystem(timeUs_t currentTimeUs)
 {
     UNUSED(currentTimeUs);
 
+#if defined(SITL_BUILD)
+    if (sitlLoadWindowStartUs == 0) {
+        sitlLoadWindowStartUs = currentTimeUs;
+        sitlLoadBusyTimeUs = 0;
+        return;
+    }
+
+    const timeDelta_t elapsedUs = cmpTimeUs(currentTimeUs, sitlLoadWindowStartUs);
+    if (elapsedUs > 0) {
+        const timeUs_t loadPercent = (100U * sitlLoadBusyTimeUs) / (timeUs_t)elapsedUs;
+        averageSystemLoadPercent = loadPercent > 100U ? 100U : (uint16_t)loadPercent;
+        sitlLoadWindowStartUs = currentTimeUs;
+        sitlLoadBusyTimeUs = 0;
+    }
+#else
     // Calculate system load
     if (totalWaitingTasksSamples > 0) {
         averageSystemLoadPercent = 100 * totalWaitingTasks / totalWaitingTasksSamples;
         totalWaitingTasksSamples = 0;
         totalWaitingTasks = 0;
     }
+#endif
 }
 
 #define TASK_MOVING_SUM_COUNT           32
@@ -324,6 +345,11 @@ void FAST_CODE NOINLINE scheduler(void)
 
 #if defined(SITL_BUILD)
     {
+        const timeDelta_t sitlBusyTimeUs = cmpTimeUs(micros(), currentTimeUs);
+        if (sitlBusyTimeUs > 0) {
+            sitlLoadBusyTimeUs += sitlBusyTimeUs;
+        }
+
         // Avoid busy-waiting and burning 100% CPU in SITL.  After executing the
         // current task (or finding nothing to do), sleep until just before the
         // next task is due.  For event-driven tasks (checkFunc) we limit the

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -128,9 +128,11 @@ STATIC_INLINE_UNIT_TESTED cfTask_t *queueNext(void)
 
 void taskSystem(timeUs_t currentTimeUs)
 {
-    UNUSED(currentTimeUs);
-
 #if defined(SITL_BUILD)
+    // SITL sleeps between task invocations (see the SITL_BUILD block in scheduler())
+    // instead of busy-polling, so the sample-based estimate below always finds a task
+    // already due and reads pinned near 100%. Use busy/elapsed wall-clock time instead,
+    // which stays meaningful whether or not the loop busy-polls (issue #11710).
     if (sitlLoadWindowStartUs == 0) {
         sitlLoadWindowStartUs = currentTimeUs;
         sitlLoadBusyTimeUs = 0;
@@ -145,6 +147,8 @@ void taskSystem(timeUs_t currentTimeUs)
         sitlLoadBusyTimeUs = 0;
     }
 #else
+    UNUSED(currentTimeUs);
+
     // Calculate system load
     if (totalWaitingTasksSamples > 0) {
         averageSystemLoadPercent = 100 * totalWaitingTasks / totalWaitingTasksSamples;


### PR DESCRIPTION
## Summary

A freshly-defaulted SITL build on 9.1 cannot arm: the Configurator's Status
tab shows CPU load pinned at/above 100%, tripping
`ARMING_DISABLED_SYSTEM_OVERLOADED` on an idle, correctly functioning
instance.

`averageSystemLoadPercent` (`src/main/scheduler/scheduler.c`) is a duty-cycle
estimator that counts how many `scheduler()` samples found a task already
overdue. That only produces a sane result if `scheduler()` runs far more
often than tasks become due — true on real hardware, which busy-polls. PR
#11436 made SITL's `scheduler()` sleep until just before the next task is
due instead of busy-polling (a real, worthwhile CPU-usage improvement on the
host). That eliminated the zero-load samples the old estimator relied on, so
every sample now finds >=1 task due and the average is permanently >=100.

## Changes

- Cherry-picked `5e47ffd356` ("Fix SITL system load accounting") by
  **@xznhj8129**, originally authored against `maintenance-10.x` as part of
  https://github.com/iNavFlight/inav/pull/11712. Full credit for the fix
  design and implementation goes to that commit's author — this PR ports it
  to `release/9.1`, where the same regression (`8a475617c4`, "SITL Tweaks")
  is also present.
  - Adds a `SITL_BUILD`-gated busy-time/elapsed-time duty-cycle calculation:
    `scheduler()` measures wall-clock time spent per iteration (excluding
    the intentional sleep), and `taskSystem()` converts that into a percentage
    over a rolling window, capped at 100.
  - Hardware (non-`SITL_BUILD`) load accounting is untouched.
  - `docs/SITL/SITL.md`: one-line note on how SITL load is now calculated.
- Follow-up commit (mine): moved a stale `UNUSED(currentTimeUs)` call into
  the branch where it's actually still unused, and added a short comment
  explaining why SITL needs a different calculation than hardware — raised
  by code review, no behavior change.

## Testing

- Built SITL from this branch; froze a synthetic stress test into `taskGyro()`
  temporarily (reverted before commit) to drive genuine load:
  - Idle: `cpuLoad` (MSP2_INAV_STATUS) steady at 3-4%, no
    `ARMING_DISABLED_SYSTEM_OVERLOADED`.
  - 3,000 busy-loop iterations/call: `cpuLoad` 10-12%.
  - 20,000 busy-loop iterations/call: `cpuLoad` stable 58-59%, metric tracks
    added load, still armable, no overload flag.
- Host CPU usage of the idle `SITL.elf` process measured two ways (`ps
  pcpu` and `/proc/[pid]/stat` tick deltas): steady 7.4-8% of one core,
  confirming PR #11436's sleep-based scheduling is untouched (no
  busy-polling reintroduced).
- Compiled a hardware target (MATEKF722, F7) cleanly with no warnings —
  confirms the non-`SITL_BUILD` path is unaffected (all changes are inside
  `#if defined(SITL_BUILD)` blocks).

## Code Review

Reviewed with the `inav-code-review` agent: approved, no critical or
important issues blocking merge. Two minor suggestions (explanatory comment,
misplaced `UNUSED()`) were addressed in the follow-up commit.

Fixes #11710