### PR TITLE
Remove orphaned servo_autotrim_iterm_threshold field

### DIFF
--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -178,7 +178,6 @@ typedef struct servoConfig_s {
     uint8_t servo_protocol;                 // See servoProtocolType_e
     uint8_t tri_unarmed_servo;              // send tail servo correction pulses even when unarmed
     uint8_t servo_autotrim_rotation_limit;  // Max rotation for servo midpoints to be updated
-    uint8_t servo_autotrim_iterm_threshold; // How much of the Iterm is carried over to the servo midpoints on each update
 } servoConfig_t;
 
 PG_DECLARE(servoConfig_t, servoConfig);


### PR DESCRIPTION
## Summary
Removes a dead struct field discovered during review of PR #11617.

## Changes
- Removed `servo_autotrim_iterm_threshold` from `servoConfig_t` in `src/main/flight/servos.h`

## Testing
- Confirmed via tree-wide grep: zero references anywhere (no settings.yaml entry, no reset initializer, no reader). `git log -S` shows the setting entry/initializer/reader were already removed in 2021 (commit e4f684fda6); this field was leftover from that cleanup.
- Built SITL successfully after the change (inav-builder agent), no warnings/errors touching servos.c or any translation unit including servos.h.
- Reviewed with inav-code-review agent: independently re-verified the grep result and checked PG/EEPROM layout safety (field was the trailing member of the PG-backed `servoConfig_t`; struct `sizeof` is unchanged both before and after due to alignment padding, and no other field's offset shifts, so no PG version bump is needed). Same pattern as a prior precedent removal in this struct (commit 58dc1070fc).

## Related Issues
None — discovered as a leftover from PR #11617.