### PR TITLE
Add support for Boya BY25Q64

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -92,6 +92,7 @@ struct {
     {0xEF7017, 128, 256}, // W25Q64JV-IM/JM*
     // Boya BY25Q64: 128 x 64 KiB blocks, 256-byte pages.
     {0x684017, 128, 256},
+    // Datasheet: https://www.boyamicro.com/storage/upload/pdf/BY25Q64ES.pdf
     // Winbond W25Q128
     // Datasheet: https://www.winbond.com/resource-files/w25q128fv%20rev.l%2008242015.pdf
     {0xEF4018, 256, 256},

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -90,6 +90,8 @@ struct {
     // Datasheet: https://www.winbond.com/resource-files/w25q64jv%20spi%20%20%20revc%2006032016%20kms.pdf
     {0xEF4017, 128, 256}, // W25Q64JV-IQ/JQ
     {0xEF7017, 128, 256}, // W25Q64JV-IM/JM*
+    // Boya BY25Q64: 128 x 64 KiB blocks, 256-byte pages.
+    {0x684017, 128, 256},
     // Winbond W25Q128
     // Datasheet: https://www.winbond.com/resource-files/w25q128fv%20rev.l%2008242015.pdf
     {0xEF4018, 256, 256},


### PR DESCRIPTION
Add support for Boya BY25Q64, it is an 8M flash chip
<img width="1920" height="1009" alt="image" src="https://github.com/user-attachments/assets/2c583ecf-37fb-47c0-ba15-f0806bb13e01" />
<img width="1920" height="1009" alt="image" src="https://github.com/user-attachments/assets/cf0d740c-8af0-4eeb-a410-a963aa33d99c" />
