### PR TITLE
Fix telemetry_hott_unittest link failure from new GPS-mode display code

### DIFF
--- a/src/test/unit/telemetry_hott_unittest.cc
+++ b/src/test/unit/telemetry_hott_unittest.cc
@@ -35,6 +35,7 @@ extern "C" {
     #include "drivers/serial.h"
     #include "drivers/system.h"
 
+    #include "fc/rc_modes.h"
     #include "fc/runtime_config.h"
 
     #include "flight/pid.h"
@@ -43,6 +44,7 @@ extern "C" {
     #include "io/serial.h"
 
     #include "navigation/navigation.h"
+    PG_REGISTER(navConfig_t, navConfig, PG_NAV_CONFIG, 0);
 
     #include "sensors/battery.h"
     #include "sensors/sensors.h"
@@ -56,6 +58,25 @@ extern "C" {
     uint16_t testBatteryVoltage = 0;
     int16_t testAmperage = 0;
     int32_t testMAhDrawn = 0;
+
+    uint32_t armingFlags = 0;
+    uint32_t flightModeFlags = 0;
+
+    bool IS_RC_MODE_ACTIVE(boxId_e boxId)
+    {
+        UNUSED(boxId);
+        return false;
+    }
+
+    bool isWaypointMissionRTHActive(void)
+    {
+        return false;
+    }
+
+    bool navigationRequiresAngleMode(void)
+    {
+        return false;
+    }
 }
 
 #include "unittest_macros.h"


### PR DESCRIPTION
## Summary

CI was failing to link `telemetry_hott_unittest` with:
```
undefined reference to `flightModeFlags'
undefined reference to `IS_RC_MODE_ACTIVE'
```

## Root cause

`hottPrepareGPSResponse()` in `src/main/telemetry/hott.c` gained code that
reads `FLIGHT_MODE()`/`IS_RC_MODE_ACTIVE()`/`ARMING_FLAG()` and calls
`navConfig()`, `isWaypointMissionRTHActive()`, and
`navigationRequiresAngleMode()` to display GPS/RTH/WP mode status.

`src/test/unit/target.h` unconditionally `#define USE_GPS`, so the unit
test now compiles this code path, but `src/test/unit/CMakeLists.txt`'s
`depends` list for `telemetry_hott_unittest.cc` only links `hott.c` plus
two GPS/string helpers - it was never updated to link
`fc/runtime_config.c`, `fc/rc_modes.c`, or `navigation/navigation.c`, so
the new symbols were undefined at link time.

## Fix

Rather than pulling in `navigation.c` and its dependency chain, stub the
needed globals/functions directly in the test file, matching the
existing precedent in `rcdevice_unittest.cc` (which already stubs
`armingFlags` the same way): `armingFlags`, `flightModeFlags`, a
zero-registered `navConfig`, `IS_RC_MODE_ACTIVE()`,
`isWaypointMissionRTHActive()`, and `navigationRequiresAngleMode()` all
return/hold neutral defaults - safe since no existing test case
exercises those mode display paths.

## Testing

Built and ran `telemetry_hott_unittest` locally: links cleanly, all 3
existing test cases (`UpdateGPSCoordinates1/2/3`) pass.