### PR TITLE
Fix publish-baseline never firing due to unrelated Release job failures

### DIFF
--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -37,15 +37,46 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.name == 'Build pre-release' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.event == 'push'
     concurrency:
       group: size-baseline-${{ github.event.workflow_run.head_branch }}
       cancel-in-progress: true
     permissions:
-      actions: read   # to download artifacts from the triggering workflow run
+      actions: read   # to download artifacts and query job conclusions from the triggering workflow run
     steps:
+      # Don't gate on github.event.workflow_run.conclusion: "Build
+      # pre-release" also runs a separate Release job (nightly upload to
+      # iNavFlight/inav-nightly) that can fail for reasons unrelated to the
+      # build itself (e.g. an expired NIGHTLY_TOKEN) and drags the whole
+      # run's conclusion to failure even when the build succeeded and
+      # produced the artifacts we actually need. Check the specific job
+      # that produces them instead.
+      - name: Check build job succeeded
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          CONCLUSION=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --paginate \
+            --jq '.jobs[] | select(.name == "build / upload-artifacts") | .conclusion')
+          if [ -z "$CONCLUSION" ]; then
+            # Job not found at all usually means the caller/callee job names
+            # changed (e.g. nightly-build.yml's "build" job or ci.yml's
+            # "upload-artifacts" job got renamed) — that's a workflow
+            # structure mismatch, not an expected build failure, and is
+            # exactly the kind of thing that silently broke baseline
+            # publishing before. Warn louder than a plain failed build.
+            echo "::warning::build / upload-artifacts job not found in run ${RUN_ID} — job name may have changed, skipping baseline publish"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          elif [ "$CONCLUSION" != "success" ]; then
+            echo "::notice::build / upload-artifacts did not succeed (conclusion: ${CONCLUSION}), skipping baseline publish"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download size report
+        if: steps.check.outputs.proceed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: size-report
@@ -53,6 +84,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download branch name
+        if: steps.check.outputs.proceed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: branch-name
@@ -60,6 +92,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish baseline
+        if: steps.check.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
`publish-baseline` (in `ci-size-report.yml`, part of the RAM/flash size-diff
PR comment feature) never actually published a baseline, even on branches
that were pushing and building successfully. PR #11800 (based on
`release/9.1`) still showed "No size baseline is available yet" despite
CI having run successfully for days.

## Root Cause
`publish-baseline` gated on `github.event.workflow_run.conclusion ==
'success'` for the entire "Build pre-release" (`nightly-build.yml`) run.
But that workflow also runs a separate `Release` job that publishes a
nightly build to `iNavFlight/inav-nightly` using `NIGHTLY_TOKEN` — a job
completely unrelated to producing the size report. When that job fails
(confirmed live: `Bad credentials` from an invalid/expired `NIGHTLY_TOKEN`
on a real `release/9.1` push), it drags the *entire* run's conclusion to
`failure`, even though every build job — including the one that produces
the `size-report`/`branch-name` artifacts `publish-baseline` needs —
succeeded. As a result, `publish-baseline` silently never ran, and no
`size-baseline-*` release has ever existed in `iNavFlight/pr-test-builds`.

## Changes
- `.github/workflows/ci-size-report.yml`: `publish-baseline` no longer
  gates on the aggregate `workflow_run.conclusion`. It now queries the
  specific `build / upload-artifacts` job's conclusion via `gh api
  repos/{repo}/actions/runs/{run_id}/jobs` and only proceeds if that job
  succeeded — decoupling baseline publishing from the unrelated `Release`
  job's reliability.
- Distinguishes "job not found" (e.g. a future rename of the caller/callee
  job names) from "job failed", warning louder on the former since that's
  a workflow-structure mismatch rather than an expected build failure —
  and is the same silent-failure class as the bug this PR fixes.

## Testing
- Diagnosed against real CI data: `gh run view` on the actual failing
  `release/9.1` push run showed every build job (`build (0)`..`build
  (14)`, `upload-artifacts`, etc.) as `success` and only the `Release` job
  as `failure` ("Bad credentials"), confirming the aggregate-conclusion
  gate was the root cause.
- Verified no `size-baseline-release/9.1` or `size-baseline-master`
  release exists yet in `iNavFlight/pr-test-builds`, consistent with
  `publish-baseline` never having successfully run.
- YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Can't fully execute a `workflow_run`-triggered workflow locally; will
  confirm live once merged and a subsequent push to `release/9.1` (or
  `master`, since `workflow_run` always uses the default branch's copy of
  this file) triggers it.

## Code Review
Reviewed with the `inav-code-review` agent — approved, with two minor
observability suggestions (both addressed): clarified the `actions: read`
permission comment, and upgraded the "job not found" case to a warning
instead of a notice.

## Related
Continues the size-diff PR comment feature from #11791/#11794/#11795/#11796/#11797.