### PR TITLE
Terrain - dedicated OSD element

### DIFF
--- a/docs/Terrain.md
+++ b/docs/Terrain.md
@@ -61,10 +61,14 @@ Copying can be done via **iNav MSC (Mass Storage Class)** is not recommended.
 
 # Enabling and Displaying Terrain Data
 
-To display altitude above terrain in iNav, the OSD element **“Rangefinder distance”** must be enabled. If terrain data are
-available on the SD card and no valid data are available from a dedicated rangefinder, the value calculated by the terrain
-system will be displayed. If a rangefinder is present and providing valid data, its measurements always take priority and the
-actual distance to the ground will be shown.
+There are two OSD elements that can display altitude above terrain:
+
+- **“Terrain AGL”** — a dedicated element that shows the altitude above ground level calculated **exclusively by the terrain
+  subsystem**. Rangefinder measurements are never shown by this element. If no valid terrain value is available, dashes are
+  displayed. Use this element if you want to see the terrain-derived value regardless of whether a rangefinder is fitted.
+- **“Rangefinder distance”** — behaves as before. If a rangefinder is present and providing valid data, its measurements
+  always take priority and the actual distance to the ground is shown. Only when no valid rangefinder data are available and
+  terrain data are present on the SD card is the value calculated by the terrain system displayed instead.
 
 Loading terrain data from the SD card is enabled via the CLI using the following command:
 
@@ -82,7 +86,7 @@ display dropouts, or automatic disabling of the feature during flight. Using a q
 stability and reliability of the terrain feature.
 
 # Troubleshooting
-- OSD shows no terrain value / "Rangefinder distance" is dash:
+- OSD shows no terrain value / "Terrain AGL" or "Rangefinder distance" is dash:
   - Verify `terrain_enabled = ON` is set and saved (`set terrain_enabled = ON` → `save` → reboot)
   - Confirm the SD card is mounted: check `status` in the CLI for SD card state
   - Confirm a valid GPS fix is present before expecting any terrain value to appear

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2502,7 +2502,6 @@ static bool osdDrawSingleElement(uint8_t item)
 #elif defined(USE_TERRAIN)
             range = terrainGetLastDistanceCm();
 #endif
-
             if (range < 0) {
                 buff[0] = buff[1] = buff[2] = '-';
             } else {
@@ -2511,7 +2510,21 @@ static bool osdDrawSingleElement(uint8_t item)
         }
             break;
 #endif
-
+#ifdef USE_TERRAIN
+        case OSD_TERRAIN_AGL:
+        {
+            int32_t range =  terrainGetLastDistanceCm();
+            if (range < 0) {
+                for(uint8_t i = 1; i < osdConfig()->decimals_altitude + 1; i++){
+                    buff[i] = '-';
+                }
+            } else {
+                osdFormatAltitudeSymbol(buff, range);
+            }
+            buff[0] = SYM_TERRAIN_FOLLOWING;
+            break;
+        }
+#endif
     case OSD_ONTIME:
         {
             osdFormatOnTime(buff);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -233,7 +233,7 @@ static bool osdDisplayHasCanvas;
 #define AH_MAX_PITCH_DEFAULT 20 // Specify default maximum AHI pitch value displayed (degrees)
 
 PG_REGISTER_WITH_RESET_TEMPLATE(osdConfig_t, osdConfig, PG_OSD_CONFIG, 0);
-PG_REGISTER_WITH_RESET_FN(osdLayoutsConfig_t, osdLayoutsConfig, PG_OSD_LAYOUTS_CONFIG, 3);
+PG_REGISTER_WITH_RESET_FN(osdLayoutsConfig_t, osdLayoutsConfig, PG_OSD_LAYOUTS_CONFIG, 4);
 
 /* OSD formatting helpers replacing common tfp_sprintf patterns
  * for reduced code size and CPU overhead. */

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -379,6 +379,7 @@ typedef enum {
     OSD_THROTTLE_GAUGE,
     OSD_GPS_EXTRA_STATS,
     OSD_AUTO_SPEED,  // 170
+    OSD_TERRAIN_AGL, // 171,
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 


### PR DESCRIPTION
This PR **is not** mandatory for terrain functionality.  


INAV CONFIGURATOR PR:  https://github.com/iNavFlight/inav-configurator/pull/2728

Dedicated OSD element was requested by Jetrel. Originally is terrain value showed in "distance" OSD element, it shared with real ranger finder. New OSD element is special only for AGL from terrain. 

<img width="374" height="369" alt="image" src="https://github.com/user-attachments/assets/084b1c9b-8f14-4a90-a1fd-a0dee3a10080" />

<img width="564" height="892" alt="image" src="https://github.com/user-attachments/assets/5c24ef41-a2b8-412f-87f6-8dc1ab4b7cfd" />



