### PR TITLE
Restore DSHOT on outputs whose timer channel has no DMA request line

### DIFF
--- a/src/main/target/BLUEJAYF4/target.c
+++ b/src/main/target/BLUEJAYF4/target.c
@@ -28,8 +28,7 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM5, CH1,  PA0, TIM_USE_OUTPUT_AUTO,               0, 0 ), // S1_OUT - DMA1_ST2
     DEF_TIM(TIM5, CH2,  PA1, TIM_USE_OUTPUT_AUTO,               0, 0 ), // S2_OUT - DMA1_ST4
     DEF_TIM(TIM2, CH3,  PA2, TIM_USE_OUTPUT_AUTO,               0, 0 ), // S3_OUT - DMA1_ST1
-    DEF_TIM(TIM9, CH2,  PA3, TIM_USE_OUTPUT_AUTO,               0, 0 ), // S4_OUT - no DMA
-    //DEF_TIM(TIM5, CH4,  PA3, TIM_USE_OUTPUT_AUTO,             0, 1 ), // S4_OUT - DMA1_ST3 (Could be DMA1_ST1 with dmaopt=0)
+    DEF_TIM(TIM5, CH4,  PA3, TIM_USE_OUTPUT_AUTO,               0, 1 ), // S4_OUT - DMA1_ST3 -- was TIM9_CH2, which has no DMA request line on F405 (no DSHOT). dmavar 0 is not usable here: it is DMA1 Stream1, already taken by S3_OUT (TIM2_CH3)
     DEF_TIM(TIM3, CH4,  PB0, TIM_USE_OUTPUT_AUTO, 		0, 0 ), // S5_OUT - DMA1_ST2 -- used to be TIM_USE_LED
     DEF_TIM(TIM3, CH3,  PB1, TIM_USE_OUTPUT_AUTO,               0, 0 ), // S6_OUT - DMA1_ST7
 };

--- a/src/main/target/COLIBRI/target.c
+++ b/src/main/target/COLIBRI/target.c
@@ -36,9 +36,9 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_OUTPUT_AUTO,   0, 0), // S1_OUT
     DEF_TIM(TIM3,  CH1, PB4,  TIM_USE_OUTPUT_AUTO,   0, 0), // S2_OUT
     DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_OUTPUT_AUTO,   0, 0), // S3_OUT
-    DEF_TIM(TIM12, CH2, PB15, TIM_USE_OUTPUT_AUTO,   0, 0), // S4_OUT
+    DEF_TIM(TIM1, CH3N, PB15, TIM_USE_OUTPUT_AUTO,   0, 1), // S4_OUT -- was TIM12_CH2, which has no DMA request line on F405 (no DSHOT); dmavar 1 is TIM1_CH3's dedicated DMA2 Stream6 line
     DEF_TIM(TIM3,  CH2, PB5,  TIM_USE_OUTPUT_AUTO,   0, 0), // S5_OUT
-    DEF_TIM(TIM12, CH1, PB14, TIM_USE_OUTPUT_AUTO,   0, 0), // S6_OUT
+    DEF_TIM(TIM1, CH2N, PB14, TIM_USE_OUTPUT_AUTO,   0, 1), // S6_OUT -- was TIM12_CH1, which has no DMA request line on F405 (no DSHOT); dmavar 1 is TIM1_CH2's dedicated DMA2 Stream2 line. dmavar 0 is the combined TIM1 CH1-3 request, which would collide with S4_OUT now that both are live TIM1 channels
     DEF_TIM(TIM10, CH1, PB8,  TIM_USE_OUTPUT_AUTO,   0, 0), // S7_OUT
     DEF_TIM(TIM11, CH1, PB9,  TIM_USE_OUTPUT_AUTO,   0, 0), // S8_OUT
 

--- a/src/main/target/FISHDRONEF4/target.c
+++ b/src/main/target/FISHDRONEF4/target.c
@@ -30,7 +30,7 @@ timerHardware_t timerHardware[] = {
     // DEF_TIM(TIM2,   CH4, PB11, TIM_USE_PWM,                 0, 0 ),
     // DEF_TIM(TIM1,   CH1, PA8,  TIM_USE_PWM,                 0, 0 ),
 
-    DEF_TIM(TIM12,  CH1, PB14,  TIM_USE_OUTPUT_AUTO,    0, 0 ),
+    DEF_TIM(TIM1,  CH2N, PB14,  TIM_USE_OUTPUT_AUTO,    0, 0 ), // was TIM12_CH1, which has no DMA request line on F405 (no DSHOT); TIM1_CH2N dmavar 0 is DMA2 Stream6. PB15 below cannot also be moved: TIM1_CH3 has only DMA2 Stream6 as well, and TIM1_CH2's other option (DMA2 Stream2) is held by TIM8_CH1/PC6
     DEF_TIM(TIM12,  CH2, PB15,  TIM_USE_OUTPUT_AUTO,    0, 0 ),
     DEF_TIM(TIM8,   CH1, PC6,   TIM_USE_OUTPUT_AUTO,    0, 1 ),
     DEF_TIM(TIM8,   CH2, PC7,   TIM_USE_OUTPUT_AUTO,    0, 1 ),

--- a/src/main/target/FRSKYF405/target.c
+++ b/src/main/target/FRSKYF405/target.c
@@ -29,7 +29,7 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM3,  CH4,  PB1,  TIM_USE_OUTPUT_AUTO, 0, 0),  // S4
     DEF_TIM(TIM8,  CH3,  PC8,  TIM_USE_OUTPUT_AUTO, 0, 1),  // S5
     DEF_TIM(TIM8,  CH4,  PC9,  TIM_USE_OUTPUT_AUTO, 0, 0),  // S6
-    DEF_TIM(TIM12, CH1,  PB14, TIM_USE_OUTPUT_AUTO, 0, 0),  // S7 - no DShot (TIM12 has no DMA)
+    DEF_TIM(TIM8, CH2N,  PB14, TIM_USE_OUTPUT_AUTO, 0, 1),  // S7 -- was TIM12_CH1, which has no DMA request line on F405 (no DSHOT); TIM8_CH2N dmavar 1 is DMA2 Stream3
     DEF_TIM(TIM12, CH2,  PB15, TIM_USE_OUTPUT_AUTO, 0, 0),  // S8 - no DShot (TIM12 has no DMA)
     DEF_TIM(TIM1,  CH1,  PA8,  TIM_USE_OUTPUT_AUTO, 0, 0),  // S9
 

--- a/src/main/target/MATEKF405SE/target.c
+++ b/src/main/target/MATEKF405SE/target.c
@@ -27,11 +27,11 @@ timerHardware_t timerHardware[] = {
 
     DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_OUTPUT_AUTO,   1, 0), // S3 D(1,7,5)
     DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_OUTPUT_AUTO,   1, 0), // S4 D(1,2,5)
-    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_OUTPUT_AUTO,   1, 0), // S5 D(2,4,7)
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_OUTPUT_AUTO,   1, 1), // S5 D(2,4,7) -- dmavar 1 is the dedicated line this comment already names; dmavar 0 was the combined TIM8 CH1-3 request
     DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_OUTPUT_AUTO,   1, 0), // S6 D(2,7,7)
-    DEF_TIM(TIM12, CH1, PB14, TIM_USE_OUTPUT_AUTO,   1, 0), // S7
-    DEF_TIM(TIM12, CH2, PB15, TIM_USE_OUTPUT_AUTO,   1, 0), // S8
-    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_OUTPUT_AUTO,   1, 0), // S9
+    DEF_TIM(TIM1, CH2N, PB14, TIM_USE_OUTPUT_AUTO,   1, 1), // S7 -- was TIM12_CH1, which has no DMA request line on F405 (no DSHOT); dmavar 1 is DMA2 Stream2
+    DEF_TIM(TIM1, CH3N, PB15, TIM_USE_OUTPUT_AUTO,   1, 1), // S8 -- was TIM12_CH2, which has no DMA request line on F405 (no DSHOT); dmavar 1 is DMA2 Stream6
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_OUTPUT_AUTO,   1, 1), // S9 -- dmavar 1 (DMA2 Stream1) keeps S9 off the combined TIM1 CH1-3 request now that S7/S8 are live TIM1 channels
 
     DEF_TIM(TIM2,  CH1, PA15, TIM_USE_LED,   0, 0), //2812LED  D(1,5,3)
 

--- a/src/main/target/NEXUS/target.c
+++ b/src/main/target/NEXUS/target.c
@@ -23,7 +23,7 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM2, CH2, PB3, TIM_USE_OUTPUT_AUTO, 0, 0),  // S4
     DEF_TIM(TIM4, CH1, PB6, TIM_USE_OUTPUT_AUTO, 0, 0),  // M1/ESC
     DEF_TIM(TIM5, CH3, PA2, TIM_USE_OUTPUT_AUTO, 0, 0),  // shared w/ UART2 TX
-    DEF_TIM(TIM9, CH2, PA3, TIM_USE_OUTPUT_AUTO, 0, 0),  // shared w/ UART2 RX
+    DEF_TIM(TIM5, CH4, PA3, TIM_USE_OUTPUT_AUTO, 0, 0),  // shared w/ UART2 RX -- was TIM9_CH2, which has no DMA request line on F722 (no DSHOT)
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/SPARKY2/target.c
+++ b/src/main/target/SPARKY2/target.c
@@ -32,10 +32,10 @@ timerHardware_t timerHardware[] = {
 
     DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_OUTPUT_AUTO,   0, 0 ), // S1_OUT
     DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_OUTPUT_AUTO,   0, 0 ), // S2_OUT
-    DEF_TIM(TIM9,  CH2, PA3,  TIM_USE_OUTPUT_AUTO,   0, 0 ), // S3_OUT
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_OUTPUT_AUTO,   0, 1 ), // S3_OUT -- was TIM9_CH2, which has no DMA request line on F405 (no DSHOT); TIM2_CH4 dmavar 1 is DMA1 Stream6, free
     DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_OUTPUT_AUTO,   0, 0 ), // S4_OUT
     DEF_TIM(TIM5,  CH2, PA1,  TIM_USE_OUTPUT_AUTO,   0, 0 ), // S5_OUT - GPIO_PartialRemap_TIM3
-    DEF_TIM(TIM5,  CH1, PA0,  TIM_USE_OUTPUT_AUTO,   0, 0 ), // S6_OUT
+    DEF_TIM(TIM2,  CH1, PA0,  TIM_USE_OUTPUT_AUTO,   0, 0 ), // S6_OUT -- was TIM5_CH1, which shared S2_OUT's DMA stream; TIM2_CH1 is DMA1 Stream5, free
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);


### PR DESCRIPTION
## Summary

Several targets place a motor output on a timer channel that has **no DMA request line at all** on that MCU — TIM9/TIM10/TIM11/TIM12 on F405, TIM9 on F722. Such an output can never do DSHOT at any `dmavar`: it still works for PWM/Oneshot/Multishot, but `motorConfigDshot()` silently fails to arm DMA while `pwmMotorConfig()` reports success, so the user gets a motor that doesn't spin with no boot error.

These were previously left alone because the existing analysis only searched for a better `dmavar` — and no `dmavar` helps when the channel has no request line. The **pin**, however, usually reaches another timer that does.

## Changes

| Target | Output | Pin | Was | Now |
|---|---|---|---|---|
| SPARKY2 | S3_OUT | PA3 | `TIM9_CH2` | `TIM2_CH4` dmavar 1 (DMA1 St6) |
| SPARKY2 | S6_OUT | PA0 | `TIM5_CH1` | `TIM2_CH1` (DMA1 St5) |
| BLUEJAYF4 | S4_OUT | PA3 | `TIM9_CH2` | `TIM5_CH4` dmavar 1 (DMA1 St3) |
| COLIBRI | S4_OUT | PB15 | `TIM12_CH2` | `TIM1_CH3N` dmavar 1 (DMA2 St6) |
| COLIBRI | S6_OUT | PB14 | `TIM12_CH1` | `TIM1_CH2N` dmavar 1 (DMA2 St2) |
| MATEKF405SE | S7 | PB14 | `TIM12_CH1` | `TIM1_CH2N` dmavar 1 (DMA2 St2) |
| MATEKF405SE | S8 | PB15 | `TIM12_CH2` | `TIM1_CH3N` dmavar 1 (DMA2 St6) |
| FRSKYF405 | S7 | PB14 | `TIM12_CH1` | `TIM8_CH2N` dmavar 1 (DMA2 St3) |
| NEXUS (F722) | — | PA3 | `TIM9_CH2` | `TIM5_CH4` |
| FISHDRONEF4 | — | PB14 | `TIM12_CH1` | `TIM1_CH2N` (DMA2 St6) |

Two co-fixes are required rather than optional:

- **SPARKY2 S6_OUT** shared S2_OUT's DMA stream, so the board had a collision alongside the dead output. With both changes SPARKY2 has **no hazards at any motor count**.
- **MATEKF405SE**: moving S7/S8 onto TIM1 makes them live siblings of S9 (`TIM1_CH1`), so S9 moves to dmavar 1 to leave the combined TIM1 CH1-3 request line, and S5 (`TIM8_CH3`) moves to dmavar 1 — the dedicated line its own comment already named. With these, MATEKF405SE also has **no hazards at any motor count**.

## Deliberate partial fixes

- **FRSKYF405 S8** (PB15) stays on TIM12. Its only DMA-capable alternative is `TIM8_CH3N`, and `TIM8_CH3` already drives PC8 — two pins on one compare register can only ever emit the same waveform, which is worse than lacking DSHOT.
- **FISHDRONEF4 PB15** stays on TIM12: `TIM1_CH3` can only ever use DMA2 Stream6 (now held by PB14), and `TIM1_CH2`'s other option, DMA2 Stream2, is held by `TIM8_CH1` on PC6. Only one of the two pads can get DSHOT without reordering outputs, which would renumber the pads.
- **COLIBRI**'s remaining dead outputs are on PB8/PB9, whose only alternatives (`TIM10_CH1`, `TIM11_CH1`) also lack a request line, and `TIM4_CH3` on PB8 belongs to the LED strip's timer.

**No output changes position in `timerHardware[]`, so no pad is renumbered.**

## Testing

Every pin/timer pairing is confirmed against the STM32F405 / STM32F722 datasheet alternate-function tables — necessary because on F4 the AF is derived from the timer name alone (`timer_def_stm32f4xx.h:25`, `GPIO_AF_##tim`) with no per-pin table, so a wrong pairing compiles cleanly and just leaves the pad dead.

Each target was simulated over a motorCount 1..12 sweep and compared against its `maintenance-10.x` baseline: dead outputs are removed and **no stream collision, shared-request hazard, or duplicate compare-register use is introduced**.

Builds pass for SPARKY2, BLUEJAYF4, MATEKF405SE, FRSKYF405, NEXUS, FISHDRONEF4.

COLIBRI does **not** link on `maintenance-10.x` either before or after this change (`undefined reference to checkBatteryVoltageState` from `multifunction.c` and `osd.c`) — that failure is pre-existing and unrelated to this PR.