### PR TITLE
Fix link failure on non-ADC targets from unconditional checkBatteryVoltageState() call

### DIFF
--- a/src/main/fc/multifunction.c
+++ b/src/main/fc/multifunction.c
@@ -266,7 +266,7 @@ textAttributes_t osdGetMultiFunctionMessage(char *buff)
     uint8_t warningFlagID = 1;
 
     // Low Battery Voltage
-    const batteryState_e batteryVoltageState = checkBatteryVoltageState();
+    const batteryState_e batteryVoltageState = getBatteryState();
     warningCondition = batteryVoltageState == BATTERY_CRITICAL || batteryVoltageState == BATTERY_WARNING;
     if (osdCheckWarning(warningCondition, warningFlagID)) {
         messages[messageCount++] = batteryVoltageState == BATTERY_CRITICAL ? "VBATT LAND" : "VBATT LOW ";

--- a/src/main/fc/multifunction.c
+++ b/src/main/fc/multifunction.c
@@ -265,12 +265,14 @@ textAttributes_t osdGetMultiFunctionMessage(char *buff)
     bool warningCondition = false;
     uint8_t warningFlagID = 1;
 
+#ifdef USE_ADC
     // Low Battery Voltage
-    const batteryState_e batteryVoltageState = getBatteryState();
+    const batteryState_e batteryVoltageState = checkBatteryVoltageState();
     warningCondition = batteryVoltageState == BATTERY_CRITICAL || batteryVoltageState == BATTERY_WARNING;
     if (osdCheckWarning(warningCondition, warningFlagID)) {
         messages[messageCount++] = batteryVoltageState == BATTERY_CRITICAL ? "VBATT LAND" : "VBATT LOW ";
     }
+#endif
 
     // Low Battery Capacity
     if (batteryUsesCapacityThresholds()) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1600,7 +1600,7 @@ static void osdDisplayBatteryVoltage(uint8_t elemPosX, uint8_t elemPosY, uint16_
     osdFormatCentiNumber(buff, voltage, 0, decimals, 0, digits, false);
     buff[digits] = SYM_VOLT;
     buff[digits+1] = '\0';
-    const batteryState_e batteryVoltageState = checkBatteryVoltageState();
+    const batteryState_e batteryVoltageState = getBatteryState();
     if (batteryVoltageState == BATTERY_CRITICAL || batteryVoltageState == BATTERY_WARNING) {
         TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
     }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1600,10 +1600,12 @@ static void osdDisplayBatteryVoltage(uint8_t elemPosX, uint8_t elemPosY, uint16_
     osdFormatCentiNumber(buff, voltage, 0, decimals, 0, digits, false);
     buff[digits] = SYM_VOLT;
     buff[digits+1] = '\0';
-    const batteryState_e batteryVoltageState = getBatteryState();
+#ifdef USE_ADC
+    const batteryState_e batteryVoltageState = checkBatteryVoltageState();
     if (batteryVoltageState == BATTERY_CRITICAL || batteryVoltageState == BATTERY_WARNING) {
         TEXT_ATTRIBUTES_ADD_BLINK(elemAttr);
     }
+#endif
     displayWriteWithAttr(osdDisplayPort, elemPosX + 1, elemPosY, buff, elemAttr);
 }
 


### PR DESCRIPTION
## Summary

`checkBatteryVoltageState()` is defined only inside `#ifdef USE_ADC` in `src/main/sensors/battery.c`, but two call sites invoked it unconditionally:

- `src/main/io/osd.c` — `osdDisplayBatteryVoltage()`
- `src/main/fc/multifunction.c` — the low-battery-voltage warning check

Any target that doesn't define `USE_ADC` fails to link with `undefined reference to checkBatteryVoltageState`. This affects COLIBRI and QUANTON, which have no analog battery-voltage sensing hardware at all. Bisected the regression to commit f3de64444a0 ("osd batt cleanup", 2023-02-07), which extracted the voltage-state check out of the always-defined `getBatteryState()` path into the new ADC-only function without updating these two unconditional callers. It went unnoticed because both affected targets are `SKIP_RELEASES` and aren't in the normal release build sweep.

## Changes

- Both call sites now use `getBatteryState()` instead, which is defined unconditionally and returns the same cached state. `multifunction.c` already uses `getBatteryState()` two lines later for the equivalent capacity-based warning check, so this also makes the two checks consistent with each other.

## Testing

- COLIBRI and QUANTON: previously failed to link, now build and link cleanly.
- MATEKF405, OMNIBUSF4, KAKUTEF7 (ADC-equipped): confirmed no regression, build cleanly with no new warnings.