### PR TITLE
Fix Betaflight Passthrough broken by line-coding mirror (9.1 regression)

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -603,6 +603,23 @@ static void nopConsumer(uint8_t data)
 void serialPassthrough(serialPort_t *left, serialPort_t *right, serialConsumer
                        *leftC, serialConsumer *rightC)
 {
+#ifdef USE_VCP
+    // Track current encoding applied to right port for VCP mirroring.
+    // Baseline from the HOST's line coding at passthrough entry, not from the
+    // right port's settings: the mirror must only react to host-side CHANGES
+    // during the session. Initializing from right->baudRate/options would make
+    // the first mirror tick rewrite the passthrough UART's explicitly-requested
+    // encoding (e.g. CLI `serialpassthrough <id> 420000`) with whatever the
+    // host COM port is currently set to (115200 during the CLI session),
+    // breaking ELRS/Betaflight passthrough flashing (issue #11783).
+    // Captured before the drain waits below so a host line-coding change made
+    // while either wait is running is still treated as a session change.
+    portOptions_t currentOptions = usbVcpGetLineCoding();
+    uint32_t currentBaudRate = usbVcpGetBaudRate(left);
+    bool leftIsVcp = (left->identifier == SERIAL_PORT_USB_VCP);
+    uint32_t lastMirrorTime = 0;
+#endif
+
     waitForSerialPortToFinishTransmitting(left);
     waitForSerialPortToFinishTransmitting(right);
 
@@ -613,21 +630,6 @@ void serialPassthrough(serialPort_t *left, serialPort_t *right, serialConsumer
 
     LED0_OFF;
     LED1_OFF;
-
-#ifdef USE_VCP
-    // Track current encoding applied to right port for VCP mirroring.
-    // Baseline from the HOST's line coding at passthrough entry, not from the
-    // right port's settings: the mirror must only react to host-side CHANGES
-    // during the session. Initializing from right->baudRate/options would make
-    // the first mirror tick rewrite the passthrough UART's explicitly-requested
-    // encoding (e.g. CLI `serialpassthrough <id> 420000`) with whatever the
-    // host COM port is currently set to (115200 during the CLI session),
-    // breaking ELRS/Betaflight passthrough flashing (issue #11783).
-    portOptions_t currentOptions = usbVcpGetLineCoding();
-    uint32_t currentBaudRate = usbVcpGetBaudRate(left);
-    bool leftIsVcp = (left->identifier == SERIAL_PORT_USB_VCP);
-    uint32_t lastMirrorTime = 0;
-#endif
 
     static escapeSequenceState_t escapeSequenceState;
     escapeSequenceInit(&escapeSequenceState);

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -615,9 +615,16 @@ void serialPassthrough(serialPort_t *left, serialPort_t *right, serialConsumer
     LED1_OFF;
 
 #ifdef USE_VCP
-    // Track current encoding applied to right port for VCP mirroring
-    portOptions_t currentOptions = right->options;
-    uint32_t currentBaudRate = right->baudRate;
+    // Track current encoding applied to right port for VCP mirroring.
+    // Baseline from the HOST's line coding at passthrough entry, not from the
+    // right port's settings: the mirror must only react to host-side CHANGES
+    // during the session. Initializing from right->baudRate/options would make
+    // the first mirror tick rewrite the passthrough UART's explicitly-requested
+    // encoding (e.g. CLI `serialpassthrough <id> 420000`) with whatever the
+    // host COM port is currently set to (115200 during the CLI session),
+    // breaking ELRS/Betaflight passthrough flashing (issue #11783).
+    portOptions_t currentOptions = usbVcpGetLineCoding();
+    uint32_t currentBaudRate = usbVcpGetBaudRate(left);
     bool leftIsVcp = (left->identifier == SERIAL_PORT_USB_VCP);
     uint32_t lastMirrorTime = 0;
 #endif


### PR DESCRIPTION
## Summary

Fixes Betaflight Passthrough broken in 9.1.0 (issue #11783): ELRS Configurator's
"Betaflight Passthrough" flash failed to detect/flash an ELRS RX through the FC.

Root cause: commit `3bbc0ae9f4` ("Passthrough, USB Improvements", PR #11256) added a
line-coding mirror to `serialPassthrough()`. Every 15ms it reads the host PC's USB
COM port line coding (`usbVcpGetBaudRate`/`usbVcpGetLineCoding`) and applies it to
the passthrough UART. The mirror baseline was initialized from the **right port's**
settings (`currentBaudRate = right->baudRate`).

ELRS Configurator runs its CLI session at 115200, then issues
`serialpassthrough <id> 420000`. The first 15ms mirror tick sees host baud 115200 !=
current 420000 and **rewrites the passthrough UART to 115200** — then, when the tool
closes and reopens the port at 420000 and immediately sends the ESP bootloader sync
bytes, they go out at the wrong baud and the RX is never detected.

## Changes

- `src/main/io/serial.c`: initialize the VCP line-coding mirror baseline from the
  **host's** line coding at passthrough entry (`usbVcpGetLineCoding()` /
  `usbVcpGetBaudRate(left)`) instead of from the right port's settings. The mirror
  now only reacts to host-side line-coding **changes** during the session, and never
  rewrites the explicitly-requested passthrough encoding at the first tick.

The STM32 8E1 line-coding mirror use case the feature was built for (host switches
its COM port from 8N1 to 8E1 mid-session, e.g. STM32 bootloader programming) is
preserved: a mid-session host change is still mirrored.

## Testing

- **Testing needed. I could not reproduce the problem**


- **Synthetic emulation reproduced what may be the same issue.  9.1.0 (buggy):** FC HUMMINGBIRD_FC305_H7 + ELRS
  ESP32C3 RX on UART5 (SERIAL_RX/CRSF). Emulated ELRS Configurator timing (reopen
  @420000, bootloader sync sent ~0.1ms later) failed 4/4 runs — 0 bytes or garbage.
  A 50ms-delay control passed (clean `UNIFIED_ESP32C3_2400_RX`), suggesting the
  transport works and the failure is the baud race.
- **Hardware verification with fix:** same exact-timing reproduction now returns
  the clean RX target (`UNIFIED_ESP32C3_2400_RX`) — passthrough detection works.
  (Later runs returning 0 bytes were the ELRS RX entering WiFi AP mode after ~60s
  with no bound transmitter — the documented RX behavior, not the passthrough.)
- **Builds:** HUMMINGBIRD_FC305 (F722XE, release/9.1) and HUMMINGBIRD_FC305_H7
  (H743) both compile clean, no warnings; flashed and booted the H7 build.


## Code Review

Reviewed with inav-code-review agent — no critical issues found.

Hopefully fixes #11783