### PR TITLE
 Fix I2C3 SCL alternate function on AT32 PB13

### DIFF
--- a/src/main/drivers/bus_i2c_at32f43x.c
+++ b/src/main/drivers/bus_i2c_at32f43x.c
@@ -345,7 +345,10 @@ void i2cInit(I2CDevice device)
     i2cUnstick(scl, sda);
 
     // Init pins
-    IOConfigGPIOAF(scl, IOCFG_I2C, hardware->af);
+    // PB13 routes I2C3_SCL through AF7; its AF4 function is I2C3_SMBA.
+    const uint8_t sclAf = (hardware->dev == I2C3 && hardware->scl == IO_TAG(PB13))
+        ? GPIO_MUX_7 : hardware->af;
+    IOConfigGPIOAF(scl, IOCFG_I2C, sclAf);
     IOConfigGPIOAF(sda, IOCFG_I2C, hardware->af);
 
     // Init I2C peripheral


### PR DESCRIPTION
The driver previously configured both SCL and SDA with AF4. However, PB13 requires AF7 for I2C3_SCL (its AF4 is I2C3_SMBA), which caused missing clock signals. Update the driver to use AF7 for PB13 when assigned to I2C3 SCL, keeping PB14 SDA on AF4.