### PR TITLE
Point baseline publishing at Build pre-release, not the dead ci.yml p…

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,13 +7,24 @@ This directory contains automated CI/CD workflows for the INAV project.
 ### Build and Test
 
 #### `ci.yml` - Build Firmware
-**Triggers:** Pull requests, pushes to maintenance branches
+**Triggers:** Pull requests (`workflow_call` too, used by `nightly-build.yml`).
+Also declares an `on: push:` trigger, but it's currently a no-op — a
+`branches:` list containing only a negative pattern (`'!maintenance-8.x.x'`)
+matches nothing per GitHub's own docs, confirmed empirically (zero
+push-triggered runs of this workflow exist in this repo's history). Direct
+push builds happen via `nightly-build.yml` instead (see below).
 **Purpose:** Compiles INAV firmware for all targets to verify builds succeed
 **Matrix:** 15 parallel build jobs for faster CI
 
-#### `nightly-build.yml` - Nightly Builds
-**Triggers:** Scheduled nightly
-**Purpose:** Creates nightly development builds for testing
+#### `nightly-build.yml` - "Build pre-release"
+**Triggers:** `push` to `master`, `maintenance-8.x.x`, `maintenance-9.x`,
+`maintenance-10.x`, `release/9.1` — **not** a schedule, despite the
+filename. Invokes `ci.yml`'s jobs via `workflow_call`, then publishes a
+prerelease to the companion `iNavFlight/inav-nightly` repo.
+**Purpose:** Creates nightly development builds for testing, and is the
+actual per-push validation + baseline-generation point for
+`ci-size-report.yml` (see below) since `ci.yml`'s own push trigger doesn't
+fire.
 
 ### Documentation
 
@@ -49,7 +60,8 @@ This directory contains automated CI/CD workflows for the INAV project.
 ### Pull Request Helpers
 
 #### `ci-size-report.yml` - RAM/Flash Usage Delta PR Comment
-**Triggers:** `workflow_run` after "Build firmware" (`ci.yml`) completes
+**Triggers:** `workflow_run` after "Build firmware" (`ci.yml`, PR builds) or
+"Build pre-release" (`nightly-build.yml`, branch-push builds) completes
 **Purpose:** Posts/updates a PR comment showing flash and RAM usage delta vs.
 the PR's base branch, for 4 representative targets spanning flash/RAM size
 tiers (MATEKF405, MATEKF722, MATEKF765, MATEKH743 — note MATEKF722 and
@@ -61,10 +73,18 @@ every PR.
 1. `ci.yml` extracts a small per-target size report (`arm-none-eabi-size`
    on each built `.elf`) right after each build and uploads it as an
    artifact — no second build anywhere in this flow.
-2. On pushes to a branch, `ci-size-report.yml` persists that size report as
-   a release asset (`size-baseline-<branch>`) in the companion
-   `iNavFlight/pr-test-builds` repo — the "known good" baseline for that
-   branch, overwritten on every push.
+2. On pushes to `master`/`maintenance-9.x`/`maintenance-10.x`/`release/9.1`,
+   `nightly-build.yml` ("Build pre-release") invokes `ci.yml` via
+   `workflow_call` as part of building nightly releases — this already
+   produces the size report above at no extra build cost. When that
+   completes, `ci-size-report.yml` persists it as a release asset
+   (`size-baseline-<branch>`) in the companion `iNavFlight/pr-test-builds`
+   repo — the "known good" baseline for that branch, overwritten on every
+   push. (`ci.yml`'s *own* `on: push:` trigger is broken — a `branches:`
+   list containing only a negative pattern matches nothing per GitHub's
+   docs — so this deliberately listens to `nightly-build.yml` instead of
+   trying to fix that separately; verified empirically that `ci.yml` alone
+   has zero push-triggered runs in this repo's history.)
 3. On PR builds, it fetches the PR's base branch's persisted baseline (no
    rebuild), diffs it against the PR's own size report, and posts/updates a
    comment (marker `<!-- pr-size-diff -->`).

--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -1,31 +1,42 @@
 name: CI Size Report
 
-# Runs after "Build firmware" completes. Uses workflow_run (rather than
-# pull_request/push directly) so that secrets are available even for PRs
-# from forks — same reasoning as pr-test-builds.yml.
+# Uses workflow_run (rather than pull_request/push directly) so that
+# secrets are available even for PRs from forks — same reasoning as
+# pr-test-builds.yml.
 #
-# Two jobs:
-#  - publish-baseline: on any branch push that triggers ci.yml (in practice,
-#    almost always maintenance-9.x/maintenance-10.x — see ci.yml's own push
-#    trigger for the exact filter), persists the size report as a release
-#    asset in the companion iNavFlight/pr-test-builds repo, so PR runs never
-#    need to rebuild the base branch to get a comparison point. Stale
-#    baselines for since-deleted branches aren't cleaned up automatically
-#    (same known limitation pr-test-builds has for old PR releases).
-#  - pr-comment: on PR builds, fetches that persisted baseline, diffs the
-#    4 representative targets, and posts/updates a PR comment.
+# Listens to two different upstream workflows, for two different jobs:
+#  - publish-baseline listens for "Build pre-release" (nightly-build.yml),
+#    NOT "Build firmware" directly. ci.yml's own `on: push:` trigger is
+#    broken (a branches: list with only a negative pattern matches
+#    nothing — confirmed empirically, zero push-triggered "Build firmware"
+#    runs exist). "Build pre-release" is push-triggered correctly and
+#    already invokes ci.yml's jobs via `uses:` (workflow_call) as part of
+#    building nightly releases — piggybacking here costs nothing extra,
+#    no second build. Persists the size report as a release asset in the
+#    companion iNavFlight/pr-test-builds repo, so PR runs never need to
+#    rebuild the base branch to get a comparison point. Only fires for
+#    branches nightly-build.yml's own push trigger covers (currently
+#    master, maintenance-9.x, maintenance-10.x, release/9.1 — see that
+#    file). Stale baselines for since-deleted branches aren't cleaned up
+#    automatically (same known limitation pr-test-builds has for old PR
+#    releases).
+#  - pr-comment listens for "Build firmware" (ci.yml) directly — PR builds
+#    genuinely do trigger it via `pull_request`, that part isn't broken.
+#    Fetches the persisted baseline, diffs the 4 representative targets,
+#    and posts/updates a PR comment.
 #
 # Requires the same repository secret PR_BUILDS_TOKEN as pr-test-builds.yml
 # (Contents: write access to iNavFlight/pr-test-builds).
 on:
   workflow_run:
-    workflows: ["Build firmware"]
+    workflows: ["Build firmware", "Build pre-release"]
     types: [completed]
 
 jobs:
   publish-baseline:
     runs-on: ubuntu-latest
     if: >
+      github.event.workflow_run.name == 'Build pre-release' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.conclusion == 'success'
     concurrency:
@@ -73,6 +84,7 @@ jobs:
   pr-comment:
     runs-on: ubuntu-latest
     if: >
+      github.event.workflow_run.name == 'Build firmware' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,12 +241,16 @@ jobs:
           path: base_ref.txt
           retention-days: 1
       - name: Save branch name
-        if: github.event_name == 'push'
+        # Covers both a direct push and being invoked via workflow_call
+        # (e.g. from nightly-build.yml) — github.event_name reports
+        # 'workflow_call' in the latter case, not 'push', even though
+        # github.ref_name still correctly reflects the branch either way.
+        if: github.event_name != 'pull_request'
         env:
           REF_NAME: ${{ github.ref_name }}
         run: echo "$REF_NAME" > branch.txt
       - name: Upload branch name
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: branch-name

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,6 +8,8 @@ on:
       - master
       - maintenance-8.x.x
       - maintenance-9.x
+      - maintenance-10.x
+      - release/9.1
     paths:
       - 'src/**'
       - '.github/**'


### PR DESCRIPTION
…ush trigger

ci.yml's own push trigger is a no-op (a branches: list with only a negative pattern matches nothing per GitHub's docs; confirmed zero push-triggered runs exist in this repo's history). nightly-build.yml ("Build pre-release") is push-triggered correctly and already invokes ci.yml's jobs via workflow_call to build nightly releases -- listen to it instead, at no extra build cost. Add maintenance-10.x and release/9.1 to its branch list so baselines exist for those bases too.

Also fix ci.yml's "Save branch name" step: it was gated on github.event_name == 'push', but that reports as 'workflow_call' when invoked from nightly-build.yml, not 'push' -- so branch.txt would never have been produced on the path this now depends on.