### PR TITLE
Mavlink Yaw and Landing fixes

### DIFF
--- a/src/main/mavlink/mavlink_guided.c
+++ b/src/main/mavlink/mavlink_guided.c
@@ -94,6 +94,7 @@ bool mavlinkHandleIncomingSetPositionTargetGlobalInt(void)
     const bool xIgnored = (typeMask & POSITION_TARGET_TYPEMASK_X_IGNORE) != 0;
     const bool yIgnored = (typeMask & POSITION_TARGET_TYPEMASK_Y_IGNORE) != 0;
     const bool zIgnored = (typeMask & POSITION_TARGET_TYPEMASK_Z_IGNORE) != 0;
+    const bool yawIgnored = (typeMask & POSITION_TARGET_TYPEMASK_YAW_IGNORE) != 0;
 
     // Altitude-only SET_POSITION_TARGET_GLOBAL_INT mirrors MAV_CMD_DO_CHANGE_ALTITUDE semantics.
     if (xIgnored && yIgnored && !zIgnored) {
@@ -119,7 +120,18 @@ bool mavlinkHandleIncomingSetPositionTargetGlobalInt(void)
         wp.lat = msg.lat_int;
         wp.lon = msg.lon_int;
         wp.alt = zIgnored ? 0 : (int32_t)lrintf(msg.alt * 100.0f);
+        // Waypoint 255 takes its heading from P1 in whole degrees, honouring 1-359 only,
+        // which is what gives a multirotor nose-first travel to the target. Leaving P1 at
+        // zero means the aircraft translates on its existing heading, flying sideways or
+        // backwards to the point.
         wp.p1 = 0;
+        if (!yawIgnored && isfinite(msg.yaw)) {
+            int16_t headingDeg = (int16_t)lrintf(RADIANS_TO_DEGREES(msg.yaw));
+            headingDeg = (int16_t)((headingDeg % 360 + 360) % 360);
+            if (headingDeg > 0) {
+                wp.p1 = headingDeg;
+            }
+        }
         wp.p2 = 0;
         wp.p3 = mavlinkFrameUsesAbsoluteAltitude(frame) ? NAV_WP_ALTMODE : 0;
         wp.flag = 0;

--- a/src/main/mavlink/mavlink_mission.c
+++ b/src/main/mavlink/mavlink_mission.c
@@ -769,6 +769,18 @@ static bool mavlinkHandleMissionItemCommon(
             wp.lon = lon;
             wp.alt = mavlinkMissionAltitudeToCentimeters(altMeters);
             wp.p3 = mavlinkFrameUsesAbsoluteAltitude(frame) ? NAV_WP_ALTMODE : 0;
+
+            /* A LAND item's altitude is where the aircraft touches down, not an altitude to
+             * hold on the way there. Ground stations send zero for it - QGC forces it to zero
+             * outright - and INAV flies the approach leg with the waypoint altitude as its
+             * target, so taking it literally descends all the way in from the previous
+             * waypoint instead of arriving overhead and then landing. Approach at the
+             * altitude of the preceding waypoint and let the LAND action do the descent. */
+            if (wp.alt <= 0 && mavlinkMissionUploadWaypointCount > 0) {
+                const navWaypoint_t *previous = &mavlinkMissionUploadWaypoints[mavlinkMissionUploadWaypointCount - 1];
+                wp.alt = previous->alt;
+                wp.p3 = previous->p3;
+            }
             break;
 
         case MAV_CMD_DO_JUMP:

--- a/src/main/mavlink/mavlink_mission.c
+++ b/src/main/mavlink/mavlink_mission.c
@@ -1,5 +1,8 @@
 #include "mavlink/mavlink_internal.h"
 
+#include "flight/mixer.h"
+#include "flight/mixer_profile.h"
+
 #include "mavlink/mavlink_guided.h"
 #include "mavlink/mavlink_mission.h"
 #include "mavlink/mavlink_runtime.h"
@@ -775,8 +778,18 @@ static bool mavlinkHandleMissionItemCommon(
              * outright - and INAV flies the approach leg with the waypoint altitude as its
              * target, so taking it literally descends all the way in from the previous
              * waypoint instead of arriving overhead and then landing. Approach at the
-             * altitude of the preceding waypoint and let the LAND action do the descent. */
-            if (wp.alt <= 0 && mavlinkMissionUploadWaypointCount > 0) {
+             * altitude of the preceding waypoint and let the LAND action do the descent.
+             *
+             * Rotary platforms only. A fixed wing cannot stop over the point and descend, so
+             * it keeps the altitude it was given: with an autoland approach configured the
+             * landing altitudes come from that config and the waypoint contributes only its
+             * position, and without one the existing descending approach is left alone. A
+             * VTOL counts as rotary here because it lands on its multirotor profile. */
+            const bool rotaryLanding = isMultirotorTypePlatform(mixerConfig()->platformType) ||
+                                       platformTypeConfigured(PLATFORM_MULTIROTOR) ||
+                                       platformTypeConfigured(PLATFORM_TRICOPTER);
+
+            if (rotaryLanding && wp.alt <= 0 && mavlinkMissionUploadWaypointCount > 0) {
                 const navWaypoint_t *previous = &mavlinkMissionUploadWaypoints[mavlinkMissionUploadWaypointCount - 1];
                 wp.alt = previous->alt;
                 wp.p3 = previous->p3;

--- a/src/test/unit/mavlink_unittest.cc
+++ b/src/test/unit/mavlink_unittest.cc
@@ -3505,6 +3505,14 @@ serialPortConfig_t *findNextSerialPortConfig(serialPortFunction_e function)
     return NULL;
 }
 
+// No mixer-profile switching is configured in these tests, so nothing here is a VTOL and
+// the platform is whatever the fixture set on mixer profile 0.
+bool platformTypeConfigured(flyingPlatformType_e platformType)
+{
+    UNUSED(platformType);
+    return false;
+}
+
 portSharing_e determinePortSharing(const serialPortConfig_t *portConfig, serialPortFunction_e function)
 {
     UNUSED(portConfig);


### PR DESCRIPTION
## Two MAVLink fixes found flying QGroundControl on a multicopter

### Mission LAND descended across the whole final leg

A `NAV_LAND` item's altitude is where the aircraft touches down, not an altitude to hold on the way there. Ground stations send zero for it — QGC forces it to zero outright in `SimpleMissionItem.cc` — and INAV flies the approach leg using the waypoint altitude as its target. A mission ending

```
NAV_WAYPOINT  GLOBAL_RELATIVE_ALT  z=20
NAV_LAND      GLOBAL_RELATIVE_ALT  z=0
```

therefore descended continuously from 20 m across the final leg instead of arriving overhead and landing.
The approach now holds the preceding waypoint's altitude and leaves the descent to the `LAND` action, which already performs it on arrival.
This is gated to Multicopters and VTOL so nothing in Fixed-wing behavior changes.

### Guided go-to flew sideways to the target

Waypoint 255 takes its heading from `P1` in whole degrees, honouring 1–359 only — that's what makes a multirotor travel nose-first. The `SET_POSITION_TARGET_GLOBAL_INT` handler left `P1` at zero, so a ground station's "go to location" never requested a heading and the aircraft translated on whatever heading it was already holding, flying sideways or backwards to the point.

`P1` is now populated from the message yaw unless the type mask marks it ignored.