### PR TITLE
ci: publish .uf2 test builds (RP2350) alongside .hex in PR releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: matrix-${{ env.BUILD_NAME }}.${{ matrix.id }}
-          path: ./build/*.hex
+          path: |
+            ./build/*.hex
+            ./build/*.uf2
           retention-days: 1
       - name: Upload size report
         uses: actions/upload-artifact@v4
@@ -167,7 +169,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: matrix-${{ env.BUILD_NAME }}.single
-          path: ./build/*.hex
+          path: |
+            ./build/*.hex
+            ./build/*.uf2
           retention-days: 1
       - name: Upload size report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-test-builds.yml
+++ b/.github/workflows/pr-test-builds.yml
@@ -86,10 +86,17 @@ jobs:
           PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
           printf '%s\n\n%s\n\n%s\n' \
             "Test build for [PR #${PR_NUMBER}](${PR_URL}) — commit \`${SHORT_SHA}\`" \
-            "**${HEX_COUNT} targets built.** Find your board's \`.hex\` file by name (e.g. \`MATEKF405SE.hex\`)." \
+            "**${HEX_COUNT} targets built.** Find your board's \`.hex\` file by name (e.g. \`MATEKF405SE.hex\`); targets that also publish a \`.uf2\` (e.g. \`RP2350_PICO\`) attach it alongside for BOOTSEL drag-and-drop flashing." \
             "> Development build for testing only. Use Full Chip Erase when flashing." \
             > release-notes.md
-          gh release create "pr-${PR_NUMBER}" hexes/*.hex \
+          # Attach .uf2 images when present (RP2350 targets publish them for
+          # BOOTSEL drag-and-drop). Build an explicit asset list so a PR that
+          # produced no .uf2 doesn't pass a literal unmatched glob to gh.
+          ASSETS=(hexes/*.hex)
+          if compgen -G "hexes/*.uf2" > /dev/null; then
+            ASSETS+=(hexes/*.uf2)
+          fi
+          gh release create "pr-${PR_NUMBER}" "${ASSETS[@]}" \
             --repo iNavFlight/pr-test-builds \
             --prerelease \
             --title "PR #${PR_NUMBER} (${SHORT_SHA})" \


### PR DESCRIPTION
## Summary

Backport of #11856 (already merged to `maintenance-10.x`) to **`release/9.1`**.

The `PR Test Builds` workflow is triggered by `workflow_run`, which executes from the **default branch (master)**. Since **master is fed from `release/9.1`**, this change must land on 9.1 (and then ride 9.1 → master) before PR test-build releases can attach `.uf2` images.

RP2350_PICO targets (see #11854) generate a `.uf2` for BOOTSEL drag-and-drop flashing in addition to the `.hex` that pr-test-builds publishes.

## Changes

**`.github/workflows/ci.yml`**
- Upload `./build/*.uf2` alongside `./build/*.hex` in the firmware matrix and single-target jobs (multiline path; `upload-artifact@v4` unions the globs and defaults `if-no-files-found: warn`, so jobs without a `.uf2` are unaffected).

**`.github/workflows/pr-test-builds.yml`**
- Attach `hexes/*.uf2` to the PR test-build release when present, guarded so PRs without a `.uf2` don't pass a literal unmatched glob to `gh release create`.
- Mention `.uf2` in the release notes.

The `.uf2` is produced by RP2350 targets via the in-tree `elf2uf2.py` (python3, always on runners) — **no picotool / apt dependency** (picotool isn't packaged in Ubuntu 24.04).

## Notes

- Byte-identical to the `maintenance-10.x` version of the change for `pr-test-builds.yml`; `ci.yml` carries only the `.uf2` upload-glob hunks.
- Safe on branches without a `.uf2`-producing target: upload glob matches nothing (warn-only), release asset list stays `.hex`-only.