### PR TITLE
Add support for ALEX RC ALEXF722V3 flight controller

### DIFF
--- a/docs/boards/ALEXF722V3.md
+++ b/docs/boards/ALEXF722V3.md
@@ -10,7 +10,7 @@ The **ALEX F722-V3** is a flight controller manufactured by **ALEX RC**, built a
 - **IMU:** ICM42688P / ICM42605 (SPI1, CW90_DEG)
 - **Barometer:** SPL06-001 (I2C1)
 - **OSD:** AT7456E / MAX7456 (SPI2)
-- **Blackbox:** SPI Flash 16MB (W25Q128FV / M25P16, SPI3)
+- **Blackbox:** SPI Flash on SPI3 (16MB W25Q128FV / 2MB M25P16)
 - **Compass:** External QMC5883P / IST8310 / HMC5883 on I2C1
 - **Camera Switch:** Onboard dual-camera switching (CAM1 / CAM2) via PINIO1 (PC0)
 - **BEC:** 5V and 12V outputs

--- a/docs/boards/ALEXF722V3.md
+++ b/docs/boards/ALEXF722V3.md
@@ -1,0 +1,48 @@
+# ALEX F722-V3 Flight Controller
+
+The **ALEX F722-V3** is a flight controller manufactured by **ALEX RC**, built around the STM32F722RET6 MCU.
+
+## Hardware Specifications
+
+- **Manufacturer:** ALEX RC
+- **Target Name:** ALEXF722V3
+- **MCU:** STM32F722RET6 (216MHz ARM Cortex-M7)
+- **IMU:** ICM42688P / ICM42605 (SPI1, CW90_DEG)
+- **Barometer:** SPL06-001 (I2C1)
+- **OSD:** AT7456E / MAX7456 (SPI2)
+- **Blackbox:** SPI Flash 16MB (W25Q128FV / M25P16, SPI3)
+- **Compass:** External QMC5883P / IST8310 / HMC5883 on I2C1
+- **Camera Switch:** Onboard dual-camera switching (CAM1 / CAM2) via PINIO1 (PC0)
+- **BEC:** 5V and 12V outputs
+- **LED:** WS2812 programmable LED pads (PB3)
+- **Buzzer:** Active buzzer pad (PC13, inverted)
+- **Voltage / Current Sensing:** Onboard ADC channels (PC1 for VBAT, PC3 for Current)
+
+---
+
+## Pinout & Port Mapping
+
+### Serial Ports (UARTs)
+
+| Pin Markings | Function | INAV Serial Port | Typical Usage |
+|:---:|:---:|:---:|:---|
+| **USB** | Virtual COM Port | VCP | Configurator / CLI |
+| **TX1 / RX1** | UART1 (PB6 / PB7) | UART1 | MSP / Telemetry |
+| **T2 / R2** | UART2 (PA2 / PA3) | UART2 | Serial Receiver (CRSF / ELRS / SBUS) |
+| **T4** | UART4 (PA0 / PA1) | UART4 | GPS Module (UBLOX) |
+| **TX5 / RX5** | UART5 (PC12 / PD2)| UART5 | ESC Telemetry / Peripherals |
+| **T6 / R6** | UART6 (PC6 / PC7) | UART6 | DJI O3 / Walksnail / HD VTX |
+
+### I2C Bus
+
+| Pin Markings | MCU Pin | Function |
+|:---:|:---:|:---|
+| **SCL** | PB8 | I2C1 Clock (Barometer & External Compass) |
+| **SDA** | PB9 | I2C1 Data (Barometer & External Compass) |
+
+### Camera Switch (PINIO)
+
+The board features a built-in camera switcher between **CAM1** and **CAM2**:
+- Controlled via **PINIO 1** (MCU Pin PC0).
+- Configured in INAV as USER1 mode in the **Modes** tab.
+- Assign USER1 to an AUX channel switch on your radio transmitter to switch cameras mid-flight.

--- a/docs/boards/ALEXF722V3.md
+++ b/docs/boards/ALEXF722V3.md
@@ -1,10 +1,10 @@
 # ALEX F722-V3 Flight Controller
 
-The **ALEX F722-V3** is a flight controller manufactured by **ALEX RC**, built around the STM32F722RET6 MCU.
+The **ALEX F722-V3** is a flight controller manufactured by **INDIAN ROBOTICS SOLUTION PRIVATE LIMITED**, built around the STM32F722RET6 MCU.
 
 ## Hardware Specifications
 
-- **Manufacturer:** ALEX RC
+- **Manufacturer:** INDIAN ROBOTICS SOLUTION PRIVATE LIMITED
 - **Target Name:** ALEXF722V3
 - **MCU:** STM32F722RET6 (216MHz ARM Cortex-M7)
 - **IMU:** ICM42688P / ICM42605 (SPI1, CW90_DEG)

--- a/src/main/target/ALEXF722V3/CMakeLists.txt
+++ b/src/main/target/ALEXF722V3/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_stm32f722xe(ALEXF722V3)

--- a/src/main/target/ALEXF722V3/config.c
+++ b/src/main/target/ALEXF722V3/config.c
@@ -1,0 +1,28 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <platform.h>
+
+#include "fc/fc_msp_box.h"
+#include "io/piniobox.h"
+
+void targetConfiguration(void)
+{
+    pinioBoxConfigMutable()->permanentId[0] = BOX_PERMANENT_ID_USER1; 
+    pinioBoxConfigMutable()->permanentId[1] = BOX_PERMANENT_ID_USER2;
+}

--- a/src/main/target/ALEXF722V3/target.c
+++ b/src/main/target/ALEXF722V3/target.c
@@ -1,0 +1,49 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <platform.h>
+#include "drivers/io.h"
+#include "drivers/bus.h"
+#include "drivers/timer.h"
+#include "drivers/sensor.h"
+#include "drivers/pwm_mapping.h"
+
+BUSDEV_REGISTER_SPI_TAG(busdev_mpu6000, DEVHW_MPU6000, GYRO_SPI_BUS, GYRO1_CS_PIN, NONE, 0, DEVFLAGS_NONE, IMU_MPU6000_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_mpu6000_2, DEVHW_MPU6000, GYRO_SPI_BUS, GYRO2_CS_PIN, NONE, 1, DEVFLAGS_NONE, IMU_MPU6000_ALIGN);
+
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688, DEVHW_ICM42605, GYRO_SPI_BUS, GYRO1_CS_PIN, NONE, 0, DEVFLAGS_NONE, IMU_ICM42605_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_icm42688_2, DEVHW_ICM42605, GYRO_SPI_BUS, GYRO2_CS_PIN, NONE, 1, DEVFLAGS_NONE, IMU_ICM42605_ALIGN);
+
+BUSDEV_REGISTER_SPI_TAG(busdev_bmi270, DEVHW_BMI270, GYRO_SPI_BUS, GYRO1_CS_PIN, NONE, 0, DEVFLAGS_NONE, IMU_BMI270_ALIGN);
+BUSDEV_REGISTER_SPI_TAG(busdev_bmi270_2, DEVHW_BMI270, GYRO_SPI_BUS, GYRO2_CS_PIN, NONE, 1, DEVFLAGS_NONE, IMU_BMI270_ALIGN);
+
+timerHardware_t timerHardware[] = {
+    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_OUTPUT_AUTO, 0, 0), // S1
+    DEF_TIM(TIM8, CH4, PC9,  TIM_USE_OUTPUT_AUTO, 0, 0), // S2
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_OUTPUT_AUTO, 0, 1), // S3
+    DEF_TIM(TIM1, CH2, PA9,  TIM_USE_OUTPUT_AUTO, 0, 1), // S4
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_OUTPUT_AUTO, 0, 0), // S5
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_OUTPUT_AUTO, 0, 0), // S6
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_OUTPUT_AUTO, 0, 1), // S7
+    DEF_TIM(TIM3, CH1, PB4,  TIM_USE_OUTPUT_AUTO, 0, 0), // S8
+
+    DEF_TIM(TIM2, CH2, PB3, TIM_USE_LED, 0, 0), // 2812LED
+
+};
+
+const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);

--- a/src/main/target/ALEXF722V3/target.h
+++ b/src/main/target/ALEXF722V3/target.h
@@ -1,0 +1,178 @@
+/*
+ * This file is part of INAV.
+ *
+ * INAV is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INAV is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INAV.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "ALEX"
+#define USBD_PRODUCT_STRING  "ALEXF722V3"
+
+#define USE_TARGET_CONFIG
+
+/*** Indicators ***/
+#define LED0                    PC14
+#define LED1                    PC15
+
+#define BEEPER                  PC13
+#define BEEPER_INVERTED
+
+// *** SPI & I2C ***
+#define USE_SPI
+
+#define USE_SPI_DEVICE_1
+#define SPI1_NSS1_PIN           PA4
+#define SPI1_NSS2_PIN           PB2
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6 
+#define SPI1_MOSI_PIN           PA7
+
+#define USE_SPI_DEVICE_2 
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define USE_SPI_DEVICE_3
+#define SPI3_NSS_PIN            PA15
+#define SPI3_SCK_PIN            PC10
+#define SPI3_MISO_PIN           PC11
+#define SPI3_MOSI_PIN           PB5
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL                PB8
+#define I2C1_SDA                PB9
+
+// *** IMU sensors ***
+
+#define USE_TARGET_IMU_HARDWARE_DESCRIPTORS
+#define USE_DUAL_GYRO
+
+#define GYRO_SPI_BUS         BUS_SPI1
+#define GYRO1_CS_PIN          SPI1_NSS1_PIN
+#define GYRO2_CS_PIN          SPI1_NSS2_PIN
+
+// MPU6000
+#define USE_IMU_MPU6000
+#define IMU_MPU6000_ALIGN       CW90_DEG
+
+// ICM42605/ICM42688P
+#define USE_IMU_ICM42605
+#define IMU_ICM42605_ALIGN       CW90_DEG
+
+//BMI270
+#define USE_IMU_BMI270
+#define IMU_BMI270_ALIGN        CW90_DEG
+
+// *** SPI2 OSD ***
+#define USE_MAX7456
+#define MAX7456_SPI_BUS         BUS_SPI2
+#define MAX7456_CS_PIN          SPI2_NSS_PIN
+
+// *** SPI3 FLASH ***
+#define USE_FLASHFS
+#define USE_FLASH_M25P16
+#define M25P16_CS_PIN           SPI3_NSS_PIN
+#define M25P16_SPI_BUS          BUS_SPI3
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+// *** UART ***
+#define USE_VCP
+
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_UART4
+#define USE_UART5
+#define USE_UART6
+
+#define UART1_TX_PIN            PB6
+#define UART1_RX_PIN            PB7
+
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define UART3_TX_PIN            NONE
+#define UART3_RX_PIN            PB11
+
+#define UART4_TX_PIN            PA0
+#define UART4_RX_PIN            PA1
+
+#define UART5_TX_PIN            PC12
+#define UART5_RX_PIN            PD2
+
+#define UART6_TX_PIN            PC6
+#define UART6_RX_PIN            PC7
+
+#define SERIAL_PORT_COUNT       7
+
+
+#define DEFAULT_RX_TYPE         RX_TYPE_SERIAL
+#define SERIALRX_PROVIDER       SERIALRX_CRSF
+#define SERIALRX_UART           SERIAL_PORT_USART2
+
+// *** I2C/Baro/Mag/Pitot ***
+#define DEFAULT_I2C_BUS         BUS_I2C1
+
+#define USE_BARO
+#define BARO_I2C_BUS            BUS_I2C1
+#define USE_BARO_BMP280
+#define USE_BARO_SPL06
+#define USE_BARO_DPS310
+
+#define TEMPERATURE_I2C_BUS     BUS_I2C1
+#define BNO055_I2C_BUS          BUS_I2C1
+
+#define USE_MAG
+#define MAG_I2C_BUS             BUS_I2C1
+#define USE_MAG_ALL
+
+#define PITOT_I2C_BUS           BUS_I2C1
+
+// *** PINIO ***
+#define USE_PINIO
+#define USE_PINIOBOX
+#define PINIO1_PIN              PC0
+#define PINIO2_PIN              PC2
+
+// *** ADC ***
+#define USE_ADC
+//#define ADC_INSTANCE                ADC3
+//#define ADC1_DMA_STREAM             DMA2_Stream0
+#define ADC_CHANNEL_1_PIN           PC1
+#define ADC_CHANNEL_2_PIN           PC3
+#define VBAT_ADC_CHANNEL            ADC_CHN_1
+#define CURRENT_METER_ADC_CHANNEL   ADC_CHN_2
+
+
+// *** LED2812 ***
+#define USE_LED_STRIP
+#define WS2811_PIN                      PB3
+
+// *** OTHERS ***
+#define DEFAULT_FEATURES        (FEATURE_TX_PROF_SEL | FEATURE_OSD | FEATURE_CURRENT_METER | FEATURE_VBAT | FEATURE_TELEMETRY | FEATURE_SOFTSERIAL )
+
+
+#define USE_DSHOT
+#define USE_ESC_SENSOR
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define MAX_PWM_OUTPUT_PORTS    8


### PR DESCRIPTION
## Description
Adds target definition and documentation for the **ALEX F722-V3** flight controller manufactured by **ALEX RC**.

## Hardware Specifications
- **MCU:** STM32F722RET6 (216MHz ARM Cortex-M7)
- **IMU:** ICM42688P / ICM42605 on SPI1 (`CW90_DEG`)
- **Barometer:** SPL06-001 on I2C1
- **OSD:** AT7456E / MAX7456 on SPI2
- **Blackbox:** 16MB SPI Flash (W25Q128FV / M25P16) on SPI3
- **Compass:** External QMC5883P / IST8310 on I2C1 (PB8/PB9)
- **Camera Switch:** Dual camera switching between CAM1 and CAM2 via PINIO1 (`PC0`)
- **UARTs:** 5 Hardware UARTs
  - UART1: MSP / Telemetry (PB6/PB7)
  - UART2: Serial Receiver CRSF / ELRS / SBUS (PA2/PA3)
  - UART4: GPS (PA0/PA1)
  - UART5: ESC Telemetry / Peripherals (PC12/PD2)
  - UART6: HD VTX / DJI O3 (PC6/PC7)
- **Outputs:** 8 Motor/Servo outputs
- **LED:** WS2812 programmable LED on PB3
- **Buzzer:** Active buzzer on PC13 (inverted)
- **ADC:** Onboard VBAT (PC1) and Current (PC3) sensing

## Testing & Verification
- Tested and verified on physical hardware running INAV 8.x / 9.x.
- Verified sensors live: ICM42605/42688P Gyro/Accel, SPL06 Barometer, External Compass, MAX7456 OSD, SPI Flash, PINIO Camera switcher, and DShot motor outputs.