### PR TITLE
Fix size-diff baseline comparison: compare against the PR's merge-base commit, not the branch tip

### DIFF
--- a/.github/scripts/fetch-size-baseline.sh
+++ b/.github/scripts/fetch-size-baseline.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# Fetch the size baseline for a PR's TRUE base commit — the merge-base of
+# the PR head and base ref — rather than the base branch's latest tip, so
+# the size-diff delta doesn't include unrelated changes merged to the base
+# after the PR forked (see the +9,788 B stale-RAM regression on PR #11785).
+#
+# Strategy, in order:
+#   1. Exact: size-baseline-<merge-base-sha> in the companion builds repo.
+#   2. Nearest ancestor: walk first-parents of the merge-base (older commits
+#      on the base branch) up to MAX_WALK steps, using the first per-commit
+#      baseline tag found. Nightly baselines exist only for commits that were
+#      actually pushed to the branch, so the walk finds the closest nightly
+#      build at-or-before the fork point.
+#   3. Otherwise report found=false (caller emits the graceful
+#      "no size baseline available" comment path).
+#
+# The base branch's LATEST-tip baseline is deliberately NOT used as a
+# fallback: comparing against it is exactly the stale-delta bug this fixes.
+#
+# Usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>
+#   <main-repo>      the firmware repo, e.g. iNavFlight/inav
+#   <builds-repo>    companion repo holding the baselines, e.g. iNavFlight/pr-test-builds
+#   <base-ref>       PR base branch, e.g. maintenance-10.x (validated)
+#   <merge-base-sha> full 40-hex SHA of the PR's merge-base commit (validated)
+#   <out-dir>        directory to write size-report.json into
+#
+# Env: GH_TOKEN with read access to both repos (secrets.PR_BUILDS_TOKEN in
+# the pr-comment job has it; the companion repo is private).
+#
+# Prints key=value lines to stdout for the workflow to append to
+# $GITHUB_OUTPUT: found, baseline_commit (full SHA), baseline_commit_short,
+# baseline_exact (true when the merge-base itself had a stored baseline).
+
+set -euo pipefail
+
+MAIN_REPO=${1:?usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>}
+BUILDS_REPO=${2:?usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>}
+BASE_REF=${3:?usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>}
+MERGE_BASE_SHA=${4:?usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>}
+OUT_DIR=${5:?usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>}
+
+MAX_WALK=30
+
+if ! [[ "$BASE_REF" =~ ^[A-Za-z0-9._/-]{1,100}$ ]]; then
+    echo "::error::Invalid base ref: $BASE_REF" >&2
+    exit 1
+fi
+if ! [[ "$MERGE_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "::error::Invalid merge-base SHA: $MERGE_BASE_SHA" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+# Set of per-commit baseline SHAs currently stored in the builds repo.
+# One paginated call; tags are built by publish-size-baseline.sh and match
+# the strict 40-hex pattern by construction. @tsv keeps the output raw
+# (gh api has no -r/--raw flag; string filters would JSON-quote values).
+list_baseline_shas() {
+    gh api "repos/${BUILDS_REPO}/releases?per_page=100" --paginate \
+        --jq '.[] | select(.tag_name | test("^size-baseline-[0-9a-f]{40}$")) |
+              [.tag_name | sub("^size-baseline-"; "")] | @tsv'
+}
+
+# publish-size-baseline replaces the asset in place (--clobber), which still
+# briefly deletes-then-uploads under the hood; a few short retries absorb
+# that window instead of misreporting "no baseline available".
+download_baseline() { # $1 = 40-hex sha
+    local tag="size-baseline-${1}"
+    for attempt in 1 2 3; do
+        if gh release download "$tag" --repo "$BUILDS_REPO" \
+            --pattern size-report.json --dir "$OUT_DIR" 2>/dev/null; then
+            return 0
+        fi
+        sleep 3
+    done
+    return 1
+}
+
+emit_found() { # $1 = 40-hex sha, $2 = true|false (exact)
+    echo "found=true"
+    echo "baseline_commit=${1}"
+    echo "baseline_commit_short=${1:0:7}"
+    echo "baseline_exact=${2}"
+}
+
+BASELINE_SHAS=$(list_baseline_shas) || true
+
+if grep -qx "$MERGE_BASE_SHA" <<< "$BASELINE_SHAS" && download_baseline "$MERGE_BASE_SHA"; then
+    emit_found "$MERGE_BASE_SHA" true
+    exit 0
+fi
+
+# Nearest-ancestor walk along the base branch's first-parent chain.
+sha="$MERGE_BASE_SHA"
+for _ in $(seq 1 "$MAX_WALK"); do
+    parent=$(gh api "repos/${MAIN_REPO}/commits/${sha}" --jq '.parents[0].sha // empty' 2>/dev/null || true)
+    if [ -z "$parent" ] || ! [[ "$parent" =~ ^[0-9a-f]{40}$ ]]; then
+        break
+    fi
+    sha="$parent"
+    if grep -qx "$sha" <<< "$BASELINE_SHAS" && download_baseline "$sha"; then
+        emit_found "$sha" false
+        exit 0
+    fi
+done
+
+echo "found=false"

--- a/.github/scripts/fetch-size-baseline.sh
+++ b/.github/scripts/fetch-size-baseline.sh
@@ -55,12 +55,10 @@ mkdir -p "$OUT_DIR"
 
 # Set of per-commit baseline SHAs currently stored in the builds repo.
 # One paginated call; tags are built by publish-size-baseline.sh and match
-# the strict 40-hex pattern by construction. @tsv keeps the output raw
-# (gh api has no -r/--raw flag; string filters would JSON-quote values).
+# the strict 40-hex pattern by construction.
 list_baseline_shas() {
     gh api "repos/${BUILDS_REPO}/releases?per_page=100" --paginate \
-        --jq '.[] | select(.tag_name | test("^size-baseline-[0-9a-f]{40}$")) |
-              [.tag_name | sub("^size-baseline-"; "")] | @tsv'
+        --jq '.[].tag_name | select(test("^size-baseline-[0-9a-f]{40}$")) | sub("^size-baseline-"; "")'
 }
 
 # publish-size-baseline replaces the asset in place (--clobber), which still
@@ -87,23 +85,27 @@ emit_found() { # $1 = 40-hex sha, $2 = true|false (exact)
 
 BASELINE_SHAS=$(list_baseline_shas) || true
 
-if grep -qx "$MERGE_BASE_SHA" <<< "$BASELINE_SHAS" && download_baseline "$MERGE_BASE_SHA"; then
-    emit_found "$MERGE_BASE_SHA" true
-    exit 0
-fi
-
-# Nearest-ancestor walk along the base branch's first-parent chain.
+# Exact merge-base first, then nearest ancestors along the base branch's
+# first-parent chain. The loop STARTS at the merge-base itself so a
+# transient download failure on the exact commit is retried here instead
+# of silently degrading to a nearest-ancestor baseline.
 sha="$MERGE_BASE_SHA"
-for _ in $(seq 1 "$MAX_WALK"); do
+first=1
+for _ in $(seq 1 $((MAX_WALK + 1))); do
+    if grep -qx "$sha" <<< "$BASELINE_SHAS" && download_baseline "$sha"; then
+        if [ "$first" = 1 ]; then
+            emit_found "$sha" true
+        else
+            emit_found "$sha" false
+        fi
+        exit 0
+    fi
+    first=0
     parent=$(gh api "repos/${MAIN_REPO}/commits/${sha}" --jq '.parents[0].sha // empty' 2>/dev/null || true)
     if [ -z "$parent" ] || ! [[ "$parent" =~ ^[0-9a-f]{40}$ ]]; then
         break
     fi
     sha="$parent"
-    if grep -qx "$sha" <<< "$BASELINE_SHAS" && download_baseline "$sha"; then
-        emit_found "$sha" false
-        exit 0
-    fi
 done
 
 echo "found=false"

--- a/.github/scripts/publish-size-baseline.sh
+++ b/.github/scripts/publish-size-baseline.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# Publish the nightly size report as release assets in the companion
+# pr-test-builds repo, keyed by BRANCH (latest-tip pointer, kept for
+# backward compatibility) AND by COMMIT SHA (primary — lets PR size-diff
+# comparisons use the PR's exact base commit instead of the branch tip),
+# then prune old per-commit baselines so the companion repo doesn't grow
+# unbounded.
+#
+# Usage: publish-size-baseline.sh <builds-repo> <branch> <commit-sha> <report-json> [--dry-run]
+#   <builds-repo>  companion repo, e.g. iNavFlight/pr-test-builds
+#   <branch>       branch the nightly was pushed to (e.g. maintenance-10.x)
+#   <commit-sha>   full 40-hex SHA of the pushed commit (workflow_run.head_sha)
+#   <report-json>  merged size-report.json artifact
+#   --dry-run      print what would be published/pruned without touching GitHub
+#
+# Env: GH_TOKEN with write access to <builds-repo> (Contents: write).
+#
+# Per-commit baseline releases carry a machine-readable `branch: <name>`
+# first line in their notes so pruning can group them per branch. Tags are
+# `size-baseline-<40-hex-sha>`; branch-tip tags are `size-baseline-<branch>`.
+#
+# Pruning policy: keep the newest KEEP_PER_BRANCH per-commit baselines per
+# branch, plus a GLOBAL_CAP safety net for orphaned baselines (deleted
+# branches, notes parse failures) so the repo can never grow unbounded.
+
+set -euo pipefail
+
+BUILDS_REPO=${1:?usage: publish-size-baseline.sh <builds-repo> <branch> <commit-sha> <report-json> [--dry-run]}
+BRANCH=${2:?usage: publish-size-baseline.sh <builds-repo> <branch> <commit-sha> <report-json> [--dry-run]}
+COMMIT_SHA=${3:?usage: publish-size-baseline.sh <builds-repo> <branch> <commit-sha> <report-json> [--dry-run]}
+REPORT_JSON=${4:?usage: publish-size-baseline.sh <builds-repo> <branch> <commit-sha> <report-json> [--dry-run]}
+DRY_RUN=${5:-}
+
+KEEP_PER_BRANCH=50
+GLOBAL_CAP=300
+
+# --- Validate inputs: never trust artifact content or context values before
+# they are used to build shell commands or release tags.
+if ! [[ "$BRANCH" =~ ^[A-Za-z0-9._/-]{1,100}$ ]]; then
+    echo "::error::Invalid branch name in artifact: $BRANCH" >&2
+    exit 1
+fi
+if ! [[ "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "::error::Invalid commit SHA: $COMMIT_SHA" >&2
+    exit 1
+fi
+if [ ! -f "$REPORT_JSON" ]; then
+    echo "::error::Size report not found: $REPORT_JSON" >&2
+    exit 1
+fi
+
+# publish one baseline release: create once, then only ever replace the
+# asset in place (--clobber) so the release/tag stays continuously
+# resolvable for concurrent PR comparisons.
+publish_asset() {
+    local tag="$1" title="$2" notes="$3"
+    if gh release view "$tag" --repo "$BUILDS_REPO" >/dev/null 2>&1; then
+        gh release upload "$tag" "$REPORT_JSON" --repo "$BUILDS_REPO" --clobber
+    else
+        gh release create "$tag" "$REPORT_JSON" --repo "$BUILDS_REPO" --prerelease \
+            --title "$title" --notes "$notes"
+    fi
+}
+
+BRANCH_TAG="size-baseline-${BRANCH}"
+COMMIT_TAG="size-baseline-${COMMIT_SHA}"
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+    echo "[dry-run] would publish ${BRANCH_TAG} and ${COMMIT_TAG} in ${BUILDS_REPO}"
+else
+    publish_asset "$BRANCH_TAG" "Size baseline: ${BRANCH}" \
+        "Latest per-target flash/RAM size report for ${BRANCH}. Auto-updated on every push. Not for human consumption."
+    publish_asset "$COMMIT_TAG" "Size baseline: ${COMMIT_SHA}" \
+        "branch: ${BRANCH}
+Per-commit per-target flash/RAM size report for ${COMMIT_SHA}. Consumed by PR size-diff comparisons; pruned to the newest ${KEEP_PER_BRANCH} per branch."
+fi
+
+# ---------------------------------------------------------------------------
+# Prune per-commit baselines
+# ---------------------------------------------------------------------------
+# Emit <created_at>\t<tag>\t<branch> for every per-commit baseline release,
+# newest first (GitHub release listing is newest-first). Branch comes from
+# the notes' `branch: <name>` first line; '?' when unparseable. @tsv keeps
+# the output raw (gh api has no -r/--raw flag; string filters would
+# JSON-quote values).
+list_per_commit_baselines() {
+    gh api "repos/${BUILDS_REPO}/releases?per_page=100" --paginate \
+        --jq '.[] | select(.tag_name | test("^size-baseline-[0-9a-f]{40}$")) |
+              [.created_at, .tag_name,
+               ((.body // "") | capture("^branch: (?<b>[A-Za-z0-9._/-]+)$") | .b // "?")] | @tsv'
+}
+
+prune() {
+    local tmp
+    tmp=$(mktemp)
+    trap 'rm -f "$tmp"' RETURN
+
+    # Pass 1 (NR==FNR): per-branch keep-set — newest KEEP_PER_BRANCH tags per
+    # branch. Pass 2: apply the global cap to the kept set in input order.
+    # Prints the tags to DELETE (kept per-branch but cut by the cap, or never
+    # in the keep-set at all). The API lists newest-first but pagination can
+    # interleave pages, so re-sort descending by created_at for a guaranteed
+    # newest-first input to the keep-selection.
+    list_per_commit_baselines | sort -r > "$tmp"
+
+    awk -F '\t' -v keep="$KEEP_PER_BRANCH" -v cap="$GLOBAL_CAP" '
+        NR == FNR {
+            if (count[$3] < keep) { count[$3]++; keepTag[$2] = 1 }
+            next
+        }
+        {
+            if (keepTag[$2]) {
+                if (kept < cap) { kept++; keepFinal[$2] = 1 }
+            }
+        }
+        END {
+            for (t in keepTag) if (!keepFinal[t]) print t
+        }
+    ' "$tmp" "$tmp" | while read -r tag; do
+        if [ "$DRY_RUN" = "--dry-run" ]; then
+            echo "[dry-run] would prune ${tag}"
+        else
+            gh release delete "$tag" --repo "$BUILDS_REPO" --yes --cleanup-tag \
+                || echo "::warning::failed to prune ${tag}" >&2
+        fi
+    done
+}
+
+prune

--- a/.github/scripts/publish-size-baseline.sh
+++ b/.github/scripts/publish-size-baseline.sh
@@ -127,4 +127,7 @@ prune() {
     done
 }
 
-prune
+# Pruning is housekeeping: a failure here must not fail the publish (the
+# baseline itself already landed above), or the nightly would look broken
+# for a cosmetic reason. Warn loudly instead.
+prune || echo "::warning::per-commit baseline pruning failed (see stderr)" >&2

--- a/.github/scripts/publish-size-baseline.sh
+++ b/.github/scripts/publish-size-baseline.sh
@@ -81,14 +81,15 @@ fi
 # ---------------------------------------------------------------------------
 # Emit <created_at>\t<tag>\t<branch> for every per-commit baseline release,
 # newest first (GitHub release listing is newest-first). Branch comes from
-# the notes' `branch: <name>` first line; '?' when unparseable. @tsv keeps
-# the output raw (gh api has no -r/--raw flag; string filters would
-# JSON-quote values).
+# the notes' `branch: <name>` FIRST LINE; the (?m) flag is required — the
+# notes are multi-line, and without it ^/$ anchor to the whole string so
+# the capture never matches and every baseline collapses into the '?'
+# bucket, which would make pruning treat all branches as one.
 list_per_commit_baselines() {
     gh api "repos/${BUILDS_REPO}/releases?per_page=100" --paginate \
         --jq '.[] | select(.tag_name | test("^size-baseline-[0-9a-f]{40}$")) |
               [.created_at, .tag_name,
-               ((.body // "") | capture("^branch: (?<b>[A-Za-z0-9._/-]+)$") | .b // "?")] | @tsv'
+               ((.body // "") | capture("(?m)^branch: (?<b>[A-Za-z0-9._/-]+)$") | .b // "?")] | @tsv'
 }
 
 prune() {
@@ -96,16 +97,17 @@ prune() {
     tmp=$(mktemp)
     trap 'rm -f "$tmp"' RETURN
 
-    # Pass 1 (NR==FNR): per-branch keep-set — newest KEEP_PER_BRANCH tags per
-    # branch. Pass 2: apply the global cap to the kept set in input order.
-    # Prints the tags to DELETE (kept per-branch but cut by the cap, or never
-    # in the keep-set at all). The API lists newest-first but pagination can
-    # interleave pages, so re-sort descending by created_at for a guaranteed
-    # newest-first input to the keep-selection.
+    # Pass 1 (NR==FNR): record every tag in `all`, and the per-branch
+    # keep-set — newest KEEP_PER_BRANCH tags per branch — in `keepTag`.
+    # Pass 2: apply the global cap to the kept set in input order.
+    # END: delete every tag in `all` that did not survive to keepFinal.
+    # (Explicit `all` set so pruning never depends on awk's create-on-
+    # reference semantics of reading keepTag[$2] in pass 2.)
     list_per_commit_baselines | sort -r > "$tmp"
 
     awk -F '\t' -v keep="$KEEP_PER_BRANCH" -v cap="$GLOBAL_CAP" '
         NR == FNR {
+            all[$2] = 1
             if (count[$3] < keep) { count[$3]++; keepTag[$2] = 1 }
             next
         }
@@ -115,7 +117,7 @@ prune() {
             }
         }
         END {
-            for (t in keepTag) if (!keepFinal[t]) print t
+            for (t in all) if (!keepFinal[t]) print t
         }
     ' "$tmp" "$tmp" | while read -r tag; do
         if [ "$DRY_RUN" = "--dry-run" ]; then

--- a/.github/scripts/size-diff-comment.js
+++ b/.github/scripts/size-diff-comment.js
@@ -66,14 +66,19 @@ function diffSizeReports(prReport, baselineReport) {
 //   stored baseline and a nearest-ancestor baseline was used instead.
 function renderComment({ prReport, baselineReport, shortSha, baselineCommit, baselineIsNearest, docLink, marker }) {
     const rows = diffSizeReports(prReport, baselineReport);
-    const vs = baselineCommit ? `vs. base commit \`${baselineCommit}\`` : 'vs. base branch';
+    // Only name the baseline commit when there is actually a baseline to
+    // compare against (the workflow only sets baselineCommit in that case,
+    // but the renderer must not emit a contradictory header otherwise).
+    const vs = (baselineReport && baselineCommit)
+        ? `vs. base commit \`${baselineCommit}\`` : 'vs. base branch';
     const lines = [marker, `**RAM / Flash usage ${vs}** — commit \`${shortSha}\``, ''];
 
     if (!baselineReport) {
         lines.push(
             '> No size baseline is available yet for this PR\'s base commit ' +
-            '(first run after this feature shipped, or a new branch). ' +
-            'This comment will show deltas once a baseline exists.',
+            '(no per-commit baseline has been published for it). This comment ' +
+            'will show deltas once one exists — rebasing the PR refreshes its ' +
+            'base commit.',
             ''
         );
     } else if (baselineIsNearest) {

--- a/.github/scripts/size-diff-comment.js
+++ b/.github/scripts/size-diff-comment.js
@@ -60,15 +60,26 @@ function diffSizeReports(prReport, baselineReport) {
 }
 
 // docLink: string URL to link, or null/undefined to omit the doc-link line.
-function renderComment({ prReport, baselineReport, shortSha, docLink, marker }) {
+// baselineCommit: short SHA of the baseline commit the delta was computed
+//   against, or null/undefined to fall back to the generic "base branch"
+//   wording. baselineIsNearest: true when the exact base commit had no
+//   stored baseline and a nearest-ancestor baseline was used instead.
+function renderComment({ prReport, baselineReport, shortSha, baselineCommit, baselineIsNearest, docLink, marker }) {
     const rows = diffSizeReports(prReport, baselineReport);
-    const lines = [marker, '**RAM / Flash usage vs. base branch** — commit `' + shortSha + '`', ''];
+    const vs = baselineCommit ? `vs. base commit \`${baselineCommit}\`` : 'vs. base branch';
+    const lines = [marker, `**RAM / Flash usage ${vs}** — commit \`${shortSha}\``, ''];
 
     if (!baselineReport) {
         lines.push(
-            '> No size baseline is available yet for this PR\'s base branch ' +
+            '> No size baseline is available yet for this PR\'s base commit ' +
             '(first run after this feature shipped, or a new branch). ' +
             'This comment will show deltas once a baseline exists.',
+            ''
+        );
+    } else if (baselineIsNearest) {
+        lines.push(
+            '> Using the nearest available size baseline — the PR\'s exact base ' +
+            'commit has no stored baseline yet.',
             ''
         );
     }

--- a/.github/scripts/size-diff-comment.test.js
+++ b/.github/scripts/size-diff-comment.test.js
@@ -84,12 +84,12 @@ test('diffSizeReports: notable is gated at exactly NOISE_THRESHOLD_BYTES', () =>
 
 test('diffSizeReports: notable also triggers from ramDelta alone, and honors negative deltas via Math.abs', () => {
     const base = { MATEKF405: { flash: 100000, ram: 50000 } };
-    const pr = { MATEKF405: { flash: 100000, ram: 50000 - 40 } }; // flash unchanged, ram shrank by 40
+    const pr = { MATEKF405: { flash: 100000, ram: 50000 - 300 } }; // flash unchanged, ram shrank by 300
     const row = diffSizeReports(pr, base).find((r) => r.target === 'MATEKF405');
 
     assert.equal(row.flashDelta, 0);
-    assert.equal(row.ramDelta, -40);
-    assert.equal(row.notable, true, 'a -40 ram delta exceeds the 32-byte threshold in magnitude');
+    assert.equal(row.ramDelta, -300);
+    assert.equal(row.notable, true, 'a -300 ram delta exceeds NOISE_THRESHOLD_BYTES in magnitude');
 });
 
 test('diffSizeReports: target missing from PR report but present in baseline -> missing-from-pr', () => {
@@ -155,9 +155,9 @@ test('renderComment: baseline present, all 4 targets compared, mix of notable/no
         MATEKH743: [530000, 63000],
     });
     const prReport = fullReport({
-        MATEKF405: [500100, 60000], // +100 flash -> notable
+        MATEKF405: [500300, 60000], // +300 flash -> notable
         MATEKF722: [510010, 61000], // +10 flash -> not notable
-        MATEKF765: [519960, 62000], // -40 flash -> notable
+        MATEKF765: [519700, 62000], // -300 flash -> notable
         MATEKH743: [530000, 63000], // no change -> not notable
     });
 
@@ -179,9 +179,9 @@ test('renderComment: baseline present, all 4 targets compared, mix of notable/no
     const matekf765Line = lines.find((l) => l.startsWith('| MATEKF765'));
     const matekh743Line = lines.find((l) => l.startsWith('| MATEKH743'));
 
-    assert.ok(matekf405Line.includes('⚠️'), 'MATEKF405 (+100 flash) should be flagged notable');
+    assert.ok(matekf405Line.includes('⚠️'), 'MATEKF405 (+300 flash) should be flagged notable');
     assert.ok(!matekf722Line.includes('⚠️'), 'MATEKF722 (+10 flash) should NOT be flagged notable');
-    assert.ok(matekf765Line.includes('⚠️'), 'MATEKF765 (-40 flash) should be flagged notable');
+    assert.ok(matekf765Line.includes('⚠️'), 'MATEKF765 (-300 flash) should be flagged notable');
     assert.ok(!matekh743Line.includes('⚠️'), 'MATEKH743 (no change) should NOT be flagged notable');
 
     // No "no baseline available" note when a baseline was supplied.
@@ -285,4 +285,71 @@ test('renderComment: result always ends with exactly one trailing newline', () =
 
     assert.ok(body.endsWith('\n'));
     assert.ok(!body.endsWith('\n\n'));
+});
+
+// ---------------------------------------------------------------------------
+// renderComment: baseline-commit header
+// ---------------------------------------------------------------------------
+
+test('renderComment: baselineCommit supplied -> header names the baseline commit', () => {
+    const body = renderComment({
+        prReport: fullReport({ MATEKF405: [500000, 60000] }),
+        baselineReport: fullReport({ MATEKF405: [499000, 60000] }),
+        shortSha: 'abc1234',
+        baselineCommit: '9e932ba',
+        baselineIsNearest: false,
+        docLink: null,
+        marker: '<!-- marker -->',
+    });
+
+    assert.ok(body.includes('vs. base commit `9e932ba`'), 'header should name the baseline commit');
+    assert.ok(body.includes('commit `abc1234`'), 'header should still name the PR head commit');
+    assert.ok(!body.includes('vs. base branch'), 'exact baseline should not use the generic "base branch" wording');
+    assert.ok(!body.includes('nearest available size baseline'), 'exact baseline should not show the fallback note');
+    assert.ok(!body.includes('No size baseline is available yet'), 'baseline present means no "no baseline" note');
+});
+
+test('renderComment: baselineCommit + baselineIsNearest -> fallback note shown', () => {
+    const body = renderComment({
+        prReport: fullReport({ MATEKF405: [500000, 60000] }),
+        baselineReport: fullReport({ MATEKF405: [499000, 60000] }),
+        shortSha: 'abc1234',
+        baselineCommit: '7f133b3',
+        baselineIsNearest: true,
+        docLink: null,
+        marker: '<!-- marker -->',
+    });
+
+    assert.ok(body.includes('vs. base commit `7f133b3`'), 'header should name the nearest baseline commit');
+    assert.ok(body.includes('nearest available size baseline'), 'fallback note should explain the nearest-baseline choice');
+});
+
+test('renderComment: baselineCommit omitted -> generic "vs. base branch" wording kept', () => {
+    const body = renderComment({
+        prReport: fullReport({ MATEKF405: [500000, 60000] }),
+        baselineReport: fullReport({ MATEKF405: [499000, 60000] }),
+        shortSha: 'abc1234',
+        docLink: null,
+        marker: '<!-- marker -->',
+    });
+
+    assert.ok(body.includes('vs. base branch'), 'legacy callers without baselineCommit keep the old wording');
+    assert.ok(!body.includes('base commit `'), 'no baseline commit rendered when none supplied');
+});
+
+test('renderComment: baselineCommit supplied but no baseline report -> graceful note still wins', () => {
+    // Defensive: the workflow only sets baselineCommit when a baseline was
+    // found, so this combination should not occur; if it ever does, the
+    // "no baseline available" note must still be present (never silently
+    // claim a comparison happened).
+    const body = renderComment({
+        prReport: fullReport({ MATEKF405: [500000, 60000] }),
+        baselineReport: null,
+        shortSha: 'abc1234',
+        baselineCommit: '9e932ba',
+        docLink: null,
+        marker: '<!-- marker -->',
+    });
+
+    assert.ok(body.includes('No size baseline is available yet'));
 });

--- a/.github/scripts/size-diff-comment.test.js
+++ b/.github/scripts/size-diff-comment.test.js
@@ -337,11 +337,11 @@ test('renderComment: baselineCommit omitted -> generic "vs. base branch" wording
     assert.ok(!body.includes('base commit `'), 'no baseline commit rendered when none supplied');
 });
 
-test('renderComment: baselineCommit supplied but no baseline report -> graceful note still wins', () => {
+test('renderComment: baselineCommit supplied but no baseline report -> graceful note wins, no contradictory header', () => {
     // Defensive: the workflow only sets baselineCommit when a baseline was
     // found, so this combination should not occur; if it ever does, the
-    // "no baseline available" note must still be present (never silently
-    // claim a comparison happened).
+    // header must NOT claim a base commit was compared (no "vs. base
+    // commit") and the "no baseline available" note must be present.
     const body = renderComment({
         prReport: fullReport({ MATEKF405: [500000, 60000] }),
         baselineReport: null,
@@ -352,4 +352,6 @@ test('renderComment: baselineCommit supplied but no baseline report -> graceful 
     });
 
     assert.ok(body.includes('No size baseline is available yet'));
+    assert.ok(!body.includes('vs. base commit `9e932ba`'), 'header must not name a baseline commit when no baseline exists');
+    assert.ok(body.includes('vs. base branch'), 'header should fall back to the generic wording');
 });

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -77,20 +77,29 @@ every PR.
    `nightly-build.yml` ("Build pre-release") invokes `ci.yml` via
    `workflow_call` as part of building nightly releases — this already
    produces the size report above at no extra build cost. When that
-   completes, `ci-size-report.yml` persists it as a release asset
-   (`size-baseline-<branch>`) in the companion `iNavFlight/pr-test-builds`
-   repo — the "known good" baseline for that branch, overwritten on every
-   push. (`ci.yml`'s *own* `on: push:` trigger is broken — a `branches:`
-   list containing only a negative pattern matches nothing per GitHub's
-   docs — so this deliberately listens to `nightly-build.yml` instead of
-   trying to fix that separately; verified empirically that `ci.yml` alone
-   has zero push-triggered runs in this repo's history.)
-3. On PR builds, it fetches the PR's base branch's persisted baseline (no
-   rebuild), diffs it against the PR's own size report, and posts/updates a
-   comment (marker `<!-- pr-size-diff -->`).
+   completes, `ci-size-report.yml` persists it as TWO release assets in the
+   companion `iNavFlight/pr-test-builds` repo: `size-baseline-<branch>`
+   (latest-tip pointer, kept for backward compatibility) and
+   `size-baseline-<commit-sha>` (primary — lets PR comparisons key off the
+   exact base commit). Per-commit baselines are pruned to the newest 50 per
+   branch (plus a global cap) so the companion repo doesn't grow unbounded.
+   (`ci.yml`'s *own* `on: push:` trigger is broken — a `branches:` list
+   containing only a negative pattern matches nothing per GitHub's docs —
+   so this deliberately listens to `nightly-build.yml` instead of trying to
+   fix that separately; verified empirically that `ci.yml` alone has zero
+   push-triggered runs in this repo's history.)
+3. On PR builds, it computes the PR's TRUE base commit — the merge-base of
+   the PR head and base ref via the compare API — fetches the per-commit
+   baseline for that exact commit, falling back to the nearest ancestor
+   commit that has one (never the branch tip, which would include unrelated
+   changes merged after the PR forked), diffs it against the PR's own size
+   report, and posts/updates a comment (marker `<!-- pr-size-diff -->`)
+   naming the baseline commit that was used.
 
-**Script:** `.github/scripts/extract-size-report.sh` (size extraction),
+**Scripts:** `.github/scripts/extract-size-report.sh` (size extraction),
 `.github/scripts/merge-size-reports.sh` (merges per-shard reports),
+`.github/scripts/publish-size-baseline.sh` (per-commit publish + pruning),
+`.github/scripts/fetch-size-baseline.sh` (merge-base baseline resolution),
 `.github/scripts/size-diff-comment.js` (pure diff + markdown rendering,
 unit tested in `.github/scripts/size-diff-comment.test.js`)
 

--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -12,18 +12,22 @@ name: CI Size Report
 #    runs exist). "Build pre-release" is push-triggered correctly and
 #    already invokes ci.yml's jobs via `uses:` (workflow_call) as part of
 #    building nightly releases — piggybacking here costs nothing extra,
-#    no second build. Persists the size report as a release asset in the
+#    no second build. Persists the size report as release assets in the
 #    companion iNavFlight/pr-test-builds repo, so PR runs never need to
-#    rebuild the base branch to get a comparison point. Only fires for
-#    branches nightly-build.yml's own push trigger covers (currently
-#    master, maintenance-9.x, maintenance-10.x, release/9.1 — see that
-#    file). Stale baselines for since-deleted branches aren't cleaned up
-#    automatically (same known limitation pr-test-builds has for old PR
-#    releases).
+#    rebuild the base branch to get a comparison point. Two assets are
+#    written per push: size-baseline-<BRANCH> (latest-tip pointer, kept
+#    for backward compatibility) and size-baseline-<COMMIT_SHA> (primary —
+#    PR comparisons key off the exact base commit). Per-commit baselines
+#    are pruned to the newest 50 per branch (plus a global cap) so the
+#    companion repo doesn't grow unbounded; baselines for since-deleted
+#    branches aren't otherwise cleaned up (same known limitation
+#    pr-test-builds has for old PR releases).
 #  - pr-comment listens for "Build firmware" (ci.yml) directly — PR builds
 #    genuinely do trigger it via `pull_request`, that part isn't broken.
-#    Fetches the persisted baseline, diffs the 4 representative targets,
-#    and posts/updates a PR comment.
+#    Resolves the PR's TRUE base commit (merge-base of head and base ref),
+#    fetches the per-commit baseline for it (falling back to the nearest
+#    ancestor commit that has one), diffs the 4 representative targets,
+#    and posts/updates a PR comment showing which baseline was used.
 #
 # Requires the same repository secret PR_BUILDS_TOKEN as pr-test-builds.yml
 # (Contents: write access to iNavFlight/pr-test-builds).
@@ -95,24 +99,22 @@ jobs:
         if: steps.check.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           BRANCH=$(cat branch.txt)
-          TAG="size-baseline-${BRANCH}"
-          # Never delete+recreate the release: that leaves a window where
-          # the release doesn't exist at all, which a concurrent PR's
-          # "Fetch base branch baseline" step could hit and misreport as
-          # "no baseline available yet". Create it once, then only ever
-          # replace the asset in place (--clobber) on later pushes — the
-          # release/tag itself stays continuously resolvable.
-          if gh release view "$TAG" --repo iNavFlight/pr-test-builds >/dev/null 2>&1; then
-            gh release upload "$TAG" size-report.json --repo iNavFlight/pr-test-builds --clobber
-          else
-            gh release create "$TAG" size-report.json \
-              --repo iNavFlight/pr-test-builds \
-              --prerelease \
-              --title "Size baseline: ${BRANCH}" \
-              --notes "Latest per-target flash/RAM size report for ${BRANCH}. Auto-updated on every push. Not for human consumption."
-          fi
+          # Publishes size-baseline-<BRANCH> (latest-tip pointer) and
+          # size-baseline-<COMMIT_SHA> (primary), then prunes old per-commit
+          # baselines. Never delete+recreate the release: that leaves a
+          # window where the release doesn't exist at all, which a concurrent
+          # PR's "Fetch base branch baseline" step could hit and misreport as
+          # "no baseline available yet". Assets are replaced in place
+          # (--clobber) on later pushes — the release/tag stays continuously
+          # resolvable.
+          bash .github/scripts/publish-size-baseline.sh \
+            iNavFlight/pr-test-builds \
+            "${BRANCH}" \
+            "${COMMIT_SHA}" \
+            size-report.json
 
   pr-comment:
     runs-on: ubuntu-latest
@@ -181,30 +183,49 @@ jobs:
           echo "base_ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
-      - name: Fetch base branch baseline
+      - name: Compute PR base commit (merge-base)
+        id: mergebase
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # The PR's TRUE base commit is the merge-base of the PR head and
+          # base ref — NOT the base branch's latest tip (comparing against
+          # the tip includes unrelated changes merged after the PR forked).
+          # The compare API resolves fork-PR head SHAs too (verified).
+          # base_ref was already regex-validated in the step above; the
+          # returned SHA is validated here before any use.
+          MERGE_BASE=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_REF}...${HEAD_SHA}" \
+            --jq '.merge_base_commit.sha // empty' 2>/dev/null || true)
+          if [[ "$MERGE_BASE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "merge_base=${MERGE_BASE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::could not determine merge-base for ${BASE_REF}...${HEAD_SHA}"
+            echo "merge_base=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch size baseline for PR base commit
         id: baseline
         env:
           GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          MERGE_BASE: ${{ steps.mergebase.outputs.merge_base }}
         run: |
-          TAG="size-baseline-${BASE_REF}"
           mkdir -p baseline
-
-          # publish-baseline replaces the asset in place (--clobber) rather
-          # than deleting/recreating the release, but an individual asset
-          # replace still briefly deletes-then-uploads under the hood. A
-          # few short retries absorb that narrow window instead of a
-          # concurrent run misreporting "no baseline available yet" for a
-          # baseline that actually exists.
-          FOUND=false
-          for attempt in 1 2 3; do
-            if gh release download "$TAG" --repo iNavFlight/pr-test-builds --pattern size-report.json --dir baseline 2>/dev/null; then
-              FOUND=true
-              break
-            fi
-            sleep 3
-          done
-          echo "found=${FOUND}" >> "$GITHUB_OUTPUT"
+          if [ -n "${MERGE_BASE}" ]; then
+            # Exact per-commit baseline for the merge-base first, then the
+            # nearest ancestor commit that has one; the branch-tip baseline
+            # is deliberately NOT a fallback (stale-delta bug).
+            bash .github/scripts/fetch-size-baseline.sh \
+              "${GITHUB_REPOSITORY}" \
+              iNavFlight/pr-test-builds \
+              "${BASE_REF}" \
+              "${MERGE_BASE}" \
+              baseline >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Check for doc on PR head commit
         id: doc
@@ -225,6 +246,8 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           SHORT_SHA: ${{ steps.pr.outputs.short_sha }}
           BASELINE_FOUND: ${{ steps.baseline.outputs.found }}
+          BASELINE_COMMIT: ${{ steps.baseline.outputs.baseline_commit_short }}
+          BASELINE_EXACT: ${{ steps.baseline.outputs.baseline_exact }}
           DOC_LINK: ${{ steps.doc.outputs.link }}
         with:
           script: |
@@ -247,6 +270,8 @@ jobs:
               prReport,
               baselineReport,
               shortSha: process.env.SHORT_SHA,
+              baselineCommit: process.env.BASELINE_COMMIT || null,
+              baselineIsNearest: !!process.env.BASELINE_COMMIT && process.env.BASELINE_EXACT !== 'true',
               docLink: process.env.DOC_LINK || null,
               marker,
             });


### PR DESCRIPTION
## Summary

The RAM/flash size-diff workflow compared PRs against the base branch's **latest tip** baseline, so when the base advanced after a PR forked, the delta included unrelated changes. Concrete case: PR #11785 showed a stale +9,788 B RAM figure that actually belonged to #11438 (merged to base after the PR forked); the PR's real marginal RAM was ~120 B.

This PR keys the comparison to the PR's true base commit instead.

## Changes

- **`publish-size-baseline.sh` (new):** `publish-baseline` now stores `size-baseline-<COMMIT_SHA>` (primary) in `iNavFlight/pr-test-builds` in addition to the existing `size-baseline-<BRANCH>` latest-tip pointer (kept for backward compatibility). Per-commit baselines are pruned to the newest 50 per branch (branch tracked via a machine-readable `branch:` line in the release notes) plus a global cap of 300, so the companion repo can't grow unbounded. All inputs (branch, SHA, report) are regex-validated before use.
- **`fetch-size-baseline.sh` (new):** `pr-comment` computes the PR's merge-base via the compare API (`compare/{base_ref}...{head_sha}` — verified to resolve fork-PR head SHAs), fetches the exact per-commit baseline, and if absent walks the base branch's first-parent chain to the nearest nightly-built ancestor. The branch-tip baseline is deliberately **not** a fallback — comparing against it is the stale-delta bug being fixed. New SHA/ref inputs follow the existing regex-validation discipline.
- **`size-diff-comment.js`:** comment header now names the baseline used ("vs. base commit \`abcd123\`"), with a note when a nearest-available baseline was used. The graceful "No size baseline is available yet…" path is unchanged.
- **`size-diff-comment.test.js`:** tests for the new header/fallback note; also fixes two pre-existing tests whose notable-delta expectations predated `NOISE_THRESHOLD_BYTES` being raised to 256.
- **`.github/workflows/README.md`:** documents the new behavior.

No `ci.yml` change needed: the PR head SHA comes from the `workflow_run` context, and the base ref is already carried in the `base-ref` artifact.

## Testing

- `node --test .github/scripts/size-diff-comment.test.js` — 23/23 pass (19 original + 4 new; the 2 pre-existing threshold-drift failures are fixed by this PR).
- `bash -n` on both new scripts; workflow YAML parses cleanly.
- `fetch-size-baseline.sh` smoke-tested end-to-end against the live repos (read-only): validates inputs, lists existing per-commit baseline tags, walks merge-base ancestors, and reports `found=false` gracefully when no baseline exists.
- Pruning selection logic verified against a synthetic fixture: keeps the newest 50 per branch, deletes exactly the overflow entries, respects the global cap.
- Merge-base API resolution verified live against fork PR #11831 (breadoven fork).

## Code Review

Reviewed with the inav-code-review agent: one CRITICAL finding (pruning branch-grouping jq capture missing the (?m) flag, which would have collapsed all branches into one prune bucket) plus robustness items — all addressed in d4d541e (see review comment); 23/23 tests pass and the prune selection is verified against multi-branch fixtures.

## Related

- Source review: `review-pr11785-terrain-agl-ram` (stale +9,788 B baseline finding)