### PR TITLE
Fix broken SITL build: unbalanced #if SITL_BUILD in taskSystem() (merge #11727 artifact)

### DIFF
--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -149,21 +149,6 @@ void taskSystem(timeUs_t currentTimeUs)
 #else
     UNUSED(currentTimeUs);
 
-#if defined(SITL_BUILD)
-    if (sitlLoadWindowStartUs == 0) {
-        sitlLoadWindowStartUs = currentTimeUs;
-        sitlLoadBusyTimeUs = 0;
-        return;
-    }
-
-    const timeDelta_t elapsedUs = cmpTimeUs(currentTimeUs, sitlLoadWindowStartUs);
-    if (elapsedUs > 0) {
-        const timeUs_t loadPercent = (100U * sitlLoadBusyTimeUs) / (timeUs_t)elapsedUs;
-        averageSystemLoadPercent = loadPercent > 100U ? 100U : (uint16_t)loadPercent;
-        sitlLoadWindowStartUs = currentTimeUs;
-        sitlLoadBusyTimeUs = 0;
-    }
-#else
     // Calculate system load
     if (totalWaitingTasksSamples > 0) {
         averageSystemLoadPercent = 100 * totalWaitingTasks / totalWaitingTasksSamples;


### PR DESCRIPTION
## Problem

`maintenance-10.x` does not build for SITL. Every SITL build fails at `scheduler.c`:

```
src/main/scheduler/scheduler.c:131: error: unterminated #else
src/main/scheduler/scheduler.c:148: error: expected declaration or statement at end of input
```

(plus a cascade of `-Werror=unused-function`/`unused-variable` on the scheduler queue statics, because the malformed conditional excludes their users). Unit-test builds are unaffected — they define `UNIT_TEST`, not `SITL_BUILD`, so the broken branch isn't compiled there and CI's unit jobs stay green while SITL is dead.

## Cause

`taskSystem()` had two independent fixes for the SITL load-accounting bug (#11710) land on different lines — one on `release/9.1`, one via the MAVLink stack — that both rewrote the same block. The `release/9.1` merge (#11727) resolved that conflict by **concatenating both copies** rather than choosing one: it kept the `release/9.1` block as the outer `#if defined(SITL_BUILD)` and pasted the other copy *inside* the `#else` branch. The inner `#endif` then closes the duplicate's `#if`, leaving the outer `#if` (line 131) with no matching `#endif`.

## Fix

Remove the duplicated `#if defined(SITL_BUILD)` block from inside the `#else`, restoring the single intended (`release/9.1`) version. No functional change to load accounting — the two copies were the same wall-clock algorithm.

## Verified

SITL builds and links cleanly with `-Werror` after the change. `taskSystem()` is now byte-identical to the intended `release/9.1` version.
