### PR TITLE
Backport to 9.x: fix build-SITL-Mac VLA-folding-constant error in log.c

### DIFF
--- a/src/main/common/log.c
+++ b/src/main/common/log.c
@@ -205,8 +205,12 @@ void _logBufferHex(logTopic_e topic, unsigned level, const void *buffer, size_t 
 {
     // Print lines of up to maxBytes bytes. We need 5 characters per byte
     // 0xAB[space|\n]
-    const size_t charsPerByte = 5;
-    const size_t maxBytes = 8;
+    // charsPerByte/maxBytes must be true compile-time constants (not `const`
+    // locals) so the buffer size below is a real constant expression, not a VLA.
+    enum {
+        charsPerByte = 5,
+        maxBytes = 8,
+    };
     char buf[LOG_PREFIX_FORMATTED_SIZE + charsPerByte * maxBytes + 1]; // +1 for the null terminator
     size_t bufPos = LOG_PREFIX_FORMATTED_SIZE;
     const uint8_t *inputPtr = buffer;


### PR DESCRIPTION
Cherry-pick of 87ed42bed from `master` onto `maintenance-9.x` (original author credited in the commit).

`build-SITL-Mac` currently fails on every PR targeting `maintenance-9.x`: `src/main/common/log.c:210` sizes a stack buffer with `const size_t` locals, which clang on the macOS runners now rejects under `-Werror,-Wgnu-folding-constant`. Replacing the locals with an `enum` (as already done on master) makes the array size a true constant expression.

Example of an affected PR: #11723 (all jobs pass except `build-SITL-Mac`).