### PR TITLE
Document rangefinder requirement for FW autoland flare phase

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -3304,7 +3304,7 @@ Modifier for pitch to throttle ratio at final approach. In Percent.
 
 ### nav_fw_land_flare_alt
 
-Initial altitude of the flare phase
+Initial altitude of the flare phase. Requires a healthy rangefinder; without one the aircraft stays in the glide phase (see nav_fw_land_glide_alt/nav_fw_land_glide_pitch) all the way to touchdown.
 
 | Default | Min | Max |
 | --- | --- | --- |
@@ -3314,7 +3314,7 @@ Initial altitude of the flare phase
 
 ### nav_fw_land_flare_pitch
 
-Pitch value for flare phase. In degrees
+Pitch value for flare phase. In degrees. Only applies with a healthy rangefinder; the flare phase never activates without one.
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -4341,7 +4341,7 @@ groups:
         min: 100
         max: 5000
       - name: nav_fw_land_flare_alt
-        description: "Initial altitude of the flare phase"
+        description: "Initial altitude of the flare phase. Requires a healthy rangefinder; without one the aircraft stays in the glide phase (see nav_fw_land_glide_alt/nav_fw_land_glide_pitch) all the way to touchdown."
         default_value: 150
         field: flareAltitude
         min: 0
@@ -4353,7 +4353,7 @@ groups:
         min: -15
         max: 45
       - name: nav_fw_land_flare_pitch
-        description: "Pitch value for flare phase. In degrees"
+        description: "Pitch value for flare phase. In degrees. Only applies with a healthy rangefinder; the flare phase never activates without one."
         default_value: 8
         field: flarePitch
         min: -15


### PR DESCRIPTION
## Summary

`nav_fw_land_flare_alt`/`nav_fw_land_flare_pitch` (and the flare phase they control) only take effect when a healthy rangefinder is present — see the `getHwRangefinderStatus() == HW_SENSOR_OK` gate on the GLIDE→FLARE transition in `navigation.c`. This is intentional (also noted in `docs/Fixed Wing Landing.md`'s step 7), but wasn't mentioned in the settings descriptions themselves, where a user tuning these values would actually look.

On a GPS-only aircraft (no rangefinder), flare can never trigger: the aircraft holds level pitch with motor off from `nav_fw_land_glide_alt` (default 200cm) all the way to touchdown, with no further altitude control. This produces a consistent, deterministic height/distance overshoot on final approach that no combination of the RTH-landing (`nav_land_*`) or FW-autoland tuning parameters can fix, since none of them apply during glide/flare.

## Changes

- Add the rangefinder requirement to the `nav_fw_land_flare_alt` and `nav_fw_land_flare_pitch` descriptions in `settings.yaml`
- Regenerate `docs/Settings.md` via `src/utils/update_cli_docs.py`

## Note

This is a documentation-only change. It does not alter flight behavior or resolve the underlying overshoot for GPS-only users — it only makes the existing rangefinder requirement discoverable where the relevant settings are configured. Whether a rangefinder-independent (baro/GPS AGL) fallback for flare should be added is a separate, open design question.

Relates to #11751