### PR TITLE
Report CI size-diff RAM delta per linker region, not combined

### DIFF
--- a/.github/scripts/compute-region-sizes.py
+++ b/.github/scripts/compute-region-sizes.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Compute per-linker-region byte usage for one .elf, from its companion
+.map file (Memory Configuration table) and `arm-none-eabi-size -A` output.
+
+Why: `arm-none-eabi-size -B` (Berkeley format, used for the flat flash/ram
+totals elsewhere in this pipeline) sums ALL writable sections into one
+"data"/"bss" pair regardless of which physical memory region they're linked
+into (e.g. F4/F7 parts split writable memory across RAM and CCM; H7 across
+RAM and DTCM). That single combined number is what CI historically reported
+as "RAM Delta", which misattributes growth that actually landed in a
+different, smaller, often more memory-pressured region. This script instead
+matches each section's load address against the target's own linker-defined
+memory regions (from its .map file), so the breakdown is exact and requires
+no per-MCU-family section-name table to maintain.
+
+Usage: compute-region-sizes.py <elf> <map-file> [size-tool]
+Prints a JSON object of {"<region>": <bytes>, ...} to stdout, one entry per
+writable region (attributes containing "w") that has nonzero used bytes.
+This is informational/non-gating, so any failure (missing/unparsable map,
+`size` tool error) prints "{}" and exits 0 rather than aborting the
+caller's build-artifact pipeline over a region breakdown it can live
+without - callers degrade gracefully to the flat flash/ram figures.
+"""
+import json
+import re
+import subprocess
+import sys
+
+
+def parse_memory_regions(map_path):
+    """Returns [(name, origin, end), ...] for writable, nonzero-length
+    regions, parsed from the map file's "Memory Configuration" table."""
+    try:
+        with open(map_path, encoding='utf-8', errors='replace') as f:
+            text = f.read()
+    except OSError:
+        return []
+
+    m = re.search(r'^Memory Configuration\s*\n\s*\n[^\n]*\n(.*?)\n\s*\nLinker script and memory map',
+                  text, re.MULTILINE | re.DOTALL)
+    if not m:
+        return []
+
+    regions = []
+    for line in m.group(1).splitlines():
+        parts = line.split()
+        if len(parts) < 3 or parts[0] == '*default*':
+            continue
+        name, origin_str, length_str = parts[0], parts[1], parts[2]
+        attrs = parts[3] if len(parts) > 3 else ''
+        try:
+            origin = int(origin_str, 16)
+            length = int(length_str, 16)
+        except ValueError:
+            continue
+        if length <= 0 or 'w' not in attrs:
+            continue
+        regions.append((name, origin, origin + length))
+    return regions
+
+
+def parse_section_sizes(elf_path, size_tool):
+    """Returns [(section_name, size, addr), ...] via `size -A` (sysv), the
+    one format that reports per-section addresses needed for region
+    matching (Berkeley's -B only gives family totals, no addresses)."""
+    out = subprocess.run([size_tool, '-A', elf_path], capture_output=True, text=True, check=True).stdout
+    sections = []
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) != 3:
+            continue
+        name, size_str, addr_str = parts
+        if name in ('section', 'Total'):
+            continue
+        try:
+            size, addr = int(size_str), int(addr_str)
+        except ValueError:
+            continue
+        sections.append((name, size, addr))
+    return sections
+
+
+def compute(elf_path, map_path, size_tool):
+    regions = parse_memory_regions(map_path)
+    if not regions:
+        return {}
+
+    usage = {name: 0 for name, _, _ in regions}
+    for _section_name, size, addr in parse_section_sizes(elf_path, size_tool):
+        # Non-allocated sections (debug info, symbol/string tables, comments)
+        # report addr 0 - they're never actually placed in memory, so they
+        # must be excluded explicitly rather than relying on address-range
+        # matching alone: a region whose own origin is 0x0 (e.g. some parts'
+        # ITCM alias) would otherwise false-match every one of them and
+        # report several megabytes of phantom "usage".
+        if size <= 0 or addr == 0:
+            continue
+        for name, start, end in regions:
+            if start <= addr < end:
+                usage[name] += size
+                break
+
+    return {name: bytes_ for name, bytes_ in usage.items() if bytes_ > 0}
+
+
+def main():
+    if len(sys.argv) not in (3, 4):
+        print('usage: compute-region-sizes.py <elf> <map-file> [size-tool]', file=sys.stderr)
+        sys.exit(1)
+    elf_path, map_path = sys.argv[1], sys.argv[2]
+    size_tool = sys.argv[3] if len(sys.argv) == 4 else 'arm-none-eabi-size'
+
+    try:
+        result = compute(elf_path, map_path, size_tool)
+    except (OSError, subprocess.CalledProcessError) as e:
+        print(f'compute-region-sizes.py: {e} - falling back to no region breakdown', file=sys.stderr)
+        result = {}
+
+    print(json.dumps(result))
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/extract-size-report.sh
+++ b/.github/scripts/extract-size-report.sh
@@ -6,7 +6,14 @@
 # Usage: extract-size-report.sh <build-dir> <output-json> [size-tool]
 #
 # flash = .text + .data (what's programmed into flash)
-# ram   = .data + .bss  (what's reserved in RAM at runtime)
+# ram   = .data + .bss  (what's reserved in RAM at runtime, summed across
+#         EVERY writable memory region the target has — e.g. RAM+CCM on
+#         F4/F7 parts, RAM+DTCM on H7. It's a total, not one region.)
+# regions = { "<name>": <bytes>, ... } — the same total broken out per
+#         linker memory region (RAM, CCM, DTCM, ...), computed from the
+#         build's own .map file via compute-region-sizes.py. Omitted for a
+#         target whose .map file is missing, so consumers must treat it as
+#         optional.
 #
 # Runs inside the (unprivileged) build job on the PR's own checkout, so a
 # PR could in principle modify this script to misreport its own numbers.
@@ -46,6 +53,8 @@ if [ "${#ELFS[@]}" -eq 0 ]; then
     exit 0
 fi
 
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+
 JQ_ARGS=()
 for elf in "${ELFS[@]}"; do
     target=$(basename "$elf" .elf)
@@ -56,13 +65,29 @@ for elf in "${ELFS[@]}"; do
     flash=$((text + data))
     ram=$((data + bss))
 
-    JQ_ARGS+=(--argjson "entry_${#JQ_ARGS[@]}" "{\"target\":\"${target}\",\"flash\":${flash},\"ram\":${ram}}")
+    # cmake's stm32.cmake/at32.cmake link every target with -Wl,-Map,<elf>.map
+    # (alongside -Wl,--print-memory-usage), so the per-region breakdown this
+    # script computes here matches exactly what the linker itself reported at
+    # build time. A missing map (e.g. a toolchain change that stops emitting
+    # one) degrades to just the flat flash/ram totals above, not a hard error.
+    map="${elf}.map"
+    regions='{}'
+    if [ -f "$map" ]; then
+        regions=$(python3 "${SCRIPT_DIR}/compute-region-sizes.py" "$elf" "$map" "$SIZE_TOOL") || regions='{}'
+    fi
+
+    JQ_ARGS+=(--argjson "entry_${#JQ_ARGS[@]}" "{\"target\":\"${target}\",\"flash\":${flash},\"ram\":${ram},\"regions\":${regions}}")
 done
 
 # Build via jq rather than manual string concatenation, so the target name
 # (an .elf basename, not otherwise validated) is JSON-escaped properly
-# instead of relying on it never containing a special character.
-jq -n "${JQ_ARGS[@]}" 'reduce $ARGS.named[] as $e ({}; .[$e.target] = {flash: $e.flash, ram: $e.ram})' \
-    > "$OUTPUT_JSON"
+# instead of relying on it never containing a special character. Omit
+# "regions" entirely when empty rather than storing a misleading {} that
+# would read as "this target has no writable memory regions".
+jq -n "${JQ_ARGS[@]}" '
+    reduce $ARGS.named[] as $e ({};
+        .[$e.target] = {flash: $e.flash, ram: $e.ram}
+            + (if ($e.regions | length) > 0 then {regions: $e.regions} else {} end)
+    )' > "$OUTPUT_JSON"
 
 echo "Wrote size report for ${#ELFS[@]} target(s) to $OUTPUT_JSON"

--- a/.github/scripts/size-diff-comment.js
+++ b/.github/scripts/size-diff-comment.js
@@ -4,7 +4,16 @@
 // dependency so it can be unit tested directly and reused (via require)
 // from the actions/github-script step in ci-size-report.yml.
 //
-// Report shape: { "<target>": { "flash": <bytes>, "ram": <bytes> }, ... }
+// Report shape: { "<target>": { "flash": <bytes>, "ram": <bytes>,
+//   "regions": { "<name>": <bytes>, ... } }, ... }
+//
+// "regions" is optional and, when present, breaks "ram" down by linker
+// memory region (e.g. RAM/CCM on F4/F7 parts, RAM/DTCM on H7) — "ram" alone
+// is the sum of those regions and stays purely additive/informational once
+// a regional breakdown exists. A region delta is only rendered when BOTH
+// the PR and baseline entries carry "regions" for that target; if either
+// side predates the field (e.g. an old stored baseline), the row falls
+// back to the combined "ram" figure instead of a partial breakdown.
 
 'use strict';
 
@@ -15,9 +24,9 @@
 // manager as a possible coverage gap, not decided unilaterally here.
 const REPRESENTATIVE_TARGETS = ['MATEKF405', 'MATEKF722', 'MATEKF765', 'MATEKH743'];
 
-// Below this magnitude a delta is noise (rounding/toolchain jitter), not a
-// real change worth calling out.
-const NOISE_THRESHOLD_BYTES = 256;
+// Below these magnitudes a delta is noise, not worth flagging.
+const FLASH_NOISE_THRESHOLD_BYTES = 4096;
+const RAM_NOISE_THRESHOLD_BYTES = 1024;
 
 function formatDelta(deltaBytes, baseBytes) {
     const sign = deltaBytes > 0 ? '+' : deltaBytes < 0 ? '' : '±';
@@ -45,6 +54,25 @@ function diffSizeReports(prReport, baselineReport) {
 
         const flashDelta = pr.flash - base.flash;
         const ramDelta = pr.ram - base.ram;
+
+        // Only trust a per-region breakdown when both sides have one - a
+        // region missing from just one side (schema drift, or a region a
+        // target gained/lost) would otherwise render a misleading partial
+        // delta for that region.
+        let regionDeltas;
+        if (pr.regions && base.regions) {
+            const names = Array.from(new Set([...Object.keys(pr.regions), ...Object.keys(base.regions)])).sort();
+            regionDeltas = names.map((name) => {
+                const prBytes = pr.regions[name] || 0;
+                const baseBytes = base.regions[name] || 0;
+                return { name, delta: prBytes - baseBytes, baseBytes };
+            });
+        }
+
+        const notable = regionDeltas
+            ? Math.abs(flashDelta) >= FLASH_NOISE_THRESHOLD_BYTES || regionDeltas.some((r) => Math.abs(r.delta) >= RAM_NOISE_THRESHOLD_BYTES)
+            : Math.abs(flashDelta) >= FLASH_NOISE_THRESHOLD_BYTES || Math.abs(ramDelta) >= RAM_NOISE_THRESHOLD_BYTES;
+
         return {
             target,
             status: 'compared',
@@ -54,7 +82,8 @@ function diffSizeReports(prReport, baselineReport) {
             baseRam: base.ram,
             flashDelta,
             ramDelta,
-            notable: Math.abs(flashDelta) >= NOISE_THRESHOLD_BYTES || Math.abs(ramDelta) >= NOISE_THRESHOLD_BYTES,
+            regionDeltas,
+            notable,
         };
     });
 }
@@ -95,7 +124,9 @@ function renderComment({ prReport, baselineReport, shortSha, baselineCommit, bas
         for (const row of rows) {
             if (row.status === 'compared') {
                 const flashCell = formatDelta(row.flashDelta, row.baseFlash);
-                const ramCell = formatDelta(row.ramDelta, row.baseRam);
+                const ramCell = row.regionDeltas
+                    ? row.regionDeltas.map((r) => `${r.name}: ${formatDelta(r.delta, r.baseBytes)}`).join('<br>')
+                    : formatDelta(row.ramDelta, row.baseRam);
                 const notableMark = row.notable ? ' ⚠️' : '';
                 lines.push(`| ${row.target}${notableMark} | ${flashCell} | ${ramCell} |`);
             } else if (row.status === 'no-baseline') {
@@ -121,4 +152,11 @@ function renderComment({ prReport, baselineReport, shortSha, baselineCommit, bas
     return lines.join('\n').trimEnd() + '\n';
 }
 
-module.exports = { REPRESENTATIVE_TARGETS, NOISE_THRESHOLD_BYTES, diffSizeReports, renderComment, formatDelta };
+module.exports = {
+    REPRESENTATIVE_TARGETS,
+    FLASH_NOISE_THRESHOLD_BYTES,
+    RAM_NOISE_THRESHOLD_BYTES,
+    diffSizeReports,
+    renderComment,
+    formatDelta,
+};

--- a/.github/scripts/size-diff-comment.test.js
+++ b/.github/scripts/size-diff-comment.test.js
@@ -13,7 +13,8 @@ const assert = require('node:assert/strict');
 
 const {
     REPRESENTATIVE_TARGETS,
-    NOISE_THRESHOLD_BYTES,
+    FLASH_NOISE_THRESHOLD_BYTES,
+    RAM_NOISE_THRESHOLD_BYTES,
     diffSizeReports,
     renderComment,
     formatDelta,
@@ -65,31 +66,49 @@ test('diffSizeReports: target present in both PR and baseline with a real delta 
     assert.equal(row.ramDelta, -200);
 });
 
-test('diffSizeReports: notable is gated at exactly NOISE_THRESHOLD_BYTES', () => {
+test('diffSizeReports: notable (flash) is gated at exactly FLASH_NOISE_THRESHOLD_BYTES', () => {
     const baseSizes = { flash: 100000, ram: 50000 };
 
-    const atThreshold = { MATEKF405: { flash: baseSizes.flash + NOISE_THRESHOLD_BYTES, ram: baseSizes.ram } };
-    const belowThreshold = { MATEKF405: { flash: baseSizes.flash + NOISE_THRESHOLD_BYTES - 1, ram: baseSizes.ram } };
+    const atThreshold = { MATEKF405: { flash: baseSizes.flash + FLASH_NOISE_THRESHOLD_BYTES, ram: baseSizes.ram } };
+    const belowThreshold = { MATEKF405: { flash: baseSizes.flash + FLASH_NOISE_THRESHOLD_BYTES - 1, ram: baseSizes.ram } };
     const base = { MATEKF405: baseSizes };
 
     const rowAtThreshold = diffSizeReports(atThreshold, base).find((r) => r.target === 'MATEKF405');
     const rowBelowThreshold = diffSizeReports(belowThreshold, base).find((r) => r.target === 'MATEKF405');
 
-    assert.equal(rowAtThreshold.flashDelta, NOISE_THRESHOLD_BYTES);
-    assert.equal(rowAtThreshold.notable, true, 'a delta of exactly NOISE_THRESHOLD_BYTES should be notable');
+    assert.equal(rowAtThreshold.flashDelta, FLASH_NOISE_THRESHOLD_BYTES);
+    assert.equal(rowAtThreshold.notable, true, 'a delta of exactly FLASH_NOISE_THRESHOLD_BYTES should be notable');
 
-    assert.equal(rowBelowThreshold.flashDelta, NOISE_THRESHOLD_BYTES - 1);
-    assert.equal(rowBelowThreshold.notable, false, 'a delta one byte below NOISE_THRESHOLD_BYTES should not be notable');
+    assert.equal(rowBelowThreshold.flashDelta, FLASH_NOISE_THRESHOLD_BYTES - 1);
+    assert.equal(rowBelowThreshold.notable, false, 'a delta one byte below FLASH_NOISE_THRESHOLD_BYTES should not be notable');
+});
+
+test('diffSizeReports: notable (ram) is gated at exactly RAM_NOISE_THRESHOLD_BYTES, independently of flash', () => {
+    const baseSizes = { flash: 100000, ram: 50000 };
+
+    const atThreshold = { MATEKF405: { flash: baseSizes.flash, ram: baseSizes.ram + RAM_NOISE_THRESHOLD_BYTES } };
+    const belowThreshold = { MATEKF405: { flash: baseSizes.flash, ram: baseSizes.ram + RAM_NOISE_THRESHOLD_BYTES - 1 } };
+    const base = { MATEKF405: baseSizes };
+
+    const rowAtThreshold = diffSizeReports(atThreshold, base).find((r) => r.target === 'MATEKF405');
+    const rowBelowThreshold = diffSizeReports(belowThreshold, base).find((r) => r.target === 'MATEKF405');
+
+    assert.equal(rowAtThreshold.ramDelta, RAM_NOISE_THRESHOLD_BYTES);
+    assert.equal(rowAtThreshold.notable, true, 'a ram delta of exactly RAM_NOISE_THRESHOLD_BYTES should be notable');
+
+    assert.equal(rowBelowThreshold.ramDelta, RAM_NOISE_THRESHOLD_BYTES - 1);
+    assert.equal(rowBelowThreshold.notable, false, 'a ram delta one byte below RAM_NOISE_THRESHOLD_BYTES should not be notable');
 });
 
 test('diffSizeReports: notable also triggers from ramDelta alone, and honors negative deltas via Math.abs', () => {
     const base = { MATEKF405: { flash: 100000, ram: 50000 } };
-    const pr = { MATEKF405: { flash: 100000, ram: 50000 - 300 } }; // flash unchanged, ram shrank by 300
+    const ramShrink = RAM_NOISE_THRESHOLD_BYTES + 300;
+    const pr = { MATEKF405: { flash: 100000, ram: 50000 - ramShrink } }; // flash unchanged, ram shrank
     const row = diffSizeReports(pr, base).find((r) => r.target === 'MATEKF405');
 
     assert.equal(row.flashDelta, 0);
-    assert.equal(row.ramDelta, -300);
-    assert.equal(row.notable, true, 'a -300 ram delta exceeds NOISE_THRESHOLD_BYTES in magnitude');
+    assert.equal(row.ramDelta, -ramShrink);
+    assert.equal(row.notable, true, 'a ram delta exceeding RAM_NOISE_THRESHOLD_BYTES in magnitude is notable');
 });
 
 test('diffSizeReports: target missing from PR report but present in baseline -> missing-from-pr', () => {
@@ -155,9 +174,9 @@ test('renderComment: baseline present, all 4 targets compared, mix of notable/no
         MATEKH743: [530000, 63000],
     });
     const prReport = fullReport({
-        MATEKF405: [500300, 60000], // +300 flash -> notable
+        MATEKF405: [504100, 60000], // +4100 flash -> notable
         MATEKF722: [510010, 61000], // +10 flash -> not notable
-        MATEKF765: [519700, 62000], // -300 flash -> notable
+        MATEKF765: [515700, 62000], // -4300 flash -> notable
         MATEKH743: [530000, 63000], // no change -> not notable
     });
 
@@ -179,9 +198,9 @@ test('renderComment: baseline present, all 4 targets compared, mix of notable/no
     const matekf765Line = lines.find((l) => l.startsWith('| MATEKF765'));
     const matekh743Line = lines.find((l) => l.startsWith('| MATEKH743'));
 
-    assert.ok(matekf405Line.includes('⚠️'), 'MATEKF405 (+300 flash) should be flagged notable');
+    assert.ok(matekf405Line.includes('⚠️'), 'MATEKF405 (+4100 flash) should be flagged notable');
     assert.ok(!matekf722Line.includes('⚠️'), 'MATEKF722 (+10 flash) should NOT be flagged notable');
-    assert.ok(matekf765Line.includes('⚠️'), 'MATEKF765 (-300 flash) should be flagged notable');
+    assert.ok(matekf765Line.includes('⚠️'), 'MATEKF765 (-4300 flash) should be flagged notable');
     assert.ok(!matekh743Line.includes('⚠️'), 'MATEKH743 (no change) should NOT be flagged notable');
 
     // No "no baseline available" note when a baseline was supplied.
@@ -354,4 +373,63 @@ test('renderComment: baselineCommit supplied but no baseline report -> graceful 
     assert.ok(body.includes('No size baseline is available yet'));
     assert.ok(!body.includes('vs. base commit `9e932ba`'), 'header must not name a baseline commit when no baseline exists');
     assert.ok(body.includes('vs. base branch'), 'header should fall back to the generic wording');
+});
+
+// ---------------------------------------------------------------------------
+// renderComment: per-region (RAM vs CCM/DTCM) breakdown
+// ---------------------------------------------------------------------------
+//
+// When both sides of a comparison carry a `regions` breakdown, renderComment
+// reports each region's own delta instead of one combined "RAM Δ" figure
+// that silently mixes growth across separate, non-fungible memory regions
+// (e.g. RAM vs. CCM on F4/F7, RAM vs. DTCM on H7).
+test('renderComment: RAM and CCM region deltas are reported separately, not combined into one RAM Δ', () => {
+    const baselineReport = {
+        MATEKF405: { flash: 500000, ram: 60000, regions: { RAM: 50000, CCM: 10000 } },
+    };
+    const prReport = {
+        // Combined ram grew by 3740 B (60000 -> 63740), matching the real CI
+        // report, but the regional breakdown shows RAM grew by only 608 B
+        // while CCM grew by 3132 B (608 + 3132 = 3740).
+        MATEKF405: { flash: 500000, ram: 63740, regions: { RAM: 50608, CCM: 13132 } },
+    };
+
+    const body = renderComment({
+        prReport,
+        baselineReport,
+        shortSha: 'abc1234',
+        docLink: null,
+        marker: '<!-- marker -->',
+    });
+
+    assert.ok(
+        body.includes('RAM: +608 B'),
+        `expected the RAM region's own delta ("RAM: +608 B") to be reported separately, got:\n${body}`
+    );
+    assert.ok(
+        body.includes('CCM: +3132 B'),
+        `expected the CCM region's own delta ("CCM: +3132 B") to be reported separately, got:\n${body}`
+    );
+    assert.ok(
+        !body.includes('+3740 B'),
+        `RAM and CCM deltas must not be silently combined into one "+3740 B" figure, got:\n${body}`
+    );
+});
+
+test('renderComment: falls back to the combined RAM Δ when only one side has a regions breakdown', () => {
+    // A baseline captured before this field existed (or a target that lost
+    // its region info) must not produce a partial/misleading breakdown.
+    const baselineReport = { MATEKF405: { flash: 500000, ram: 60000 } };
+    const prReport = { MATEKF405: { flash: 500000, ram: 63740, regions: { RAM: 50608, CCM: 13132 } } };
+
+    const body = renderComment({
+        prReport,
+        baselineReport,
+        shortSha: 'abc1234',
+        docLink: null,
+        marker: '<!-- marker -->',
+    });
+
+    assert.ok(body.includes('+3740 B'), `expected the combined RAM Δ fallback, got:\n${body}`);
+    assert.ok(!body.includes('RAM: +608 B'), `must not render a partial region breakdown, got:\n${body}`);
 });


### PR DESCRIPTION
## Summary
The size-diff bot's "RAM Δ" summed every writable memory region (RAM + CCM/DTCM) into one figure, hiding which region a PR's growth actually landed in. Confirmed on MATEKF405: bot reported "+3,740 B RAM Δ" when the `RAM:` region itself only grew 608 B — the rest was CCM.

## Changes
- New `compute-region-sizes.py`: cross-references `arm-none-eabi-size -A` section addresses against the target's own `.map` file memory regions to compute exact per-region usage (no per-MCU-family section table to maintain).
- `extract-size-report.sh`: adds an optional `regions` field per target; falls back to `{}` if the `.map` file or size tool is unavailable.
- `size-diff-comment.js`: renders each region's delta separately when both PR and baseline reports have `regions`; falls back to the old combined figure otherwise, so existing stored baselines keep working.
- Split the shared 256 B notability threshold into separate flash (4096 B) and RAM (1024 B, per-region) thresholds — the old one was too tight for flash's much larger budget.

## Testing
- `node --test .github/scripts/size-diff-comment.test.js` — 26/26 pass, including a test reproducing the real MATEKF405 numbers and one covering the old-baseline fallback.
- Ran `extract-size-report.sh` against 13 real built targets (F4/F7/H7/AT32 families); region sums match the linker's own `--print-memory-usage` output (e.g. MATEKF405: RAM 108004 vs. linker's 108008, CCM exact).
- Verified graceful degradation: missing `.map` file and a broken size-tool path both fall back to `{}` instead of failing the build/artifact-upload pipeline.

## Code Review
Reviewed with inav-code-review agent; addressed the one IMPORTANT finding (unhandled subprocess failure could abort the whole size-report step) and added the suggested asymmetric-baseline test.