### PR TITLE
Fix ADS-B stale calculated values when a slot is recycled

### DIFF
--- a/src/main/io/adsb.c
+++ b/src/main/io/adsb.c
@@ -235,8 +235,9 @@ void adsbNewVehicle(adsbVehicleValues_t* vehicleValuesLocal) {
 
         if (vehicle != NULL) {
             memcpy(&(vehicle->vehicleValues), vehicleValuesLocal, sizeof(vehicle->vehicleValues));
-            recalculateVehicle(vehicle);
+            // ttl must be set first: recalculateVehicle() early-returns while ttl == 0
             vehicle->ttl = MAX(0, ADSB_MAX_SECONDS_KEEP_INACTIVE_PLANE_IN_LIST - vehicleValuesLocal->tslc);
+            recalculateVehicle(vehicle);
             return;
         }
     }


### PR DESCRIPTION
## Summary

Fixes #11773: in `adsbNewVehicle()` (`src/main/io/adsb.c`), a newly claimed (recycled) vehicle slot could present a real vehicle's identity (ICAO, GPS position) paired with a *different*, expired vehicle's stale distance/bearing, still flagged `valid == true`, for up to one scheduler tick.

`recalculateVehicle()` opens with `if (vehicle->ttl == 0) return;`. In the GPS-mode branch of `adsbNewVehicle()`, the call happened **before** the new `ttl` was assigned, so on a slot claimed via `findFreeSpaceInList()` (which matches `ttl == 0`) the recalc was a guaranteed no-op, leaving the previous occupant's `calculatedVehicleValues` untouched until the next periodic recalc pass in `adsbTtlClean()`.

## Changes

- `src/main/io/adsb.c`: in the GPS-mode branch, assign `vehicle->ttl` **before** calling `recalculateVehicle(vehicle)` so the freshly claimed slot is recalculated immediately with the new vehicle's data.

The non-GPS branch is unchanged (it explicitly sets `calculatedVehicleValues.valid = false` and never calls `recalculateVehicle()`). The `adsbTtlClean()` call site already guards with `ttl > 0` and is unaffected.

Behavior note: an out-of-range vehicle (`dist > ADSB_LIMIT_CM`, 64 km) claiming a slot now drops the slot (`ttl = 0` inside recalc) instead of being kept active with stale values — matching how `adsbTtlClean()` treats out-of-range vehicles, and consistent with the fix's intent.

## Testing

- Built SITL + MATEKF722SE + SPEEDYBEEF405AIO via the inav-builder agent: all SUCCESS, zero warnings/errors for `adsb.c`.
- Code review performed with the inav-code-review agent — PASS, no critical issues.
- Not runtime-tested on hardware: requires a live ADS-B receiver with GPS fix to observe the one-tick window.

Note: `maintenance-10.x` contains the same out-of-order pattern in `adsbNewVehicle()` (recalc before ttl) and should receive this fix as a follow-up backport.

Fixes #11773
