### PR TITLE
Fix macro redefinition and unit test failures caused by shared platform.h leak

### DIFF
--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -31,7 +31,10 @@
 // Use floating point M_PI instead explicitly.
 #define M_PIf   3.14159265358979323846f
 #define M_LN2f  0.69314718055994530942f
+// glibc's <cmath> also defines M_Ef (GNU extension); guard against the redefinition warning
+#ifndef M_Ef
 #define M_Ef    2.71828182845904523536f
+#endif
 
 #define RAD (M_PIf / 180.0f)
 

--- a/src/main/io/displayport_msp_dji_compat.h
+++ b/src/main/io/displayport_msp_dji_compat.h
@@ -22,7 +22,7 @@
 
 #include "platform.h"
 
-#if defined(USE_OSD) && defined(USE_MSP_DISPLAYPORT) && !defined(DISABLE_MSP_DJI_COMPAT)
+#if defined(USE_OSD) && defined(USE_MSP_DISPLAYPORT) && !defined(DISABLE_MSP_DJI_COMPAT) && !defined(OSD_UNIT_TEST)
 #include "osd.h"
 uint8_t getDJICharacter(uint8_t ch, uint8_t page);
 #define isDJICompatibleVideoSystem(osdConfigPtr) (osdConfigPtr->video_system == VIDEO_SYSTEM_DJICOMPAT || osdConfigPtr->video_system == VIDEO_SYSTEM_DJICOMPAT_HD)

--- a/src/main/io/displayport_msp_osd.c
+++ b/src/main/io/displayport_msp_osd.c
@@ -28,7 +28,9 @@
 
 #include "platform.h"
 
-#if defined(USE_OSD) && defined(USE_MSP_OSD)
+// OSD_UNIT_TEST's minimal build doesn't link the DJI/MSP displayport driver's
+// dependencies, so this file compiles to an empty translation unit for it.
+#if defined(USE_OSD) && defined(USE_MSP_OSD) && !defined(OSD_UNIT_TEST)
 
 #include "common/utils.h"
 #include "common/printf.h"

--- a/src/main/io/gimbal_serial.c
+++ b/src/main/io/gimbal_serial.c
@@ -83,7 +83,7 @@ static gimbalDevice_t serialGimbalDevice = {
     .currentPanPWM = PWM_RANGE_MIDDLE
 };
 
-#if (defined(USE_HEADTRACKER) && defined(USE_HEADTRACKER_SERIAL))
+#if (defined(USE_HEADTRACKER) && defined(USE_HEADTRACKER_SERIAL)) && !defined(GIMBAL_UNIT_TEST)
 
 static headTrackerVTable_t headTrackerVTable = {
     .process = headtrackerSerialProcess,

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -103,7 +103,9 @@ static gpsProviderDescriptor_t gpsProviders[GPS_PROVIDER_COUNT] = {
 #endif
 
     /* MSP GPS */
-#ifdef USE_GPS_PROTO_MSP
+    // GPS_NULL_PORT_UNIT_TEST's minimal build links only io/gps.c, so optional
+    // protocols/features that pull in other production globals are excluded here.
+#if defined(USE_GPS_PROTO_MSP) && !defined(GPS_NULL_PORT_UNIT_TEST)
     { true, 0, &gpsRestartMSP, &gpsHandleMSP },
 #else
     { false, 0, NULL, NULL },
@@ -123,7 +125,7 @@ static gpsProviderDescriptor_t gpsProviders[GPS_PROVIDER_COUNT] = {
 #endif
 
     /* DRONECAN GPS */
-#ifdef USE_GPS_PROTO_DRONECAN
+#if defined(USE_GPS_PROTO_DRONECAN) && !defined(GPS_NULL_PORT_UNIT_TEST)
     {true, 0, &gpsRestartDronecan, &gpsHandleDronecan },
 #else
     {false, 0, NULL, NULL },
@@ -228,7 +230,7 @@ void gpsSetProtocolTimeout(timeMs_t timeoutMs)
     gpsState.timeoutMs = timeoutMs;
 }
 
-#ifdef USE_GPS_FIX_ESTIMATION
+#if defined(USE_GPS_FIX_ESTIMATION) && !defined(GPS_NULL_PORT_UNIT_TEST)
 bool canEstimateGPSFix(void)
 {
 #if defined(USE_GPS) && defined(USE_BARO)
@@ -246,8 +248,8 @@ bool canEstimateGPSFix(void)
 }
 #endif
 
-#ifdef USE_GPS_FIX_ESTIMATION
-void processDisableGPSFix(void) 
+#if defined(USE_GPS_FIX_ESTIMATION) && !defined(GPS_NULL_PORT_UNIT_TEST)
+void processDisableGPSFix(void)
 {
     static int32_t last_lat = 0;
     static int32_t last_lon = 0;
@@ -278,7 +280,7 @@ void processDisableGPSFix(void)
 }
 #endif
 
-#ifdef USE_GPS_FIX_ESTIMATION
+#if defined(USE_GPS_FIX_ESTIMATION) && !defined(GPS_NULL_PORT_UNIT_TEST)
 //called after gpsSolDRV is copied to gpsSol and processed by "Disable GPS Fix logical condition"
 void updateEstimatedGPSFix(void) 
 {
@@ -362,7 +364,7 @@ void gpsProcessNewDriverData(void)
 {
     gpsSol = gpsSolDRV;
 
-#ifdef USE_GPS_FIX_ESTIMATION
+#if defined(USE_GPS_FIX_ESTIMATION) && !defined(GPS_NULL_PORT_UNIT_TEST)
     processDisableGPSFix();
     updateEstimatedGPSFix();
 #endif
@@ -375,7 +377,7 @@ void gpsProcessNewDriverData(void)
 //On GPS sensor timeout - called after updateEstimatedGPSFix()
 void gpsProcessNewSolutionData(bool timeout)
 {
-#ifdef USE_GPS_FIX_ESTIMATION
+#if defined(USE_GPS_FIX_ESTIMATION) && !defined(GPS_NULL_PORT_UNIT_TEST)
     if ( gpsSol.numSat == 99 ) {
         ENABLE_STATE(GPS_ESTIMATED_FIX);
         DISABLE_STATE(GPS_FIX);
@@ -394,7 +396,7 @@ void gpsProcessNewSolutionData(bool timeout)
             gpsSol.flags.validEPE = false;
             DISABLE_STATE(GPS_FIX);
         }
-#ifdef USE_GPS_FIX_ESTIMATION
+#if defined(USE_GPS_FIX_ESTIMATION) && !defined(GPS_NULL_PORT_UNIT_TEST)
     }
 #endif
 
@@ -445,7 +447,7 @@ void gpsTryEstimateOnTimeout(void)
     gpsResetSolution(&gpsSol);
     DISABLE_STATE(GPS_FIX);
 
-#ifdef USE_GPS_FIX_ESTIMATION
+#if defined(USE_GPS_FIX_ESTIMATION) && !defined(GPS_NULL_PORT_UNIT_TEST)
     if ( canEstimateGPSFix() ) {
         updateEstimatedGPSFix();
 
@@ -550,7 +552,7 @@ bool gpsUpdate(void)
         return false;
     }
 
-#ifdef USE_SIMULATOR
+#if defined(USE_SIMULATOR) && !defined(GPS_NULL_PORT_UNIT_TEST)
     if (ARMING_FLAG(SIMULATOR_MODE_HITL)) {
         if ( SIMULATOR_HAS_OPTION(HITL_GPS_TIMEOUT)) {
             gpsSetState(GPS_LOST_COMMUNICATION);

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -37,169 +37,389 @@
 
 #define I2C1_OVERCLOCK false
 #define I2C2_OVERCLOCK false
+#ifndef USE_I2C_PULLUP
 #define USE_I2C_PULLUP          // Enable built-in pullups on all boards in case external ones are too week
+#endif
 
+#ifndef USE_SERIAL_RX
 #define USE_SERIAL_RX
+#endif
+#ifndef USE_SERIALRX_SPEKTRUM
 #define USE_SERIALRX_SPEKTRUM   // Cheap and fairly common protocol
+#endif
+#ifndef USE_SERIALRX_SBUS
 #define USE_SERIALRX_SBUS       // Very common protocol
+#endif
+#ifndef USE_SERIALRX_IBUS
 #define USE_SERIALRX_IBUS       // Cheap FlySky & Turnigy receivers
+#endif
+#ifndef USE_SERIALRX_FPORT
 #define USE_SERIALRX_FPORT
+#endif
+#ifndef USE_SERIALRX_FPORT2
 #define USE_SERIALRX_FPORT2
+#endif
 
 //#define USE_DEV_TOOLS           // tools for dev use only. Undefine for release builds.
 
 #define COMMON_DEFAULT_FEATURES (FEATURE_TX_PROF_SEL)
 
+#ifndef USE_SERVO_SBUS
 #define USE_SERVO_SBUS
+#endif
 
+#ifndef USE_ADC_AVERAGING
 #define USE_ADC_AVERAGING
+#endif
+#ifndef USE_64BIT_TIME
 #define USE_64BIT_TIME
+#endif
+#ifndef USE_BLACKBOX
 #define USE_BLACKBOX
+#endif
+#ifndef USE_GPS
 #define USE_GPS
+#endif
+#ifndef USE_GPS_PROTO_UBLOX
 #define USE_GPS_PROTO_UBLOX
+#endif
+#ifndef USE_GPS_PROTO_MSP
 #define USE_GPS_PROTO_MSP
+#endif
+#ifndef USE_GPS_PROTO_DRONECAN
 #define USE_GPS_PROTO_DRONECAN
+#endif
+#ifndef USE_TELEMETRY
 #define USE_TELEMETRY
+#endif
+#ifndef USE_TELEMETRY_LTM
 #define USE_TELEMETRY_LTM
+#endif
+#ifndef USE_GPS_FIX_ESTIMATION
 #define USE_GPS_FIX_ESTIMATION
+#endif
 
 // This is the shortest period in microseconds that the scheduler will allow
 #define SCHEDULER_DELAY_LIMIT           10
 
 #if defined(MAG_I2C_BUS) || defined(VCM5883_I2C_BUS)
+#ifndef USE_MAG_VCM5883
 #define USE_MAG_VCM5883
 #endif
+#endif
 
+#ifndef USE_MR_BRAKING_MODE
 #define USE_MR_BRAKING_MODE
+#endif
+#ifndef USE_PITOT
 #define USE_PITOT
+#endif
+#ifndef USE_PITOT_ADC
 #define USE_PITOT_ADC
+#endif
 
+#ifndef USE_DYNAMIC_FILTERS
 #define USE_DYNAMIC_FILTERS
+#endif
+#ifndef USE_GYRO_KALMAN
 #define USE_GYRO_KALMAN
+#endif
+#ifndef USE_SMITH_PREDICTOR
 #define USE_SMITH_PREDICTOR
+#endif
+#ifndef USE_RATE_DYNAMICS
 #define USE_RATE_DYNAMICS
+#endif
+#ifndef USE_EXTENDED_CMS_MENUS
 #define USE_EXTENDED_CMS_MENUS
+#endif
 
 // Allow default rangefinders
+#ifndef USE_RANGEFINDER
 #define USE_RANGEFINDER
+#endif
+#ifndef USE_RANGEFINDER_MSP
 #define USE_RANGEFINDER_MSP
+#endif
+#ifndef USE_RANGEFINDER_BENEWAKE
 #define USE_RANGEFINDER_BENEWAKE
+#endif
+#ifndef USE_RANGEFINDER_VL53L0X
 #define USE_RANGEFINDER_VL53L0X
+#endif
+#ifndef USE_RANGEFINDER_VL53L1X
 #define USE_RANGEFINDER_VL53L1X
+#endif
+#ifndef USE_RANGEFINDER_US42
 #define USE_RANGEFINDER_US42
+#endif
+#ifndef USE_RANGEFINDER_TOF10120_I2C
 #define USE_RANGEFINDER_TOF10120_I2C
+#endif
+#ifndef USE_RANGEFINDER_TERARANGER_EVO_I2C
 #define USE_RANGEFINDER_TERARANGER_EVO_I2C
+#endif
+#ifndef USE_RANGEFINDER_USD1_V0
 #define USE_RANGEFINDER_USD1_V0
+#endif
+#ifndef USE_RANGEFINDER_NANORADAR
 #define USE_RANGEFINDER_NANORADAR
+#endif
 
 // Allow default optic flow boards
+#ifndef USE_OPFLOW
 #define USE_OPFLOW
+#endif
+#ifndef USE_OPFLOW_CXOF
 #define USE_OPFLOW_CXOF
+#endif
+#ifndef USE_OPFLOW_MSP
 #define USE_OPFLOW_MSP
+#endif
 
 // Allow default airspeed sensors
+#ifndef USE_PITOT
 #define USE_PITOT
+#endif
+#ifndef USE_PITOT_MS4525
 #define USE_PITOT_MS4525
+#endif
+#ifndef USE_PITOT_MS5525
 #define USE_PITOT_MS5525
+#endif
+#ifndef USE_PITOT_MSP
 #define USE_PITOT_MSP
+#endif
+#ifndef USE_PITOT_DLVR
 #define USE_PITOT_DLVR
+#endif
 
+#ifndef USE_1WIRE
 #define USE_1WIRE
+#endif
+#ifndef USE_1WIRE_DS2482
 #define USE_1WIRE_DS2482
+#endif
 
+#ifndef USE_TEMPERATURE_SENSOR
 #define USE_TEMPERATURE_SENSOR
+#endif
+#ifndef USE_TEMPERATURE_LM75
 #define USE_TEMPERATURE_LM75
+#endif
+#ifndef USE_TEMPERATURE_DS18B20
 #define USE_TEMPERATURE_DS18B20
+#endif
 
+#ifndef USE_MSP_DISPLAYPORT
 #define USE_MSP_DISPLAYPORT
+#endif
+#ifndef USE_DASHBOARD
 #define USE_DASHBOARD
+#endif
+#ifndef DASHBOARD_ARMED_BITMAP
 #define DASHBOARD_ARMED_BITMAP
+#endif
+#ifndef USE_OLED_UG2864
 #define USE_OLED_UG2864
+#endif
 
+#ifndef USE_OSD
 #define USE_OSD
+#endif
+#ifndef USE_FRSKYOSD
 #define USE_FRSKYOSD
+#endif
+#ifndef USE_DJI_HD_OSD
 #define USE_DJI_HD_OSD
+#endif
+#ifndef USE_MSP_OSD
 #define USE_MSP_OSD
+#endif
 
+#ifndef NAV_NON_VOLATILE_WAYPOINT_CLI
 #define NAV_NON_VOLATILE_WAYPOINT_CLI
+#endif
 
+#ifndef USE_D_BOOST
 #define USE_D_BOOST
+#endif
+#ifndef USE_ANTIGRAVITY
 #define USE_ANTIGRAVITY
+#endif
 
+#ifndef USE_I2C_IO_EXPANDER
 #define USE_I2C_IO_EXPANDER
+#endif
 
+#ifndef USE_MSP_OVER_TELEMETRY
 #define USE_MSP_OVER_TELEMETRY
+#endif
 
+#ifndef USE_SERIALRX_SRXL2
 #define USE_SERIALRX_SRXL2     // Spektrum SRXL2 protocol
+#endif
+#ifndef USE_SERIALRX_JETIEXBUS
 #define USE_SERIALRX_JETIEXBUS
+#endif
+#ifndef USE_TELEMETRY_SRXL
 #define USE_TELEMETRY_SRXL
+#endif
+#ifndef USE_SPEKTRUM_CMS_TELEMETRY
 #define USE_SPEKTRUM_CMS_TELEMETRY
+#endif
 //#define USE_SPEKTRUM_VTX_CONTROL //Some functions from betaflight still not implemented
+#ifndef USE_SPEKTRUM_VTX_TELEMETRY
 #define USE_SPEKTRUM_VTX_TELEMETRY
+#endif
 
+#ifndef USE_VTX_COMMON
 #define USE_VTX_COMMON
+#endif
 
+#ifndef USE_SERIALRX_GHST
 #define USE_SERIALRX_GHST
+#endif
+#ifndef USE_TELEMETRY_GHST
 #define USE_TELEMETRY_GHST
+#endif
 
+#ifndef USE_POWER_LIMITS
 #define USE_POWER_LIMITS
+#endif
 
+#ifndef USE_SAFE_HOME
 #define USE_SAFE_HOME
+#endif
+#ifndef USE_FW_AUTOLAND
 #define USE_FW_AUTOLAND
+#endif
+#ifndef USE_AUTOTUNE_FIXED_WING
 #define USE_AUTOTUNE_FIXED_WING
+#endif
+#ifndef USE_LOG
 #define USE_LOG
+#endif
 #define USE_BOOTLOG 2048
+#ifndef USE_STATS
 #define USE_STATS
+#endif
+#ifndef USE_CMS
 #define USE_CMS
+#endif
+#ifndef CMS_MENU_OSD
 #define CMS_MENU_OSD
+#endif
+#ifndef NAV_NON_VOLATILE_WAYPOINT_STORAGE
 #define NAV_NON_VOLATILE_WAYPOINT_STORAGE
+#endif
+#ifndef USE_TELEMETRY_IBUS
 #define USE_TELEMETRY_IBUS
+#endif
+#ifndef USE_TELEMETRY_SMARTPORT
 #define USE_TELEMETRY_SMARTPORT
+#endif
+#ifndef USE_TELEMETRY_CRSF
 #define USE_TELEMETRY_CRSF
+#endif
+#ifndef USE_TELEMETRY_JETIEXBUS
 #define USE_TELEMETRY_JETIEXBUS
+#endif
 // These are rather exotic serial protocols
+#ifndef USE_RX_MSP
 #define USE_RX_MSP
+#endif
+#ifndef USE_MSP_RC_OVERRIDE
 #define USE_MSP_RC_OVERRIDE
+#endif
+#ifndef USE_SERIALRX_CRSF
 #define USE_SERIALRX_CRSF
+#endif
+#ifndef USE_SERIAL_PASSTHROUGH
 #define USE_SERIAL_PASSTHROUGH
+#endif
 #define NAV_MAX_WAYPOINTS       120
+#ifndef USE_RCDEVICE
 #define USE_RCDEVICE
+#endif
+#ifndef USE_MULTI_MISSION
 #define USE_MULTI_MISSION
+#endif
+#ifndef USE_MULTI_FUNCTIONS
 #define USE_MULTI_FUNCTIONS  // defines functions only, warnings always defined
+#endif
 
 //Enable VTX control
+#ifndef USE_VTX_CONTROL
 #define USE_VTX_CONTROL
+#endif
+#ifndef USE_VTX_SMARTAUDIO
 #define USE_VTX_SMARTAUDIO
+#endif
+#ifndef USE_VTX_TRAMP
 #define USE_VTX_TRAMP
+#endif
+#ifndef USE_VTX_MSP
 #define USE_VTX_MSP
+#endif
 
+#ifndef USE_PROGRAMMING_FRAMEWORK
 #define USE_PROGRAMMING_FRAMEWORK
+#endif
+#ifndef USE_CLI_BATCH
 #define USE_CLI_BATCH
+#endif
 
 //Enable DST calculations
+#ifndef RTC_AUTOMATIC_DST
 #define RTC_AUTOMATIC_DST
+#endif
 // Wind estimator
+#ifndef USE_WIND_ESTIMATOR
 #define USE_WIND_ESTIMATOR
+#endif
 
+#ifndef USE_SIMULATOR
 #define USE_SIMULATOR
+#endif
+#ifndef USE_PITOT_VIRTUAL
 #define USE_PITOT_VIRTUAL
+#endif
+#ifndef USE_FAKE_BATT_SENSOR
 #define USE_FAKE_BATT_SENSOR
+#endif
+#ifndef USE_RANGEFINDER_FAKE
 #define USE_RANGEFINDER_FAKE
+#endif
+#ifndef USE_RX_SIM
 #define USE_RX_SIM
+#endif
 
+#ifndef USE_CMS_FONT_PREVIEW
 #define USE_CMS_FONT_PREVIEW
+#endif
 
 //ADSB RECEIVER
 #ifdef USE_GPS
+#ifndef USE_ADSB
 #define USE_ADSB
+#endif
 #define MAX_ADSB_VEHICLES               5
 #define ADSB_LIMIT_CM                   6400000
 #endif
 
+#ifndef USE_SERIAL_GIMBAL
 #define USE_SERIAL_GIMBAL
+#endif
+#ifndef USE_HEADTRACKER
 #define USE_HEADTRACKER
+#endif
+#ifndef USE_HEADTRACKER_SERIAL
 #define USE_HEADTRACKER_SERIAL
+#endif
+#ifndef USE_HEADTRACKER_MSP
 #define USE_HEADTRACKER_MSP
+#endif
 
 #if defined(STM32F7) || defined(STM32H7)
 // needs bi-direction inverter, not available on F4 hardware.
@@ -233,5 +453,9 @@
     #undef USE_TELEMETRY_SRXL
 #endif
 
+#ifndef USE_EZ_TUNE
 #define USE_EZ_TUNE
+#endif
+#ifndef USE_ADAPTIVE_FILTER
 #define USE_ADAPTIVE_FILTER
+#endif

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -62,7 +62,7 @@ set_property(SOURCE canard_unittest.cc PROPERTY extra_includes
 set_property(SOURCE canard_unittest.cc PROPERTY definitions USE_DRONECAN CANARD_ENABLE_TAO_OPTION=0 CANARD_INTERNAL=)
 
 set_property(SOURCE osd_unittest.cc PROPERTY depends "io/osd_utils.c" "io/displayport_msp_osd.c" "common/typeconversion.c")
-set_property(SOURCE osd_unittest.cc PROPERTY definitions OSD_UNIT_TEST USE_MSP_DISPLAYPORT DISABLE_MSP_BF_COMPAT)
+set_property(SOURCE osd_unittest.cc PROPERTY definitions OSD_UNIT_TEST USE_MSP_DISPLAYPORT)
 
 set_property(SOURCE gps_ublox_unittest.cc PROPERTY depends "io/gps_ublox_utils.c")
 set_property(SOURCE gps_ublox_unittest.cc PROPERTY definitions GPS_UBLOX_UNIT_TEST)

--- a/src/test/unit/rcdevice_unittest.cc
+++ b/src/test/unit/rcdevice_unittest.cc
@@ -947,7 +947,7 @@ extern "C" {
     }
 
     uint32_t millis(void) { return testData.millis++; }
-    uint32_t micros(void) { return millis() * 1000; }
+    timeUs_t micros(void) { return millis() * 1000; }
     void beeper(beeperMode_e mode) { UNUSED(mode); }
     uint8_t armingFlags = 0;
     bool cmsInMenu;

--- a/src/test/unit/target.h
+++ b/src/test/unit/target.h
@@ -21,9 +21,13 @@
 #define USE_MAG
 #define USE_BARO
 #define USE_GPS
+#ifndef USE_GPS_PROTO_UBLOX
 #define USE_GPS_PROTO_UBLOX
+#endif
 #define USE_DASHBOARD
+#ifndef USE_TELEMETRY
 #define USE_TELEMETRY
+#endif
 #define USE_TELEMETRY_HOTT
 #define USE_TELEMETRY_IBUS
 #define USE_TELEMETRY_SMARTPORT

--- a/src/test/unit/telemetry_hott_unittest.cc
+++ b/src/test/unit/telemetry_hott_unittest.cc
@@ -188,7 +188,7 @@ uint32_t millis(void) {
     return fixedMillis;
 }
 
-uint32_t micros(void) { return 0; }
+timeUs_t micros(void) { return 0; }
 
 uint32_t serialRxBytesWaiting(const serialPort_t *instance) {
     UNUSED(instance);

--- a/src/test/unit/time_unittest.cc
+++ b/src/test/unit/time_unittest.cc
@@ -23,7 +23,7 @@
 extern "C" {
     #include "common/time.h"
     #include "drivers/time.h"
-    extern timeUs_t usTicks;
+    extern uint32_t usTicks;
     extern volatile timeMs_t sysTickUptime;
     extern volatile timeMs_t sysTickValStamp;
 }


### PR DESCRIPTION
# Fix unit test CI build failure on maintenance-10.x (macro leak from shared platform.h)

## Summary

CI's `test` job (`cmake -DTOOLCHAIN=none .. && ninja check`) fails to build on `maintenance-10.x`. `gimbal_serial_unittest` fails to *link*, and several other unit tests print "macro redefined" warnings along the way. This PR fixes the link failure and eliminates every redefinition warning, verified with zero regressions on production/hardware builds.

**Scope note:** fixing the reported failure unmasked 5 more pre-existing, unrelated test failures that were always broken but never reached, because `ninja`'s default fail-fast behavior stopped scheduling new work at the first failure (`gimbal_serial_unittest`, at build step 44/122). Those 5 turned out to be fixable within reasonable scope too (see "Fix, part 2" below) — **all 17 unit test targets now pass, 196/196 gtest cases, `ninja check` exits 0.**

## Root cause

Two commits in the same MAVLink PR series (same author), merged back-to-back onto `maintenance-10.x`:

- `053c3977d6` ("Split MAVLink telemetry into modules with multi-port runtime") added `#include "target/common.h"` to `src/main/telemetry/telemetry.h`.
- `be9aaa3b82` ("Add MAVLink unit tests for the multi-port core"), its direct child, added the same include to `src/test/unit/platform.h`:
  ```diff
  +#include "target/common.h"
   #include "target.h"
  ```

`platform.h` is included by **every** unit test translation unit, not just `mavlink_unittest.cc`. `target/common.h` unconditionally `#define`s a large baseline feature set. `be9aaa3b82`'s include collided with several tests' own explicit `-D` feature macros (harmless-value but noisy "redefined" warnings), and in one case silently changed which code compiles:

`src/main/io/gimbal_serial.c`'s vtable initializer was guarded by:
```c
#if (defined(USE_HEADTRACKER) && defined(USE_HEADTRACKER_SERIAL))
static headTrackerVTable_t headTrackerVTable = {
    .process = headtrackerSerialProcess,
    .getDeviceType = headtrackerSerialGetDeviceType,
};
```
but the actual definitions of those two functions are additionally gated by `#ifndef GIMBAL_UNIT_TEST`. Before `be9aaa3b82`, `USE_HEADTRACKER_SERIAL` was never defined in the unit test build, so the reference and the (absent) definitions agreed — nothing to link. After `be9aaa3b82`, `target/common.h` unconditionally defines `USE_HEADTRACKER_SERIAL` too, so the vtable reference compiles in while the definitions stay compiled out:
```
undefined reference to `headtrackerSerialProcess'
undefined reference to `headtrackerSerialGetDeviceType'
```

**`target/common.h`'s inclusion in `platform.h` is load-bearing, not removable.** I confirmed this empirically: removing it breaks settings-code-generation (`settings.rb`, run for every unit test target via `enable_settings()`) for 14 of 17 targets. Tracing further, this is because `053c3977d6` is *also* what settings-gen now silently depends on — `settings.rb`'s `check_conditions()` builds one combined probe file (`platform.h` + every settings group header, in `settings.yaml` order) and only evaluates `#if defined(MACRO)` conditions at the very end, so it sees a macro as "on" if it's defined *anywhere* in that file. `resolve_types()` instead probes each struct *inline*, at that struct's own position in the same header sequence, so a macro only counts if something *earlier* already defined it. Once `telemetry.h` (late in the include order) started pulling in `target/common.h`, `check_conditions()` correctly saw feature macros as defined, but `resolve_types()` — probing structs from headers earlier in the list, e.g. `sensors/gyro.h` — didn't yet have them defined, and choked on fields that "should" exist (`gyroConfig_t has no member named 'dynamicGyroNotchQ'`, etc.). `platform.h` including `target/common.h` first (via `be9aaa3b82`) papers over this by making every macro visible before any group header is reached. **This ordering bug in `settings.rb` is real, pre-existing, and separate from this PR's fix — it's being tracked as its own follow-up (see below), not touched here.**

## Fix

1. **`src/main/io/gimbal_serial.c`** — added the missing `!defined(GIMBAL_UNIT_TEST)` condition to the vtable's `#if` guard, matching the guard already used for the function definitions a few dozen lines down. This is the fix for the actual link failure.
2. **`src/main/target/common.h`** — wrapped the entire unconditional "always-on baseline" block (~90 bare, presence-only `#define USE_X`-style feature-toggle macros) in `#ifndef X / #define X / #endif` guards, rather than patching only the handful of macros that happened to surface as CI warnings. These are toggle-only flags with no competing values, so the guard is a safe no-op wherever the macro isn't already defined — true for every real hardware target. I deliberately did **not** guard value-bearing macros (`SCHEDULER_DELAY_LIMIT 10`, `NAV_MAX_WAYPOINTS 120`, `USE_BOOTLOG 2048`, etc.) since blindly keeping "whichever definition came first" could silently mask a genuine value conflict rather than a harmless duplicate toggle. Verified structurally (`#if`/`#ifndef` count matches `#endif` count exactly; the set of macro names actually defined is byte-identical before/after) and via build (SITL, MATEKH743, KAKUTEF7, and MATEKF411 — a flash-constrained target that exercises the `#undef` block at the bottom of this file — all produce byte-identical/flash-identical output to the unmodified base commit, zero new warnings).
3. **`src/main/common/maths.h`** — wrapped `M_Ef` in `#ifndef M_Ef`. Unrelated to the above: INAV's own `M_Ef` collides with glibc's GNU-extension `M_Ef` (pulled in via `<cmath>` in `maths_unittest.cc`), and reproduces identically on `release/9.1` and `master` today. The two values agree to full `float` precision, so this is a safe no-op guard.
4. **`src/test/unit/target.h`** — the unit test harness's own fake-target stub (test-only, not shared with any real hardware target), included by `platform.h` right after `target/common.h`. It independently redefines `USE_GPS_PROTO_UBLOX` and `USE_TELEMETRY`, colliding with `common.h`'s definitions the same way — wrapped both in `#ifndef` guards for consistency.

Result: **zero "macro redefined" warnings anywhere in `ninja check`'s output** (down from 23+), `gimbal_serial_unittest` builds, links, and passes, and 11 other previously-passing unit tests confirmed still passing with no regressions.

(Two small follow-ups from code review: `USE_EZ_TUNE`/`USE_ADAPTIVE_FILTER` at the end of `common.h` were missed in the initial sweep and are now guarded too for consistency; a one-line comment was added explaining why `M_Ef` is guarded when `M_PIf`/`M_LN2f` aren't.)

## Fix, part 2: the 5 unmasked failures

Once `gimbal_serial_unittest` no longer blocked the build, 5 more targets failed — confirmed pre-existing on unmodified `maintenance-10.x`, not caused by this PR, and structurally different from the redefinition bug above (a macro becoming newly *enabled* for a test that was never built to handle it, not a macro being *redefined* — no `#ifndef` guard can fix this class of bug by construction). All 5 are now fixed:

**`time_unittest`, `rcdevice_unittest`, `telemetry_hott_unittest` (compile errors)** — `drivers/time.h` declares `usTicks` as a fixed `uint32_t` (a raw hardware tick counter, unrelated to `USE_64BIT_TIME`, which only widens the *derived* `timeUs_t` microsecond counter). Each test file's own mock had drifted from that: `time_unittest.cc` declared `extern timeUs_t usTicks` instead of `uint32_t`, and `rcdevice_unittest.cc`/`telemetry_hott_unittest.cc` each defined their own `micros()` mock hardcoded to return `uint32_t` instead of `timeUs_t` (`drivers/time.h`'s actual declared return type). Before `USE_64BIT_TIME` was reachable in unit tests, `timeUs_t` silently defaulted to `uint32_t`, so these mismatches were invisible — the types happened to coincide. `USE_64BIT_TIME` is genuinely, deliberately always-on in `common.h` (not part of the leak — this was already latent, just never exercised in the test harness before). Fixed each mock to match `drivers/time.h`'s real signatures.

**`gps_null_port_unittest` (link errors)** — this test's `depends` list in `CMakeLists.txt` is deliberately minimal (`io/gps.c` only, with only `USE_GPS_PROTO_UBLOX` explicitly set), reflecting its narrow original intent (test only null-port/proto-selection behavior). `USE_GPS_FIX_ESTIMATION`, `USE_GPS_PROTO_MSP`, `USE_GPS_PROTO_DRONECAN`, and `USE_SIMULATOR` all now leak in unconditionally from `common.h`, enabling extra code branches in `gps.c` that reference production globals (`posControl`, `baro`, `positionEstimationConfig()`, `rMat`, etc.) this minimal test was never built to link. This test already has its own marker macro (`GPS_NULL_PORT_UNIT_TEST`), following the same convention as `GIMBAL_UNIT_TEST` — but it wasn't referenced anywhere in `gps.c` yet. Added `&& !defined(GPS_NULL_PORT_UNIT_TEST)` to the 10 relevant guard sites (verified: a plain `-U` compiler flag does *not* work here, since `common.h`'s own `#ifndef`-guarded definitions re-establish the macro regardless — the fix has to be a source-level guard). One further `USE_GPS_FIX_ESTIMATION` occurrence, a `STATE(GPS_ESTIMATED_FIX)` flag read with no unlinked-symbol reference, was deliberately left untouched.

**`osd_unittest` (link errors, two independent bugs)**:
1. `displayport_msp_osd.c`'s entire body is gated by one outer `#if defined(USE_OSD) && defined(USE_MSP_OSD)` guard — neither macro is in this test's own `-D` list, both leak in from `common.h`, so the *entire* real DJI/MSP-displayport driver compiles in (~30 undefined symbols: `armingFlags`, `cliMode`, `mspSerialPushPort`, `bitArray*`, etc.), none of which is in the test's minimal `depends` list (`io/osd_utils.c`, `io/displayport_msp_osd.c`, `common/typeconversion.c`). Added `&& !defined(OSD_UNIT_TEST)` to that guard — same pattern as everywhere else, correctly makes the file an empty translation unit for this test again.
2. Independently: `osd_utils.c`'s `osdFormatCentiNumber` (the function actually under test) calls `isDJICompatibleVideoSystem(osdConfig())`, defined in `displayport_msp_dji_compat.h`. That header already has a dedicated `#ifdef OSD_UNIT_TEST` fallback (`isDJICompatibleVideoSystem(osdConfigPtr) (true)`, never evaluating its argument) — but the header's outer guard didn't exclude `OSD_UNIT_TEST` directly, so it took the real branch instead, referencing `osdConfig()`/`osdConfig_System`. Added `&& !defined(OSD_UNIT_TEST)` to that outer guard, routing to the existing test fallback.

   (`src/test/unit/CMakeLists.txt` previously tried to reach this same fallback a different way — defining `DISABLE_MSP_BF_COMPAT`, which is a typo; the real macro checked by the header is `DISABLE_MSP_DJI_COMPAT`. I deliberately did **not** fix the typo to the "correct" name: doing so would define `DISABLE_MSP_DJI_COMPAT` for real, which excludes `osdConfig_t.highlight_djis_missing_characters` — a field `settings.yaml` references completely unconditionally, no matching `condition:` key. That's a separate, dormant, pre-existing bug (currently unreachable, since no real target ever defines `DISABLE_MSP_DJI_COMPAT` either) that I don't want to trigger here. The header-guard fix above solves the original problem without needing that macro defined at all, so the typo'd flag was simply removed from `CMakeLists.txt` rather than "corrected.")

**Result: `ninja check` now exits 0. All 17 unit test targets pass, 196/196 gtest cases, zero regressions, zero new warnings anywhere.**

## What I deliberately did not change

`src/test/unit/CMakeLists.txt` still explicitly declares macros like `USE_ADSB`, `USE_SERIAL_GIMBAL`, `USE_HEADTRACKER`, `USE_TELEMETRY` per-test, even though `target/common.h`'s now-guarded definitions make most of these redundant today. Left as-is because: (a) not all of them are actually redundant — `USE_TELEMETRY_MAVLINK` on `mavlink_unittest` is real, since `common.h` only defines it when `MCU_FLASH_SIZE > 512`, which isn't set for unit test builds; and (b) the commit message on `be9aaa3b82` says "later stack PRs re-add their own test sections" for the `mavlink_multiport2` suite, so editing these lines now risks conflicting with in-flight follow-on work for no functional benefit.

## Testing

- `cmake -DTOOLCHAIN=none .. && ninja check` (the exact CI command): **exits 0.** All 17 unit test targets build, link, and pass — 196/196 gtest cases. Zero "redefined" warnings anywhere in the build.
- SITL, MATEKH743 (H7), KAKUTEF7 (F7), MATEKF405 (F4): clean builds, zero new warnings, byte-identical/flash-identical output vs. unmodified base commit (`a914d2dbe2`).
- MATEKF411 (flash-constrained, `MCU_FLASH_SIZE <= 512`): clean build, and directly verified via a targeted probe that the `#undef USE_SERIALRX_SPEKTRUM` / `#undef USE_TELEMETRY_SRXL` block at the bottom of `common.h` still correctly un-defines macros that were set via the new `#ifndef` guard pattern.
- `gps.c`/`displayport_msp_osd.c`/`displayport_msp_dji_compat.h` guard additions specifically verified inert for production: none of `GPS_NULL_PORT_UNIT_TEST`/`OSD_UNIT_TEST` are ever defined by any real target.

## Follow-ups (not in this PR)

1. **`settings.rb` ordering bug** (described above under "Root cause") — `check_conditions()` and `resolve_types()` disagree about macro visibility depending on include order. Currently masked by `platform.h` including `target/common.h` first; will resurface confusingly if that ordering ever changes. Needs its own scoped fix/review in the Ruby codegen tooling. Reported to project tracking separately.
2. **Dormant `settings.yaml`/`osd.h` mismatch** — `osd.h`'s `highlight_djis_missing_characters` field is guarded by `#ifndef DISABLE_MSP_DJI_COMPAT`, but `settings.yaml`'s `osd_highlight_djis_missing_font_symbols` entry references that field completely unconditionally, with no matching `condition:` key — and the `settings.yaml` DSL only supports positive "macro is defined" conditions, not negation, so there's no direct way to express "field only exists when macro X is *not* defined" today. Currently unreachable in practice (no real target defines `DISABLE_MSP_DJI_COMPAT`), avoided in this PR by not defining that macro for `osd_unittest` either — but it's a landmine for whoever eventually does need that macro defined (e.g. a future target or test). Worth its own follow-up.

## Note for future test additions

`src/test/unit/platform.h` is shared across every unit test translation unit — anything added there has global blast radius across all other tests, not just the one being worked on. Same is true of `src/main/telemetry/telemetry.h` in this case, since it's included by settings-gen's combined probe. Worth keeping in mind for the rest of the `mavlink_multiport2` test stack (cc @xznhj8129, since this PR series is what surfaced both issues above).
