### PR TITLE
CLI "showdefaults" fix

### DIFF
--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -46,6 +46,12 @@ copy screen output to a file and save it.
 
 Alternatively, use the `diff` command to dump only those settings that differ from their default values (those that have been changed).
 
+Adding `showdefaults` to the Dump and Diff commands, e.g. `diff showdefaults`, will add a comment line showing the default value where it differs from the set value.
+
+```
+#default set fw_ff_pitch = 50
+set fw_ff_pitch = 120
+```
 
 ## Restore via CLI.
 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -542,7 +542,7 @@ static void dumpPgValue(const setting_t *value, uint8_t dumpMask)
 {
     char name[SETTING_MAX_NAME_LENGTH];
     const char *format = "set %s = ";
-    const char *defaultFormat = "#set %s = ";
+    const char *defaultFormat = "#default set %s = ";
     // During a dump, the PGs have been backed up to their "copy"
     // regions and the actual values have been reset to its
     // defaults. This means that settingGetValuePointer() will
@@ -556,10 +556,10 @@ static void dumpPgValue(const setting_t *value, uint8_t dumpMask)
         if (dumpMask & SHOW_DEFAULTS && !equalsDefault) {
             cliPrintf(defaultFormat, name);
             // if the craftname has a leading space, then enclose the name in quotes
-            if (strcmp(name, "name") == 0 && ((const char *)valuePointer)[0] == ' ') {
-                cliPrintf("\"%s\"", (const char *)valuePointer);
+            if (strcmp(name, "name") == 0 && ((const char *)defaultValuePointer)[0] == ' ') {
+                cliPrintf("\"%s\"", (const char *)defaultValuePointer);
             } else {
-                printValuePointer(value, valuePointer, 0);
+                printValuePointer(value, defaultValuePointer, 0);
             }
             cliPrintLinefeed();
         }


### PR DESCRIPTION
Fixes use of CLI "showdefaults" Diff/Dump command option so that actual default values are shown rather than the set value. "default" has also been added to the default setting line to make it clear that's what it is.