### PR TITLE
Added configs for supporting LSM6DS320x on ORBITF435

### DIFF
--- a/src/main/target/ORBITF435/target.c
+++ b/src/main/target/ORBITF435/target.c
@@ -32,6 +32,7 @@
 #include "drivers/pinio.h"
 #include "drivers/sensor.h"
 
+BUSDEV_REGISTER_SPI_TAG(busdev_lsm6dxx, DEVHW_LSM6D, LSM6DXX_SPI_BUS, LSM6DXX_CS_PIN, NONE, 0,  DEVFLAGS_NONE,  IMU_LSM6DXX_ALIGN);
 BUSDEV_REGISTER_SPI_TAG(busdev_icm42688, DEVHW_ICM42605, ICM42688_SPI_BUS,  ICM42688_CS_PIN,  NONE,  0,  DEVFLAGS_NONE,  IMU_ICM42688_ALIGN);
 
 timerHardware_t timerHardware[] = {

--- a/src/main/target/ORBITF435/target.h
+++ b/src/main/target/ORBITF435/target.h
@@ -95,6 +95,11 @@
 #define ICM42688_CS_PIN         PA4
 #define ICM42688_SPI_BUS        BUS_SPI1
 
+#define USE_IMU_LSM6DXX
+#define IMU_LSM6DXX_ALIGN       CW270_DEG
+#define LSM6DXX_SPI_BUS         BUS_SPI1
+#define LSM6DXX_CS_PIN          PA4
+
 // *************** I2C(Baro & I2C) **************************
 #define USE_I2C
 #define USE_BARO


### PR DESCRIPTION
The LSM6DSK320x will be used in the new ORBITF435 flight controllers due to a shortage of the ICM42688P. 