### PR TITLE
add CoreWingF405WMiniV2 with clean commit.

### DIFF
--- a/src/main/target/COREWINGF405MINIV2/CMakeLists.txt
+++ b/src/main/target/COREWINGF405MINIV2/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f405xg(COREWINGF405WMINIV2)

--- a/src/main/target/COREWINGF405MINIV2/config.c
+++ b/src/main/target/COREWINGF405MINIV2/config.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of the GNU General Public License Version 3, as described below:
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+//#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+#include "fc/fc_msp_box.h"
+#include "fc/config.h"
+#include "io/serial.h"
+#include "io/piniobox.h"
+
+void targetConfiguration(void)
+{
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART6)].functionMask = FUNCTION_RX_SERIAL;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART5)].functionMask = FUNCTION_GPS;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART1)].functionMask = FUNCTION_MSP;
+
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1;
+}

--- a/src/main/target/COREWINGF405MINIV2/target.c
+++ b/src/main/target/COREWINGF405MINIV2/target.c
@@ -1,0 +1,50 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+//#include "drivers/pinio.h"
+#include "drivers/sensor.h"
+#include "drivers/timer_def_stm32f4xx.h"
+
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688,  DEVHW_ICM42605, ICM42605_SPI_BUS,  ICM42605_CS_PIN,  NONE,  0,  DEVFLAGS_NONE,  IMU_ICM42605_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_bmi270,    DEVHW_BMI270,   BMI270_SPI_BUS,    BMI270_CS_PIN,    NONE,  0,  DEVFLAGS_NONE,  IMU_BMI270_ALIGN);
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM4,   CH2, PB7,  TIM_USE_OUTPUT_AUTO,   1, 0), // S1 D(1,3,2)
+    DEF_TIM(TIM4,   CH1, PB6,  TIM_USE_OUTPUT_AUTO,   1, 0), // S2 D(1,0,2)
+
+    DEF_TIM(TIM3,   CH3, PB0,  TIM_USE_OUTPUT_AUTO,   1, 0), // S3 D(1,7,5)
+    DEF_TIM(TIM3,   CH4, PB1,  TIM_USE_OUTPUT_AUTO,   1, 0), // S4 D(1,2,5)
+    DEF_TIM(TIM8,   CH3, PC8,  TIM_USE_OUTPUT_AUTO,   1, 0), // S5 D(2,4,7)
+    DEF_TIM(TIM8,   CH4, PC9,  TIM_USE_OUTPUT_AUTO,   1, 0), // S6 D(2,7,7)
+    
+    DEF_TIM(TIM8,  CH2N, PB14, TIM_USE_OUTPUT_AUTO,   1, 0), // S7
+    DEF_TIM(TIM2,   CH1, PA15, TIM_USE_OUTPUT_AUTO,   1, 0), // S8
+    DEF_TIM(TIM2,   CH3, PB10, TIM_USE_OUTPUT_AUTO,   1, 0), // S9
+    DEF_TIM(TIM2,   CH4, PB11, TIM_USE_OUTPUT_AUTO,   1, 0), // S10
+    DEF_TIM(TIM12,  CH2, PB15, TIM_USE_OUTPUT_AUTO,   1, 0), // S11 
+
+    DEF_TIM(TIM1,   CH1, PA8,  TIM_USE_LED,   0, 0), //2812LED  D(1,5,3)
+    DEF_TIM(TIM5,   CH3, PA2,  TIM_USE_ANY,   0, 0), //TX2  softserial1_Tx
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/COREWINGF405MINIV2/target.h
+++ b/src/main/target/COREWINGF405MINIV2/target.h
@@ -1,0 +1,183 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "CW4WM2"
+#define USBD_PRODUCT_STRING  "CoreWing F405 Wing Mini V2"
+
+// LEDs
+#define LED0                    PA14  //Blue
+#define LED1                    PA13  //Green
+
+// Beeper
+#define BEEPER                  PC15
+#define BEEPER_INVERTED
+
+/*
+ * Buses
+ */
+
+// SPI1
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN   	PA6
+#define SPI1_MOSI_PIN   	PA7
+
+// SPI2
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN   	PC2
+#define SPI2_MOSI_PIN   	PC3
+
+// SPI3
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PB3
+#define SPI3_MISO_PIN   	PB4
+#define SPI3_MOSI_PIN   	PB5
+
+// Serial ports
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define USE_UART2
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define USE_UART3
+#define UART3_TX_PIN            PC10
+#define UART3_RX_PIN            PC11
+
+#define USE_UART4
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1
+
+#define USE_UART5
+#define UART5_TX_PIN            PC12
+#define UART5_RX_PIN            PD2
+
+#define USE_UART6
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+//Optional Softserial on UART2 TX Pin PA2
+#define USE_SOFTSERIAL1
+#define SOFTSERIAL_1_TX_PIN      PA2
+#define SOFTSERIAL_1_RX_PIN      PA2
+
+#define SERIAL_PORT_COUNT       8
+
+/*
+ * I2C
+ */
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+
+/*
+ * Sensor drivers
+ */
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS
+
+#define USE_IMU_ICM42605        //Using ICM42688
+#define IMU_ICM42605_ALIGN      CW270_DEG
+#define ICM42605_CS_PIN         PA4
+#define ICM42605_SPI_BUS        BUS_SPI1
+#define ICM42605_EXTI_PIN       PC4
+
+#define USE_IMU_BMI270          //Using BMI270
+#define IMU_BMI270_ALIGN        CW180_DEG
+#define BMI270_CS_PIN           PA4
+#define BMI270_SPI_BUS          BUS_SPI1
+#define BMI270_EXTI_PIN         PC4
+ 
+// Baro
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_DPS310
+#define USE_BARO_SPL06
+
+//Mag
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+#define USE_RANGEFINDER
+#define USE_RANGEFINDER_US42
+#define RANGEFINDER_I2C_BUS     BUS_I2C1
+#define PITOT_I2C_BUS           BUS_I2C1
+#define TEMPERATURE_I2C_BUS     BUS_I2C1
+
+// OSD
+#define USE_MAX7456
+#define MAX7456_CS_PIN          PB12
+#define MAX7456_SPI_BUS         BUS_SPI2
+
+// SD Card
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+#define SDCARD_SPI_BUS          BUS_SPI3
+#define SDCARD_CS_PIN           PC14
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART6
+
+// *************** ADC ***************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC0
+#define ADC_CHANNEL_2_PIN           PC1
+#define ADC_CHANNEL_3_PIN           PC5
+//#define ADC_CHANNEL_4_PIN           PC4
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+//#define RSSI_ADC_CHANNEL            ADC_CHN_4
+#define AIRSPEED_ADC_CHANNEL        ADC_CHN_3
+
+// *************** LED2812 ************************
+#define USE_LED_STRIP
+#define WS2811_PIN                      PA8
+
+// ***************  OTHERS *************************
+//#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_BLACKBOX | FEATURE_AIRMODE)
+#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_BLACKBOX)
+#define VBAT_SCALE_DEFAULT      1100
+#define CURRENT_METER_SCALE   195
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define MAX_PWM_OUTPUT_PORTS       11
+
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                  PC13


### PR DESCRIPTION
Rebuilding PR #11723 with a clean commit of 4 target files.  Built against maintenance-10.x with no errors.

# CoreWing F405 Wing Mini V2

## Summary
Adds support for the CoreWing F405 Wing Mini V2 flight controller board — the compact variant of the CoreWing F405 Wing V2 (`COREWINGF405WINGV2`, merged in #11291).

## Hardware Specifications
| Component | Specification |
|-----------|---------------|
| **MCU** | STM32F405RGT6 |
| **Gyro** | ICM42688P (ICM42605 driver, CW270) or BMI270 (CW180), depending on board variant, on SPI1 with EXTI on PC4 |
| **OSD** | MAX7456 on SPI2 |
| **Blackbox** | SD Card on SPI3 |
| **Barometer** | SPA06-003 on I2C1 (SPL06/DPS310 drivers) |
| **Magnetometer** | All supported via I2C1 |
| **Motor/Servo Outputs** | S1-S11 with DMA (full DSHOT support) |
| **UARTs** | 6 (UART1-6) + USB VCP + 1 Softserial = 8 ports |
| **LEDs** | PA14 (Blue), PA13 (Green) |
| **Beeper** | PC15 (Inverted) |
| **LED Strip** | PA8 |
| **ADC** | Vbat (PC0), Current (PC1), Airspeed (PC5) |
| **PINIO** | PC13 (USER1, VTX/CAM power switch) |
| **Default RX** | CRSF on UART6 |

## Default Port Configuration
| Port | Function |
|------|----------|
| UART1 | MSP (internally tied to the onboard BLE/WiFi wireless module) |
| UART5 | GPS |
| UART6 | CRSF RX |

## Pin Mapping

### Motor/Servo Outputs
| Output | Pin | Timer |
|--------|-----|-------|
| S1 | PB7 | TIM4 CH2 |
| S2 | PB6 | TIM4 CH1 |
| S3 | PB0 | TIM3 CH3 |
| S4 | PB1 | TIM3 CH4 |
| S5 | PC8 | TIM8 CH3 |
| S6 | PC9 | TIM8 CH4 |
| S7 | PB14 | TIM8 CH2N |
| S8 | PA15 | TIM2 CH1 |
| S9 | PB10 | TIM2 CH3 |
| S10 | PB11 | TIM2 CH4 |
| S11 | PB15 | TIM12 CH2 |

### SPI Bus Assignment
| Bus | Pins (SCK/MISO/MOSI) | Device |
|-----|----------------------|--------|
| SPI1 | PA5/PA6/PA7 | ICM42688P or BMI270 Gyro (CS: PA4, EXTI: PC4) |
| SPI2 | PB13/PC2/PC3 | MAX7456 OSD (CS: PB12) |
| SPI3 | PB3/PB4/PB5 | SD Card (CS: PC14) |

### I2C Bus Assignment
| Bus | Pins (SCL/SDA) | Devices |
|-----|----------------|---------|
| I2C1 | PB8/PB9 | Barometer, Magnetometer, Rangefinder, Pitot |

### UART Pin Mapping
| UART | TX | RX |
|------|----|----|
| UART1 | PA9 | PA10 |
| UART2 | PA2 | PA3 |
| UART3 | PC10 | PC11 |
| UART4 | PA0 | PA1 |
| UART5 | PC12 | PD2 |
| UART6 | PC6 | PC7 |
| Softserial1 | PA2 | PA2 |

## Differences from CoreWing F405 Wing V2 (#11291)
- **PC4 is the gyro data-ready (EXTI) input instead of analog RSSI**, so the gyros are registered with explicit target hardware descriptors and the RSSI ADC channel is not available on this board
- **BMI270 IMU variant** supported in addition to ICM42688P (board variant dependent), aligned CW180
- **Current meter scale 195** (vs 158) to match the Mini's integrated PDB
- Explicit `VBAT_SCALE_DEFAULT 1100`
- Same outputs, OSD, SD card, PINIO (PC13) VTX power switch, and port layout as the Wing V2

## Notes
- Designed for fixed-wing aircraft with 11 servo/motor outputs
- Supports rangefinder (US42) and pitot tube via I2C1
- SD card blackbox logging enabled by default
- 2S-6S LiPo input with onboard voltage/current sensing

## PR Type
Enhancement

## Description
- Adds support for CoreWing F405 Wing Mini V2 flight controller board
- Configures ICM42688P (CW270) / BMI270 (CW180) gyro on SPI1 with EXTI on PC4
- Enables 11 motor/servo outputs with full DMA/DSHOT support
- Includes 6 UARTs, OSD, SD card blackbox, barometer, magnetometer, LED strip, and PINIO features

## Block Diagram

```mermaid
flowchart LR
  MCU["STM32F405RGT6"]
  SPI1["SPI1: ICM42688P / BMI270 Gyro"]
  SPI2["SPI2: MAX7456 OSD"]
  SPI3["SPI3: SD Card"]
  I2C["I2C1: SPA06-003 Baro + Mag"]
  OUTPUTS["11 Servo/Motor Outputs"]
  UART["6 UARTs + USB VCP"]
  PINIO["PINIO: USER1 (VTX power)"]

  MCU --> SPI1
  MCU --> SPI2
  MCU --> SPI3
  MCU --> I2C
  MCU --> OUTPUTS
  MCU --> UART
  MCU --> PINIO
```

## Build Verification
Built successfully against both `maintenance-9.x` (`inav_9.0.1_COREWINGF405WMINIV2.hex`) and `master` (`inav_9.1.0_COREWINGF405WMINIV2.hex`) with arm-gnu-toolchain 13.2.rel1.
