### PR TITLE
ci: publish .uf2 test builds (RP2350) alongside .hex in PR releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y install ninja-build
+        # picotool is required to generate .uf2 images (RP2350 targets upload
+        # them alongside .hex); unavailable on the base image.
+        run: sudo apt-get update && sudo apt-get -y install ninja-build picotool
       - name: Setup environment
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -127,7 +129,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: matrix-${{ env.BUILD_NAME }}.${{ matrix.id }}
-          path: ./build/*.hex
+          path: |
+            ./build/*.hex
+            ./build/*.uf2
           retention-days: 1
       - name: Upload size report
         uses: actions/upload-artifact@v4
@@ -143,7 +147,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y install ninja-build
+        # picotool is required to generate .uf2 images (RP2350 targets upload
+        # them alongside .hex); unavailable on the base image.
+        run: sudo apt-get update && sudo apt-get -y install ninja-build picotool
       - name: Setup environment
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -167,7 +173,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: matrix-${{ env.BUILD_NAME }}.single
-          path: ./build/*.hex
+          path: |
+            ./build/*.hex
+            ./build/*.uf2
           retention-days: 1
       - name: Upload size report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        # picotool is required to generate .uf2 images (RP2350 targets upload
-        # them alongside .hex); unavailable on the base image.
-        run: sudo apt-get update && sudo apt-get -y install ninja-build picotool
+        run: sudo apt-get update && sudo apt-get -y install ninja-build
       - name: Setup environment
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -147,9 +145,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        # picotool is required to generate .uf2 images (RP2350 targets upload
-        # them alongside .hex); unavailable on the base image.
-        run: sudo apt-get update && sudo apt-get -y install ninja-build picotool
+        run: sudo apt-get update && sudo apt-get -y install ninja-build
       - name: Setup environment
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true

--- a/.github/workflows/pr-test-builds.yml
+++ b/.github/workflows/pr-test-builds.yml
@@ -86,10 +86,17 @@ jobs:
           PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
           printf '%s\n\n%s\n\n%s\n' \
             "Test build for [PR #${PR_NUMBER}](${PR_URL}) — commit \`${SHORT_SHA}\`" \
-            "**${HEX_COUNT} targets built.** Find your board's \`.hex\` file by name (e.g. \`MATEKF405SE.hex\`)." \
+            "**${HEX_COUNT} targets built.** Find your board's \`.hex\` file by name (e.g. \`MATEKF405SE.hex\`); targets that also publish a \`.uf2\` (e.g. \`RP2350_PICO\`) attach it alongside for BOOTSEL drag-and-drop flashing." \
             "> Development build for testing only. Use Full Chip Erase when flashing." \
             > release-notes.md
-          gh release create "pr-${PR_NUMBER}" hexes/*.hex \
+          # Attach .uf2 images when present (RP2350 targets publish them for
+          # BOOTSEL drag-and-drop). Build an explicit asset list so a PR that
+          # produced no .uf2 doesn't pass a literal unmatched glob to gh.
+          ASSETS=(hexes/*.hex)
+          if compgen -G "hexes/*.uf2" > /dev/null; then
+            ASSETS+=(hexes/*.uf2)
+          fi
+          gh release create "pr-${PR_NUMBER}" "${ASSETS[@]}" \
             --repo iNavFlight/pr-test-builds \
             --prerelease \
             --title "PR #${PR_NUMBER} (${SHORT_SHA})" \


### PR DESCRIPTION
## Summary

RP2350_PICO targets (see #11854) generate a **`.uf2`** image for BOOTSEL drag-and-drop flashing, in addition to the `.hex` that the PR test-builds workflow publishes. This PR makes CI carry that `.uf2` through to the pr-test-builds release.

## Changes

**`.github/workflows/ci.yml`**
- Upload `./build/*.uf2` alongside `./build/*.hex` in the firmware matrix job and the single-target job (multiline path; `upload-artifact@v4` unions the globs and defaults `if-no-files-found: warn`, so jobs/targets without a `.uf2` are unaffected).

**`.github/workflows/pr-test-builds.yml`**
- Attach `hexes/*.uf2` to the PR test-build release when present, guarded so PRs without a `.uf2` don't pass a literal unmatched glob to `gh release create`.
- Mention `.uf2` in the release notes.

No new CI dependency: the `.uf2` is produced by the RP2350 target's own cmake, which falls back to the in-tree `elf2uf2.py` (python3 — always on runners) when `picotool` isn't installed. (Do **not** `apt-get install picotool`: it isn't packaged in Ubuntu 24.04, which is what `ubuntu-latest` runs.)

## Notes for reviewers

- **Safe on branches without the RP2350 target** (e.g. upstream `maintenance-10.x` today): no `.uf2` files exist, so the upload glob matches nothing (warn-only) and the release asset list stays `.hex`-only. Verified: `upload-artifact@v4` defaults `if-no-files-found: warn`.
- **Not validated by this PR's own CI**: workflow changes run from the base branch, so the effect only appears once merged and a `.uf2`-producing target builds.
- Nightly/release builds are intentionally unchanged (hex-only).