### PR TITLE
Fix duplicate timer channels on FURYF4OSD and WARPF7

### DIFF
--- a/src/main/target/FURYF4OSD/target.c
+++ b/src/main/target/FURYF4OSD/target.c
@@ -28,8 +28,8 @@ timerHardware_t timerHardware[] = {
       DEF_TIM(TIM3, CH3,  PB0, TIM_USE_OUTPUT_AUTO, 0, 0 ), // S2_OUT - D(1, 7, 5)
       DEF_TIM(TIM3, CH4,  PB1, TIM_USE_OUTPUT_AUTO, 0, 0 ), // S3_OUT - D(1, 2, 5)
       DEF_TIM(TIM2, CH3,  PA2, TIM_USE_OUTPUT_AUTO, 0, 0 ), // S4_OUT - D(1, 1, 3)
-      DEF_TIM(TIM2, CH3, PB10, TIM_USE_ANY, 0, 0),
-      DEF_TIM(TIM2, CH4, PB11, TIM_USE_ANY, 0, 0), 
+      // PB10/PB11 (UART3) reach only TIM2_CH3/TIM2_CH4, the compare registers already
+      // driving S4_OUT/S1_OUT, so they cannot carry independent outputs.
       DEF_TIM(TIM5, CH1, PA0, TIM_USE_LED, 0, 0 ), // LED_STRIP - DMA1_ST2_CH6
 };
 

--- a/src/main/target/FURYF4OSD/target.h
+++ b/src/main/target/FURYF4OSD/target.h
@@ -169,4 +169,4 @@
 #define USE_DSHOT
 #define USE_ESC_SENSOR
 
-#define MAX_PWM_OUTPUT_PORTS       6
+#define MAX_PWM_OUTPUT_PORTS       4

--- a/src/main/target/WARPF7/target.c
+++ b/src/main/target/WARPF7/target.c
@@ -40,13 +40,13 @@ timerHardware_t timerHardware[] = {
 
     DEF_TIM(TIM2,   CH3,    PB10,   TIM_USE_OUTPUT_AUTO,    0, 0), // S3
 
-    DEF_TIM(TIM2,   CH4,    PB11,   TIM_USE_OUTPUT_AUTO,    0, 0), // S4
+    DEF_TIM(TIM2,   CH4,    PB11,   TIM_USE_OUTPUT_AUTO,    0, 1), // S4 -- dmavar 1: DMA1 Stream6, S1's TIM3_CH3 has only DMA1 Stream7
 
     // DEF_TIM(TIM3,   CH4,    PC9,    TIM_USE_OUTPUT_AUTO,    0, 0), // S5
     DEF_TIM(TIM8, CH4, PC9, TIM_USE_OUTPUT_AUTO, 0, 0),
 
-    DEF_TIM(TIM3,   CH3,    PC8,    TIM_USE_OUTPUT_AUTO,    0, 0), // S6
-    //DEF_TIM(TIM8, CH3, PC8, TIM_USE_OUTPUT_AUTO, 0, 0),
+    // DEF_TIM(TIM3,   CH3,    PC8,    TIM_USE_OUTPUT_AUTO,    0, 0), // S6
+    DEF_TIM(TIM8, CH3, PC8, TIM_USE_OUTPUT_AUTO, 0, 0),
 
     // DEF_TIM(TIM3,   CH2,    PC7,    TIM_USE_OUTPUT_AUTO,    0, 0), // S7
     DEF_TIM(TIM8, CH2, PC7, TIM_USE_OUTPUT_AUTO, 0, 0),


### PR DESCRIPTION
## Summary

Two targets declare the same `(timer, channel)` on two different pins. Both pins are then muxed to one compare register, so they can only ever emit the same waveform — the second pad is not an independent output for any protocol, DSHOT or otherwise, and at higher motor counts the two entries fight over the same CCR.

A sweep of all 249 targets found these were the only two affected. After this PR that bucket is empty.

## Changes

### FURYF4OSD — PB10/PB11 removed

`TIM2_CH3` was declared on both PA2 (S4_OUT) and PB10; `TIM2_CH4` on both PA3 (S1_OUT) and PB11.

Per the STM32F405 datasheet AF table, PB10's only timer function is `TIM2_CH3` (AF1) and PB11's only timer function is `TIM2_CH4` (AF1) — there is no free channel to remap them to, so the two `TIM_USE_ANY` entries are removed. Both pads are this board's UART3 TX/RX. `MAX_PWM_OUTPUT_PORTS` drops 6 → 4 to match the outputs that remain.

**User-visible:** FURYF4OSD advertises 4 outputs instead of 6. Outputs 5 and 6 never worked as independent outputs, so nothing that previously functioned is lost.

### WARPF7 — S6 moved to TIM8_CH3

`TIM3_CH3` was declared on both PB0 (S1) and PC8 (S6), so S6 could only mirror S1. PC8 also reaches `TIM8_CH3`, which no other output on this board uses (`DEF_TIM_AF__PC8__TCH_TIM8_CH3` already exists in `timer_def_stm32f7xx.h`), so S6 moves there. The board keeps all eight documented outputs.

Also in this file: S4 (PB11, `TIM2_CH4`) moves to its second DMA option, DMA1 Stream6. Its default Stream7 is the only stream `TIM3_CH3` can use, so S1 claimed it first and S4 silently died at four motors. #11803 makes this same change on `maintenance-10.x`; `release/9.1` does not have it.

## Testing

- Both targets build clean, no warnings (FURYF4OSD 68.1% flash / 84.6% RAM; WARPF7 94.3% FLASH1).
- Role/DMA resolution simulated against a port of `pwm_mapping.c`'s algorithm across motor counts 1–8: WARPF7 is now hazard-free at every count; FURYF4OSD reports no remaining duplicate or motor-vs-motor collision.
- Every `DEF_TIM` in both files re-validated against the STM32F405/F722 datasheet AF tables.
- **Not tested on hardware** — I have neither board. Confirmation from a FURYF4OSD or WARPF7 owner that motors still map correctly would be valuable before merge.

## Notes

Pre-existing and not addressed here: FURYF4OSD's S3_OUT (`TIM3_CH4`, DMA1 Stream2) and LED strip (`TIM5_CH1`, DMA1 Stream2) share a stream, so the LED strip does not light when S3 uses DSHOT. Each channel has exactly one DMA option and PA0 has no other usable timer, so it cannot be fixed by remapping. Documented in #11803.

This PR touches lines that #11803 annotates with comments; whichever merges second will need a trivial comment-level conflict resolution.