### PR TITLE
Fix PWM motor-role double-counting in pwmEnsureEnoughtMotors()

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -274,6 +274,13 @@ void pwmEnsureEnoughtMotors(uint8_t motorCount)
 {
     uint8_t motorOnlyOutputs = 0;
 
+    // pwmClaimTimer() syncs every sibling pad sharing a physical timer as soon
+    // as the first motor-only pad in a group is processed, so later siblings
+    // already satisfy TIM_IS_MOTOR_ONLY on their own turn below. Without this
+    // guard each of them would be counted again, inflating motorOnlyOutputs
+    // for an n-pad shared-timer group to 2n-1 instead of n.
+    bool timerCounted[HARDWARE_TIMER_DEFINITION_COUNT] = { false };
+
     for (int idx = 0; idx < timerHardwareCount; idx++) {
         timerHardware_t *timHw = &timerHardware[idx];
 
@@ -283,7 +290,8 @@ void pwmEnsureEnoughtMotors(uint8_t motorCount)
             continue;
         }
 
-        if (TIM_IS_MOTOR_ONLY(timHw->usageFlags)) {
+        if (TIM_IS_MOTOR_ONLY(timHw->usageFlags) && !timerCounted[timer2id(timHw->tim)]) {
+            timerCounted[timer2id(timHw->tim)] = true;
             motorOnlyOutputs++;
             motorOnlyOutputs += pwmClaimTimer(timHw->tim, timHw->usageFlags);
         }

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -292,8 +292,20 @@ void pwmEnsureEnoughtMotors(uint8_t motorCount)
 
         if (TIM_IS_MOTOR_ONLY(timHw->usageFlags) && !timerCounted[timer2id(timHw->tim)]) {
             timerCounted[timer2id(timHw->tim)] = true;
-            motorOnlyOutputs++;
-            motorOnlyOutputs += pwmClaimTimer(timHw->tim, timHw->usageFlags);
+            pwmClaimTimer(timHw->tim, timHw->usageFlags);
+
+            // Count every non-conflicted pad on this physical timer. After the
+            // claim sync each pad carries the same motor-only flags, so the
+            // group contributes its TRUE size n -- counting "1 + claim changes"
+            // would undercount an all-motor-only group (the claim changes
+            // nothing there) to 1 instead of n, which then over-promotes AUTO
+            // outputs in pass 2 and silently removes servo-capable outputs.
+            for (int j = 0; j < timerHardwareCount; j++) {
+                timerHardware_t *sibling = &timerHardware[j];
+                if (sibling->tim == timHw->tim && !checkPwmTimerConflicts(sibling) && TIM_IS_MOTOR_ONLY(sibling->usageFlags)) {
+                    motorOnlyOutputs++;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Pass 1 of `pwmEnsureEnoughtMotors()` in `src/main/drivers/pwm_mapping.c` overcounts motor-only outputs that share a physical timer: a group of `n` shared-timer outputs that are already motor-only at the start of pass 1 inflates the `motorOnlyOutputs` counter by `2n - 1` instead of `n`.

`pwmClaimTimer()` force-syncs every output sharing a physical timer as soon as the first one is visited. Each sibling then independently satisfies `TIM_IS_MOTOR_ONLY` when the loop reaches its own index later in the same pass, and gets counted again — pass 1 has no guard against this, unlike pass 2's `!TIM_IS_MOTOR_ONLY(...)` check for the same class of re-visit.

The inflated count makes pass 2 more conservative than it should be when deciding whether to promote remaining `AUTO` outputs to motors. This can silently demote an output the user configured as a motor down to servo, with no error, log message, or other indication.

## Trigger paths

Both hit an ordinary user, not just unusual `target.c` authoring:

- **Compile-time:** `target.c` declares 2+ channels sharing one physical timer as plain `TIM_USE_MOTOR` (not `TIM_USE_OUTPUT_AUTO`) — hit at boot regardless of user action. A survey of the target tree found 34 targets with this pattern (e.g. `KROOZX`, `SPRACINGF7DUAL`, `IFLIGHT_BLITZ_F7_AIO`).
- **Runtime:** the standard `timer_output_mode <timer> MOTORS` override, exposed in Configurator's Mixer tab, applied to a physical timer serving 2+ outputs. `timerHardwareOverride()` applies the override before the `TIM_IS_MOTOR_ONLY` check, so an override-forced group hits the same inflation as a compile-time-declared one.

## Fix

Adds a per-physical-timer `timerCounted[]` dedup guard to pass 1, so each physical timer's motor-only group is counted exactly once regardless of how many of its channels get individually re-visited later in the same pass — mirroring the de-duplication pass 2 already has.

## Branch scope

Confirmed present on `release/9.1`. Confirmed **not** present on `maintenance-10.x` — that branch's `pwmEnsureEnoughtMotors()` was already replaced by a unified `pwmBuildTimerOutputList()` (direct per-pad assignment, no separate inflatable counter) as an apparent unintentional side effect of unrelated refactor work, so no `maintenance-10.x` fix is needed.

## Testing

- SITL build (`cmake -DSITL=ON`, `make SITL.elf`) compiles cleanly with no new warnings.
- Verified via a deterministic Python port of this exact algorithm (`simulate_pwm_roles.py` in the INAV harness tooling, not part of this PR) — before the fix, a synthetic 2-channel shared-timer group forced to `MOTORS` inflated the count to 3 and silently demoted a third output at `motorCount=3`; after the fix, the group counts correctly as 2 and the third output promotes as expected.

## Related Issues

None filed yet — found while debugging PWM/DSHOT output setup on a custom target.