### PR TITLE
Fix MSP2_INAV_WIND returning stale non-zero values when invalid

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1604,8 +1604,12 @@ static bool mspFcProcessOutCommand(uint16_t cmdMSP, sbuf_t *dst, mspPostProcessF
 #ifdef USE_WIND_ESTIMATOR
         {
             uint16_t windAngle = 0;
-            uint16_t windSpeed = (uint16_t)getEstimatedHorizontalWindSpeed(&windAngle);
-            uint8_t windFlags = isEstimatedWindSpeedValid() ? 1 : 0;
+            uint16_t windSpeed = 0;
+            uint8_t windFlags = 0;
+            if (isEstimatedWindSpeedValid()) {
+                windSpeed = (uint16_t)getEstimatedHorizontalWindSpeed(&windAngle);
+                windFlags = 1;
+            }
             sbufWriteU16(dst, windSpeed);
             sbufWriteU16(dst, windAngle / 100);
             sbufWriteU8(dst, windFlags);


### PR DESCRIPTION
## Summary

Flagged by Qodo's automated review on PR #11761 (a `release/9.1` → `maintenance-10.x` merge PR): `MSP2_INAV_WIND`'s handler in `fc_msp.c` called `getEstimatedHorizontalWindSpeed()` unconditionally and only used `isEstimatedWindSpeedValid()` to set the `flags` byte, not to gate the actual `windSpeed`/`windAngle` values. Confirmed real:

- In `wind_estimator.c`, `estimatedWind[]` is written only inside the successful-estimate branch of `updateWindEstimator()` (the low-pass filter update) — it is **never reset** when `hasValidWindEstimate` clears (timeout at 15 min without altitude change, or `validityScore` decaying to 0 from repeated stale updates).
- So once the estimate goes invalid, `getEstimatedHorizontalWindSpeed()` keeps returning the last computed value indefinitely, while the `flags` byte correctly reports invalid.
- This contradicts `MSP2_INAV_WIND`'s own documentation (`docs/development/msp/msp_messages.json`): *"returns zeroes when wind estimation is not compiled in or not yet valid. Check bit 0 of `flags` before using speed/angle values."*
- Every other consumer of this API already follows the "check validity before reading" pattern instead of relying on the estimator to self-zero: `io/gps.c`, `io/osd.c`, `flight/rth_estimator.c`, `navigation/navigation.c`, `flight/imu.c`, `mavlink/mavlink_streams.c`, `programming/logic_condition.c`, `sensors/pitotmeter.c`. `MSP2_INAV_WIND` was the only caller that didn't.

## Changes

`src/main/fc/fc_msp.c`: gate `windSpeed`/`windAngle` on `isEstimatedWindSpeedValid()`, matching the established pattern and the message's documented contract — send `0, 0, flags=0` when invalid, the real values with `flags=1` when valid.

## Testing

- SITL build (`USE_WIND_ESTIMATOR` + `USE_GPS` both active via `target/common.h`) — compiles cleanly, zero warnings/errors in `fc_msp.c` or `wind_estimator.c`.
- Verified by reading `wind_estimator.c`: `estimatedWind[]` has exactly one write site (the filter update inside the successful-estimate branch) and no reset path, confirming the staleness is real and not just a theoretical race.
- Grepped every other call site of `getEstimatedWindSpeed()`/`getEstimatedHorizontalWindSpeed()`/`isEstimatedWindSpeedValid()` in `src/main` to confirm the fix matches the codebase-wide convention rather than introducing a new one.

Targets `release/9.1` per this repo's bugfix base-branch convention; will flow forward to `maintenance-10.x` on the next sync.