### PR TITLE
Fix INVALID SETTING / arming block on 512 KB targets

### DIFF
--- a/docs/Mavlink.md
+++ b/docs/Mavlink.md
@@ -6,6 +6,10 @@ INAV supports up to 4 concurrent MAVLink telemetry ports (`MAX_MAVLINK_PORTS`), 
 
 INAV builds against the checked-in generated `storm32` MAVLink headers/dialect bundle, which includes the native mLRS messages used by the implementation. The STorM32 dialect is a superset of the ArduPilot and common message sets.
 
+## Target support
+
+MAVLink is built only into targets with more than 512 KB of flash (STM32F405, STM32F745, STM32F765, STM32H743, AT32F435, etc.). On 512 KB targets, which includes every STM32F722 and STM32F411 board, the whole subsystem is absent: no MAVLink telemetry, no MAVLink serial RX, and no MSP-over-MAVLink tunnel. Everything described on this page applies only to the larger targets.
+
 ## What INAV currently supports
 
 - Multiport MAVLink telemetry on up to 4 serial ports, with per-port stream rates, radio type, and high-latency mode.

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -3370,6 +3370,7 @@ groups:
         min: INT16_MIN
         max: INT16_MAX
       - name: mavlink_port1_ext_status_rate
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink[0].extended_status_rate
         description: "Rate of the extended status message for MAVLink telemetry on port 1"
         type: uint8_t
@@ -3377,12 +3378,14 @@ groups:
         max: 255
         default_value: 2
       - name: mavlink_autopilot_type
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink_common.autopilot_type
         description: "Autopilot type to advertise for MAVLink telemetry"
         table: mavlink_autopilot_type
         default_value: "GENERIC"
         type: uint8_t
       - name: mavlink_port1_rc_chan_rate
+        condition: USE_TELEMETRY_MAVLINK
         description: "Rate of the RC channels message for MAVLink telemetry on port 1"
         field: mavlink[0].rc_channels_rate
         type: uint8_t
@@ -3390,6 +3393,7 @@ groups:
         max: 255
         default_value: 1
       - name: mavlink_port1_pos_rate
+        condition: USE_TELEMETRY_MAVLINK
         description: "Rate of the position message for MAVLink telemetry on port 1"
         field: mavlink[0].position_rate
         type: uint8_t
@@ -3397,6 +3401,7 @@ groups:
         max: 255
         default_value: 2
       - name: mavlink_port1_extra1_rate
+        condition: USE_TELEMETRY_MAVLINK
         description: "Rate of the extra1 message for MAVLink telemetry on port 1"
         field: mavlink[0].extra1_rate
         type: uint8_t
@@ -3404,6 +3409,7 @@ groups:
         max: 255
         default_value: 2
       - name: mavlink_port1_extra2_rate
+        condition: USE_TELEMETRY_MAVLINK
         description: "Rate of the extra2 message for MAVLink telemetry on port 1"
         field: mavlink[0].extra2_rate
         type: uint8_t
@@ -3411,6 +3417,7 @@ groups:
         max: 255
         default_value: 2
       - name: mavlink_port1_extra3_rate
+        condition: USE_TELEMETRY_MAVLINK
         description: "Rate of the extra3 message for MAVLink telemetry on port 1"
         field: mavlink[0].extra3_rate
         type: uint8_t
@@ -3418,6 +3425,7 @@ groups:
         max: 255
         default_value: 1
       - name: mavlink_version
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink_common.version
         description: "Version of MAVLink to use"
         type: uint8_t
@@ -3425,18 +3433,21 @@ groups:
         max: 2
         default_value: 2
       - name: mavlink_port1_min_txbuffer
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink[0].min_txbuff
         description: "Minimum percent of TX buffer space free for MAVLink port 1. Requires RADIO_STATUS messages."
         default_value: 33
         min: 0
         max: 100
       - name: mavlink_port1_radio_type
+        condition: USE_TELEMETRY_MAVLINK
         description: "MAVLink radio type for port 1. Affects RSSI and LQ reporting on OSD."
         field: mavlink[0].radio_type
         table: mavlink_radio_type
         default_value: "GENERIC"
         type: uint8_t
       - name: mavlink_sysid
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink_common.sysid
         description: "MAVLink System ID"
         type: uint8_t
@@ -3444,57 +3455,67 @@ groups:
         max: 255
         default_value: 1
       - name: mavlink_port1_high_latency
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink[0].high_latency
         description: "Enable MAVLink high-latency mode on port 1"
         type: bool
         default_value: OFF
       - name: mavlink_port2_min_txbuffer
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink[1].min_txbuff
         description: "Minimum percent of TX buffer space free for MAVLink port 2. Requires RADIO_STATUS messages."
         default_value: 33
         min: 0
         max: 100
       - name: mavlink_port2_radio_type
+        condition: USE_TELEMETRY_MAVLINK
         description: "MAVLink radio type for port 2. Affects RSSI and LQ reporting on OSD."
         field: mavlink[1].radio_type
         table: mavlink_radio_type
         default_value: "GENERIC"
         type: uint8_t
       - name: mavlink_port2_high_latency
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink[1].high_latency
         description: "Enable MAVLink high-latency mode on port 2"
         type: bool
         default_value: OFF
       - name: mavlink_port3_min_txbuffer
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink[2].min_txbuff
         description: "Minimum percent of TX buffer space free for MAVLink port 3. Requires RADIO_STATUS messages."
         default_value: 33
         min: 0
         max: 100
       - name: mavlink_port3_radio_type
+        condition: USE_TELEMETRY_MAVLINK
         description: "MAVLink radio type for port 3. Affects RSSI and LQ reporting on OSD."
         field: mavlink[2].radio_type
         table: mavlink_radio_type
         default_value: "GENERIC"
         type: uint8_t
       - name: mavlink_port3_high_latency
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink[2].high_latency
         description: "Enable MAVLink high-latency mode on port 3"
         type: bool
         default_value: OFF
       - name: mavlink_port4_min_txbuffer
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink[3].min_txbuff
         description: "Minimum percent of TX buffer space free for MAVLink port 4. Requires RADIO_STATUS messages."
         default_value: 33
         min: 0
         max: 100
       - name: mavlink_port4_radio_type
+        condition: USE_TELEMETRY_MAVLINK
         description: "MAVLink radio type for port 4. Affects RSSI and LQ reporting on OSD."
         field: mavlink[3].radio_type
         table: mavlink_radio_type
         default_value: "GENERIC"
         type: uint8_t
       - name: mavlink_port4_high_latency
+        condition: USE_TELEMETRY_MAVLINK
         field: mavlink[3].high_latency
         description: "Enable MAVLink high-latency mode on port 4"
         type: bool

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -56,7 +56,7 @@
 #include "telemetry/ghst.h"
 
 
-PG_REGISTER_WITH_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 11);
+PG_REGISTER_WITH_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 12);
 
 PG_RESET_TEMPLATE(telemetryConfig_t, telemetryConfig,
     .telemetry_switch = SETTING_TELEMETRY_SWITCH_DEFAULT,

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -97,8 +97,10 @@ typedef struct telemetryConfig_s {
     uint16_t accEventThresholdLow;
     uint16_t accEventThresholdNegX;
 #endif
+#ifdef USE_TELEMETRY_MAVLINK
     mavlinkTelemetryCommonConfig_t mavlink_common;
     mavlinkTelemetryPortConfig_t mavlink[MAX_MAVLINK_PORTS];
+#endif
     bool crsf_use_legacy_baro_packet;
 } telemetryConfig_t;
 


### PR DESCRIPTION
mavlink_version and mavlink_sysid declare min 1, but the MAVLink block of the telemetryConfig reset template is compiled out when USE_TELEMETRY_MAVLINK is not defined, so both default to 0 on targets with MCU_FLASH_SIZE <= 512 (F722, F411). settingsValidate() then fails, ARMING_DISABLED_INVALID_SETTING is latched at boot, and the OSD reports MAVLINK_VERSION / INVALID SETTING. Arming is blocked and resetting to defaults does not clear it.

Condition the mavlink_* settings on USE_TELEMETRY_MAVLINK and guard the matching telemetryConfig members, mirroring how USE_TELEMETRY_SIM is already handled in the same struct. This also drops 21 settings that did nothing on those boards.

Document in Mavlink.md that MAVLink needs more than 512 KB of flash, which was never stated when the subsystem was gated by flash size.