### PR TITLE
Sweep MSP SET handlers to lenient dataSize gates (forward compat)

### DIFF
--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -3661,7 +3661,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_COMMON_SET_TZ:
-        if (dataSize >= 2)
+        if (dataSize == 2)
             timeConfigMutable()->tz_offset = (int16_t)sbufReadU16(src);
         else if (dataSize >= 3) {
             timeConfigMutable()->tz_offset = (int16_t)sbufReadU16(src);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2173,6 +2173,10 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     const unsigned int dataSize = sbufBytesRemaining(src);  /* Payload size in Bytes */
 
+    // SET handlers use lenient >= / < gates per forward-compat policy: MSP payloads
+    // only gain fields at the end, so a newer configurator's longer message is
+    // accepted by applying the known prefix and ignoring the trailing bytes.
+
     switch (cmdMSP) {
     case MSP_SELECT_SETTING:
         if (sbufReadU8Safe(&tmp_u8, src) && (!ARMING_FLAG(ARMED)))
@@ -3742,12 +3746,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP2_INAV_OSD_SET_PREFERENCES:
         {
-            if (
-                    dataSize >= 9
-#ifdef USE_ADSB
-                    || dataSize >= 10
-#endif
-            ) {
+            if (dataSize >= 9) {
                 osdConfigMutable()->video_system = sbufReadU8(src);
                 osdConfigMutable()->main_voltage_decimals = sbufReadU8(src);
                 osdConfigMutable()->ahi_reverse_roll = sbufReadU8(src);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -2220,7 +2220,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_SET_PID:
-        if (dataSize == PID_ITEM_COUNT * 4) {
+        if (dataSize >= PID_ITEM_COUNT * 4) {
             for (int i = 0; i < PID_ITEM_COUNT; i++) {
                 pidBankMutable()->pid[i].P = sbufReadU8(src);
                 pidBankMutable()->pid[i].I = sbufReadU8(src);
@@ -2235,7 +2235,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP_SET_MODE_RANGE:
         sbufReadU8Safe(&tmp_u8, src);
-        if ((dataSize == 5) && (tmp_u8 < MAX_MODE_ACTIVATION_CONDITION_COUNT)) {
+        if ((dataSize >= 5) && (tmp_u8 < MAX_MODE_ACTIVATION_CONDITION_COUNT)) {
             modeActivationCondition_t *mac = modeActivationConditionsMutable(tmp_u8);
             tmp_u8 = sbufReadU8(src);
             const box_t *box = findBoxByPermanentId(tmp_u8);
@@ -2256,7 +2256,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP_SET_ADJUSTMENT_RANGE:
         sbufReadU8Safe(&tmp_u8, src);
-        if ((dataSize == 7) && (tmp_u8 < MAX_ADJUSTMENT_RANGE_COUNT)) {
+        if ((dataSize >= 7) && (tmp_u8 < MAX_ADJUSTMENT_RANGE_COUNT)) {
             adjustmentRange_t *adjRange = adjustmentRangesMutable(tmp_u8);
             tmp_u8 = sbufReadU8(src);
             if (tmp_u8 < MAX_SIMULTANEOUS_ADJUSTMENT_COUNT) {
@@ -2346,7 +2346,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_MISC:
-        if (dataSize == 22) {
+        if (dataSize >= 22) {
         sbufReadU16(src);   // midrc
 
         sbufReadU16(src); //Was min_throttle
@@ -2394,7 +2394,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_INAV_SET_MISC:
-        if (dataSize == 41) {
+        if (dataSize >= 41) {
             sbufReadU16(src);       // midrc
 
             sbufReadU16(src);   // was min_throttle
@@ -2465,7 +2465,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_INAV_SET_BATTERY_CONFIG:
-        if (dataSize == 29) {
+        if (dataSize >= 29) {
 #ifdef USE_ADC
             batteryMetersConfigMutable()->voltage.scale = sbufReadU16(src);
             batteryMetersConfigMutable()->voltageSource = sbufReadU8(src);
@@ -2511,7 +2511,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_MOTOR:
-        if (dataSize == 8 * sizeof(uint16_t)) {
+        if (dataSize >= 8 * sizeof(uint16_t)) {
             for (int i = 0; i < 8; i++) {
                 const int16_t disarmed = sbufReadU16(src);
                 if (i < MAX_SUPPORTED_MOTORS) {
@@ -2523,7 +2523,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_SERVO_CONFIGURATION:
-        if (dataSize != (1 + 14)) {
+        if (dataSize < (1 + 14)) {
             return MSP_RESULT_ERROR;
         }
         tmp_u8 = sbufReadU8(src);
@@ -2539,7 +2539,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_INAV_SET_SERVO_CONFIG:
-        if (dataSize != 8) {
+        if (dataSize < 8) {
             return MSP_RESULT_ERROR;
         }
         tmp_u8 = sbufReadU8(src);
@@ -2552,7 +2552,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP_SET_SERVO_MIX_RULE:
         sbufReadU8Safe(&tmp_u8, src);
-        if ((dataSize == 9) && (tmp_u8 < MAX_SERVO_RULES)) {
+        if ((dataSize >= 9) && (tmp_u8 < MAX_SERVO_RULES)) {
             customServoMixersMutable(tmp_u8)->targetChannel = sbufReadU8(src);
             customServoMixersMutable(tmp_u8)->inputSource = sbufReadU8(src);
             customServoMixersMutable(tmp_u8)->rate = sbufReadU16(src);
@@ -2566,7 +2566,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP2_INAV_SET_SERVO_MIXER:
         sbufReadU8Safe(&tmp_u8, src);
-        if ((dataSize == 7) && (tmp_u8 < MAX_SERVO_RULES)) {
+        if ((dataSize >= 7) && (tmp_u8 < MAX_SERVO_RULES)) {
             customServoMixersMutable(tmp_u8)->targetChannel = sbufReadU8(src);
             customServoMixersMutable(tmp_u8)->inputSource = sbufReadU8(src);
             customServoMixersMutable(tmp_u8)->rate = sbufReadU16(src);
@@ -2583,7 +2583,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #ifdef USE_PROGRAMMING_FRAMEWORK
     case MSP2_INAV_SET_LOGIC_CONDITIONS:
         sbufReadU8Safe(&tmp_u8, src);
-        if ((dataSize == 15) && (tmp_u8 < MAX_LOGIC_CONDITIONS)) {
+        if ((dataSize >= 15) && (tmp_u8 < MAX_LOGIC_CONDITIONS)) {
             logicConditionsMutable(tmp_u8)->enabled = sbufReadU8(src);
             logicConditionsMutable(tmp_u8)->activatorId = sbufReadU8(src);
             logicConditionsMutable(tmp_u8)->operation = sbufReadU8(src);
@@ -2598,7 +2598,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP2_INAV_SET_PROGRAMMING_PID:
         sbufReadU8Safe(&tmp_u8, src);
-        if ((dataSize == 20) && (tmp_u8 < MAX_PROGRAMMING_PID_COUNT)) {
+        if ((dataSize >= 20) && (tmp_u8 < MAX_PROGRAMMING_PID_COUNT)) {
             programmingPidsMutable(tmp_u8)->enabled = sbufReadU8(src);
             programmingPidsMutable(tmp_u8)->setpoint.type = sbufReadU8(src);
             programmingPidsMutable(tmp_u8)->setpoint.value = sbufReadU32(src);
@@ -2616,7 +2616,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_INAV_SET_GVAR:
-        if (dataSize != 5) {
+        if (dataSize < 5) {
             return MSP_RESULT_ERROR;
         }
         {
@@ -2743,7 +2743,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
 #if defined(USE_RX_MSP) && defined(USE_MSP_RC_OVERRIDE)
     case MSP2_INAV_FLIGHT_AXIS_ANGLE_OVERRIDE:
-        if (dataSize != 7) {
+        if (dataSize < 7) {
             return MSP_RESULT_ERROR;
         }
         {
@@ -2756,7 +2756,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_INAV_FLIGHT_AXIS_RATE_OVERRIDE:
-        if (dataSize != 7) {
+        if (dataSize < 7) {
             return MSP_RESULT_ERROR;
         }
         {
@@ -2770,7 +2770,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #endif
     case MSP2_COMMON_SET_MOTOR_MIXER:
         sbufReadU8Safe(&tmp_u8, src);
-        if ((dataSize == 9) && (tmp_u8 < MAX_SUPPORTED_MOTORS)) {
+        if ((dataSize >= 9) && (tmp_u8 < MAX_SUPPORTED_MOTORS)) {
             primaryMotorMixerMutable(tmp_u8)->throttle = constrainf(sbufReadU16(src) / 1000.0f, 0.0f, 4.0f) - 2.0f;
             primaryMotorMixerMutable(tmp_u8)->roll = constrainf(sbufReadU16(src) / 1000.0f, 0.0f, 4.0f) - 2.0f;
             primaryMotorMixerMutable(tmp_u8)->pitch = constrainf(sbufReadU16(src) / 1000.0f, 0.0f, 4.0f) - 2.0f;
@@ -2780,7 +2780,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_3D:
-        if (dataSize == 6) {
+        if (dataSize >= 6) {
             reversibleMotorsConfigMutable()->deadband_low = sbufReadU16(src);
             reversibleMotorsConfigMutable()->deadband_high = sbufReadU16(src);
             reversibleMotorsConfigMutable()->neutral = sbufReadU16(src);
@@ -2789,7 +2789,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_RC_DEADBAND:
-        if (dataSize == 5) {
+        if (dataSize >= 5) {
             rcControlsConfigMutable()->deadband = sbufReadU8(src);
             rcControlsConfigMutable()->yaw_deadband = sbufReadU8(src);
             rcControlsConfigMutable()->alt_hold_deadband = sbufReadU8(src);
@@ -2803,7 +2803,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_SENSOR_ALIGNMENT:
-        if (dataSize == 4) {
+        if (dataSize >= 4) {
             sbufReadU8(src); // was gyroConfigMutable()->gyro_align
             sbufReadU8(src); // was accelerometerConfigMutable()->acc_align
 #ifdef USE_MAG
@@ -2821,7 +2821,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_ADVANCED_CONFIG:
-        if (dataSize == 9) {
+        if (dataSize >= 9) {
             sbufReadU8(src);    // gyroConfig()->gyroSyncDenominator
             sbufReadU8(src);    // BF: masterConfig.pid_process_denom
             sbufReadU8(src);    // BF: motorConfig()->useUnsyncedPwm
@@ -2875,7 +2875,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_PID_ADVANCED:
-        if (dataSize == 17) {
+        if (dataSize >= 17) {
             sbufReadU16(src);   // pidProfileMutable()->rollPitchItermIgnoreRate
             sbufReadU16(src);   // pidProfileMutable()->yawItermIgnoreRate
             sbufReadU16(src); //pidProfile()->yaw_p_limit
@@ -2898,7 +2898,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_INAV_PID:
-        if (dataSize == 15) {
+        if (dataSize >= 15) {
             sbufReadU8(src);  //Legacy, no longer in use async processing value
             sbufReadU16(src);  //Legacy, no longer in use async processing value
             sbufReadU16(src);  //Legacy, no longer in use async processing value
@@ -2916,7 +2916,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_SENSOR_CONFIG:
-        if (dataSize == 6) {
+        if (dataSize >= 6) {
             accelerometerConfigMutable()->acc_hardware = sbufReadU8(src);
 #ifdef USE_BARO
             barometerConfigMutable()->baro_hardware = sbufReadU8(src);
@@ -2948,7 +2948,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_NAV_POSHOLD:
-        if (dataSize == 13) {
+        if (dataSize >= 13) {
             navConfigMutable()->general.flags.user_control_mode = sbufReadU8(src);
             navConfigMutable()->general.max_auto_speed = sbufReadU16(src);
             if (mixerConfig()->platformType == PLATFORM_AIRPLANE) {
@@ -2970,7 +2970,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_RTH_AND_LAND_CONFIG:
-        if (dataSize == 21) {
+        if (dataSize >= 21) {
             navConfigMutable()->general.min_rth_distance = sbufReadU16(src);
             navConfigMutable()->general.flags.rth_climb_first = sbufReadU8(src);
             navConfigMutable()->general.flags.rth_climb_ignore_emerg = sbufReadU8(src);
@@ -2989,7 +2989,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_FW_CONFIG:
-        if (dataSize == 12) {
+        if (dataSize >= 12) {
             currentBatteryProfileMutable->nav.fw.cruise_throttle = sbufReadU16(src);
             currentBatteryProfileMutable->nav.fw.min_throttle = sbufReadU16(src);
             currentBatteryProfileMutable->nav.fw.max_throttle = sbufReadU16(src);
@@ -3035,7 +3035,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_POSITION_ESTIMATION_CONFIG:
-        if (dataSize == 12) {
+        if (dataSize >= 12) {
             positionEstimationConfigMutable()->w_z_baro_p = constrainf(sbufReadU16(src) / 100.0f, 0.0f, 10.0f);
             positionEstimationConfigMutable()->w_z_gps_p = constrainf(sbufReadU16(src) / 100.0f, 0.0f, 10.0f);
             positionEstimationConfigMutable()->w_z_gps_v = constrainf(sbufReadU16(src) / 100.0f, 0.0f, 10.0f);
@@ -3094,7 +3094,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #ifdef USE_BLACKBOX
     case MSP2_SET_BLACKBOX_CONFIG:
         // Don't allow config to be updated while Blackbox is logging
-        if ((dataSize == 9) && blackboxMayEditConfig()) {
+        if ((dataSize >= 9) && blackboxMayEditConfig()) {
             blackboxConfigMutable()->device = sbufReadU8(src);
             blackboxConfigMutable()->rate_num = sbufReadU16(src);
             blackboxConfigMutable()->rate_denom = sbufReadU16(src);
@@ -3136,7 +3136,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_INAV_OSD_UPDATE_POSITION: {
-        if (dataSize == 3) {
+        if (dataSize >= 3) {
             uint8_t item;
             sbufReadU8Safe(&item, src);
             if (item >= OSD_ITEM_COUNT) {
@@ -3287,7 +3287,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
 #ifdef USE_GPS
     case MSP_SET_RAW_GPS:
-        if (dataSize == 14) {
+        if (dataSize >= 14) {
 	    gpsSol.fixType = sbufReadU8(src);
 	    if (gpsSol.fixType) {
 		ENABLE_STATE(GPS_FIX);
@@ -3317,7 +3317,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #endif
 
     case MSP_SET_WP:
-        if (dataSize == 21) {
+        if (dataSize >= 21) {
 
             const uint8_t msp_wp_no = sbufReadU8(src);     // get the waypoint number
             navWaypoint_t msp_wp;
@@ -3349,7 +3349,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
         break;
     case MSP2_COMMON_SET_RADAR_POS:
-        if (dataSize == 19) {
+        if (dataSize >= 19) {
             const uint8_t msp_radar_no = MIN(sbufReadU8(src), RADAR_MAX_POIS - 1); // Radar poi number, 0 to 3
             radar_pois[msp_radar_no].state = sbufReadU8(src);                      // 0=undefined, 1=armed, 2=lost
             radar_pois[msp_radar_no].gps.lat = sbufReadU32(src);                   // lat 10E7
@@ -3363,7 +3363,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_FEATURE:
-        if (dataSize == 4) {
+        if (dataSize >= 4) {
             featureClearAll();
             featureSet(sbufReadU32(src)); // features bitmap
             rxUpdateRSSISource(); // For FEATURE_RSSI_ADC
@@ -3372,7 +3372,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_BOARD_ALIGNMENT:
-        if (dataSize == 6) {
+        if (dataSize >= 6) {
             boardAlignmentMutable()->rollDeciDegrees = sbufReadU16(src);
             boardAlignmentMutable()->pitchDeciDegrees = sbufReadU16(src);
             boardAlignmentMutable()->yawDeciDegrees = sbufReadU16(src);
@@ -3381,7 +3381,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_VOLTAGE_METER_CONFIG:
-        if (dataSize == 4) {
+        if (dataSize >= 4) {
 #ifdef USE_ADC
             batteryMetersConfigMutable()->voltage.scale = sbufReadU8(src) * 10;
             currentBatteryProfileMutable->voltage.cellMin = sbufReadU8(src) * 10;
@@ -3398,7 +3398,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_CURRENT_METER_CONFIG:
-        if (dataSize == 7) {
+        if (dataSize >= 7) {
             batteryMetersConfigMutable()->current.scale = sbufReadU16(src);
             batteryMetersConfigMutable()->current.offset = sbufReadU16(src);
             batteryMetersConfigMutable()->current.type = sbufReadU8(src);
@@ -3408,7 +3408,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_MIXER:
-        if (dataSize == 1) {
+        if (dataSize >= 1) {
             sbufReadU8(src); //This is ignored, no longer supporting mixerMode
             mixerUpdateStateFlags();    // Required for correct preset functionality
         } else
@@ -3416,7 +3416,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_RX_CONFIG:
-        if (dataSize == 24) {
+        if (dataSize >= 24) {
             rxConfigMutable()->serialrx_provider = sbufReadU8(src);
             rxConfigMutable()->maxcheck = sbufReadU16(src);
             sbufReadU16(src); // midrc
@@ -3485,7 +3485,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #endif
 
     case MSP_SET_FAILSAFE_CONFIG:
-        if (dataSize == 20) {
+        if (dataSize >= 20) {
             failsafeConfigMutable()->failsafe_delay = sbufReadU8(src);
             failsafeConfigMutable()->failsafe_off_delay = sbufReadU8(src);
             currentBatteryProfileMutable->failsafe_throttle = sbufReadU16(src);
@@ -3505,7 +3505,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP_SET_RSSI_CONFIG:
         sbufReadU8Safe(&tmp_u8, src);
-        if ((dataSize == 1) && (tmp_u8 <= MAX_SUPPORTED_RC_CHANNEL_COUNT)) {
+        if ((dataSize >= 1) && (tmp_u8 <= MAX_SUPPORTED_RC_CHANNEL_COUNT)) {
             rxConfigMutable()->rssi_channel = tmp_u8;
             rxUpdateRSSISource();
         } else {
@@ -3514,7 +3514,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_RX_MAP:
-        if (dataSize == MAX_MAPPABLE_RX_INPUTS) {
+        if (dataSize >= MAX_MAPPABLE_RX_INPUTS) {
             for (int i = 0; i < MAX_MAPPABLE_RX_INPUTS; i++) {
                 rxConfigMutable()->rcmap[i] = sbufReadU8(src);
             }
@@ -3552,7 +3552,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
 #ifdef USE_LED_STRIP
     case MSP_SET_LED_COLORS:
-        if (dataSize == LED_CONFIGURABLE_COLOR_COUNT * 4) {
+        if (dataSize >= LED_CONFIGURABLE_COLOR_COUNT * 4) {
             for (int i = 0; i < LED_CONFIGURABLE_COLOR_COUNT; i++) {
                 hsvColor_t *color = &ledStripConfigMutable()->colors[i];
                 color->h = sbufReadU16(src);
@@ -3564,7 +3564,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_LED_STRIP_CONFIG:
-        if (dataSize == (1 + sizeof(uint32_t))) {
+        if (dataSize >= (1 + sizeof(uint32_t))) {
             tmp_u8 = sbufReadU8(src);
             if (tmp_u8 >= LED_MAX_STRIP_LENGTH) {
                 return MSP_RESULT_ERROR;
@@ -3586,7 +3586,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_INAV_SET_LED_STRIP_CONFIG_EX:
-        if (dataSize == (1 + sizeof(ledConfig_t))) {
+        if (dataSize >= (1 + sizeof(ledConfig_t))) {
             tmp_u8 = sbufReadU8(src);
             if (tmp_u8 >= LED_MAX_STRIP_LENGTH) {
                 return MSP_RESULT_ERROR;
@@ -3599,7 +3599,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP_SET_LED_STRIP_MODECOLOR:
-        if (dataSize == 3) {
+        if (dataSize >= 3) {
             ledModeIndex_e modeIdx = sbufReadU8(src);
             int funIdx = sbufReadU8(src);
             int color = sbufReadU8(src);
@@ -3626,7 +3626,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #endif
 
     case MSP_SET_RTC:
-        if (dataSize == 6) {
+        if (dataSize >= 6) {
             // Use seconds and milliseconds to make senders
             // easier to implement. Generating a 64 bit value
             // might not be trivial in some platforms.
@@ -3661,9 +3661,9 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_COMMON_SET_TZ:
-        if (dataSize == 2)
+        if (dataSize >= 2)
             timeConfigMutable()->tz_offset = (int16_t)sbufReadU16(src);
-        else if (dataSize == 3) {
+        else if (dataSize >= 3) {
             timeConfigMutable()->tz_offset = (int16_t)sbufReadU16(src);
             timeConfigMutable()->tz_automatic_dst = (uint8_t)sbufReadU8(src);
         } else
@@ -3671,7 +3671,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         break;
 
     case MSP2_INAV_SET_MIXER:
-        if (dataSize == 9) {
+        if (dataSize >= 9) {
 	    mixerConfigMutable()->motorDirectionInverted = sbufReadU8(src);
 	    sbufReadU8(src); // Was yaw_jump_prevention_limit
         mixerConfigMutable()->motorstopOnLow = sbufReadU8(src);
@@ -3715,7 +3715,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP2_INAV_OSD_SET_ALARMS:
         {
-            if (dataSize == 24) {
+            if (dataSize >= 24) {
                 osdConfigMutable()->rssi_alarm = sbufReadU8(src);
                 osdConfigMutable()->time_alarm = sbufReadU16(src);
                 osdConfigMutable()->alt_alarm = sbufReadU16(src);
@@ -3743,9 +3743,9 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
     case MSP2_INAV_OSD_SET_PREFERENCES:
         {
             if (
-                    dataSize == 9
+                    dataSize >= 9
 #ifdef USE_ADSB
-                    || dataSize == 10
+                    || dataSize >= 10
 #endif
             ) {
                 osdConfigMutable()->video_system = sbufReadU8(src);
@@ -3758,7 +3758,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
                 osdConfigMutable()->units = sbufReadU8(src);
                 osdConfigMutable()->stats_energy_unit = sbufReadU8(src);
 #ifdef USE_ADSB
-                if(dataSize == 10) {
+                if(dataSize >= 10) {
                     osdConfigMutable()->adsb_warning_style = sbufReadU8(src);
                 }
 #endif
@@ -3772,7 +3772,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP2_INAV_SET_MC_BRAKING:
 #ifdef USE_MR_BRAKING_MODE
-        if (dataSize == 14) {
+        if (dataSize >= 14) {
             navConfigMutable()->mc.braking_speed_threshold = sbufReadU16(src);
             navConfigMutable()->mc.braking_disengage_speed = sbufReadU16(src);
             navConfigMutable()->mc.braking_timeout = sbufReadU16(src);
@@ -3804,7 +3804,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
 #ifdef USE_TEMPERATURE_SENSOR
     case MSP2_INAV_SET_TEMP_SENSOR_CONFIG:
-        if (dataSize == sizeof(tempSensorConfig_t) * MAX_TEMP_SENSORS) {
+        if (dataSize >= sizeof(tempSensorConfig_t) * MAX_TEMP_SENSORS) {
             for (uint8_t index = 0; index < MAX_TEMP_SENSORS; ++index) {
                 tempSensorConfig_t *sensorConfig = tempSensorConfigMutable(index);
                 sensorConfig->type = sbufReadU8(src);
@@ -3849,7 +3849,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #endif
 #ifdef USE_SAFE_HOME
     case MSP2_INAV_SET_SAFEHOME:
-        if (dataSize == 10) {
+        if (dataSize >= 10) {
             uint8_t i;
             if (!sbufReadU8Safe(&i, src) || i >= MAX_SAFE_HOMES) {
                 return MSP_RESULT_ERROR;
@@ -3868,7 +3868,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
 #ifdef USE_FW_AUTOLAND
     case MSP2_INAV_SET_FW_APPROACH:
-        if (dataSize == 15) {
+        if (dataSize >= 15) {
             uint8_t i;
             if (!sbufReadU8Safe(&i, src) || i >= MAX_FW_LAND_APPOACH_SETTINGS) {
                 return MSP_RESULT_ERROR;
@@ -3900,7 +3900,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
 #ifdef USE_GEOZONE
     case MSP2_INAV_SET_GEOZONE:
-        if (dataSize == 14) {
+        if (dataSize >= 14) {
             uint8_t geozoneId;
             if (!sbufReadU8Safe(&geozoneId, src) || geozoneId >= MAX_GEOZONES_IN_CONFIG) {
                 return MSP_RESULT_ERROR;
@@ -3919,7 +3919,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         }
         break;
     case MSP2_INAV_SET_GEOZONE_VERTEX:
-        if (dataSize == 10 || dataSize == 14) {
+        if (dataSize >= 10) {
             uint8_t geozoneId = 0;
             if (!sbufReadU8Safe(&geozoneId, src) || geozoneId >= MAX_GEOZONES_IN_CONFIG) {
                 return MSP_RESULT_ERROR;
@@ -3931,7 +3931,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
                 return MSP_RESULT_ERROR;
             }
 
-            if (geoZonesConfig(geozoneId)->shape == GEOZONE_SHAPE_CIRCULAR) {
+            if (geoZonesConfig(geozoneId)->shape == GEOZONE_SHAPE_CIRCULAR && dataSize >= 14) {
                 if (!geozoneSetVertex(geozoneId, vertexId + 1, sbufReadU32(src), 0)) {
                     return MSP_RESULT_ERROR;
                 }
@@ -3947,7 +3947,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
     case MSP2_INAV_EZ_TUNE_SET:
         {
 
-            if (dataSize < 10 || dataSize > 11) {
+            if (dataSize < 10) {
                 return MSP_RESULT_ERROR;
             }
 
@@ -3961,7 +3961,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
             ezTuneMutable()->rate = sbufReadU8(src);
             ezTuneMutable()->expo = sbufReadU8(src);
 
-            if (dataSize == 11) {
+            if (dataSize >= 11) {
                 ezTuneMutable()->snappiness = sbufReadU8(src);
             }
             ezTuneUpdate();
@@ -3974,7 +3974,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 
     case MSP2_INAV_SET_RATE_DYNAMICS:
 
-        if (dataSize == 6) {
+        if (dataSize >= 6) {
             ((controlConfig_t*)currentControlProfile)->rateDynamics.sensitivityCenter = sbufReadU8(src);
             ((controlConfig_t*)currentControlProfile)->rateDynamics.sensitivityEnd = sbufReadU8(src);
             ((controlConfig_t*)currentControlProfile)->rateDynamics.correctionCenter = sbufReadU8(src);
@@ -3992,7 +3992,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
 #ifdef USE_PROGRAMMING_FRAMEWORK
     case MSP2_INAV_SET_CUSTOM_OSD_ELEMENTS:
         sbufReadU8Safe(&tmp_u8, src);
-        if ((dataSize == (OSD_CUSTOM_ELEMENT_TEXT_SIZE - 1) + (CUSTOM_ELEMENTS_PARTS * 3) + 4) && (tmp_u8 < MAX_CUSTOM_ELEMENTS)) {
+        if ((dataSize >= (OSD_CUSTOM_ELEMENT_TEXT_SIZE - 1) + (CUSTOM_ELEMENTS_PARTS * 3) + 4) && (tmp_u8 < MAX_CUSTOM_ELEMENTS)) {
             for (int i = 0; i < CUSTOM_ELEMENTS_PARTS; i++) {
                 uint8_t type = sbufReadU8(src);
                 if (type >= CUSTOM_ELEMENT_TYPE_END)
@@ -4037,7 +4037,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
     case MSP2_INAV_SET_CRUISE_HEADING:
         // Set heading while Cruise / Course Hold is active.
         // Payload: I32  heading_centidegrees  (0–35999)
-        if (dataSize == 4) {
+        if (dataSize >= 4) {
             int32_t headingCd;
             if (sbufReadI32Safe(&headingCd, src) && navSetCruiseHeading(headingCd)) {
                 break;
@@ -4048,7 +4048,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
     case MSP2_INAV_SET_WP_INDEX:
         // Jump to waypoint N during an active WP mission.
         // Payload: U8  wp_index  (0-based, relative to mission start waypoint)
-        if (dataSize == 1) {
+        if (dataSize >= 1) {
             uint8_t wpIndex;
             if (sbufReadU8Safe(&wpIndex, src) && navSetActiveWaypointIndex(wpIndex)) {
                 break;
@@ -4069,7 +4069,7 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
         return MSP_RESULT_ERROR;
 
     case MSP2_INAV_ARM_DISARM:
-        if (dataSize == 1) {
+        if (dataSize >= 1) {
             uint8_t arm;
             if (sbufReadU8Safe(&arm, src) && arm <= 1 && fcSetArmState(arm)) {
                 break;
@@ -4839,7 +4839,7 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
 
 #if defined(USE_BARO) || defined(USE_GPS)
     case MSP2_INAV_SET_ALT_TARGET:
-        if (dataSize != (sizeof(int32_t) + sizeof(uint8_t))) {
+        if (dataSize < (sizeof(int32_t) + sizeof(uint8_t))) {
             *ret = MSP_RESULT_ERROR;
             break;
         }
@@ -4855,7 +4855,7 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
 #endif
 
     case MSP2_INAV_SET_LOCAL_TARGET:
-        if (dataSize != 3 * sizeof(int32_t) || !isGCSValid()) {
+        if (dataSize < 3 * sizeof(int32_t) || !isGCSValid()) {
             *ret = MSP_RESULT_ERROR;
             break;
         }
@@ -4902,7 +4902,7 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
         break;
 
     case MSP2_INAV_SET_GLOBAL_TARGET:
-        if ((dataSize != (3 * sizeof(int32_t) + sizeof(uint8_t)) && dataSize != (4 * sizeof(int32_t) + sizeof(uint8_t))) || !isGCSValid()) {
+        if (dataSize < (3 * sizeof(int32_t) + sizeof(uint8_t)) || !isGCSValid()) {
             *ret = MSP_RESULT_ERROR;
             break;
         }
@@ -4914,7 +4914,7 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
             targetLlh.alt = (int32_t)sbufReadU32(src);
 
             const geoAltitudeDatumFlag_e datumFlag = (geoAltitudeDatumFlag_e)sbufReadU8(src);
-            const bool hasLoiterRadius = dataSize == (4 * sizeof(int32_t) + sizeof(uint8_t));
+            const bool hasLoiterRadius = dataSize >= (4 * sizeof(int32_t) + sizeof(uint8_t));
             const int32_t loiterRadius = hasLoiterRadius ? (int32_t)sbufReadU32(src) : 0;
 
             if (datumFlag == NAV_WP_TERRAIN_DATUM || loiterRadius < 0) {
@@ -4991,7 +4991,7 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
         }
         break;
     case MSP2_INAV_SET_TIMER_OUTPUT_MODE:
-        if(dataSize == 2) {
+        if(dataSize >= 2) {
             uint8_t timer = sbufReadU8(src);
             uint8_t outputMode = sbufReadU8(src);
             if(timer < HARDWARE_TIMER_DEFINITION_COUNT) {

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -3930,7 +3930,10 @@ static mspResult_e mspFcProcessInCommand(uint16_t cmdMSP, sbuf_t *src)
                 return MSP_RESULT_ERROR;
             }
 
-            if (geoZonesConfig(geozoneId)->shape == GEOZONE_SHAPE_CIRCULAR && dataSize >= 14) {
+            if (geoZonesConfig(geozoneId)->shape == GEOZONE_SHAPE_CIRCULAR) {
+                if (dataSize < 14) {
+                    return MSP_RESULT_ERROR;
+                }
                 if (!geozoneSetVertex(geozoneId, vertexId + 1, sbufReadU32(src), 0)) {
                     return MSP_RESULT_ERROR;
                 }


### PR DESCRIPTION
## Summary

Apply the forward-compat MSP policy (2026-08-27) to the remaining strict-gate
SET handlers in `fc_msp.c`: MSP payloads only ever gain fields at the END, so
a configurator from a NEWER firmware version sending a longer message must be
accepted by older firmware — apply the known leading fields and ignore the
trailing bytes. Strict equality gates silently reject the whole message
(including the known fields) every time a field is appended.

This PR sweeps 62 gates in `mspFcProcessInCommand` from exact-size
(`dataSize == N` / `dataSize != N`) to minimum-size (`dataSize >= N` /
`dataSize < N`), keeping the existing `else return MSP_RESULT_ERROR` path so
shorter-than-required payloads are still rejected cleanly.

## Changes

- Converted gates (representative list; full list in commit message):
  - v1: `MSP_SET_MISC` (22), `MSP_SET_MOTOR` (16), `MSP_SET_SERVO_CONFIGURATION` (15),
    `MSP_SET_RC_DEADBAND` (5), `MSP_SET_SENSOR_ALIGNMENT` (4),
    `MSP_SET_ADVANCED_CONFIG` (9), `MSP_SET_PID_ADVANCED` (17),
    `MSP_SET_INAV_PID` (15), `MSP_SET_SENSOR_CONFIG` (6),
    `MSP_SET_NAV_POSHOLD` (13), `MSP_SET_RTH_AND_LAND_CONFIG` (21),
    `MSP_SET_FW_CONFIG` (12), `MSP_SET_POSITION_ESTIMATION_CONFIG` (12),
    `MSP_SET_RAW_GPS` (14), `MSP_SET_WP` (21), `MSP_SET_FEATURE` (4),
    `MSP_SET_BOARD_ALIGNMENT` (6), `MSP_SET_VOLTAGE_METER_CONFIG` (4),
    `MSP_SET_CURRENT_METER_CONFIG` (7), `MSP_SET_MIXER` (1),
    `MSP_SET_RX_CONFIG` (24), `MSP_SET_FAILSAFE_CONFIG` (20),
    `MSP_SET_RSSI_CONFIG` (1), `MSP_SET_RX_MAP` (4), `MSP_SET_3D` (6),
    `MSP_SET_MODE_RANGE` (5), `MSP_SET_ADJUSTMENT_RANGE` (7),
    `MSP_SET_SERVO_MIX_RULE` (9), `MSP_SET_LED_COLORS`,
    `MSP_SET_LED_STRIP_CONFIG`, `MSP_SET_LED_STRIP_MODECOLOR` (3),
    `MSP_SET_RTC` (6)
  - v2: `MSP2_SET_PID`, `MSP2_INAV_SET_MISC` (41),
    `MSP2_INAV_SET_BATTERY_CONFIG` (29), `MSP2_INAV_SET_SERVO_CONFIG` (8),
    `MSP2_INAV_SET_SERVO_MIXER` (7), `MSP2_INAV_SET_LOGIC_CONDITIONS` (15),
    `MSP2_INAV_SET_PROGRAMMING_PID` (20), `MSP2_INAV_SET_GVAR` (5),
    `MSP2_INAV_FLIGHT_AXIS_ANGLE_OVERRIDE` (7),
    `MSP2_INAV_FLIGHT_AXIS_RATE_OVERRIDE` (7),
    `MSP2_COMMON_SET_MOTOR_MIXER` (9), `MSP2_SET_BLACKBOX_CONFIG` (9),
    `MSP2_INAV_OSD_UPDATE_POSITION` (3), `MSP2_COMMON_SET_RADAR_POS` (19),
    `MSP2_INAV_SET_MIXER` (9), `MSP2_INAV_OSD_SET_ALARMS` (24),
    `MSP2_INAV_OSD_SET_PREFERENCES` (9/10), `MSP2_INAV_SET_MC_BRAKING` (14),
    `MSP2_INAV_SET_TEMP_SENSOR_CONFIG`, `MSP2_INAV_SET_SAFEHOME` (10),
    `MSP2_INAV_SET_FW_APPROACH` (15), `MSP2_INAV_SET_GEOZONE` (14),
    `MSP2_INAV_SET_GEOZONE_VERTEX` (10/14), `MSP2_INAV_EZ_TUNE_SET` (10/11),
    `MSP2_INAV_SET_RATE_DYNAMICS` (6), `MSP2_INAV_SET_CUSTOM_OSD_ELEMENTS`,
    `MSP2_INAV_SET_CRUISE_HEADING` (4), `MSP2_INAV_SET_WP_INDEX` (1),
    `MSP2_INAV_ARM_DISARM` (1), `MSP2_INAV_SET_ALT_TARGET` (5),
    `MSP2_INAV_SET_LOCAL_TARGET` (12), `MSP2_INAV_SET_GLOBAL_TARGET` (13/17),
    `MSP2_INAV_SET_TIMER_OUTPUT_MODE` (2)

- Each converted handler's read sequence consumes exactly N bytes (the gate
  constant), so trailing bytes are never read — no over-read, no partial
  state mutation from trailing garbage.
- Indexed handlers (MODE_RANGE, ADJUSTMENT_RANGE, SERVO_MIX_RULE,
  SERVO_MIXER, LOGIC_CONDITIONS, PROGRAMMING_PID, MOTOR_MIXER, RSSI_CONFIG,
  CUSTOM_OSD_ELEMENTS) keep their `tmp_u8 < MAX` index bounds checks.
- Two-size handlers (SET_TZ 2/3, OSD_SET_PREFERENCES 9/10,
  SET_GEOZONE_VERTEX 10/14, EZ_TUNE_SET 10/11, SET_GLOBAL_TARGET 13/17)
  keep inner `dataSize >=` guards so the optional trailing field is only
  read when actually present.
- `SET_GEOZONE_VERTEX`'s circular-shape extra u32 read is now gated on
  `dataSize >= 14`, which also fixes a latent over-read in the old
  10-byte + circular path.

## Kept strict (documented in survey.md)

- `MSP_PASSTHROUGH_SERIAL_FUNCTION_ID` / `MSP_PASSTHROUGH_ESC_4WAY` —
  commands, not config SETs
- `MSP2_COMMON_GET_RADAR_GPS` (dataflash read) — GET-like with optional length
- `MSP_WP_MISSION_LOAD` / `SAVE` — one-shot storage commands with a single
  reserved ID byte
- `MSP2_INAV_ACTIVATE_LANDING` / `ACTIVATE_RTH` — zero-payload action commands
- `MSP2_INAV_TIMER_OUTPUT_MODE` — query command (0=all, 1=one)

## Testing

- SITL build compiles clean (zero warnings/errors)
- `test_lenient_gates_spot.py` (new): 36/36 checks pass across 5
  representative handlers (RC_DEADBAND, RX_MAP, MIXER, BATTERY_CONFIG,
  RATE_DYNAMICS) — for each: exact-size applied, LONGER payload accepted with
  known fields applied + trailing ignored, SHORTER payload rejected with
  state unchanged
- `sitl_msp_smoke_test.py`: 29/29 pass (no regression in general MSP paths)
- Read-count audit: every converted handler's `sbufRead*` sequence sums to
  exactly the gate constant

## Code Review

Reviewed with the inav-code-review agent. Verdict: APPROVE after one fix.
The review verified: no over-reads (every converted handler's read sequence
consumes ≤ the gate constant), all nine indexed handlers keep their
`tmp_u8 < MAX` bounds checks, exact-size behavior preserved for every
handler, and the GEOZONE_VERTEX circular-shape extra-u32 read is now gated
on `dataSize >= 14` (which also fixes a latent over-read in the old
10-byte + circular path).

One defect found and fixed (`4080173`): the first pass changed
`MSP2_COMMON_SET_TZ`'s first branch to `dataSize >= 2`, which made the
`else if dataSize >= 3` branch unreachable — a 3-byte TZ message would
silently drop `tz_automatic_dst`. The 2-byte branch is exact again
(offset only), and only the 3-byte branch is lenient (offset + DST,
trailing ignored). Regression-guarded in `test_lenient_gates_spot.py`
(3-byte exact now verifies both fields applied).