### PR TITLE
Fix: Remove static CRC table duplication in MAVLink helpers

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -411,6 +411,7 @@ main_sources(COMMON_SRC
     mavlink/mavlink_command.h
     mavlink/mavlink_guided.c
     mavlink/mavlink_guided.h
+    mavlink/mavlink_helpers.c
     mavlink/mavlink_internal.h
     mavlink/mavlink_mission.c
     mavlink/mavlink_mission.h

--- a/src/main/mavlink/mavlink_helpers.c
+++ b/src/main/mavlink/mavlink_helpers.c
@@ -15,18 +15,24 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
+#include "platform.h"
 
 #include "target/common.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+
+/* Single translation unit that compiles the MAVLink helper definitions
+ * (mavlink_get_msg_entry, mavlink_parse_char, ...) with external linkage.
+ * All other TUs include the MAVLink headers with MAVLINK_SEPARATE_HELPERS
+ * set (see rx/mavlink.h and mavlink/mavlink_types.h), so they see only the
+ * extern prototypes from protocol.h and no longer each instantiate a
+ * private static copy of every helper — including the ~3.7 KB
+ * mavlink_message_crcs[] table inside mavlink_get_msg_entry(), which was
+ * duplicated once per including TU. */
 #define MAVLINK_COMM_NUM_BUFFERS MAX_MAVLINK_PORTS
-/* Helpers compile once with external linkage in mavlink/mavlink_helpers.c;
- * without this every TU gets a static copy, incl. the ~3.7 KB CRC table. */
 #define MAVLINK_SEPARATE_HELPERS
 #include "storm32/mavlink.h"
-#pragma GCC diagnostic pop
+#include "mavlink_helpers.h"
 
-void mavlinkRxHandleMessage(const mavlink_rc_channels_override_t *msg);
-bool mavlinkRxInit(const struct rxConfig_s *initialRxConfig, struct rxRuntimeConfig_s *rxRuntimeConfig);
+#pragma GCC diagnostic pop

--- a/src/main/mavlink/mavlink_helpers.c
+++ b/src/main/mavlink/mavlink_helpers.c
@@ -22,15 +22,14 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 
-/* Single translation unit that compiles the MAVLink helper definitions
- * (mavlink_get_msg_entry, mavlink_parse_char, ...) with external linkage.
- * All other TUs include the MAVLink headers with MAVLINK_SEPARATE_HELPERS
- * set (see rx/mavlink.h and mavlink/mavlink_types.h), so they see only the
- * extern prototypes from protocol.h and no longer each instantiate a
- * private static copy of every helper — including the ~3.7 KB
- * mavlink_message_crcs[] table inside mavlink_get_msg_entry(), which was
- * duplicated once per including TU. */
+/* Single external-linkage definition TU for the MAVLink helpers. All
+ * other TUs include the MAVLink headers with MAVLINK_SEPARATE_HELPERS set
+ * (see rx/mavlink.h, mavlink/mavlink_types.h) and get only the extern
+ * prototypes from protocol.h, so each helper — and its local static data,
+ * e.g. the mavlink_message_crcs[] table — exists exactly once. */
+#ifndef MAVLINK_COMM_NUM_BUFFERS
 #define MAVLINK_COMM_NUM_BUFFERS MAX_MAVLINK_PORTS
+#endif
 #define MAVLINK_SEPARATE_HELPERS
 #include "storm32/mavlink.h"
 #include "mavlink_helpers.h"

--- a/src/main/mavlink/mavlink_types.h
+++ b/src/main/mavlink/mavlink_types.h
@@ -29,7 +29,9 @@
 #define MAVLINK_COMM_NUM_BUFFERS MAX_MAVLINK_PORTS
 #endif
 /* Single external definition lives in mavlink/mavlink_helpers.c. */
+#ifndef MAVLINK_SEPARATE_HELPERS
 #define MAVLINK_SEPARATE_HELPERS
+#endif
 #include "storm32/mavlink.h"
 #pragma GCC diagnostic pop
 

--- a/src/main/mavlink/mavlink_types.h
+++ b/src/main/mavlink/mavlink_types.h
@@ -28,6 +28,8 @@
 #ifndef MAVLINK_COMM_NUM_BUFFERS
 #define MAVLINK_COMM_NUM_BUFFERS MAX_MAVLINK_PORTS
 #endif
+/* Single external definition lives in mavlink/mavlink_helpers.c. */
+#define MAVLINK_SEPARATE_HELPERS
 #include "storm32/mavlink.h"
 #pragma GCC diagnostic pop
 

--- a/src/main/rx/mavlink.h
+++ b/src/main/rx/mavlink.h
@@ -22,9 +22,10 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 #define MAVLINK_COMM_NUM_BUFFERS MAX_MAVLINK_PORTS
-/* Helpers compile once with external linkage in mavlink/mavlink_helpers.c;
- * without this every TU gets a static copy, incl. the ~3.7 KB CRC table. */
+/* Helpers compile once with external linkage in mavlink/mavlink_helpers.c. */
+#ifndef MAVLINK_SEPARATE_HELPERS
 #define MAVLINK_SEPARATE_HELPERS
+#endif
 #include "storm32/mavlink.h"
 #pragma GCC diagnostic pop
 

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -82,6 +82,11 @@ set_property(SOURCE mavlink_unittest.cc PROPERTY depends
     "fc/fc_mavlink.c" "mavlink/mavlink_command.c" "mavlink/mavlink_guided.c" "mavlink/mavlink_mission.c" "mavlink/mavlink_modes.c" "mavlink/mavlink_ports.c"
     "mavlink/mavlink_routing.c" "mavlink/mavlink_runtime.c" "mavlink/mavlink_streams.c" "telemetry/mavlink.c"
     "common/crc.c" "common/maths.c" "common/streambuf.c" "common/string_light.c" "msp/msp_serial.c")
+# mavlink_helpers.c has no sibling header in src/main (its header is the
+# vendored lib/main/MAVLink/mavlink_helpers.h), so it goes in extra_sources
+# to skip the depends .c -> .h transform.
+set_property(SOURCE mavlink_unittest.cc PROPERTY extra_sources
+    "mavlink/mavlink_helpers.c")
 set_property(SOURCE mavlink_unittest.cc PROPERTY definitions USE_TELEMETRY USE_TELEMETRY_MAVLINK USE_MAVLINK_MSP_TUNNEL)
 set_property(SOURCE mavlink_unittest.cc PROPERTY extra_includes
     "../../lib/main/MAVLink")


### PR DESCRIPTION
## Summary

Removes duplicated static data in the MAVLink helper functions. `mavlink_helpers.h` defines every helper — and the `mavlink_message_crcs[]` table inside `mavlink_get_msg_entry()` — with internal (`static`) linkage via the `MAVLINK_HELPER` macro, so **every TU that includes the MAVLink headers compiles its own private copy** of the functions and of the ~3.7 KB CRC table. A plain grep for `"static inline"` misses this because the macro hides the `static` keyword from the call site.

## Changes

- Define `MAVLINK_SEPARATE_HELPERS` in the two INAV headers that include `storm32/mavlink.h` (`src/main/rx/mavlink.h`, `src/main/mavlink/mavlink_types.h`), so the vendored `protocol.h` emits only extern prototypes (its own documented mechanism, `#ifdef MAVLINK_SEPARATE_HELPERS` block).
- Add `src/main/mavlink/mavlink_helpers.c` — a single translation unit that compiles all helper definitions once with external linkage.
- Wire the new file into `src/main/CMakeLists.txt` and the `mavlink_unittest.cc` build (via `extra_sources`, since the unit-test helper requires a sibling `.h` for `depends` entries and this file's header is the vendored one).

No `lib/` files are touched, so the fix survives `generate.sh` regeneration.

## Testing

- **Firmware build (BLUEBERRYF405, arm-none-eabi 13.2):** clean, zero errors and warnings.
- **Binary measurement** (`arm-none-eabi-nm --size-sort -S -C`):
  - Before: `mavlink_message_crcs.0` + `.1`, 2 × 4,044 B = **8,088 B duplicated**
  - After: 1 copy (4,044 B) — **flash 667,416 → 661,336 B (−6,080 B)**, **RAM 122,884 → 122,500 B (−384 B)**
  - (Table size varies by dialect set; the storm32 set here is 337 entries vs 312 in earlier measurements — same mechanism.)
- **Unit tests:** `mavlink_unittest` — 96/96 pass.

## Notes

- The vendored `protocol.h` SEPARATE_HELPERS prototype block declares 13 of 22 non-convenience helpers; the other 9 (`mavlink_get_channel_buffer`, `mavlink_sign_packet`, `mavlink_get_crc_extra`, etc.) are referenced only within `mavlink_helpers.h` itself, so no implicit declarations occur. Verified: no INAV source or test calls them.
- Channel parse state (`m_mavlink_status[]`, per-channel buffers) becomes globally shared instead of per-TU — no observable INAV change (only `mavlink_runtime.c` parses MAVLink), and the RAM delta is consistent with exactly two live copies before.