### PR TITLE
Add sticky overrun tracking to sbuf_t for MSP variable-layout reads

### DIFF
--- a/src/main/common/streambuf.c
+++ b/src/main/common/streambuf.c
@@ -24,6 +24,7 @@ sbuf_t *sbufInit(sbuf_t *sbuf, uint8_t *ptr, uint8_t *end)
 {
     sbuf->ptr = ptr;
     sbuf->end = end;
+    sbuf->overrun = false;
     return sbuf;
 }
 
@@ -95,12 +96,16 @@ void sbufWriteStringWithZeroTerminator(sbuf_t *dst, const char *string)
 
 uint8_t sbufReadU8(sbuf_t *src)
 {
+    if (src->ptr >= src->end) {
+        src->overrun = true;
+        return 0;
+    }
     return *src->ptr++;
 }
 
 int8_t sbufReadI8(sbuf_t *src)
 {
-    return *src->ptr++;
+    return (int8_t)sbufReadU8(src);
 }
 
 uint16_t sbufReadU16(sbuf_t *src)
@@ -216,4 +221,5 @@ void sbufSwitchToReader(sbuf_t *buf, uint8_t *base)
 {
     buf->end = buf->ptr;
     buf->ptr = base;
+    buf->overrun = false;
 }

--- a/src/main/common/streambuf.c
+++ b/src/main/common/streambuf.c
@@ -94,7 +94,13 @@ void sbufWriteStringWithZeroTerminator(sbuf_t *dst, const char *string)
     sbufWriteData(dst, string, strlen(string) + 1);
 }
 
-uint8_t sbufReadU8(sbuf_t *src)
+// Use the raw attribute rather than NOINLINE because NOINLINE expands to
+// nothing on non-F7/H7 targets (common.h:29), but LTO is enabled for all
+// release targets and these read primitives are inlined into hundreds of
+// call sites (e.g. mspFcProcessInCommand), duplicating the overrun check
+// at each site and costing ~9 KB of flash on -O2 targets. Keeping them
+// out-of-line confines the check to one copy.
+__attribute__((noinline)) uint8_t sbufReadU8(sbuf_t *src)
 {
     if (src->ptr >= src->end) {
         src->overrun = true;
@@ -108,7 +114,7 @@ int8_t sbufReadI8(sbuf_t *src)
     return (int8_t)sbufReadU8(src);
 }
 
-uint16_t sbufReadU16(sbuf_t *src)
+__attribute__((noinline)) uint16_t sbufReadU16(sbuf_t *src)
 {
     uint16_t ret;
     ret = sbufReadU8(src);
@@ -116,7 +122,7 @@ uint16_t sbufReadU16(sbuf_t *src)
     return ret;
 }
 
-uint32_t sbufReadU32(sbuf_t *src)
+__attribute__((noinline)) uint32_t sbufReadU32(sbuf_t *src)
 {
     uint32_t ret;
     ret = sbufReadU8(src);

--- a/src/main/common/streambuf.h
+++ b/src/main/common/streambuf.h
@@ -26,6 +26,7 @@
 typedef struct sbuf_s {
     uint8_t *ptr;          // data pointer must be first (sbuff_t* is equivalent to uint8_t **)
     uint8_t *end;
+    bool overrun;          // sticky: set by an unsafe sbufRead* call that ran past end
 } sbuf_t;
 
 sbuf_t *sbufInit(sbuf_t *sbuf, uint8_t *ptr, uint8_t *end);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2676,6 +2676,10 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
                     }
                 }
             }
+
+            if (src->overrun) {
+                return MSP_RESULT_ERROR;
+            }
         }
         break;
 
@@ -3124,6 +3128,11 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             for (unsigned ii = 0; ii < MIN(osdCharacterBytes, sizeof(chr.data)); ii++) {
                 chr.data[ii] = sbufReadU8(src);
             }
+
+            if (src->overrun) {
+                return MSP_RESULT_ERROR;
+            }
+
             displayPort_t *osdDisplayPort = osdGetDisplayPort();
             if (osdDisplayPort) {
                 displayWriteFontCharacter(osdDisplayPort, addr, &chr);


### PR DESCRIPTION
## Summary

Third and final piece of the MSP payload bounds hardening effort tracked under #11672. `MSP2_INAV_SET_AUX_RC` and `MSP_OSD_CHAR_WRITE` have runtime-determined payload layouts (length depends on a resolution mode / addressing mode encoded in the payload itself), so they can't use the compile-time struct pattern applied to the fixed-layout SET handlers in the prior PR. Both are already correctly bounded today by their own `dataSize` checks (confirmed by an earlier audit), so this is defense-in-depth, not a bug fix.

## Changes

- Add a sticky `overrun` bool to `sbuf_t` (`common/streambuf.h`), appended as the trailing field so `ptr` stays first (`sbuf_t*` is used interchangeably with `uint8_t**` elsewhere in the tree).
- `sbufReadU8` now checks buffer bounds before dereferencing; on an out-of-bounds read it sets `overrun` and returns 0 instead of reading past `end`. `sbufReadU16`/`sbufReadU32` are built on `sbufReadU8` and inherit the check automatically. `sbufReadI8` was rewritten to delegate to `sbufReadU8` (was a separate, unchecked implementation) — same result, one bounds check instead of two.
- `sbufInit` clears `overrun` on construction; `sbufSwitchToReader` clears it when a write buffer flips to read mode.
- `MSP2_INAV_SET_AUX_RC` and `MSP_OSD_CHAR_WRITE` each check `src->overrun` once after their read sequence and reject the command (`MSP_RESULT_ERROR`) if it tripped.
- `sbufReadData`/`sbufReadDataSafe` are deliberately untouched — out of scope, neither handler calls them, and `sbufReadDataSafe` already has its own independent length check.

This keeps every existing call site's shape unchanged (`field = sbufReadU8(src);`), avoiding a wider mechanical rewrite across the ~40 other `sbufRead*` call sites in the tree, while giving these two variable-layout handlers the same guarantee the fixed-layout ones already have.

## Testing

- Clean SITL build, no new warnings.
- SITL round-trip test covering `MSP2_INAV_SET_AUX_RC`: all 4 resolution modes (2/4/8/16-bit) verified against baseline behavior (well-formed frames apply the expected channel values, including the raw=0 skip semantics and 16-bit clamping), plus truncated/edge-case frames (all cleanly rejected by the handler's existing `dataSize` checks; FC stayed responsive, no crash/hang). Confirmed it isn't possible to construct a frame that passes the handler's own bounds checks yet still trips `overrun` — this is genuinely defense-in-depth, matching the prior audit's conclusion.
- `MSP_OSD_CHAR_WRITE` exercised end-to-end in SITL (no OSD hardware needed — `osdGetDisplayPort()` safely returns NULL when nothing is attached) and passed.
- Audited all 16 `sbuf_t` construction sites tree-wide: 3 use designated initializers (implicitly zero-init `overrun` per C99), 4 go through `sbufInit` (now explicit), and the remaining 9 are write-only telemetry/OSD/RC-device frame builders whose `overrun` field is never read.
- Independent code review: approve.

Addresses #11672.