### PR TITLE
Implement missing getCurrentControlProfile()

### DIFF
--- a/src/main/fc/control_profile.c
+++ b/src/main/fc/control_profile.c
@@ -91,6 +91,16 @@ void setControlProfile(uint8_t profileIndex)
     currentControlProfile = controlProfiles(profileIndex);
 }
 
+uint8_t getCurrentControlProfile(void)
+{
+    for (uint8_t profileIndex = 0; profileIndex < MAX_CONTROL_PROFILE_COUNT; profileIndex++) {
+        if (currentControlProfile == controlProfiles(profileIndex)) {
+            return profileIndex;
+        }
+    }
+    return 0;
+}
+
 void activateControlConfig(void)
 {
     generateThrottleCurve(currentControlProfile);

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -34,6 +34,8 @@ set_property(SOURCE time_unittest.cc PROPERTY depends "drivers/time.c")
 
 set_property(SOURCE circular_queue_unittest.cc PROPERTY depends "common/circular_queue.c")
 
+set_property(SOURCE control_profile_unittest.cc PROPERTY depends "fc/control_profile.c")
+
 set_property(SOURCE osd_unittest.cc PROPERTY depends "io/osd_utils.c" "io/displayport_msp_osd.c" "common/typeconversion.c")
 set_property(SOURCE osd_unittest.cc PROPERTY definitions OSD_UNIT_TEST USE_MSP_DISPLAYPORT DISABLE_MSP_BF_COMPAT)
 

--- a/src/test/unit/control_profile_unittest.cc
+++ b/src/test/unit/control_profile_unittest.cc
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "fc/control_profile.h"
+
+// control_profile.c's activateControlConfig() calls generateThrottleCurve()
+// (declared in fc/rc_curves.h). That real implementation lives in
+// fc/rc_curves.c, which pulls in flight/mixer.c, rx/rx.c and a large chunk
+// of the mixer/RX subsystem -- none of which is exercised by this test
+// (we never call activateControlConfig()/changeControlProfile()). Provide a
+// trivial stand-in so the real, unmodified fc/control_profile.c still links.
+struct controlConfig_s;
+void generateThrottleCurve(const struct controlConfig_s *controlConfig)
+{
+    (void)controlConfig;
+}
+}
+
+// This test exercises the real (unmodified) fc/control_profile.c.
+TEST(ControlProfileTest, GetCurrentControlProfileTracksSetControlProfile)
+{
+    for (uint8_t index = 0; index < MAX_CONTROL_PROFILE_COUNT; index++) {
+        setControlProfile(index);
+        EXPECT_EQ(getCurrentControlProfile(), index)
+            << "getCurrentControlProfile() should report the profile index "
+               "most recently passed to setControlProfile()";
+    }
+}
+
+TEST(ControlProfileTest, SetControlProfileClampsOutOfRangeIndexToZero)
+{
+    // setControlProfile() clamps any index >= MAX_CONTROL_PROFILE_COUNT to 0
+    // (see fc/control_profile.c). getCurrentControlProfile() should reflect
+    // that clamped value, not the out-of-range value that was requested.
+    setControlProfile(1);
+    ASSERT_EQ(getCurrentControlProfile(), 1);
+
+    setControlProfile(MAX_CONTROL_PROFILE_COUNT);
+    EXPECT_EQ(getCurrentControlProfile(), 0);
+}


### PR DESCRIPTION
## Summary

`fc/control_profile.h` declares `getCurrentControlProfile()` but `fc/control_profile.c` never implements it. It's called from `rc_adjustments.c`'s `applySelectAdjustment()` under `USE_INFLIGHT_PROFILE_ADJUSTMENT` (currently disabled everywhere), so any build enabling that flag would fail to link.

An earlier PR (#11528) proposed an implementation for this but was closed unmerged after the reporter found they no longer needed it, leaving the issue open to decide implement-vs-remove.

## Decision

Implement it, since a real (if currently disabled) caller exists — removing the declaration would leave that caller referencing a nonexistent function the moment `USE_INFLIGHT_PROFILE_ADJUSTMENT` is enabled.

## Changes

- `src/main/fc/control_profile.c`: linear scan matching `currentControlProfile` against `controlProfiles(index)`, returning 0 if no match — consistent with `setControlProfile()`'s own clamp-to-0 behavior for an out-of-range index.
- `src/test/unit/control_profile_unittest.cc` (new): verifies `getCurrentControlProfile()` tracks `setControlProfile()`, including the clamp-to-0 case.

## Testing

Full host unit suite (`make check`): 43/43 pass, including the 2 new cases. No regressions.

## Related Issues

Ref #11616