### PR TITLE
Support custom Tramp power levels and AUX pit mode

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -7580,6 +7580,56 @@ Enable the 3x shorter stopbit on softserial. Need for some IRC Tramp VTXes.
 
 ---
 
+### vtx_tramp_power_a
+
+Custom Tramp power level 1 in mW. Set consecutive ascending levels, then zeros; all zero keeps automatic tables. Reboot after changes. The reported maximum (or vtx_max_power_override) still limits power.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | 0 | 10000 |
+
+---
+
+### vtx_tramp_power_b
+
+Custom Tramp power level 2 in mW. Set consecutive ascending levels, then zeros; all zero keeps automatic tables. Reboot after changes. The reported maximum (or vtx_max_power_override) still limits power.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | 0 | 10000 |
+
+---
+
+### vtx_tramp_power_c
+
+Custom Tramp power level 3 in mW. Set consecutive ascending levels, then zeros; all zero keeps automatic tables. Reboot after changes. The reported maximum (or vtx_max_power_override) still limits power.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | 0 | 10000 |
+
+---
+
+### vtx_tramp_power_d
+
+Custom Tramp power level 4 in mW. Set consecutive ascending levels, then zeros; all zero keeps automatic tables. Reboot after changes. The reported maximum (or vtx_max_power_override) still limits power.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | 0 | 10000 |
+
+---
+
+### vtx_tramp_power_e
+
+Custom Tramp power level 5 in mW. Set consecutive ascending levels, then zeros; all zero keeps automatic tables. Reboot after changes. The reported maximum (or vtx_max_power_override) still limits power.
+
+| Default | Min | Max |
+| --- | --- | --- |
+| 0 | 0 | 10000 |
+
+---
+
 ### yaw_deadband
 
 These are values (in us) by how much RC input can be different before it's considered valid. For transmitters with jitter on outputs, this value can be increased. Defaults are zero, but can be increased up to 10 or so if rc inputs twitch while idle.

--- a/docs/VTx.md
+++ b/docs/VTx.md
@@ -31,3 +31,53 @@ If you have problems getting SmartAudio working. There are a couple of CLI param
 - If you are using softserial, you can try using the alternate method by setting [`vtx_smartaudio_alternate_softserial_method`](https://github.com/iNavFlight/inav/blob/master/docs/Settings.md#vtx_smartaudio_alternate_softserial_method) to OFF.
 
 - If you are using TBS Sixty9 VTX you may consider to set count of stop bits to 1, using [`set vtx_smartaudio_stopbits = 1`](https://github.com/iNavFlight/inav/blob/master/docs/Settings.md#vtx_smartaudio_stopbits)
+
+### Custom IRC Tramp power levels
+
+Tramp normally selects a built-in power table from the maximum power reported by
+its device. For devices with different levels, configure up to five ascending
+power values in milliwatts with `vtx_tramp_power_a` through `vtx_tramp_power_e`.
+Use consecutive entries followed by zeros. All zeros retain automatic selection;
+an invalid table (gaps, duplicates, descending values) also falls back to automatic
+selection. Reboot after changing the table.
+
+For a BLITZ Whoop 2.5W:
+
+```
+set vtx_tramp_power_a = 25
+set vtx_tramp_power_b = 400
+set vtx_tramp_power_c = 1000
+set vtx_tramp_power_d = 2500
+set vtx_tramp_power_e = 0
+set vtx_power = 1
+save
+```
+
+This changes the power values and their labels, not the VTX's reported maximum.
+The driver continues to clamp requests to that maximum. Only if the hardware's
+maximum is independently confirmed and the device reports it incorrectly, use
+`vtx_max_power_override` to provide the correct maximum. It does not unlock the
+VTX or verify actual RF power. Power selection remains one-based: this example
+maps levels 1–4 to 25, 400, 1000 and 2500 mW.
+
+The VTX settings parameter-group version changes from 2 to 3. Save `diff all`
+before upgrading and restore the VTX settings afterwards; the new table defaults
+to automatic selection.
+
+### Tramp pit mode on an AUX switch
+
+Assign **VTX PIT MODE** in Modes (permanent mode ID 69). For example, with the
+first two mode-condition slots already in use, this assigns AUX5 / channel 9:
+
+```
+aux 2 69 4 1800 2100
+save
+```
+
+The assigned range requests pit mode while disarmed. Arming exits pit mode and
+prevents entering it in flight. The switch is ignored without a valid receiver
+signal. Without a mode assignment, existing hardware-button/MSP control is left
+alone. Pit mode changes use the Tramp `I` command (0 = enter, 1 = exit), and the
+driver retries if subsequent status reports do not match the request. Verify the
+VTX's own pit indicator before relying on it; driver support is not a guarantee
+that every Tramp-compatible device implements the command.

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -5072,7 +5072,9 @@ bool mspFCProcessInOutCommand(uint16_t cmdMSP, sbuf_t *dst, sbuf_t *src, mspResu
         sbufWriteU8(dst, powerLevel);
         sbufWriteU16(dst, 0);
 
-        const char *str = vtxDevice->capability.powerNames[powerLevel - 1];
+        // Tramp reserves label zero for the unselected "---" entry.
+        const uint8_t nameIndex = vtxCommonGetDeviceType(vtxDevice) == VTXDEV_TRAMP ? powerLevel : powerLevel - 1;
+        const char *str = vtxDevice->capability.powerNames[nameIndex];
         const uint32_t str_len = strnlen(str, 5);  // these _should_ all be null-terminated
         sbufWriteU8(dst, str_len);
         for (uint32_t i = 0; i < str_len; i++)

--- a/src/main/fc/fc_msp_box.c
+++ b/src/main/fc/fc_msp_box.c
@@ -117,6 +117,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { .boxId = BOXAUTOSPEED,        .boxName = "AUTO SPEED",        .permanentId = 69 },
     { .boxId = BOXTERRAINAGLHOLD,   .boxName = "TERRAIN AGL HOLD",  .permanentId = 70 },
     { .boxId = BOXINFLIGHTMENU,     .boxName = "IN FLIGHT MENU",    .permanentId = 71 },
+    { .boxId = BOXVTXPITMODE,       .boxName = "VTX PIT MODE",      .permanentId = 72 },
     { .boxId = CHECKBOX_ITEM_COUNT, .boxName = NULL,                .permanentId = 0xFF }
 };
 
@@ -337,6 +338,12 @@ void initActiveBoxIds(void)
 
     ADD_ACTIVE_BOX(BOXFAILSAFE);
 
+#ifdef USE_VTX_CONTROL
+    if (feature(FEATURE_VTX)) {
+        ADD_ACTIVE_BOX(BOXVTXPITMODE);
+    }
+#endif
+
 #if defined(USE_RCDEVICE) || defined(USE_MSP_DISPLAYPORT)
     ADD_ACTIVE_BOX(BOXCAMERA1);
     ADD_ACTIVE_BOX(BOXCAMERA2);
@@ -448,6 +455,7 @@ void packBoxModeFlags(boxBitmask_t * mspBoxModeFlags)
     CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXUSER2)),           BOXUSER2);
     CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXUSER3)),           BOXUSER3);
     CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXUSER4)),           BOXUSER4);
+    CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXVTXPITMODE)),       BOXVTXPITMODE);
     CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXLOITERDIRCHN)),    BOXLOITERDIRCHN);
 #if defined(USE_RX_MSP) && defined(USE_MSP_RC_OVERRIDE)
     CHECK_ACTIVE_BOX(IS_ENABLED(IS_RC_MODE_ACTIVE(BOXMSPRCOVERRIDE)),   BOXMSPRCOVERRIDE);

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -88,6 +88,7 @@ typedef enum {
     BOXAUTOSPEED     = 60,
     BOXTERRAINAGLHOLD = 61,
     BOXINFLIGHTMENU  = 62,
+    BOXVTXPITMODE    = 63,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -4392,6 +4392,36 @@ groups:
         field: maxPowerOverride
         min: 0
         max: 10000
+      - name: vtx_tramp_power_a
+        description: "Custom Tramp power level 1 in mW. Set consecutive ascending levels, then zeros; all zero keeps automatic tables. Reboot after changes. The reported maximum (or vtx_max_power_override) still limits power."
+        field: trampPowerLevels[0]
+        min: 0
+        max: 10000
+        default_value: 0
+      - name: vtx_tramp_power_b
+        description: "Custom Tramp power level 2 in mW. Set consecutive ascending levels, then zeros; all zero keeps automatic tables. Reboot after changes. The reported maximum (or vtx_max_power_override) still limits power."
+        field: trampPowerLevels[1]
+        min: 0
+        max: 10000
+        default_value: 0
+      - name: vtx_tramp_power_c
+        description: "Custom Tramp power level 3 in mW. Set consecutive ascending levels, then zeros; all zero keeps automatic tables. Reboot after changes. The reported maximum (or vtx_max_power_override) still limits power."
+        field: trampPowerLevels[2]
+        min: 0
+        max: 10000
+        default_value: 0
+      - name: vtx_tramp_power_d
+        description: "Custom Tramp power level 4 in mW. Set consecutive ascending levels, then zeros; all zero keeps automatic tables. Reboot after changes. The reported maximum (or vtx_max_power_override) still limits power."
+        field: trampPowerLevels[3]
+        min: 0
+        max: 10000
+        default_value: 0
+      - name: vtx_tramp_power_e
+        description: "Custom Tramp power level 5 in mW. Set consecutive ascending levels, then zeros; all zero keeps automatic tables. Reboot after changes. The reported maximum (or vtx_max_power_override) still limits power."
+        field: trampPowerLevels[4]
+        min: 0
+        max: 10000
+        default_value: 0
       - name: vtx_frequency_group
         field: frequencyGroup
         description: "VTx Frequency group to use. Frequency groups: FREQUENCYGROUP_5G8: 5.8GHz, FREQUENCYGROUP_2G4: 2.4GHz, FREQUENCYGROUP_1G3: 1.3GHz."

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -40,12 +40,13 @@
 #include "fc/settings.h"
 
 #include "flight/failsafe.h"
+#include "rx/rx.h"
 
 #include "io/vtx.h"
 #include "io/vtx_string.h"
 #include "io/vtx_control.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(vtxSettingsConfig_t, vtxSettingsConfig, PG_VTX_SETTINGS_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(vtxSettingsConfig_t, vtxSettingsConfig, PG_VTX_SETTINGS_CONFIG, 3);
 
 PG_RESET_TEMPLATE(vtxSettingsConfig_t, vtxSettingsConfig,
     .band = SETTING_VTX_BAND_DEFAULT,
@@ -130,31 +131,21 @@ static bool vtxProcessPitMode(vtxDevice_t *vtxDevice, const vtxSettingsConfig_t 
 {
     UNUSED(runtimeSettings);
 
+    // Leave button/MSP control alone unless the pilot assigned this mode.
+    if (!isModeActivationConditionPresent(BOXVTXPITMODE) || !rxIsReceivingSignal()) {
+        return false;
+    }
+
     uint8_t pitOnOff;
-
-    bool        currPmSwitchState = false;
-    static bool prevPmSwitchState = false;
-
     if (!vtxCommonGetPitMode(vtxDevice, &pitOnOff)) {
         return false;
     }
 
-    if (currPmSwitchState != prevPmSwitchState) {
-        prevPmSwitchState = currPmSwitchState;
-
-        if (currPmSwitchState) {
-            if (0) {
-                if (!pitOnOff) {
-                    vtxCommonSetPitMode(vtxDevice, true);
-                    return true;
-                }
-            }
-        } else {
-            if (pitOnOff) {
-                vtxCommonSetPitMode(vtxDevice, false);
-                return true;
-            }
-        }
+    // Never enter pit mode in flight; arming also exits a ground pit mode.
+    const bool requestedPitMode = IS_RC_MODE_ACTIVE(BOXVTXPITMODE) && !ARMING_FLAG(ARMED);
+    if ((pitOnOff != 0) != requestedPitMode) {
+        vtxCommonSetPitMode(vtxDevice, requestedPitMode);
+        return true;
     }
 
     return false;

--- a/src/main/io/vtx.h
+++ b/src/main/io/vtx.h
@@ -41,6 +41,7 @@ typedef struct vtxSettingsConfig_s {
     uint16_t pitModeChan;       // sets out-of-range pitmode frequency
     uint8_t lowPowerDisarm;     // min power while disarmed, from vtxLowerPowerDisarm_e
     uint16_t maxPowerOverride;  // for VTX drivers that are polling VTX capabilities - override what VTX is reporting
+    uint16_t trampPowerLevels[5]; // optional ascending mW levels; trailing zeros end the table
     uint8_t frequencyGroup;     // Frequencies being used, i.e. 5.8, 2.4, or 1.3 GHz 
 } vtxSettingsConfig_t;
 

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <ctype.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "platform.h"
 
@@ -92,6 +93,8 @@ typedef struct {
         // Actual settings to send to the VTX
         unsigned freq;
         unsigned power;
+        bool pitMode;
+        bool pitModeRequested; // do not override hardware-button state before a request
     } request;
 
     // Actual VTX state: updated from actual VTX
@@ -256,7 +259,8 @@ static vtxProtoResponseType_e vtxProtoProcessResponse(void)
 
 static void vtxProtoSetPitMode(uint16_t mode)
 {
-    vtxProtoSend(0x73, mode);
+    // IRC Tramp 'I': 0 enters pit mode, 1 exits (same polarity as Betaflight).
+    vtxProtoSend('I', mode ? 0 : 1);
 }
 
 static void vtxProtoSetPower(uint16_t power)
@@ -316,9 +320,8 @@ static void impl_Process(vtxDevice_t *vtxDevice, timeUs_t currentTimeUs)
             if (vtxState.updateReqMask != VTX_UPDATE_REQ_NONE) {
                 // Updates pending. Send an appropriate command
                 if (vtxState.updateReqMask & VTX_UPDATE_REQ_PITMODE) {
-                    // Only disabling PIT mode supported
                     vtxState.updateReqMask &= ~VTX_UPDATE_REQ_PITMODE;
-                    vtxProtoSetPitMode(0);
+                    vtxProtoSetPitMode(vtxState.request.pitMode);
                     vtxProtoSetState(VTX_STATE_QUERY_DELAY);
                 }
                 else if (vtxState.updateReqMask & VTX_UPDATE_REQ_FREQUENCY) {
@@ -365,6 +368,10 @@ static void impl_Process(vtxDevice_t *vtxDevice, timeUs_t currentTimeUs)
 
                     if (!(vtxState.updateReqMask & VTX_UPDATE_REQ_POWER) && (vtxState.state.power != vtxState.request.power)) {
                         vtxState.updateReqMask |= VTX_UPDATE_REQ_POWER;
+                    }
+
+                    if (vtxState.request.pitModeRequested && vtxState.state.pitMode != vtxState.request.pitMode) {
+                        vtxState.updateReqMask |= VTX_UPDATE_REQ_PITMODE;
                     }
 
                     // We got the status response - proceed to IDLE
@@ -446,9 +453,9 @@ static void impl_SetPitMode(vtxDevice_t *vtxDevice, uint8_t onoff)
 {
     UNUSED(vtxDevice);
 
-    if (onoff == 0) {
-        vtxState.updateReqMask |= VTX_UPDATE_REQ_PITMODE;
-    }
+    vtxState.request.pitMode = onoff != 0;
+    vtxState.request.pitModeRequested = true;
+    vtxState.updateReqMask |= VTX_UPDATE_REQ_PITMODE;
 }
 
 static bool impl_GetBandAndChannel(const vtxDevice_t *vtxDevice, uint8_t *pBand, uint8_t *pChannel)
@@ -578,6 +585,41 @@ const char * const trampPowerNames_1G3_800[VTX_TRAMP_1G3_MAX_POWER_COUNT + 1] = 
 const uint16_t trampPowerTable_1G3_2000[VTX_TRAMP_1G3_MAX_POWER_COUNT]         = { 25, 200, 2000 };
 const char * const trampPowerNames_1G3_2000[VTX_TRAMP_1G3_MAX_POWER_COUNT + 1] = { "---", "25 ", "200", "2000" };
 
+static char customPowerNames[VTX_TRAMP_5G8_MAX_POWER_COUNT][6];
+static char *customPowerNamePointers[VTX_TRAMP_5G8_MAX_POWER_COUNT + 1];
+
+static bool vtxProtoUseCustomPowerTable(void)
+{
+    const uint16_t *levels = vtxSettingsConfig()->trampPowerLevels;
+    unsigned count = 0;
+    bool ended = false;
+    for (unsigned i = 0; i < VTX_TRAMP_5G8_MAX_POWER_COUNT; i++) {
+        if (levels[i] == 0) {
+            ended = true;
+        } else {
+            // Reject holes, duplicate/decreasing powers and out-of-range EEPROM values.
+            if (ended || levels[i] > 10000 || (i > 0 && levels[i] <= levels[i - 1])) {
+                return false;
+            }
+            count++;
+        }
+    }
+    if (!count) {
+        return false;
+    }
+
+    customPowerNamePointers[0] = "---";
+    for (unsigned i = 0; i < count; i++) {
+        snprintf(customPowerNames[i], sizeof(customPowerNames[i]), "%u", (unsigned)levels[i]);
+        customPowerNamePointers[i + 1] = customPowerNames[i];
+    }
+    vtxState.metadata.powerTablePtr = levels;
+    vtxState.metadata.powerTableCount = count;
+    impl_vtxDevice.capability.powerCount = count;
+    impl_vtxDevice.capability.powerNames = customPowerNamePointers;
+    return true;
+}
+
 static void vtxProtoUpdatePowerMetadata(uint16_t maxPower)
 {
     switch (vtxSettingsConfig()->frequencyGroup) {
@@ -644,10 +686,12 @@ static void vtxProtoUpdatePowerMetadata(uint16_t maxPower)
             }
             break;
     }
+    vtxProtoUseCustomPowerTable();
 }
 
 bool vtxTrampInit(void)
 {
+    memset(&vtxState, 0, sizeof(vtxState));
     serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_VTX_TRAMP);
 
     if (portConfig) {

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -174,6 +174,12 @@ set_property(SOURCE mavlink_unittest.cc PROPERTY definitions USE_TELEMETRY USE_T
 set_property(SOURCE mavlink_unittest.cc PROPERTY extra_includes
     "../../lib/main/MAVLink")
 
+set_property(SOURCE vtx_pit_mode_unittest.cc PROPERTY definitions USE_VTX_CONTROL)
+set_property(SOURCE vtx_pit_mode_unittest.cc PROPERTY depends "io/vtx.c")
+
+set_property(SOURCE vtx_tramp_unittest.cc PROPERTY definitions USE_VTX_CONTROL USE_VTX_TRAMP)
+set_property(SOURCE vtx_tramp_unittest.cc PROPERTY depends "io/vtx_tramp.c" "io/vtx_string.c" "common/crc.c" "common/streambuf.c")
+
 function(unit_test src)
     get_filename_component(basename ${src} NAME)
     string(REPLACE ".cc" "" name ${basename} )

--- a/src/test/unit/vtx_pit_mode_unittest.cc
+++ b/src/test/unit/vtx_pit_mode_unittest.cc
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "gtest/gtest.h"
+extern "C" {
+#include "platform.h"
+#include "drivers/vtx_common.h"
+#include "fc/runtime_config.h"
+#include "fc/rc_modes.h"
+#include "io/vtx.h"
+uint32_t armingFlags;
+uint8_t cliMode;
+}
+static bool assigned, receiving, modeActive, pit;
+static int requests;
+static vtxDevice_t device{};
+extern "C" {
+bool isModeActivationConditionPresent(boxId_e id) { return id == BOXVTXPITMODE && assigned; }
+bool IS_RC_MODE_ACTIVE(boxId_e id) { return id == BOXVTXPITMODE && modeActive; }
+bool rxIsReceivingSignal(void) { return receiving; }
+bool failsafeIsActive(void) { return false; }
+void vtxControlInputPoll(void) {}
+vtxDevice_t *vtxCommonDevice(void) { return &device; }
+bool vtxCommonGetPitMode(vtxDevice_t *, uint8_t *value) { *value = pit; return true; }
+void vtxCommonSetPitMode(vtxDevice_t *, uint8_t value) { pit = value; ++requests; }
+bool vtxCommonGetPowerIndex(vtxDevice_t *, uint8_t *) { return false; }
+void vtxCommonSetPowerByIndex(vtxDevice_t *, uint8_t) {}
+bool vtxCommonGetBandAndChannel(vtxDevice_t *, uint8_t *, uint8_t *) { return false; }
+void vtxCommonSetBandAndChannel(vtxDevice_t *, uint8_t, uint8_t) {}
+void vtxCommonProcess(vtxDevice_t *, timeUs_t) {}
+}
+class PitModeTest : public ::testing::Test {
+protected:
+ void SetUp() override {
+  assigned = true; receiving = true; modeActive = false; pit = false;
+  requests = 0; armingFlags = 0; cliMode = 0;
+ }
+ void update() { for (int i=0; i<3; ++i) vtxUpdate(0); }
+};
+TEST_F(PitModeTest, UnassignedModePreservesHardwarePitMode) {
+ assigned=false; pit=true; update(); EXPECT_TRUE(pit); EXPECT_EQ(0,requests);
+}
+TEST_F(PitModeTest, AssignedSwitchControlsBothDirections) {
+ modeActive=true; update(); EXPECT_TRUE(pit); EXPECT_EQ(1,requests);
+ modeActive=false; update(); EXPECT_FALSE(pit); EXPECT_EQ(2,requests);
+}
+TEST_F(PitModeTest, ArmingExitsPitAndPreventsReentry) {
+ modeActive=true; update(); ASSERT_TRUE(pit);
+ armingFlags=ARMED; update(); EXPECT_FALSE(pit);
+ update(); EXPECT_FALSE(pit); EXPECT_EQ(2,requests);
+}
+TEST_F(PitModeTest, ReceiverLossDoesNotActOnStaleSwitch) {
+ receiving=false; modeActive=true; update(); EXPECT_FALSE(pit); EXPECT_EQ(0,requests);
+}
+TEST_F(PitModeTest, NoCommandWhenReportedStateMatchesSwitch) {
+ update(); EXPECT_EQ(0,requests);
+ modeActive=true; pit=true; update(); EXPECT_EQ(0,requests);
+}
+TEST_F(PitModeTest, CliDoesNotSendPitCommands) {
+ cliMode=1; modeActive=true; update(); EXPECT_FALSE(pit); EXPECT_EQ(0,requests);
+}

--- a/src/test/unit/vtx_tramp_unittest.cc
+++ b/src/test/unit/vtx_tramp_unittest.cc
@@ -1,0 +1,197 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <array>
+#include <deque>
+#include <vector>
+#include <cstring>
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "platform.h"
+#include "common/crc.h"
+#include "drivers/time.h"
+#include "drivers/vtx_common.h"
+#include "io/serial.h"
+#include "io/vtx.h"
+#include "io/vtx_control.h"
+#include "io/vtx_tramp.h"
+vtxSettingsConfig_t vtxSettingsConfig_System;
+vtxConfig_t vtxConfig_System;
+}
+
+static vtxDevice_t *device;
+static serialPort_t port;
+static serialPortConfig_t portConfig;
+static std::deque<uint8_t> received;
+static std::vector<std::array<uint8_t, 16>> sent;
+static timeMs_t now;
+static uint16_t reportedMax, actualPower, actualFrequency;
+static bool actualPit, ignoreNextPit, corruptNextStatus;
+
+static void respond(char command, uint16_t a, uint16_t b, uint16_t c)
+{
+    std::array<uint8_t, 16> frame{};
+    frame[0] = 15; frame[1] = command;
+    frame[2] = a; frame[3] = a >> 8;
+    frame[4] = b; frame[5] = b >> 8;
+    frame[6] = c; frame[7] = c >> 8;
+    if (command == 'v') frame[7] = actualPit;
+    frame[14] = crc8_sum_update(0, frame.data() + 1, 13);
+    if (command == 'v' && corruptNextStatus) {
+        frame[14] ^= 1;
+        corruptNextStatus = false;
+    }
+    received.insert(received.end(), frame.begin(), frame.end());
+}
+
+extern "C" {
+timeMs_t millis(void) { return now; }
+void vtxCommonSetDevice(vtxDevice_t *d) { device = d; }
+serialPortConfig_t *findSerialPortConfig(serialPortFunction_e) { return &portConfig; }
+serialPort_t *openSerialPort(serialPortIdentifier_e, serialPortFunction_e,
+    serialReceiveCallbackPtr, void *, uint32_t, portMode_t, portOptions_t) { return &port; }
+uint32_t serialRxBytesWaiting(const serialPort_t *) { return received.size(); }
+uint8_t serialRead(serialPort_t *) { uint8_t b = received.front(); received.pop_front(); return b; }
+void serialWriteBuf(serialPort_t *, const uint8_t *data, int size)
+{
+    EXPECT_EQ(16, size);
+    if (size != 16) return;
+    std::array<uint8_t, 16> frame;
+    std::memcpy(frame.data(), data, size);
+    EXPECT_EQ(crc8_sum_update(0, data + 1, 13), data[14]);
+    EXPECT_EQ(0, data[15]);
+    sent.push_back(frame);
+    uint16_t value = data[2] | (data[3] << 8);
+    switch (data[1]) {
+    case 'r': respond('r', 5000, 5999, reportedMax); break;
+    case 'v': respond('v', actualFrequency, actualPower, 0); break;
+    case 'F': actualFrequency = value; break;
+    case 'P': actualPower = value; break;
+    case 'I':
+        if (ignoreNextPit) ignoreNextPit = false;
+        else actualPit = value == 0;
+        break;
+    }
+}
+}
+
+class TrampTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        std::memset(&vtxSettingsConfig_System, 0, sizeof(vtxSettingsConfig_System));
+        std::memset(&vtxConfig_System, 0, sizeof(vtxConfig_System));
+        now = 0; reportedMax = 2500; actualPower = 25; actualFrequency = 5732;
+        actualPit = false; ignoreNextPit = false; corruptNextStatus = false;
+        received.clear(); sent.clear(); device = nullptr;
+    }
+    void tick(int n = 1) {
+        for (int i = 0; i < n; ++i) { now += 250; device->vTable->process(device, now * 1000); }
+    }
+    void start() {
+        ASSERT_TRUE(vtxTrampInit());
+        tick(3); // reset, capability request, capability reply
+        ASSERT_TRUE(device->vTable->isReady(device));
+        device->vTable->setBandAndChannel(device, 5, 3);
+        device->vTable->setPowerByIndex(device, 1);
+        tick(24);
+        sent.clear();
+    }
+    void custom() {
+        const uint16_t powers[] = {25, 400, 1000, 2500, 0};
+        std::memcpy(vtxSettingsConfig_System.trampPowerLevels, powers, sizeof(powers));
+    }
+    int commands(char command, int value = -1) {
+        int n = 0;
+        for (auto &f : sent) if (f[1] == command && (value < 0 || (f[2] | (f[3] << 8)) == value)) ++n;
+        return n;
+    }
+};
+
+TEST_F(TrampTest, DefaultTableRemainsAutomatic) {
+    start(); EXPECT_EQ(5, device->capability.powerCount);
+    EXPECT_STREQ("800", device->capability.powerNames[5]);
+}
+TEST_F(TrampTest, CustomTableUsesAllFourBlitzPowers) {
+    custom(); start(); ASSERT_EQ(4, device->capability.powerCount);
+    const char *labels[] = {"25", "400", "1000", "2500"};
+    const int powers[] = {25, 400, 1000, 2500};
+    for (int i = 0; i < 4; i++) {
+        EXPECT_STREQ(labels[i], device->capability.powerNames[i + 1]);
+        device->vTable->setPowerByIndex(device, i + 1); tick(20);
+        EXPECT_EQ(powers[i], actualPower);
+    }
+}
+TEST_F(TrampTest, CustomPowerStillRespectsReportedLimit) {
+    custom(); reportedMax = 400; start();
+    device->vTable->setPowerByIndex(device, 4); tick(20); EXPECT_EQ(400, actualPower);
+}
+TEST_F(TrampTest, ExplicitOverrideAllowsConfiguredMaximum) {
+    custom(); reportedMax = 400; vtxSettingsConfig_System.maxPowerOverride = 2500; start();
+    device->vTable->setPowerByIndex(device, 4); tick(20); EXPECT_EQ(2500, actualPower);
+}
+TEST_F(TrampTest, InvalidIndexDoesNotTransmitPower) {
+    custom(); start(); device->vTable->setPowerByIndex(device, 0);
+    device->vTable->setPowerByIndex(device, 5); tick(20); EXPECT_EQ(0, commands('P'));
+}
+TEST_F(TrampTest, HoleInCustomTableFallsBackToAutomatic) {
+    custom(); vtxSettingsConfig_System.trampPowerLevels[1] = 0; start(); EXPECT_EQ(5, device->capability.powerCount);
+}
+TEST_F(TrampTest, DecreasingCustomTableFallsBackToAutomatic) {
+    custom(); vtxSettingsConfig_System.trampPowerLevels[2] = 200; start(); EXPECT_EQ(5, device->capability.powerCount);
+}
+TEST_F(TrampTest, DuplicateCustomTableFallsBackToAutomatic) {
+    custom(); vtxSettingsConfig_System.trampPowerLevels[2] = 400; start(); EXPECT_EQ(5, device->capability.powerCount);
+}
+TEST_F(TrampTest, OutOfRangeCustomTableFallsBackToAutomatic) {
+    custom(); vtxSettingsConfig_System.trampPowerLevels[3] = 10001; start(); EXPECT_EQ(5, device->capability.powerCount);
+}
+TEST_F(TrampTest, FiveDigitLabelFits) {
+    custom(); vtxSettingsConfig_System.trampPowerLevels[4] = 10000; start();
+    EXPECT_EQ(5, device->capability.powerCount); EXPECT_STREQ("10000", device->capability.powerNames[5]);
+}
+TEST_F(TrampTest, PitModeUsesCorrectCommandAndPolarity) {
+    start(); device->vTable->setPitMode(device, 1); tick(20);
+    EXPECT_TRUE(actualPit); EXPECT_GT(commands('I', 0), 0);
+    device->vTable->setPitMode(device, 0); tick(20);
+    EXPECT_FALSE(actualPit); EXPECT_GT(commands('I', 1), 0);
+    EXPECT_EQ(0, commands('s'));
+}
+TEST_F(TrampTest, LostPitCommandIsRetriedAfterStatusMismatch) {
+    start(); ignoreNextPit = true; device->vTable->setPitMode(device, 1); tick(40);
+    EXPECT_TRUE(actualPit); EXPECT_GE(commands('I', 0), 2);
+}
+TEST_F(TrampTest, LastPitRequestWinsBeforeTransmission) {
+    start(); device->vTable->setPitMode(device, 1); device->vTable->setPitMode(device, 0); tick(20);
+    EXPECT_FALSE(actualPit); EXPECT_EQ(0, commands('I', 0));
+}
+TEST_F(TrampTest, HardwarePitModeIsPreservedWithoutExplicitRequest) {
+    actualPit = true; start(); tick(20); EXPECT_TRUE(actualPit); EXPECT_EQ(0, commands('I'));
+}
+TEST_F(TrampTest, CorruptStatusCannotChangeReportedPitMode) {
+    start(); uint8_t pit = 1;
+    actualPit = true; corruptNextStatus = true;
+    for (int i = 0; i < 30 && corruptNextStatus; ++i) tick();
+    ASSERT_FALSE(corruptNextStatus);
+    tick(); // consume and reject the corrupt response
+    EXPECT_TRUE(device->vTable->getPitMode(device, &pit)); EXPECT_EQ(0, pit);
+    tick(20); // subsequent valid polls recover normally
+    EXPECT_TRUE(device->vTable->getPitMode(device, &pit)); EXPECT_EQ(1, pit);
+}


### PR DESCRIPTION
## Problem
Discussion https://github.com/iNavFlight/inav/discussions/9841: the Tramp driver picks one of four fixed 5.8 GHz power tables (25/100/200/200/200 up to 25/100/200/500/800) from the maximum the VTX reports. Nothing above 800 mW can be commanded, and levels no table contains (iFlight BLITZ 25/400/800/1600, GEPRC RAD 1.6 W, Foxeer Reaper Extreme 2.5 W, ...) cannot be selected; commenters report a BLITZ 1.6 W where only levels 1-2 work and a Speedybee VTX-DVR whose 600 mW step is unreachable. Separately, INAV has no RC mode for VTX pit mode, and the Tramp driver can only leave pit mode, never enter it.

## Cause
On maintenance-10.x:
- `src/main/io/vtx_tramp.c:563-572` and `:605-639`: four hard-coded tables, selected by `maxPower`; no user-defined levels.
- `src/main/io/vtx.c:135` and `:146`: the pit-mode switch state is a constant `false` and entering pit mode sits behind `if (0)`; no box id exists (`src/main/fc/rc_modes.h:90` ends at `BOXINFLIGHTMENU`).
- `src/main/io/vtx_tramp.c:259` sends command `0x73` instead of `I`, and `:319-321` only ever sends "disable".
- `src/main/fc/fc_msp.c:5075` reads `powerNames[powerLevel - 1]`, but Tramp name tables put `"---"` at index 0 (`vtx_tramp.c:573`), so `MSP_VTXTABLE_POWERLEVEL` labels are off by one for Tramp.

## Change
Adds `vtx_tramp_power_a`..`e` (0-10000 mW; `PG_VTX_SETTINGS_CONFIG` 2 -> 3). `vtxProtoUseCustomPowerTable()` installs them as the power table with generated labels when they are consecutive and ascending; otherwise the automatic table stays, and the reported (or overridden) maximum still caps the power. Adds `BOXVTXPITMODE` ("VTX PIT MODE", permanent id 72), offered under `USE_VTX_CONTROL`; `vtxProcessPitMode()` requests pit mode while the mode is active, the receiver has signal and the craft is disarmed, and clears it otherwise. The Tramp driver sends `I` (0 = enter, 1 = exit), services frequency and power before pit mode, and re-requests a mismatched pit state at most `VTX_PITMODE_MAX_RETRIES` (3) times per switch change. `MSP_VTXTABLE_POWERLEVEL` uses the one-based name index for Tramp.

## Test
Not built and not run on hardware at the current head (d79d4d4); see https://github.com/iNavFlight/inav/pull/11887#issuecomment-5654143940. Cause verified by reading `src/main/io/vtx_tramp.c:319` and `src/main/io/vtx.c:146`. Two host test suites are included and registered in `src/test/unit/CMakeLists.txt`: `vtx_tramp_unittest.cc` (15 tests: automatic/custom tables, invalid tables, power cap and override, `I` polarity and checksum, lost-command retry, corrupt status) and `vtx_pit_mode_unittest.cc` (6 tests: unassigned mode, both switch directions, arming, receiver loss, CLI). They run in the `Run Tests` job of `ci.yml`; the upstream run for d79d4d4 is waiting for maintainer approval: https://github.com/iNavFlight/inav/actions/runs/34765161680. Fork build: pending.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
`docs/VTx.md`: new sections "Custom IRC Tramp power levels" (BLITZ Whoop 2.5W example, PG-version note) and "Tramp pit mode on an AUX switch" (mode id 72). `docs/Settings.md`: regenerated entries for the five new settings.
