### PR TITLE
cms: fix menu stack overflow and other safety issues found after 11782

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -102,6 +102,12 @@ static int cmsDeviceCount;
 static int cmsCurrentDevice = -1;
 static timeMs_t cmsYieldUntil = 0;
 
+// True while CMS actually holds a grab on pCurrentDisplay. cmsYieldUntil alone
+// cannot tell us this: it only records that *some* display was released for a
+// yield, not whether pCurrentDisplay - which can change mid-yield if the menu
+// switches displays - is the one that grab applies to.
+static bool cmsDisplayGrabbed = false;
+
 bool cmsDisplayPortRegister(displayPort_t *pDisplay)
 {
     if (cmsDeviceCount == CMS_MAX_DEVICE)
@@ -881,13 +887,20 @@ void cmsMenuOpen(void)
             // DisplayPort has been changed.
             // Convert cursorRow to absolute value
             currentCtx.cursorRow = cmsCursorAbsolute(pCurrentDisplay);
-            displayRelease(pCurrentDisplay);
+            if (cmsDisplayGrabbed) {
+                displayRelease(pCurrentDisplay);
+            }
             pCurrentDisplay = pNextDisplay;
         } else {
             return;
         }
     }
     displayGrab(pCurrentDisplay); // grab the display for use by the CMS
+    cmsDisplayGrabbed = true;
+    // Any yield in progress applied to whatever display was current before -
+    // we now hold a fresh grab on pCurrentDisplay (possibly a different
+    // display, if the menu switched while yielding), so it no longer applies.
+    cmsYieldUntil = 0;
 
     if (pCurrentDisplay->cols < NORMAL_SCREEN_MIN_COLS) {
         smallScreen = true;
@@ -996,9 +1009,13 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
     // Only release the display if we are still holding it. cmsYieldDisplay()
     // has already released it when a yield is in progress, and an exit can
     // happen during that window (in-flight auto-close), which would otherwise
-    // leave the display grab count unbalanced.
-    if (cmsYieldUntil == 0) {
+    // leave the display grab count unbalanced. cmsDisplayGrabbed - not the
+    // yield timer - is the source of truth: the menu can switch displays
+    // mid-yield, in which case pDisplay is grabbed even though a yield is
+    // still nominally pending.
+    if (cmsDisplayGrabbed) {
         displayRelease(pDisplay);
+        cmsDisplayGrabbed = false;
     }
     cmsYieldUntil = 0;
 
@@ -1040,8 +1057,9 @@ void cmsYieldDisplay(displayPort_t *pPort, timeMs_t duration)
     // Check if we're already yielding, in that case just extend
     // the yield time without releasing the display again, otherwise
     // the yield/grab become unbalanced.
-    if (cmsYieldUntil == 0) {
+    if (cmsDisplayGrabbed) {
         displayRelease(pPort);
+        cmsDisplayGrabbed = false;
     }
     cmsYieldUntil = millis() + duration;
 }
@@ -1567,6 +1585,7 @@ void cmsUpdate(uint32_t currentTimeUs)
         if (cmsYieldUntil > 0 && currentTimeMs > cmsYieldUntil) {
             cmsYieldUntil = 0;
             displayGrab(pCurrentDisplay);
+            cmsDisplayGrabbed = true;
             displayClearScreen(pCurrentDisplay);
         }
 

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -914,6 +914,15 @@ void cmsMenuOpen(void)
         maxMenuItems = pCurrentDisplay->rows;
     }
 
+    if (maxMenuItems > ARRAYLEN(entry_flags)) {
+        // entry_flags[] is indexed by row within the page and sized for the
+        // largest row count any of our display drivers can report. Every
+        // driver derives rows from a compile-time constant except FrSky OSD,
+        // whose grid size is a runtime value read back from the OSD hardware,
+        // so this stays a hard runtime clamp rather than a compile-time check.
+        maxMenuItems = ARRAYLEN(entry_flags);
+    }
+
     cmsMenuChange(pCurrentDisplay, currentCtx.menu, NULL);
 }
 

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -779,6 +779,11 @@ long cmsMenuChange(displayPort_t *pDisplay, const CMS_Menu *pMenu, const OSD_Ent
     if (pMenu != currentCtx.menu) {
         // Stack the current menu and move to a new menu.
 
+        if (menuStackIdx >= ARRAYLEN(menuStack)) {
+            // Stack is full - refuse to descend rather than write out of bounds
+            return 0;
+        }
+
         menuStack[menuStackIdx++] = currentCtx;
 
         currentCtx.menu = pMenu;
@@ -954,6 +959,13 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
     }
 
     cmsInMenu = false;
+
+    // Reset the menu stack. Without this it grows by one entry for every exit
+    // made from inside a submenu and is never emptied, so after a few
+    // open/close cycles menuStackIdx runs past the end of menuStack and both
+    // cmsMenuBack() and the onExit loops above read and dereference garbage.
+    menuStackIdx = 0;
+    pageTop = NULL;
 
     displayRelease(pDisplay);
     currentCtx.menu = NULL;

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -189,6 +189,15 @@ static bool cmsMenuSwitchLatched = false;
 static uint32_t cmsOpenCountdownStartTime = 0;
 static timeMs_t cmsLastInputMs = 0;
 
+// Panic stick detection state - file scope so it can be reset on every menu
+// open, otherwise a partial detection carries over into the next session.
+static uint8_t cmsPanicDualAxisCount = 0;
+static timeMs_t cmsPanicLastCheckMs = 0;
+
+// Set when this module disabled the servo output on open, so that exit always
+// restores exactly what was changed.
+static bool cmsServoOutputDisabled = false;
+
 uint32_t cmsGetOpenCountdownRemaining(void)
 {
     if (cmsOpenCountdownStartTime == 0) {
@@ -836,18 +845,22 @@ void cmsMenuOpen(void)
 {
     if (!cmsInMenu) {
         // New open
-        if (!ARMING_FLAG(ARMED)) {
-            setServoOutputEnabled(false);
-        }
         pCurrentDisplay = cmsDisplayPortSelectCurrent();
         if (!pCurrentDisplay)
             return;
         cmsInMenu = true;
         cmsOpenedInFlight = ARMING_FLAG(ARMED);
         cmsLastInputMs = millis();
+        cmsPanicDualAxisCount = 0;
+        cmsPanicLastCheckMs = 0;
         if (cmsOpenedInFlight) {
             currentCtx = (cmsCtx_t){ &menuMainInFlight, 0, 0 };
         } else {
+            // Note the servo output is only touched after the display check
+            // above has succeeded: disabling it on a failed open would leave the
+            // servos frozen with no menu open and no way to restore them.
+            setServoOutputEnabled(false);
+            cmsServoOutputDisabled = true;
             currentCtx = (cmsCtx_t){ &menuMain, 0, 0 };
             ENABLE_ARMING_FLAG(ARMING_DISABLED_CMS_MENU);
         }
@@ -935,7 +948,7 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
         if ((exitType == CMS_POPUP_SAVE) || (exitType == CMS_POPUP_SAVEREBOOT)) {
             // traverse through the menu stack and call their onExit functions
             for (int i = menuStackIdx - 1; i >= 0; i--) {
-                if (menuStack[i].menu->onExit) {
+                if (menuStack[i].menu && menuStack[i].menu->onExit) {
                     menuStack[i].menu->onExit((OSD_Entry *) NULL);
                 }
             }
@@ -945,16 +958,10 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
         break;
 
     case CMS_EXIT:
-        if (cmsOpenedInFlight) {
-            if (currentCtx.menu && currentCtx.menu->onExit) {
-                currentCtx.menu->onExit((OSD_Entry *)NULL);
-            }
-            for (int i = menuStackIdx - 1; i >= 0; i--) {
-                if (menuStack[i].menu && menuStack[i].menu->onExit) {
-                    menuStack[i].menu->onExit((OSD_Entry *)NULL);
-                }
-            }
-        }
+        // Deliberately does not run any onExit handler. Closing the menu - and in
+        // particular the in-flight auto-close on switch off, timeout, panic sticks
+        // or nav mode loss - must never apply pending edits: settings only change
+        // when the pilot explicitly confirms them with BACK or SET/YES.
         break;
     }
 
@@ -967,12 +974,27 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
     menuStackIdx = 0;
     pageTop = NULL;
 
-    displayRelease(pDisplay);
+    // Only release the display if we are still holding it. cmsYieldDisplay()
+    // has already released it when a yield is in progress, and an exit can
+    // happen during that window (in-flight auto-close), which would otherwise
+    // leave the display grab count unbalanced.
+    if (cmsYieldUntil == 0) {
+        displayRelease(pDisplay);
+    }
+    cmsYieldUntil = 0;
+
     currentCtx.menu = NULL;
 
-    if (!cmsOpenedInFlight) {
+    // Always restore what we actually disabled. Keying this off cmsOpenedInFlight
+    // instead left the servo output disabled whenever the armed state seen at open
+    // differed from the one at exit, freezing roll and pitch at centre while
+    // rcCommand and the motor outputs kept working normally.
+    if (cmsServoOutputDisabled) {
         setServoOutputEnabled(true);
+        cmsServoOutputDisabled = false;
+    }
 
+    if (!cmsOpenedInFlight) {
         if ((exitType == CMS_EXIT_SAVEREBOOT) || (exitType == CMS_POPUP_SAVEREBOOT)) {
             processDelayedSave();
             displayClearScreen(pDisplay);
@@ -1433,14 +1455,11 @@ static bool cmsDetectPanicStickMovement(timeMs_t currentTimeMs)
     // samples at 50ms intervals (150ms sustained). This gives zero false positives
     // on real navigation data while catching all panic patterns within ~200ms.
 
-    static uint8_t dualAxisCount = 0;
-    static timeMs_t lastCheckMs = 0;
-
     // Sample at ~20 Hz
-    if (currentTimeMs - lastCheckMs < 50) {
+    if (currentTimeMs - cmsPanicLastCheckMs < 50) {
         return false;
     }
-    lastCheckMs = currentTimeMs;
+    cmsPanicLastCheckMs = currentTimeMs;
 
     const int16_t rollDev  = ABS((int16_t)rxGetChannelValue(ROLL)  - 1500);
     const int16_t pitchDev = ABS((int16_t)rxGetChannelValue(PITCH) - 1500);
@@ -1448,13 +1467,13 @@ static bool cmsDetectPanicStickMovement(timeMs_t currentTimeMs)
     #define PANIC_DUAL_AXIS_THRESHOLD 100  // PWM deviation from center
 
     if (rollDev > PANIC_DUAL_AXIS_THRESHOLD && pitchDev > PANIC_DUAL_AXIS_THRESHOLD) {
-        dualAxisCount++;
-        if (dualAxisCount >= 3) {
-            dualAxisCount = 0;
+        cmsPanicDualAxisCount++;
+        if (cmsPanicDualAxisCount >= 3) {
+            cmsPanicDualAxisCount = 0;
             return true;
         }
     } else {
-        dualAxisCount = 0;
+        cmsPanicDualAxisCount = 0;
     }
 
     return false;

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -841,6 +841,16 @@ STATIC_UNIT_TESTED long cmsMenuBack(displayPort_t *pDisplay)
     return 0;
 }
 
+long cmsMenuConfirmDone(displayPort_t *pDisplay)
+{
+    // Leave the confirmation submenu and tell the caller to leave its parent as
+    // well. The in-flight edit menus have no BACK entry - they are left through
+    // the confirmation only - so both YES and NO must land on the parent menu.
+    cmsMenuBack(pDisplay);
+
+    return MENU_CHAIN_BACK;
+}
+
 void cmsMenuOpen(void)
 {
     if (!cmsInMenu) {

--- a/src/main/cms/cms.h
+++ b/src/main/cms/cms.h
@@ -33,6 +33,7 @@ displayPort_t *cmsDisplayPortGetCurrent(void);
 void cmsMenuOpen(void);
 long cmsMenuChange(displayPort_t *pPort, const CMS_Menu *menu, const OSD_Entry *from);
 long cmsMenuExit(displayPort_t *pPort, const void *ptr);
+long cmsMenuConfirmDone(displayPort_t *pPort);
 
 uint32_t cmsGetOpenCountdownRemaining(void);
 uint32_t cmsGetInactivityCloseCountdownRemaining(void);

--- a/src/main/cms/cms_menu_battery.c
+++ b/src/main/cms/cms_menu_battery.c
@@ -146,7 +146,7 @@ static CMS_Menu cmsx_menuBattSettings = {
     .entries = menuBattSettingsEntries
 };
 
-static OSD_Entry menuBatteryEntries[]=
+static const OSD_Entry menuBatteryEntries[]=
 {
     OSD_LABEL_ENTRY("-- BATTERY --"),
 
@@ -170,7 +170,7 @@ CMS_Menu cmsx_menuBattery = {
     .entries = menuBatteryEntries
 };
 
-static OSD_Entry menuBatteryInFlightEntries[]=
+static const OSD_Entry menuBatteryInFlightEntries[]=
 {
     OSD_LABEL_ENTRY("-- BATTERY --"),
 

--- a/src/main/cms/cms_menu_battery.c
+++ b/src/main/cms/cms_menu_battery.c
@@ -146,6 +146,37 @@ static CMS_Menu cmsx_menuBattSettings = {
     .entries = menuBattSettingsEntries
 };
 
+static long cmsx_menuBattSettingsInFlight_onEnter(const OSD_Entry *from)
+{
+    UNUSED(from);
+
+    setConfigBatteryProfile(battProfileIndex);
+
+    // Sync thresholds here too, not just on exit: setConfigBatteryProfile()
+    // above already switches the live profile the instant this submenu is
+    // entered, but a forced close (switch off, failsafe, panic sticks,
+    // timeout) tears the in-flight menu down without running onExit, which
+    // would otherwise leave the newly active profile's cell count and
+    // voltage thresholds stale from the previous one for the rest of the
+    // flight.
+    if (ARMING_FLAG(ARMED)) {
+        batteryUpdateThresholdsAndCells();
+    }
+
+    return 0;
+}
+
+static CMS_Menu cmsx_menuBattSettingsInFlight = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "XBATT_IF",
+    .GUARD_type = OME_MENU,
+#endif
+    .onEnter = cmsx_menuBattSettingsInFlight_onEnter,
+    .onExit = cmsx_menuBattSettings_onExit,
+    .onGlobalExit = NULL,
+    .entries = menuBattSettingsEntries
+};
+
 static const OSD_Entry menuBatteryEntries[]=
 {
     OSD_LABEL_ENTRY("-- BATTERY --"),
@@ -175,7 +206,7 @@ static const OSD_Entry menuBatteryInFlightEntries[]=
     OSD_LABEL_ENTRY("-- BATTERY --"),
 
     OSD_UINT8_CALLBACK_ENTRY("PROF", cmsx_onBatteryProfileIndexChange, (&(const OSD_UINT8_t){ &battDispProfileIndex, 1, MAX_BATTERY_PROFILE_COUNT, 1})),
-    OSD_SUBMENU_ENTRY("SETTINGS", &cmsx_menuBattSettings),
+    OSD_SUBMENU_ENTRY("SETTINGS", &cmsx_menuBattSettingsInFlight),
 
     OSD_BACK_AND_END_ENTRY,
 };

--- a/src/main/cms/cms_menu_battery.c
+++ b/src/main/cms/cms_menu_battery.c
@@ -201,11 +201,29 @@ CMS_Menu cmsx_menuBattery = {
     .entries = menuBatteryEntries
 };
 
+static long cmsx_onBatteryProfileIndexChangeInFlight(displayPort_t *displayPort, const void *ptr)
+{
+    // Same as the ground callback, but also pushes the change into the live
+    // profile immediately - a forced close of the in-flight menu (switch off,
+    // failsafe, panic sticks, timeout) never runs onExit, so waiting for exit
+    // to apply this would silently drop the profile switch.
+    cmsx_onBatteryProfileIndexChange(displayPort, ptr);
+
+    setConfigBatteryProfile(battProfileIndex);
+    if (ARMING_FLAG(ARMED)) {
+        batteryUpdateThresholdsAndCells();
+    } else {
+        activateBatteryProfile();
+    }
+
+    return 0;
+}
+
 static const OSD_Entry menuBatteryInFlightEntries[]=
 {
     OSD_LABEL_ENTRY("-- BATTERY --"),
 
-    OSD_UINT8_CALLBACK_ENTRY("PROF", cmsx_onBatteryProfileIndexChange, (&(const OSD_UINT8_t){ &battDispProfileIndex, 1, MAX_BATTERY_PROFILE_COUNT, 1})),
+    OSD_UINT8_CALLBACK_ENTRY("PROF", cmsx_onBatteryProfileIndexChangeInFlight, (&(const OSD_UINT8_t){ &battDispProfileIndex, 1, MAX_BATTERY_PROFILE_COUNT, 1})),
     OSD_SUBMENU_ENTRY("SETTINGS", &cmsx_menuBattSettingsInFlight),
 
     OSD_BACK_AND_END_ENTRY,

--- a/src/main/cms/cms_menu_battery.c
+++ b/src/main/cms/cms_menu_battery.c
@@ -62,9 +62,17 @@ static long cmsx_menuBattery_onExit(const OSD_Entry *self)
     UNUSED(self);
 
     setConfigBatteryProfile(battProfileIndex);
-    activateBatteryProfile();
+
     if (ARMING_FLAG(ARMED)) {
+        // Do not call activateBatteryProfile() while armed: it runs batteryInit(),
+        // which clears the battery state, cell count and all voltage thresholds.
+        // The battery is then re-detected in flight under load, so the pack never
+        // looks "full when plugged in" and capacity based warnings and failsafes
+        // stay disabled for the rest of the flight. Just recompute the thresholds
+        // for the newly selected profile instead.
         batteryUpdateThresholdsAndCells();
+    } else {
+        activateBatteryProfile();
     }
 
     if (featureProfAutoswitchEnabled) {

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -101,6 +101,16 @@ static long cmsx_profileIndexOnChange(displayPort_t *displayPort, const void *pt
     profileIndex = tmpProfileIndex - 1;
     profileIndexString[1] = '0' + tmpProfileIndex;
     setConfigProfile(profileIndex);
+
+    return 0;
+}
+
+static long cmsx_profileIndexOnChangeInFlight(displayPort_t *displayPort, const void *ptr)
+{
+    // Same as above, but pushes the newly selected profile all the way into the
+    // running controllers so the change takes effect immediately while armed.
+    cmsx_profileIndexOnChange(displayPort, ptr);
+
     schedulePidGainsUpdate();
     navigationUsePIDs();
     activateControlConfig();
@@ -164,28 +174,6 @@ static const CMS_Menu cmsx_menuEzTune = {
     .entries = cmsx_menuEzTuneEntries
 };
 
-static long cmsx_PidWriteback_Confirm(displayPort_t *displayPort, const void *ptr)
-{
-    UNUSED(displayPort);
-    UNUSED(ptr);
-    cmsx_PidWriteback(NULL);
-    return MENU_CHAIN_BACK;
-}
-
-static const OSD_Entry cmsx_menuPidConfirmEntries[] = {
-    OSD_LABEL_ENTRY("--- CONFIRM ---"),
-    OSD_FUNC_CALL_ENTRY("YES", cmsx_PidWriteback_Confirm),
-    { "NO", {.func = NULL}, NULL, OME_Back, 0 },
-    OSD_END_ENTRY
-};
-
-static const CMS_Menu cmsx_menuPidConfirm = {
-    .onEnter = NULL,
-    .onExit = NULL,
-    .onGlobalExit = NULL,
-    .entries = cmsx_menuPidConfirmEntries,
-};
-
 static const OSD_Entry cmsx_menuPidEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- PID --", profileIndexString),
@@ -205,7 +193,6 @@ static const OSD_Entry cmsx_menuPidEntries[] =
     RPY_PIDFF_ENTRY("YAW   D", &cmsx_pidYaw.D),
     RPY_PIDFF_ENTRY("YAW   FF", &cmsx_pidYaw.FF),
 
-    OSD_SUBMENU_ENTRY("SET", &cmsx_menuPidConfirm),
     OSD_BACK_AND_END_ENTRY,
 };
 
@@ -215,7 +202,7 @@ static const CMS_Menu cmsx_menuPid = {
     .GUARD_type = OME_MENU,
 #endif
     .onEnter = cmsx_PidOnEnter,
-    .onExit = NULL,
+    .onExit = cmsx_PidWriteback,
     .onGlobalExit = NULL,
     .entries = cmsx_menuPidEntries
 };
@@ -244,28 +231,6 @@ static long cmsx_menuPidAltMag_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static long cmsx_menuPidAltMag_onExit_Confirm(displayPort_t *displayPort, const void *ptr)
-{
-    UNUSED(displayPort);
-    UNUSED(ptr);
-    cmsx_menuPidAltMag_onExit(NULL);
-    return MENU_CHAIN_BACK;
-}
-
-static const OSD_Entry cmsx_menuPidAltMagConfirmEntries[] = {
-    OSD_LABEL_ENTRY("--- CONFIRM ---"),
-    OSD_FUNC_CALL_ENTRY("YES", cmsx_menuPidAltMag_onExit_Confirm),
-    { "NO", {.func = NULL}, NULL, OME_Back, 0 },
-    OSD_END_ENTRY
-};
-
-static const CMS_Menu cmsx_menuPidAltMagConfirm = {
-    .onEnter = NULL,
-    .onExit = NULL,
-    .onGlobalExit = NULL,
-    .entries = cmsx_menuPidAltMagConfirmEntries,
-};
-
 static const OSD_Entry cmsx_menuPidAltMagEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- ALT&MAG --", profileIndexString),
@@ -283,7 +248,6 @@ static const OSD_Entry cmsx_menuPidAltMagEntries[] =
 
     OTHER_PIDFF_ENTRY("MAG P", &cmsx_pidHead.P),
 
-    OSD_SUBMENU_ENTRY("SET", &cmsx_menuPidAltMagConfirm),
     OSD_BACK_AND_END_ENTRY,
 };
 
@@ -293,7 +257,7 @@ static const CMS_Menu cmsx_menuPidAltMag = {
     .GUARD_type = OME_MENU,
 #endif
     .onEnter = cmsx_menuPidAltMag_onEnter,
-    .onExit = NULL,
+    .onExit = cmsx_menuPidAltMag_onExit,
     .onGlobalExit = NULL,
     .entries = cmsx_menuPidAltMagEntries,
 };
@@ -320,28 +284,6 @@ static long cmsx_menuPidGpsnav_onExit(const OSD_Entry *self)
     return 0;
 }
 
-static long cmsx_menuPidGpsnav_onExit_Confirm(displayPort_t *displayPort, const void *ptr)
-{
-    UNUSED(displayPort);
-    UNUSED(ptr);
-    cmsx_menuPidGpsnav_onExit(NULL);
-    return MENU_CHAIN_BACK;
-}
-
-static const OSD_Entry cmsx_menuPidGpsnavConfirmEntries[] = {
-    OSD_LABEL_ENTRY("--- CONFIRM ---"),
-    OSD_FUNC_CALL_ENTRY("YES", cmsx_menuPidGpsnav_onExit_Confirm),
-    { "NO", {.func = NULL}, NULL, OME_Back, 0 },
-    OSD_END_ENTRY
-};
-
-static const CMS_Menu cmsx_menuPidGpsnavConfirm = {
-    .onEnter = NULL,
-    .onExit = NULL,
-    .onGlobalExit = NULL,
-    .entries = cmsx_menuPidGpsnavConfirmEntries,
-};
-
 static const OSD_Entry cmsx_menuPidGpsnavEntries[] =
 {
     OSD_LABEL_DATA_ENTRY("-- GPSNAV --", profileIndexString),
@@ -355,7 +297,6 @@ static const OSD_Entry cmsx_menuPidGpsnavEntries[] =
     OTHER_PIDFF_ENTRY("VEL D", &cmsx_pidVelXY.D),
     OTHER_PIDFF_ENTRY("VEL FF", &cmsx_pidVelXY.FF),
 
-    OSD_SUBMENU_ENTRY("SET", &cmsx_menuPidGpsnavConfirm),
     OSD_BACK_AND_END_ENTRY,
 };
 
@@ -365,7 +306,7 @@ static const CMS_Menu cmsx_menuPidGpsnav = {
     .GUARD_type = OME_MENU,
 #endif
     .onEnter = cmsx_menuPidGpsnav_onEnter,
-    .onExit = NULL,
+    .onExit = cmsx_menuPidGpsnav_onExit,
     .onGlobalExit = NULL,
     .entries = cmsx_menuPidGpsnavEntries,
 };
@@ -590,18 +531,187 @@ const CMS_Menu cmsx_menuImu = {
     .entries = cmsx_menuImuEntries,
 };
 
+//
+// In-flight PID menus
+//
+// Separate from the ground menus above on purpose. The ground CMS keeps its
+// original behaviour, where leaving a menu with BACK applies the pending edits.
+// In flight that is not acceptable: the menu can be closed at any moment by the
+// switch, the inactivity timeout or a safety trip, and a close must never change
+// anything. So these menus have no BACK entry at all - the only way out is SET,
+// which asks for an explicit confirmation and returns to the parent menu either
+// way. Nothing is committed unless YES is selected, and re-entering the menu
+// reloads the live values, so a discarded edit leaves no trace.
+//
+
+static long cmsx_PidInFlight_Apply(displayPort_t *displayPort, const void *ptr)
+{
+    UNUSED(ptr);
+
+    cmsx_PidWriteback(NULL);
+
+    return cmsMenuConfirmDone(displayPort);
+}
+
+static long cmsx_PidAltMagInFlight_Apply(displayPort_t *displayPort, const void *ptr)
+{
+    UNUSED(ptr);
+
+    cmsx_menuPidAltMag_onExit(NULL);
+
+    return cmsMenuConfirmDone(displayPort);
+}
+
+static long cmsx_PidGpsnavInFlight_Apply(displayPort_t *displayPort, const void *ptr)
+{
+    UNUSED(ptr);
+
+    cmsx_menuPidGpsnav_onExit(NULL);
+
+    return cmsMenuConfirmDone(displayPort);
+}
+
+static long cmsx_InFlight_Discard(displayPort_t *displayPort, const void *ptr)
+{
+    UNUSED(ptr);
+
+    return cmsMenuConfirmDone(displayPort);
+}
+
+#ifdef CMS_MENU_DEBUG
+#define CMS_MENU_GUARD(text) .GUARD_text = text, .GUARD_type = OME_MENU,
+#else
+#define CMS_MENU_GUARD(text)
+#endif
+
+#define CMSX_IN_FLIGHT_CONFIRM(name, applyFunc, guard)                  \
+    static const OSD_Entry name ## Entries[] = {                        \
+        OSD_LABEL_ENTRY("CONFIRM"),                                     \
+        OSD_FUNC_CALL_ENTRY("YES", applyFunc),                          \
+                                                                        \
+        OSD_FUNC_CALL_ENTRY("NO", cmsx_InFlight_Discard),               \
+        OSD_END_ENTRY                                                   \
+    };                                                                  \
+                                                                        \
+    static const CMS_Menu name = {                                      \
+        CMS_MENU_GUARD(guard)                                           \
+        .onEnter = NULL,                                                \
+        .onExit = NULL,                                                 \
+        .onGlobalExit = NULL,                                           \
+        .entries = name ## Entries,                                     \
+    }
+
+CMSX_IN_FLIGHT_CONFIRM(cmsx_menuPidInFlightConfirm, cmsx_PidInFlight_Apply, "XPIDC_IF");
+CMSX_IN_FLIGHT_CONFIRM(cmsx_menuPidAltMagInFlightConfirm, cmsx_PidAltMagInFlight_Apply, "XALTMAGC_IF");
+CMSX_IN_FLIGHT_CONFIRM(cmsx_menuPidGpsnavInFlightConfirm, cmsx_PidGpsnavInFlight_Apply, "XGPSNAVC_IF");
+
+static const OSD_Entry cmsx_menuPidInFlightEntries[] =
+{
+    OSD_LABEL_DATA_ENTRY("-- PID --", profileIndexString),
+
+    RPY_PIDFF_ENTRY("ROLL  P", &cmsx_pidRoll.P),
+    RPY_PIDFF_ENTRY("ROLL  I", &cmsx_pidRoll.I),
+    RPY_PIDFF_ENTRY("ROLL  D", &cmsx_pidRoll.D),
+    RPY_PIDFF_ENTRY("ROLL  FF", &cmsx_pidRoll.FF),
+
+    RPY_PIDFF_ENTRY("PITCH P", &cmsx_pidPitch.P),
+    RPY_PIDFF_ENTRY("PITCH I", &cmsx_pidPitch.I),
+    RPY_PIDFF_ENTRY("PITCH D", &cmsx_pidPitch.D),
+    RPY_PIDFF_ENTRY("PITCH FF", &cmsx_pidPitch.FF),
+
+    RPY_PIDFF_ENTRY("YAW   P", &cmsx_pidYaw.P),
+    RPY_PIDFF_ENTRY("YAW   I", &cmsx_pidYaw.I),
+    RPY_PIDFF_ENTRY("YAW   D", &cmsx_pidYaw.D),
+    RPY_PIDFF_ENTRY("YAW   FF", &cmsx_pidYaw.FF),
+
+    OSD_SUBMENU_ENTRY("SET", &cmsx_menuPidInFlightConfirm),
+    OSD_END_ENTRY,
+};
+
+static const CMS_Menu cmsx_menuPidInFlight = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "XPID_IF",
+    .GUARD_type = OME_MENU,
+#endif
+    .onEnter = cmsx_PidOnEnter,
+    .onExit = NULL,
+    .onGlobalExit = NULL,
+    .entries = cmsx_menuPidInFlightEntries,
+};
+
+static const OSD_Entry cmsx_menuPidAltMagInFlightEntries[] =
+{
+    OSD_LABEL_DATA_ENTRY("-- ALT&MAG --", profileIndexString),
+
+    OSD_SETTING_ENTRY("FW ALT RESPONSE", SETTING_NAV_FW_ALT_CONTROL_RESPONSE),
+
+    OTHER_PIDFF_ENTRY("ALT P", &cmsx_pidPosZ.P),
+    OTHER_PIDFF_ENTRY("ALT I", &cmsx_pidPosZ.I),
+    OTHER_PIDFF_ENTRY("ALT D", &cmsx_pidPosZ.D),
+    OTHER_PIDFF_ENTRY("ALT FF", &cmsx_pidPosZ.FF),
+
+    OTHER_PIDFF_ENTRY("VEL P", &cmsx_pidVelZ.P),
+    OTHER_PIDFF_ENTRY("VEL I", &cmsx_pidVelZ.I),
+    OTHER_PIDFF_ENTRY("VEL D", &cmsx_pidVelZ.D),
+
+    OTHER_PIDFF_ENTRY("MAG P", &cmsx_pidHead.P),
+
+    OSD_SUBMENU_ENTRY("SET", &cmsx_menuPidAltMagInFlightConfirm),
+    OSD_END_ENTRY,
+};
+
+static const CMS_Menu cmsx_menuPidAltMagInFlight = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "XALTMAG_IF",
+    .GUARD_type = OME_MENU,
+#endif
+    .onEnter = cmsx_menuPidAltMag_onEnter,
+    .onExit = NULL,
+    .onGlobalExit = NULL,
+    .entries = cmsx_menuPidAltMagInFlightEntries,
+};
+
+static const OSD_Entry cmsx_menuPidGpsnavInFlightEntries[] =
+{
+    OSD_LABEL_DATA_ENTRY("-- GPSNAV --", profileIndexString),
+
+    OTHER_PIDFF_ENTRY("POS P", &cmsx_pidPosXY.P),
+    OTHER_PIDFF_ENTRY("POS I", &cmsx_pidPosXY.I),
+    OTHER_PIDFF_ENTRY("POS D", &cmsx_pidPosXY.D),
+
+    OTHER_PIDFF_ENTRY("VEL P", &cmsx_pidVelXY.P),
+    OTHER_PIDFF_ENTRY("VEL I", &cmsx_pidVelXY.I),
+    OTHER_PIDFF_ENTRY("VEL D", &cmsx_pidVelXY.D),
+    OTHER_PIDFF_ENTRY("VEL FF", &cmsx_pidVelXY.FF),
+
+    OSD_SUBMENU_ENTRY("SET", &cmsx_menuPidGpsnavInFlightConfirm),
+    OSD_END_ENTRY,
+};
+
+static const CMS_Menu cmsx_menuPidGpsnavInFlight = {
+#ifdef CMS_MENU_DEBUG
+    .GUARD_text = "XGPSNAV_IF",
+    .GUARD_type = OME_MENU,
+#endif
+    .onEnter = cmsx_menuPidGpsnav_onEnter,
+    .onExit = NULL,
+    .onGlobalExit = NULL,
+    .entries = cmsx_menuPidGpsnavInFlightEntries,
+};
+
 static const OSD_Entry cmsx_menuImuInFlightEntries[] =
 {
     OSD_LABEL_ENTRY("-- PID TUNING --"),
 
-    // Profile dependent
-    OSD_UINT8_CALLBACK_ENTRY("PID PROF", cmsx_profileIndexOnChange, (&(const OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_PROFILE_COUNT, 1})),
-    OSD_SUBMENU_ENTRY("PID", &cmsx_menuPid),
-    OSD_SUBMENU_ENTRY("PID ALTMAG", &cmsx_menuPidAltMag),
-    OSD_SUBMENU_ENTRY("PID GPSNAV", &cmsx_menuPidGpsnav),
+    // Profile dependent. Both profile selectors take effect as soon as they are
+    // changed, exactly as they do on the ground.
+    OSD_UINT8_CALLBACK_ENTRY("PID PROF", cmsx_profileIndexOnChangeInFlight, (&(const OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_PROFILE_COUNT, 1})),
+    OSD_SUBMENU_ENTRY("PID", &cmsx_menuPidInFlight),
+    OSD_SUBMENU_ENTRY("PID ALTMAG", &cmsx_menuPidAltMagInFlight),
+    OSD_SUBMENU_ENTRY("PID GPSNAV", &cmsx_menuPidGpsnavInFlight),
 
     // Rate profile dependent
-    OSD_UINT8_CALLBACK_ENTRY("RATE PROF", cmsx_profileIndexOnChange, (&(const OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_CONTROL_PROFILE_COUNT, 1})),
+    OSD_UINT8_CALLBACK_ENTRY("RATE PROF", cmsx_profileIndexOnChangeInFlight, (&(const OSD_UINT8_t){ &tmpProfileIndex, 1, MAX_CONTROL_PROFILE_COUNT, 1})),
     OSD_SUBMENU_ENTRY("RATE", &cmsx_menuRateProfile),
     OSD_SUBMENU_ENTRY("MANU RATE", &cmsx_menuManualRateProfile),
 

--- a/src/main/cms/cms_menu_misc.c
+++ b/src/main/cms/cms_menu_misc.c
@@ -74,7 +74,9 @@ static const OSD_Entry menuMiscInFlightEntries[]=
 {
     OSD_LABEL_ENTRY("-- MISC --"),
 
-    OSD_SETTING_ENTRY("THR IDLE", SETTING_THROTTLE_IDLE),
+    // THR IDLE is deliberately not offered here: getThrottleIdleValue() caches the
+    // computed value and nothing invalidates that cache, so changing it while
+    // armed has no effect until the next reboot.
 #ifdef USE_OSD
 #ifdef USE_ADC
     OSD_SETTING_ENTRY("OSD VOLT DECIMALS", SETTING_OSD_MAIN_VOLTAGE_DECIMALS),

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -382,6 +382,7 @@ static long osdElementsOnEnter(const OSD_Entry *from)
     // and override it on the OSD so previews so this layout.
     osdCurrentLayout = from - cmsx_menuOsdLayoutEntries - 1;
     osdOverrideLayout(osdCurrentLayout, 0);
+    osdSetLayoutOverrideOwnedByMenu(true);
     return 0;
 }
 
@@ -391,6 +392,7 @@ static long osdElementsOnExit(const OSD_Entry *from)
 
     // Stop overriding OSD layout
     osdOverrideLayout(-1, 0);
+    osdSetLayoutOverrideOwnedByMenu(false);
     return 0;
 }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -6024,6 +6024,19 @@ void osdUpdate(timeUs_t currentTimeUs)
     // boxes take priority.
     unsigned activeLayout;
     if (layoutOverride >= 0) {
+#ifdef USE_CMS
+        // The layout override is only ever set by the CMS layout editor. Drop it
+        // as soon as the menu is gone, since the menu can be closed without the
+        // editor's onExit running (in-flight auto-close), which would otherwise
+        // leave the OSD stuck on the layout being edited.
+        if (!cmsInMenu) {
+            layoutOverrideUntil = 0;
+            layoutOverride = -1;
+        }
+#endif
+    }
+
+    if (layoutOverride >= 0) {
         activeLayout = layoutOverride;
         // Check for timed override, it will go into effect on
         // the next OSD iteration

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -179,6 +179,10 @@ static unsigned currentLayout = 0;
 static int layoutOverride = -1;
 static bool hasExtendedFont = false; // Wether the font supports characters > 256
 static timeMs_t layoutOverrideUntil = 0;
+// osdOverrideLayout() is also called by MSP (a timed Configurator preview,
+// unrelated to whether the CMS menu is open) - only a menu-owned override may
+// be force-cleared when the menu goes away unexpectedly.
+static bool layoutOverrideOwnedByMenu = false;
 static float GForce, GForceAxis[XYZ_AXIS_COUNT];
 
 // OSD Filters
@@ -6025,13 +6029,16 @@ void osdUpdate(timeUs_t currentTimeUs)
     unsigned activeLayout;
     if (layoutOverride >= 0) {
 #ifdef USE_CMS
-        // The layout override is only ever set by the CMS layout editor. Drop it
-        // as soon as the menu is gone, since the menu can be closed without the
-        // editor's onExit running (in-flight auto-close), which would otherwise
-        // leave the OSD stuck on the layout being edited.
-        if (!cmsInMenu) {
+        // Drop a menu-owned override as soon as the menu is gone, since the
+        // menu can be closed without the layout editor's onExit running
+        // (in-flight auto-close), which would otherwise leave the OSD stuck
+        // on the layout being edited. A timed override requested over MSP
+        // (Configurator preview) is unrelated to cmsInMenu and must not be
+        // cancelled here - it expires on its own via layoutOverrideUntil below.
+        if (!cmsInMenu && layoutOverrideOwnedByMenu) {
             layoutOverrideUntil = 0;
             layoutOverride = -1;
+            layoutOverrideOwnedByMenu = false;
         }
 #endif
     }
@@ -6112,6 +6119,11 @@ void osdOverrideLayout(int layout, timeMs_t duration)
     } else {
         layoutOverrideUntil = 0;
     }
+}
+
+void osdSetLayoutOverrideOwnedByMenu(bool owned)
+{
+    layoutOverrideOwnedByMenu = owned;
 }
 
 int osdGetActiveLayout(bool *overridden)

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -604,6 +604,7 @@ void osdStartFullRedraw(void);
 // the OSD after the given duration. Otherwise, the caller must
 // explicitely remove it.
 void osdOverrideLayout(int layout, timeMs_t duration);
+void osdSetLayoutOverrideOwnedByMenu(bool owned);
 // Returns the current current layout as well as wether its
 // set by the user configuration (modes, etc..) or by overriding it.
 int osdGetActiveLayout(bool *overridden);


### PR DESCRIPTION
Please read everything:

## Summary

Follow-up to #11782. After merge, breadoven, Jetrell and Sensei reported
several issues with the in-flight OSD menu (CMS lockups, motors slowing
down, servo/OSD freezes). This PR fixes the root cause found for the
crash/lockup reports, plus several related robustness issues discovered
while investigating them.

## What's fixed

1. **Menu stack overflow (the main crash/lockup cause).** `menuStackIdx`
   grew by one every submenu exit and was never reset. Once it grew past
   `menuStack`'s bounds, `cmsMenuChange()` wrote out of bounds and later
   reads (`cmsMenuBack()`, onExit traversal) dereferenced garbage,
   HardFaulting the FC with no watchdog to recover. Reproduced and
   confirmed on hardware (ground menu leak test + forced crash after a
   few open/close cycles). This bug predates #11782 and exists identically
   in already-released maintenance-9.x, but #11782 made it far easier to
   hit since every forced in-flight auto-close (switch off, failsafe, nav
   mode loss, panic sticks, timeout) leaves the stack wherever it was
   instead of unwinding it.
2. **Menu close is now safe from any state.** Covers: `onExit` dereferenced
   without a NULL check once the stack unwinds to zero; the forced-close
   path applying whatever was mid-edit instead of discarding it; servo
   output disabled unconditionally and restored based on stale armed
   state instead of what was actually disabled; a double `displayRelease`
   when a forced close lands during a layout-editor yield window; panic
   stick detection state not resetting between sessions.
3. **OSD layout editor override released on any menu close**, not just a
   clean exit - otherwise a forced auto-close could leave the OSD stuck
   rendering the layout being edited.
4. **In-flight PID/battery/misc menus never apply a pending edit on a
   forced close.** Was broken before, the in-flight PID menus are now separate from the
   ground menus (which are unchanged) with no BACK entry - only SET, with
   a CONFIRM prompt matching the existing VTX confirm pattern. Battery
   profile switching while armed no longer calls `activateBatteryProfile()`
   (which resets cell count/thresholds mid-flight); THR IDLE is dropped
   from the in-flight menu since it has no effect while armed.
5. **`entry_flags[32]` clamp.** Indexed by display row count; every
   driver derives rows from a compile-time constant except FrSky OSD,
   which reports its grid size at runtime from the OSD hardware. Not
   currently reachable with any display in the tree, but unbounded in
   principle. Flagged during review, fixed as a hard runtime clamp.
6. **Battery menu entries moved from RAM to flash** (`const`), saving some RAM.

## Testing that must be done..

- **Not tested on digital OSD systems** (DJI, HDZero, Avatar via MSP
  DisplayPort). All changes are in the display-agnostic CMS
  layer and should behave identically, but this hasn't been confirmed on
  real hardware. 
- **The original servo-output report (breadoven, HITL) remains
  unexplained.** I investigated a specific hypothesis (servo output
  disabled before a failed display selection, never restored) and fixed
  it as good defensive practice, but confirmed it isn't reachable on real
  hardware (`cmsDeviceCount` is set once at boot and never returns to
  zero), so it doesn't explain the original report. I don't have a
  confirmed root cause for that one yet.
