### PR TITLE
docs: fixed-wing pitch-to-throttle tuning guides

### DIFF
--- a/docs/Fixed Wing Landing.md
+++ b/docs/Fixed Wing Landing.md
@@ -88,7 +88,7 @@ In cm/s. Min: 0; Max: 3000, Default: 140
 If WP-Tracking is not used, the Plane will head straight to the landiung location without flying in line with the intended landing strip. Wind can intensively alter the final landing heading.
 
 * `nav_fw_pitch2thr`: The navigation throttle modifier has to be tuned well to allow stable navigation during climbs and descents to prevent a stall. Make sure your plane maintains Ground or Airspeed, when climbing in any navigation mode. 
-The Craft should not get slower and not speed ub significantly during a navigation climb, if P2T is tuned properly.
+The Craft should not get slower and not speed ub significantly during a navigation climb, if P2T is tuned properly. See `Fixed Wing Pitch To Throttle Tuning.md` for a full tuning procedure.
 
 * `nav_wp_radius`: This parameter might be too high if you have set up your craft with INAV 6 or INAV 7. With a too high value, the turning points for the Crosswind-Leg and Final Approach are hit too early and make it difficult for the plane to align to the runway or cut short the approach. 
 Make sure this parameter is not set greater than 1000 (cm). The better your craft and navigation system is tuned, the lower this value can be. We recommend to start with 1000 for flying wings and 800 for a Plane with Tail.

--- a/docs/Fixed Wing Pitch To Throttle Tuning.md
+++ b/docs/Fixed Wing Pitch To Throttle Tuning.md
@@ -1,0 +1,139 @@
+# Fixed-Wing Pitch-to-Throttle Tuning (`nav_fw_pitch2thr`)
+
+## What This Setting Does
+
+`nav_fw_pitch2thr` adjusts throttle in response to pitch angle, to help maintain
+constant airspeed as the aircraft climbs or descends in GPS-assisted modes
+(Position Hold, RTH, Waypoint Mission, Cruise).
+
+**Formula (from the setting's own description):**
+
+```
+throttle = nav_fw_cruise_throttle - (nav_fw_pitch2thr * pitch_angle)
+```
+
+`pitch_angle` is in degrees, negative when climbing and positive when diving,
+so this adds throttle in a climb and removes it in a dive. The result is
+clamped between `nav_fw_min_thr` and `nav_fw_max_thr`.
+
+**Units:** PWM microseconds per degree of pitch (μs/°)
+
+**Range:** 0-100. **Default:** 10.
+
+This setting only affects GPS-assisted navigation modes — manual/Acro/Angle
+flight is unaffected, so it's safe to test in Position Hold without touching
+the way the aircraft flies under direct pilot control.
+
+Two related settings shape how the correction is applied:
+
+- `nav_fw_pitch2thr_threshold`: a deadband (in decidegrees) around the
+  average pitch. Momentary pitch excursions inside the deadband get a
+  smoothed (low-pass filtered) correction instead of the instantaneous one,
+  to avoid jerky throttle response to small attitude noise.
+- `nav_fw_pitch2thr_smoothing`: controls the strength of that low-pass filter.
+
+During the final approach phase of a fixed-wing autoland,
+`nav_fw_land_final_approach_pitch2throttle_mod` scales `nav_fw_pitch2thr` up
+(as a percentage) to cut power more aggressively when the nose points down —
+see `Fixed Wing Landing.md`.
+
+## Why It Matters
+
+- **Too low** → airspeed bleeds off during climbs, builds up during descents.
+- **Correct** → airspeed stays roughly constant through altitude changes.
+- **Too high** → throttle over-compensates; airspeed changes in the opposite
+  direction, and throttle may saturate at gentle pitch angles.
+
+The default value of 10 μs/° is conservative: a 10° climb only adds 100 μs of
+throttle, and throttle only reaches maximum at 50° of pitch — an angle most
+fixed-wing aircraft never reach. In practice this means many aircraft see
+some airspeed loss in sustained climbs and some airspeed gain in sustained
+descents with the default value. Whether that matters for your aircraft, and
+how much to increase the setting, is best determined by flight testing your
+specific airframe rather than by a single number — aircraft vary widely in
+lift-to-drag ratio and thrust-to-weight ratio, both of which affect the ideal
+value (see `development/fixed-wing-pitch2thr-tuning.md` in the source tree
+for the underlying aerodynamics, and why they don't converge on one
+"correct" number even for the same setting).
+
+## Flight Testing & Tuning Procedure
+
+### Step 1: Baseline Test
+
+1. Fly in Position Hold or Loiter mode (GPS stabilized).
+2. Note the current `nav_fw_pitch2thr` value.
+3. Command a climb (e.g. +50 m altitude change) and observe airspeed:
+   - Decreases noticeably → setting too low.
+   - Stays roughly constant → setting about right.
+   - Increases → setting too high.
+4. Repeat for a descent (-50 m) — same logic, opposite direction (increasing
+   airspeed on descent means the setting is too low; decreasing means too
+   high).
+
+### Step 2: Adjust
+
+- Airspeed drops in climbs, or builds up in descents → the setting is
+  under-compensating. Increase `nav_fw_pitch2thr` by roughly 10-15 μs/° and
+  retest.
+- Airspeed increases in climbs, or throttle saturates (hits min/max) at
+  gentle pitch angles (well under 10°) → the setting is over-compensating.
+  Decrease by roughly 5-10 μs/° and retest.
+
+### Step 3: Iterate
+
+Repeat the climb/descent tests after each adjustment until airspeed stays
+within about ±1 m/s through altitude changes in Position Hold.
+
+### Step 4: Edge Cases
+
+- A steeper climb test (if safe) should approach maximum throttle at a
+  realistic pitch angle for your aircraft — if it doesn't, the setting may
+  still be conservative.
+- A moderate descent test should reduce throttle noticeably; if airspeed
+  keeps building up in descent, increase the setting further.
+
+## Signs of Incorrect Tuning
+
+**Too low:**
+- Airspeed drops during climbs, builds up during descents.
+- Altitude overshoots as the altitude controller pitches harder to
+  compensate for a climb that's losing speed.
+- Speed variations during RTH altitude changes.
+- Possible low-speed alarms during climbs.
+
+**Too high:**
+- Airspeed increases during climbs, decreases during descents.
+- Throttle hits min/max at gentle pitch angles.
+- Altitude "hunting" from over-correction.
+
+**About right:**
+- Airspeed stays within roughly ±1 m/s through altitude changes.
+- Smooth altitude transitions, no speed alarms, predictable behavior in
+  Position Hold/RTH.
+
+## Starting Points by Aircraft Type
+
+These are starting points for the flight-test procedure above, not
+guaranteed-correct values — treat them the same way you'd treat any other
+PID starting point in this manual, as something to verify by flying, not
+something to set and forget:
+
+| Aircraft Type | Typical Starting Range |
+|---|---|
+| Glider / sailplane (high L/D, low power) | 15-25 μs/° |
+| Trainer / cruiser | 25-35 μs/° |
+| Sport / FPV wing | 25-40 μs/° |
+| Aerobatic / high power-to-weight | 15-30 μs/° |
+
+If you don't know which category fits, start around 25 μs/° and use the
+flight-test procedure to refine it.
+
+## Related Documentation
+
+- `Fixed Wing Landing.md` — `nav_fw_land_final_approach_pitch2throttle_mod`
+  and other landing-phase throttle behavior.
+- `Battery.md`, `Inflight Adjustments.md` — battery-profile scoping and
+  in-flight adjustment of this and related FW throttle settings.
+- `development/fixed-wing-pitch2thr-tuning.md` — aerodynamic background on
+  why this setting behaves the way it does, for developers working on the
+  navigation throttle code.

--- a/docs/development/fixed-wing-pitch2thr-tuning.md
+++ b/docs/development/fixed-wing-pitch2thr-tuning.md
@@ -1,0 +1,192 @@
+# Fixed-Wing Pitch-to-Throttle: Implementation and Aerodynamic Background
+
+This document explains the aerodynamics behind `nav_fw_pitch2thr` for
+developers working on the fixed-wing navigation throttle code. For
+user-facing tuning guidance, see `docs/Fixed Wing Pitch To Throttle
+Tuning.md`.
+
+## Current Implementation
+
+**Function:** `fixedWingPitchToThrottleCorrection()` in
+`src/main/navigation/navigation_fixedwing.c`, called from
+`applyFixedWingPitchRollThrottleController()` in the same file.
+
+**Core formula:**
+
+```c
+int16_t pitchToThrottle = currentBatteryProfile->nav.fw.pitch_to_throttle;
+// ... pitch is low-pass filtered via a PT1 filter; the deadband decides
+// whether the raw or filtered pitch is used:
+return DECIDEGREES_TO_DEGREES(pitch) * pitchToThrottle;
+```
+
+The resulting `throttleCorrection` is:
+
+1. Clamped to `[min_throttle - cruise_throttle, max_throttle - cruise_throttle]`
+   (or `[min_throttle - cruise_throttle, 0]` during `NAV_CTL_LAND`, since
+   landing should never raise throttle for a nose-up moment).
+2. Added to `cruise_throttle`.
+3. Clamped again to the battery profile's absolute `[min_throttle,
+   max_throttle]`.
+
+(In `NAV_CTL_POS` mode outside of landing, `applyFixedWingMinSpeedController()`'s
+output is also added and the result re-clamped before this final step — a
+separate minimum-airspeed mechanism, not part of `nav_fw_pitch2thr` itself.)
+
+During `USE_FW_AUTOLAND` final approach, `pitchToThrottle` is additionally
+scaled by `navFwAutolandConfig()->finalApproachPitchToThrottleMod / 100.0f`
+(`nav_fw_land_final_approach_pitch2throttle_mod` in settings.yaml) when
+diving, to cut power more aggressively on short final.
+
+**Setting:** `nav_fw_pitch2thr` — `src/main/fc/settings.yaml`, field
+`nav.fw.pitch_to_throttle`, `uint8_t`, range 0-100, default 10. Units are
+PWM microseconds of throttle correction per degree of pitch. Related
+settings: `nav_fw_pitch2thr_threshold` (deadband, decidegrees, default 50 =
+5°) and `nav_fw_pitch2thr_smoothing` (PT1 filter strength, default 6).
+
+This is a **local linear gain**, not a lookup table or envelope mapping —
+for every degree of pitch change, throttle changes by a fixed number of
+microseconds, clamped by the battery profile's throttle range.
+
+## Why a Linear Approximation Is Used
+
+The physical relationship between flight path angle and required power
+involves `sin(γ)`, which is nonlinear. For small angles, `sin(γ) ≈ γ` (γ in
+radians):
+
+| γ | sin(γ) | γ (rad) | Error |
+|---|---|---|---|
+| 5° | 0.0872 | 0.0873 | 0.11% |
+| 10° | 0.1736 | 0.1745 | 0.52% |
+| 15° | 0.2588 | 0.2618 | 1.16% |
+
+(Houghton & Carpenter, *Aerodynamics for Engineering Students*, 5th ed.)
+
+Below about 15° the linear approximation is accurate to ~1%, which is well
+inside the accuracy of the attitude estimate itself — so a simple
+multiplication is an adequate model for the pitch range fixed-wing
+navigation actually flies at (most GPS-assisted maneuvering stays within
+±20°). The real-world limiting factor isn't the linear approximation — it's
+that the aircraft's throttle range (typically ~1000 μs of usable span) is
+too narrow to fully compensate for the power change theory calls for during
+a sustained steep climb; clamping, not curve-fitting error, is what
+dominates behavior at the edges of the envelope.
+
+## Three Theoretical Estimates for the Gain — and Why They Disagree
+
+Three independent, individually-valid simplified aerodynamic models can be
+used to estimate a "correct" value for `nav_fw_pitch2thr` from an aircraft's
+L/D and thrust-to-weight (T/W) ratio. **They give substantially different
+answers for the same aircraft**, because each linearizes around a different
+flight regime. None of the three has been implemented, flight-tested, or
+reviewed as a proposed default change — they're presented here as
+aerodynamic reasoning aids, not as recommendations.
+
+### Model 1: Climb/descent power ratio
+
+Power required to hold constant airspeed at flight path angle γ:
+
+```
+P_climb   = P_level × (1 + sin(γ) × L/D)
+P_descent = P_level × (1 - sin(γ) × L/D)
+```
+
+(Force balance: thrust = drag ± W·sin(γ) along the flight path; power =
+thrust × V. Houghton & Carpenter pp. 26-44.) Approximating throttle as
+proportional to power and using the small-angle substitution:
+
+```
+nav_fw_pitch2thr ≈ throttle_cruise × 0.01745 × L/D
+```
+
+For `throttle_cruise = 1500 μs`, `L/D = 10`: **≈262 μs/°** theoretical — but
+this saturates the throttle range at only ~2° of pitch, which isn't usable.
+Backing off to fit a realistic ±10-20° working range before saturation
+(`(max_throttle - cruise_throttle) / max_practical_climb_angle`) gives
+**~25-50 μs/°** depending on the assumed working range.
+
+### Model 2: Local force-derivative at level flight
+
+Force balance at any pitch angle γ: `T = W[cos(γ)/(L/D) + sin(γ)]`. Taking
+the derivative with respect to γ and evaluating at γ = 0 (level flight):
+
+```
+dT/dγ = W / 57.3   (per degree)
+```
+
+Converting to a throttle-fraction gain using T/W = α (thrust-to-weight at
+full throttle) and INAV's 1000 μs range:
+
+```
+nav_fw_pitch2thr ≈ 1000 / (57.3 × α)  ≈  17.5 / α   μs/°
+```
+
+For α = 1.0 (roughly 1:1 thrust-to-weight, typical of many RC aircraft):
+**≈17.5 μs/°**. This model is L/D-independent at γ = 0 — only T/W enters at
+the linearization point — and predicts that *higher* T/W aircraft need a
+*lower* gain, since the same absolute thrust change is a smaller fraction
+of a larger available thrust.
+
+### Model 3: Gravity-only vertical flight (90°)
+
+At exactly 90° pitch, drag depends only on airspeed and cancels when
+comparing a steady vertical climb to a steady vertical descent at the same
+airspeed, leaving a pure thrust-vs-weight balance. For α = T/W = 1 (climb is
+hover-only, V=0), spreading the full 1000 μs range over the ±90° envelope
+gives:
+
+```
+nav_fw_pitch2thr = 1000 μs / 90° ≈ 11.1 μs/°
+```
+
+This happens to be close to the current default of 10. Whether that's
+actually why 10 was chosen isn't verifiable — the setting predates the
+earliest history available in this repository (a single "commit
+everything" import), so there's no changelog or commit message to check.
+Treat the closeness as a coincidence worth noting, not a confirmed
+explanation.
+
+### Why the three disagree
+
+Each model linearizes the same underlying force/power balance around a
+different point or regime — Model 1 integrates power over a realistic climb
+angle range, Model 2 takes a derivative strictly at level flight, and Model
+3 only considers the 90° extremes where drag cancels by construction. None
+of them accounts for the aspects the "Limitations" sections below list
+(propeller thrust curve nonlinearity, motor efficiency vs. load, propwash,
+dynamic/transient effects), which is why empirical, flight-tested tuning
+(see the user-facing guide) is more reliable than any single formula here.
+
+## Known Limitations of the Current (Linear) Model
+
+- **No adaptation to cruise throttle.** The same gain applies regardless of
+  current cruise throttle percentage, which itself may vary with battery
+  voltage sag or payload.
+- **No adaptation to L/D regime changes** (flaps, airspeed-dependent drag
+  polar).
+- **Assumes throttle ∝ power ∝ thrust**, none of which is exactly true for
+  a propeller: thrust and power both vary nonlinearly with airspeed and RPM,
+  and motor/ESC efficiency varies with load.
+- **No propwash modeling** — tractor-configuration aircraft get extra wing
+  lift from propwash during climb, which isn't represented.
+- **Steady-state only** — pitch rate and acceleration transients aren't
+  modeled; the PT1 filter and deadband exist specifically to avoid reacting
+  to short-duration attitude noise rather than sustained pitch changes.
+
+None of these are currently addressed in `fixedWingPitchToThrottleCorrection()`
+— they're listed here as context for anyone considering changes to the
+throttle-correction model, not as a to-do list.
+
+## References
+
+**Source:** `src/main/navigation/navigation_fixedwing.c`
+(`fixedWingPitchToThrottleCorrection`,
+`applyFixedWingPitchRollThrottleController`), `src/main/fc/settings.yaml`
+(`nav_fw_pitch2thr` and related settings).
+
+**Aerodynamic theory:** Houghton, E.L. and Carpenter, P.W., *Aerodynamics
+for Engineering Students*, 5th ed., Butterworth-Heinemann — pp. 26-44 (force
+equilibrium, drag, climb/descent power), pp. 62-67 (performance
+calculations, small-angle validity).
+
+**User-facing guide:** `docs/Fixed Wing Pitch To Throttle Tuning.md`.


### PR DESCRIPTION
## Summary

Adds two documentation files for the `nav_fw_pitch2thr` setting:

- `docs/Fixed Wing Pitch To Throttle Tuning.md` — user-facing tuning guide: what the setting does, why it matters, a flight-test tuning procedure, and signs of over/under-tuning. Cross-referenced from `Fixed Wing Landing.md`.
- `docs/development/fixed-wing-pitch2thr-tuning.md` — developer-facing background on the current implementation (`fixedWingPitchToThrottleCorrection()`) and the aerodynamic theory behind it.

The developer doc covers three independent simplified aerodynamic models for estimating the gain from an aircraft's L/D and thrust-to-weight ratio. These models disagree substantially with each other (by up to ~2.5x) because each linearizes around a different flight regime — this is called out explicitly rather than presenting any one of them as an authoritative recommended value. None of them has been implemented or flight-validated; they're included as reasoning aids for anyone working on this code, not as proposed default changes.

## Test plan

- [x] All code-location and setting claims checked against current `maintenance-10.x` source (`navigation_fixedwing.c`, `settings.yaml`)
- [x] Reviewed via the project's internal doc-review process; one arithmetic/derivation error caught and fixed before this PR (an incorrect "exact" envelope-width formula was removed rather than risk compounding the error)
- [x] Docs-only change, no firmware code touched