### PR TITLE
add GEPRC_TAKER_H743MINI

### DIFF
--- a/src/main/target/GEPRC_TAKER_H743MINI/CMakeLists.txt
+++ b/src/main/target/GEPRC_TAKER_H743MINI/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32h743xi(GEPRC_TAKER_H743MINI)

--- a/src/main/target/GEPRC_TAKER_H743MINI/config.c
+++ b/src/main/target/GEPRC_TAKER_H743MINI/config.c
@@ -1,0 +1,63 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "common/axis.h"
+
+#include "config/config_master.h"
+#include "config/feature.h"
+
+#include "drivers/sensor.h"
+#include "drivers/pwm_esc_detect.h"
+#include "drivers/pwm_output.h"
+#include "drivers/serial.h"
+
+#include "fc/rc_controls.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+
+#include "rx/rx.h"
+
+#include "io/serial.h"
+
+#include "sensors/battery.h"
+#include "sensors/sensors.h"
+
+#include "telemetry/telemetry.h"
+
+#include "fc/fc_msp_box.h"
+
+#include "io/piniobox.h"
+
+
+#define BLUETOOTH_MSP_BAUDRATE      BAUD_115200
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = BOXARM;
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER1;
+
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART8)].functionMask = FUNCTION_MSP;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIAL_PORT_USART8)].msp_baudrateIndex = BLUETOOTH_MSP_BAUDRATE;
+}
+

--- a/src/main/target/GEPRC_TAKER_H743MINI/target.c
+++ b/src/main/target/GEPRC_TAKER_H743MINI/target.c
@@ -1,0 +1,51 @@
+/*
+* This file is part of INAV Project.
+*
+* INAV is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* INAV is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "drivers/bus.h"
+#include "drivers/io.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/timer.h"
+#include "drivers/sensor.h"
+
+// ICM42688P: DEVHW_ICM42605 driver detects both via WHO_AM_I
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688, DEVHW_ICM42605, ICM42605_SPI_BUS, ICM42605_CS_PIN, ICM42605_EXTI_PIN, 0, DEVFLAGS_NONE, IMU_ICM42605_ALIGN);
+
+
+timerHardware_t timerHardware[] = {
+
+    DEF_TIM(TIM3,  CH1,  PC6,   TIM_USE_MOTOR, 0, 0),
+    DEF_TIM(TIM3,  CH2,  PC7,   TIM_USE_MOTOR, 0, 1),
+    DEF_TIM(TIM3,  CH3,  PC8,   TIM_USE_MOTOR, 0, 2),
+    DEF_TIM(TIM3,  CH4,  PC9,   TIM_USE_MOTOR, 0, 3),
+
+    DEF_TIM(TIM1,  CH1,  PE9,   TIM_USE_MOTOR, 0, 4),
+    DEF_TIM(TIM1,  CH2,  PE11,  TIM_USE_MOTOR, 0, 5),
+    DEF_TIM(TIM1,  CH3,  PE13,  TIM_USE_MOTOR, 0, 6),
+    DEF_TIM(TIM1,  CH4,  PE14,  TIM_USE_MOTOR, 0, 7),
+
+    // LED STRIP
+    DEF_TIM(TIM4,  CH1,  PD12,  TIM_USE_LED, 1, 8),
+};
+
+
+
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/GEPRC_TAKER_H743MINI/target.h
+++ b/src/main/target/GEPRC_TAKER_H743MINI/target.h
@@ -1,0 +1,180 @@
+/*
+ * This file is part of INAV Project.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "GEPR"
+#define USBD_PRODUCT_STRING     "GEPRC_TAKER_H743MINI"
+
+#define USE_TARGET_CONFIG
+
+#define LED0                    PB7
+
+#define BEEPER                  PD2
+#define BEEPER_INVERTED
+
+#define USE_LED_STRIP
+#define WS2811_PIN                  PD12
+
+//**************** SPI BUS *************************
+#define USE_SPI
+
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PC2
+#define SPI2_MOSI_PIN           PC3
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PC12
+
+#define USE_SPI_DEVICE_4
+#define SPI4_SCK_PIN            PE2
+#define SPI4_MISO_PIN   	    PE5
+#define SPI4_MOSI_PIN   	    PE6
+
+// *****IMU1 ICM42688 ON  SPI2 **************
+
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS
+
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN      CW0_DEG
+#define ICM42605_SPI_BUS        BUS_SPI2
+#define ICM42605_CS_PIN         PB12
+#define ICM42605_EXTI_PIN       PB2
+
+// *************** FLASH **************************
+
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN           PA15
+#define M25P16_SPI_BUS          BUS_SPI3
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+// *************** OSD *****************************
+
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI4
+#define MAX7456_CS_PIN          PE4
+
+// *************** I2C/Baro/Mag *********************
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+#define USE_I2C_DEVICE_2
+#define I2C2_SCL                PB10
+#define I2C2_SDA                PB11
+
+
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_DPS310
+#define USE_BARO_MS5611
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C2
+#define USE_MAG_ALL
+
+#define TEMPERATURE_I2C_BUS     BUS_I2C2
+
+#define PITOT_I2C_BUS           BUS_I2C2
+
+#define USE_RANGEFINDER
+#define RANGEFINDER_I2C_BUS     BUS_I2C2
+#define BNO055_I2C_BUS          BUS_I2C2
+
+
+// ************PINIO to disable BT*****************
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN                  PC5  
+#define PINIO1_FLAGS                PINIO_FLAGS_INVERTED
+
+
+// ************PINIO to other
+#define PINIO2_PIN                  PD3               //Enable vsw
+
+
+// *************** UART *****************************
+#define USE_VCP
+
+#define USE_UART1
+#define UART1_RX_PIN            PA10
+#define UART1_TX_PIN            PA9
+
+#define USE_UART2
+#define UART2_RX_PIN            PD6
+#define UART2_TX_PIN            PD5
+
+#define USE_UART3
+#define UART3_RX_PIN            PD9
+#define UART3_TX_PIN            PD8
+
+#define USE_UART4
+#define UART4_RX_PIN            PA1
+#define UART4_TX_PIN            PA0
+
+#define USE_UART5
+#define UART5_RX_PIN            PB5
+#define UART5_TX_PIN		    PB6
+
+#define USE_UART7
+#define UART7_RX_PIN            PE7
+#define UART7_TX_PIN            PE8
+
+#define USE_UART8
+#define UART8_RX_PIN            PE0
+#define UART8_TX_PIN            PE1
+
+#define SERIAL_PORT_COUNT       8
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+// *************** ADC *****************************
+#define USE_ADC
+#define ADC_INSTANCE                ADC1
+#define ADC1_DMA_STREAM             DMA2_Stream3
+#define ADC_CHANNEL_1_PIN           PC1
+#define ADC_CHANNEL_3_PIN           PC0
+
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_3
+
+#define VBAT_SCALE_DEFAULT              1090
+
+//****************************************************
+
+#define DEFAULT_FEATURES            (FEATURE_TX_PROF_SEL | FEATURE_CURRENT_METER | FEATURE_TELEMETRY | FEATURE_VBAT | FEATURE_OSD | FEATURE_BLACKBOX)
+
+
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0xffff
+#define TARGET_IO_PORTE 0xffff
+
+#define MAX_PWM_OUTPUT_PORTS        8
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR


### PR DESCRIPTION
This is the second H743 INAV flight control system of GEPRC.
Website link:https://geprc.com/product/geprc-taker-h743-mini-32bit-60a-stack/
<img width="1740" height="1347" alt="image" src="https://github.com/user-attachments/assets/9e38ee45-1623-4cea-bd74-dff0650b40f0" />
The sample is on its way.
