### PR TITLE
Fix off-by-one in ICM42605 WHO_AM_I retry loop

### DIFF
--- a/src/main/drivers/accgyro/accgyro_icm42605.c
+++ b/src/main/drivers/accgyro/accgyro_icm42605.c
@@ -288,13 +288,12 @@ static void icm42605AccAndGyroInit(gyroDev_t *gyro)
 static bool icm42605DeviceDetect(busDevice_t * dev)
 {
     uint8_t tmp;
-    uint8_t attemptsRemaining = 5;
 
     busSetSpeed(dev, BUS_SPEED_INITIALIZATION);
 
     busWrite(dev, ICM42605_RA_PWR_MGMT0, 0x00);
 
-    do {
+    for (int attempt = 0; attempt < 5; attempt++) {
         delay(150);
 
         busRead(dev, MPU_RA_WHO_AM_I, &tmp);
@@ -315,7 +314,7 @@ static bool icm42605DeviceDetect(busDevice_t * dev)
                 // Retry detection
                 break;
         }
-    } while (attemptsRemaining--);
+    }
 
     return false;
 }


### PR DESCRIPTION
## Summary
Fix an off-by-one in `icm42605DeviceDetect()`'s WHO_AM_I retry loop: the
`do { ... } while (attemptsRemaining--)` ran the loop body 6 times instead
of the intended 5, adding an extra ~150ms delay on the chip-absent
autodetect path at boot (~900ms vs the intended ~750ms).

## Changes
- `src/main/drivers/accgyro/accgyro_icm42605.c`: replace the
  `do { ... } while (attemptsRemaining--)` with a plain
  `for (int attempt = 0; attempt < 5; attempt++)` loop and drop the
  now-unused variable. This mirrors the identical fix already merged for
  `accgyro_icm40609d.c` (66247db440), which was modeled on this file.

## Testing
- Reproduction gtest with a fully mocked bus (WHO_AM_I never matches):
  pre-fix observed 6 reads (failed, expected 5); post-fix exactly 5
  (passed). Full in-tree unit suite: 44/44 passing.
- SITL build: SUCCESS, 0 warnings / 0 errors.
- AIKONF4V3 (F405, compiles the modified driver): SUCCESS, 0 warnings /
  0 errors. FLASH 67.09% / RAM 85.14%.

## Code Review
Reviewed with inav-code-review agent: APPROVE, no critical or important
findings. (Informational: the same do/while off-by-one pattern also exists
in 6 sibling accgyro drivers — recommended as a separate follow-up sweep,
out of scope here.)

## Related
Discovered as a follow-up to `add-icm40609d-imu-driver` (PR #11765) — the
42605 driver was the template that driver was copied from.