### PR TITLE
Fix size-baseline publishing: check out repo before calling scripts

### DIFF
--- a/.github/scripts/fetch-size-baseline.sh
+++ b/.github/scripts/fetch-size-baseline.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 #
+# WARNING: This script is invoked from a GitHub Actions job via
+# `bash .github/scripts/...`. It MUST NEVER be called from a job that has
+# not first checked out a known branch (e.g. `- uses: actions/checkout@v4`
+# as the job's first step): the runner workspace is empty until then, so
+# the script doesn't exist and the call fails with exit 127, silently
+# reporting no baseline. Every job calling this script must check out
+# first.
+#
 # Fetch the size baseline for a PR's TRUE base commit — the merge-base of
 # the PR head and base ref — rather than the base branch's latest tip, so
 # the size-diff delta doesn't include unrelated changes merged to the base

--- a/.github/scripts/publish-size-baseline.sh
+++ b/.github/scripts/publish-size-baseline.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 #
+# WARNING: This script is invoked from a GitHub Actions job via
+# `bash .github/scripts/...`. It MUST NEVER be called from a job that has
+# not first checked out a known branch (e.g. `- uses: actions/checkout@v4`
+# as the job's first step): the runner workspace is empty until then, so
+# the script doesn't exist and the call fails with exit 127, silently
+# publishing nothing. Every job calling this script must check out first.
+#
 # Publish the nightly size report as release assets in the companion
 # pr-test-builds repo, keyed by BRANCH (latest-tip pointer, kept for
 # backward compatibility) AND by COMMIT SHA (primary — lets PR size-diff

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -103,6 +103,13 @@ every PR.
 `.github/scripts/size-diff-comment.js` (pure diff + markdown rendering,
 unit tested in `.github/scripts/size-diff-comment.test.js`)
 
+**⚠️ Every job that calls a `.github/scripts/` file MUST first run
+`- uses: actions/checkout@v4` as its first step.** The runner workspace is
+empty until a checkout — `bash .github/scripts/...` then fails with exit
+127 and the job silently does nothing, so a missing checkout looks like a
+missing baseline/artifact instead of a broken job. Repo scripts MUST NEVER
+be invoked from a job that has not checked out a known branch first.
+
 **Uses the same `PR_BUILDS_TOKEN` secret and `workflow_run` trigger pattern
 as `pr-test-builds.yml`** (secrets available even for fork PRs).
 

--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -48,6 +48,14 @@ jobs:
     permissions:
       actions: read   # to download artifacts and query job conclusions from the triggering workflow run
     steps:
+      # REQUIRED FIRST STEP: check out a known branch before any step calls
+      # a script from .github/scripts/. Repo scripts MUST NEVER be invoked
+      # from a job that has not checked out first: the runner workspace is
+      # empty until a checkout, so `bash .github/scripts/...` fails with
+      # exit 127 and the job silently publishes nothing. workflow_run runs
+      # this file from the default branch, so checkout's default ref is the
+      # trusted one to use.
+      - uses: actions/checkout@v4
       # Don't gate on github.event.workflow_run.conclusion: "Build
       # pre-release" also runs a separate Release job (nightly upload to
       # iNavFlight/inav-nightly) that can fail for reasons unrelated to the

--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -47,6 +47,7 @@ jobs:
       cancel-in-progress: true
     permissions:
       actions: read   # to download artifacts and query job conclusions from the triggering workflow run
+      contents: read  # for the checkout step (scripts live in this repo)
     steps:
       # REQUIRED FIRST STEP: check out a known branch before any step calls
       # a script from .github/scripts/. Repo scripts MUST NEVER be invoked


### PR DESCRIPTION
## Summary

Fixes the regression from PR #11835: the `publish-baseline` job in `.github/workflows/ci-size-report.yml` calls `.github/scripts/publish-size-baseline.sh` but has **no `actions/checkout@v4` step**, so the runner workspace is empty and every nightly publish fails with `bash: .github/scripts/publish-size-baseline.sh: No such file or directory` (exit 127). No per-commit size baselines have been published since #11835 merged, and every PR's size-diff comment reports "no size baseline is available yet for this PR's base commit" (e.g. #11839).

## Changes

- **`.github/workflows/ci-size-report.yml`**: add `- uses: actions/checkout@v4` as the **first step** of the `publish-baseline` job, with a comment explaining the requirement. (`workflow_run` runs this file from the default branch, so the default checkout ref is the trusted one.) Also declare `contents: read` for the checkout, matching the sibling `pr-comment` job.
- **`.github/scripts/publish-size-baseline.sh`** and **`.github/scripts/fetch-size-baseline.sh`**: header WARNING comments — repo scripts must NEVER be invoked from a job that has not checked out a known branch first (empty workspace → exit 127 → silent no-op).
- **`.github/workflows/README.md`**: ⚠️ note that every job calling a `.github/scripts/` file must first run `actions/checkout@v4`.

## Testing

- `bash -n` on both scripts — clean.
- YAML parses; `publish-baseline` steps verified (checkout first, publish step intact).
- `node --test .github/scripts/size-diff-comment.test.js` — 23/23 pass.
- Audited `ci.yml`, `nightly-build.yml`, `pr-test-builds.yml`: all other jobs that invoke `.github/scripts/` already check out first; `publish-baseline` was the only one missing it.
- Code review performed with the inav-code-review agent — PASS.

## Note on propagation

`workflow_run` executes the workflow file from the repo's **default branch (master)**. This fix lands on `release/9.1` first per the normal flow; it must reach `master` (via the usual release/9.1 → master merge) for nightly `publish-baseline` runs to pick it up.

Fixes the #11835 regression
