### PR TITLE
Fix settings.rb check_conditions()/resolve_types() header-order disagreement

### DIFF
--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -490,7 +490,7 @@ class Generator
         foreach_enabled_group do |group|
             count = 0
             group["members"].each do |member|
-                if is_condition_enabled(member["condition"])
+                if is_condition_enabled(member)
                     count += 1
                 end
             end
@@ -665,16 +665,21 @@ class Generator
         return min, max
     end
 
-    def is_condition_enabled(cond)
-        return !cond || @true_conditions.include?(cond)
+    # Condition truth is resolved per group/member occurrence (see
+    # check_conditions), not by condition string, since the same condition
+    # string can appear on multiple groups at different header-inclusion
+    # positions and be true at one but not the other.
+    def is_condition_enabled(obj)
+        return true unless obj["condition"]
+        obj["_condition_enabled"]
     end
 
     def foreach_enabled_member &block
         enum = Enumerator.new do |yielder|
             groups.each do |group|
-                if is_condition_enabled(group["condition"])
+                if is_condition_enabled(group)
                     group["members"].each do |member|
-                        if is_condition_enabled(member["condition"])
+                        if is_condition_enabled(member)
                             yielder.yield group, member
                         end
                     end
@@ -803,34 +808,42 @@ class Generator
             buf << "#include \"#{h}\"\n"
         end
 
-        conditions = Set.new
-        add_condition = -> (c) {
-            if c && !conditions.include?(c)
-                conditions.add(c)
-                buf << "#if "
-                in_word = false
-                c.split('').each do |ch|
-                    if in_word
-                        if !ch.match(/^[a-zA-Z0-9_]$/)
-                            in_word = false
-                            buf << ")"
-                        end
-                        buf << ch
-                    else
-                        if ch.match(/^[a-zA-Z_]$/)
-                            in_word = true
-                            buf << "defined("
-                        end
-                        buf << ch
-                    end
-                end
+        # Tag each group/member occurrence with its own unique probe, rather
+        # than deduping by condition string: the same condition string can
+        # appear on multiple groups, and since a probe's truth now depends on
+        # its position (see comment below), one occurrence being true doesn't
+        # mean another occurrence of the same string is.
+        tags = {}
+        seq = 0
+        add_condition = -> (obj) {
+            c = obj["condition"]
+            next unless c
+            seq += 1
+            tag = "COND#{seq}"
+            tags[tag] = obj
+            buf << "#if "
+            in_word = false
+            c.split('').each do |ch|
                 if in_word
-                    buf << ")"
+                    if !ch.match(/^[a-zA-Z0-9_]$/)
+                        in_word = false
+                        buf << ")"
+                    end
+                    buf << ch
+                else
+                    if ch.match(/^[a-zA-Z_]$/)
+                        in_word = true
+                        buf << "defined("
+                    end
+                    buf << ch
                 end
-                buf << "\n"
-                buf << "#pragma message(#{c.inspect})\n"
-                buf << "#endif\n"
             end
+            if in_word
+                buf << ")"
+            end
+            buf << "\n"
+            buf << "#pragma message(#{tag.inspect})\n"
+            buf << "#endif\n"
         }
 
         # Check each condition right after that group's own headers, matching
@@ -844,16 +857,19 @@ class Generator
                     buf << "#include \"#{h}\"\n" if h
                 end
             end
-            add_condition.call(group["condition"])
+            add_condition.call(group)
             group["members"].each do |member|
-                add_condition.call(member["condition"])
+                add_condition.call(member)
             end
         end
 
         stderr = compile_raw(buf)
-        @true_conditions = Set.new
+        true_tags = Set.new
         stderr.scan(/#pragma message\(\"(.*)\"\)/).each do |m|
-            @true_conditions << m[0]
+            true_tags << m[0]
+        end
+        tags.each do |tag, obj|
+            obj["_condition_enabled"] = true_tags.include?(tag)
         end
     end
 

--- a/src/utils/settings.rb
+++ b/src/utils/settings.rb
@@ -763,10 +763,13 @@ class Generator
         value
     end
 
+    # cstddef for offsetof(). Shared by every probe so they all see the same
+    # base macro state.
+    BASE_HEADERS = ["platform.h", "cstddef"]
+
     def compile_test_file(prog)
         buf = StringIO.new
-        # cstddef for offsetof()
-        headers = ["platform.h", "cstddef"]
+        headers = BASE_HEADERS.dup
         @data["groups"].each do |group|
             gh = group["headers"]
             if gh
@@ -780,6 +783,10 @@ class Generator
         end
         buf << "\n"
         buf << prog.string
+        compile_raw(buf)
+    end
+
+    def compile_raw(buf)
         mktmpdir do |dir|
             file = File.join(dir, "test.cpp")
             File.open(file, 'w') {|file| file.write(buf.string)}
@@ -792,6 +799,10 @@ class Generator
 
     def check_conditions
         buf = StringIO.new
+        BASE_HEADERS.each do |h|
+            buf << "#include \"#{h}\"\n"
+        end
+
         conditions = Set.new
         add_condition = -> (c) {
             if c && !conditions.include?(c)
@@ -822,12 +833,24 @@ class Generator
             end
         }
 
-        foreach_member do |group, member|
+        # Check each condition right after that group's own headers, matching
+        # the position resolve_types() implicitly relies on: a header's own
+        # #ifdef guard only sees macros defined by headers earlier in this
+        # sequence.
+        @data["groups"].each do |group|
+            gh = group["headers"]
+            if gh
+                gh.each do |h|
+                    buf << "#include \"#{h}\"\n" if h
+                end
+            end
             add_condition.call(group["condition"])
-            add_condition.call(member["condition"])
+            group["members"].each do |member|
+                add_condition.call(member["condition"])
+            end
         end
 
-        stderr = compile_test_file(buf)
+        stderr = compile_raw(buf)
         @true_conditions = Set.new
         stderr.scan(/#pragma message\(\"(.*)\"\)/).each do |m|
             @true_conditions << m[0]


### PR DESCRIPTION
## Summary

`src/utils/settings.rb` generates `settings_generated.h/.c` from `settings.yaml` for both real firmware builds and the unit test suite, using two functions that compile small C++ probe files with a real compiler to introspect struct layouts:

- `check_conditions()` determines which `condition:` macros from `settings.yaml` are actually defined, by evaluating `#if defined(MACRO)` checks appended to the very end of one combined probe file (after every settings-group header has already been `#include`d).
- `resolve_types()` infers a member's C type by trying to compile an expression that accesses the struct field directly.

These two functions could disagree depending on header include order: `check_conditions()` saw a macro as "on" if it was defined *anywhere* among all the concatenated headers, regardless of position, while `resolve_types()`'s struct field access is governed by that struct's own header's internal `#ifdef` guard — a purely position-dependent fact based on what was defined by *earlier* headers in the same sequence. When a macro was only defined by a header appearing *later* than the header defining a struct that needed it, `check_conditions()` would report the condition as true (member enabled), but `resolve_types()` would then fail to compile the field access and raise an unhandled "no member named X" error, crashing settings generation.

The issue manifested on `maintenance-10.x`: commit `053c3977d6` added `#include "target/common.h"` to `telemetry.h`, which sits late in the group order. That one include broke settings generation for every unit-test target with a confusing, seemingly-unrelated error (`gyroConfig_t has no member named 'dynamicGyroNotchQ'`), because `gyro.h` (an earlier group) needed `USE_DYNAMIC_FILTERS`, which `check_conditions()` wrongly reported as already visible. It was only invisible again because the very next commit added the same include to `platform.h` (always first in the probe).

That specific trigger commit doesn't exist on `release/9.1` (this PR's base), so no currently-existing header/macro ordering combination in this branch's `settings.yaml` triggers the bug today — see Testing below for byte-identical confirmation. But the same flawed algorithm is present here too, and will silently reintroduce this exact failure class the next time a header include changes such that a macro-defining header moves later relative to something that needs it.

## Changes

- Extracted the low-level compile step from `compile_test_file()` into a new `compile_raw(buf)` helper (no behavior change for existing callers: `print_stats`, `can_use_byte_offsetof`, `resolve_types`).
- Rewrote `check_conditions()` to build its probe by interleaving each settings-group's headers with that same group's own condition checks, in a single ordered pass over `@data["groups"]` — so each condition is now evaluated immediately after that specific group's own headers are included, matching the same in-order vantage point `resolve_types()` implicitly relies on.
- Deduplicated the shared base header list (`platform.h`, `cstddef`) into a `BASE_HEADERS` constant used by both `compile_test_file()` and `check_conditions()`, so they can't silently diverge.
- `check_conditions()` initially deduped its probes by condition string, so a condition was only ever checked once, at whichever group/member first used it — since the probe is now position-dependent, a later group reusing the same condition string at a different header-inclusion position would silently reuse the earlier (possibly wrong, for that position) result instead of being re-evaluated. Several real conditions in `settings.yaml` (`USE_ADC`, `USE_BARO`, `USE_PITOT`, ...) are reused across multiple groups, so this was live. Fixed by tagging each group/member occurrence with its own unique probe and storing the resolved boolean on that specific object (`is_condition_enabled(obj)`), rather than in any table keyed by a non-unique condition string.

## Testing

- Reproduced the disagreement with an isolated synthetic fixture (two settings groups where a later group's header defines a macro that an earlier group's struct field depends on) driving the real `Generator` class directly — confirmed the crash before the fix and confirmed it's resolved after.
- Reproduced the second issue (same condition string reused across groups at different positions) with a separate synthetic fixture — confirmed both groups previously resolved to the same wrong value, and now resolve independently and correctly.
- Verified generated `settings_generated.h`/`.c` are byte-identical before and after this change for a real hardware target (`MATEKF722PX`) and three unit-test targets (`maths`, `time`, `msp_refactor` unittests) — this change causes no behavior difference for this branch's current `settings.yaml` + headers.
- Ran the full C++ unit test suite: 57/58 passing. The one failure (`msp_refactor_unittest`) is a pre-existing, unrelated link error in an untracked WIP test file that references MSP functions not linked by its `CMakeLists.txt` entry — unrelated to this change; its settings generation succeeded and it compiled fine.
- Reviewed with the `inav-code-review` agent; addressed all IMPORTANT findings (trimmed a changelog-style comment per project comment standards, deduplicated the base header list to avoid the exact "two places must stay in sync" pattern that caused the original bug). Qodo's automated review then caught the condition-string-dedup issue above, which reintroduced the same failure class one level up; fixed and re-verified.

