### PR TITLE
Use Measurement For Fixed Wing Position PID D Term

### DIFF
--- a/src/main/common/fp_pid.c
+++ b/src/main/common/fp_pid.c
@@ -62,15 +62,23 @@ float navPidApply3(
         pid->reset = false;
     }
 
-    if (pidFlags & PID_DTERM_FROM_ERROR) {
-        /* Error-tracking D-term */
-        newDerivative = (error - pid->last_input) / dt;
-        pid->last_input = error;
-    } else {
-        /* Measurement tracking D-term */
-        newDerivative = -(measurement - pid->last_input) / dt;
-        pid->last_input = measurement;
+    /* Default to Measurement tracking D-term */
+    float trackingTerm = measurement;
+    int8_t sign = -1;
+
+    if (pidFlags & PID_DTERM_FROM_ERROR) {  /* Error-tracking D-term */
+        trackingTerm = error;
+        sign = 1;
     }
+
+    float trackingDelta = trackingTerm - pid->last_input;
+    pid->last_input = trackingTerm;
+
+    if (pidFlags & PID_USING_HEADING && fabsf(trackingDelta) > 18000) { // prevent D term kick around 360 heading
+        trackingDelta = wrap_18000(trackingDelta);
+    }
+
+    newDerivative = sign * trackingDelta / dt;
 
     if (pid->dTermLpfHz > 0.0f) {
         newDerivative = pid->param.kD * pt1FilterApply3(&pid->dterm_filter_state, newDerivative, dt);

--- a/src/main/common/fp_pid.h
+++ b/src/main/common/fp_pid.h
@@ -38,11 +38,12 @@ typedef struct {
 } pidControllerParam_t;
 
 typedef enum {
-    PID_DTERM_FROM_ERROR            = 1 << 0,
-    PID_ZERO_INTEGRATOR             = 1 << 1,
-    PID_SHRINK_INTEGRATOR           = 1 << 2,
-    PID_LIMIT_INTEGRATOR            = 1 << 3,
-    PID_FREEZE_INTEGRATOR           = 1 << 4,
+    PID_DTERM_FROM_ERROR    = 1 << 0,
+    PID_ZERO_INTEGRATOR     = 1 << 1,
+    PID_SHRINK_INTEGRATOR   = 1 << 2,
+    PID_LIMIT_INTEGRATOR    = 1 << 3,
+    PID_FREEZE_INTEGRATOR   = 1 << 4,
+    PID_USING_HEADING       = 1 << 5,
 } pidControllerFlags_e;
 
 typedef struct {

--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -552,12 +552,14 @@ static void updatePositionHeadingController_FW(timeUs_t currentTimeUs, timeDelta
     }
 
     // Only allow PID integrator to shrink if error is decreasing over time
-    const pidControllerFlags_e pidFlags = errorIsDecreasing ? PID_SHRINK_INTEGRATOR : 0;
+    const pidControllerFlags_e pidFlags = PID_USING_HEADING | (errorIsDecreasing ? PID_SHRINK_INTEGRATOR : 0);
 
     // Input error in (deg*100), output roll angle (deg*100)
-    float rollAdjustment = navPidApply2(&posControl.pids.fw_nav, posControl.actualState.cog + navHeadingError, posControl.actualState.cog, US2S(deltaMicros),
-                                       -DEGREES_TO_CENTIDEGREES(navConfig()->fw.max_bank_angle),
-                                        DEGREES_TO_CENTIDEGREES(navConfig()->fw.max_bank_angle),
+    uint16_t maxBankAngleCentiDeg = DEGREES_TO_CENTIDEGREES(navConfig()->fw.max_bank_angle);
+    float rollAdjustment = navPidApply2(&posControl.pids.fw_nav, posControl.actualState.cog + navHeadingError, posControl.actualState.cog,
+                                        US2S(deltaMicros),
+                                       -maxBankAngleCentiDeg,
+                                        maxBankAngleCentiDeg,
                                         pidFlags);
 
     // Apply low-pass filter to prevent rapid correction

--- a/src/main/navigation/navigation_fixedwing.c
+++ b/src/main/navigation/navigation_fixedwing.c
@@ -552,7 +552,7 @@ static void updatePositionHeadingController_FW(timeUs_t currentTimeUs, timeDelta
     }
 
     // Only allow PID integrator to shrink if error is decreasing over time
-    const pidControllerFlags_e pidFlags = PID_DTERM_FROM_ERROR | (errorIsDecreasing ? PID_SHRINK_INTEGRATOR : 0);
+    const pidControllerFlags_e pidFlags = errorIsDecreasing ? PID_SHRINK_INTEGRATOR : 0;
 
     // Input error in (deg*100), output roll angle (deg*100)
     float rollAdjustment = navPidApply2(&posControl.pids.fw_nav, posControl.actualState.cog + navHeadingError, posControl.actualState.cog, US2S(deltaMicros),

--- a/src/main/navigation/navigation_pos_estimator.c
+++ b/src/main/navigation/navigation_pos_estimator.c
@@ -739,19 +739,6 @@ static bool estimationCalculateCorrection_XY_GPS(estimationContext_t * ctx)
     return false;
 }
 
-static void estimationCalculateGroundCourse(timeUs_t currentTimeUs)
-{
-    UNUSED(currentTimeUs);
-    if ((STATE(GPS_FIX)
-#ifdef USE_GPS_FIX_ESTIMATION
-            || STATE(GPS_ESTIMATED_FIX)
-#endif
-    ) && navIsHeadingUsable()) {
-        uint32_t groundCourse = wrap_36000(RADIANS_TO_CENTIDEGREES(atan2_approx(posEstimator.est.vel.y, posEstimator.est.vel.x)));
-        posEstimator.est.cog = CENTIDEGREES_TO_DECIDEGREES(groundCourse);
-    }
-}
-
 /**
  * Calculate next estimate using IMU and apply corrections from reference sensors (GPS, BARO etc)
  *  Function is called at main loop rate
@@ -862,9 +849,6 @@ static void updateEstimatedTopic(timeUs_t currentTimeUs)
         }
     }
 
-    /* Update ground course */
-    estimationCalculateGroundCourse(currentTimeUs);
-
     /* Update uncertainty */
     posEstimator.est.eph = constrainf(ctx.newEPH, 0.0f, 2.0f * max_eph_epv);
     posEstimator.est.epv = constrainf(ctx.newEPV, 0.0f, 2.0f * max_eph_epv);
@@ -883,17 +867,18 @@ static void publishEstimatedTopic(timeUs_t currentTimeUs)
 
     /* Position and velocity are published with INAV_POSITION_PUBLISH_RATE_HZ */
     if (updateTimer(&posPublishTimer, HZ2US(INAV_POSITION_PUBLISH_RATE_HZ), currentTimeUs)) {
-        /* Publish heading update */
-        /* IMU operates in decidegrees while INAV operates in deg*100
-        * Use course over ground when GPS heading valid */
-        int16_t cogValue = isGPSHeadingValid() ? posEstimator.est.cog : attitude.values.yaw;
-        updateActualHeading(navIsHeadingUsable(), DECIDEGREES_TO_CENTIDEGREES(attitude.values.yaw), DECIDEGREES_TO_CENTIDEGREES(cogValue));
-
         /* Publish position update */
+        bool isCogValid = false;
         if (posEstimator.est.eph < positionEstimationConfig()->max_eph_epv) {
             float filteredVelX = pt1FilterApply3(&estVelFilterState_X, posEstimator.est.vel.x, HZ2S(INAV_POSITION_PUBLISH_RATE_HZ));
             float filteredVelY = pt1FilterApply3(&estVelFilterState_Y, posEstimator.est.vel.y, HZ2S(INAV_POSITION_PUBLISH_RATE_HZ));
-            // FIXME!!!!!
+
+            // /* Update ground course from x, y velocities */
+            if (isGPSHeadingValid()) {
+                posEstimator.est.cog = CENTIDEGREES_TO_DECIDEGREES(wrap_36000(RADIANS_TO_CENTIDEGREES(atan2_approx(filteredVelY, filteredVelX))));
+                isCogValid = true;
+            }
+
             updateActualHorizontalPositionAndVelocity(true, true, posEstimator.est.pos.x, posEstimator.est.pos.y, filteredVelX, filteredVelY);
         }
         else {
@@ -911,6 +896,12 @@ static void publishEstimatedTopic(timeUs_t currentTimeUs)
         else {
             updateActualAltitudeAndClimbRate(false, posEstimator.est.pos.z, 0, posEstimator.est.aglAlt, 0, EST_NONE, 0);
         }
+
+        /* Publish heading update */
+        /* IMU operates in decidegrees while INAV operates in deg*100
+         * Use course over ground when GPS heading valid */
+        int16_t cogValue = isCogValid ? posEstimator.est.cog : attitude.values.yaw;
+        updateActualHeading(navIsHeadingUsable(), DECIDEGREES_TO_CENTIDEGREES(attitude.values.yaw), DECIDEGREES_TO_CENTIDEGREES(cogValue));
 
         //Update Blackbox states
         navEPH = posEstimator.est.eph;


### PR DESCRIPTION
Changes fixed wing position PID D term from using error to measurement.

Reason - Error is based on the `virtualTargetBearing `which can change abruptly when target position changes resulting in large D term spikes. Measurement is course over ground which changes consistently with aircraft movement resulting in consistent changes in D term without spikes.

Course over ground (CoG) estimate also changed to smooth the CoG output reducing D term spikes. CoG is now only updated when the position estimate is published to Nav. This removes unnecessary recalculation of CoG at loop rate and also allows smoothing by use of filtered Vel x and Vel y.

HITL testing shows D term spikes are pretty much eliminated during WP missions which is where changes in `virtualTargetBearing `tend to occur most often. Hard to say if there is a noticeable improvement in flight control but it may help improve servo life.