### PR TITLE
Reject JUMP waypoints with an out-of-range target

### DIFF
--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -5468,6 +5468,11 @@ void setWaypoint(uint8_t wpNumber, const navWaypoint_t * wpData)
     else if ((wpNumber >= 1) && (wpNumber <= NAV_MAX_WAYPOINTS) && !FLIGHT_MODE(NAV_WP_MODE)) {
         // WP upload is not allowed why WP mode is active
         if (wpData->action == NAV_WP_ACTION_WAYPOINT || wpData->action == NAV_WP_ACTION_JUMP || wpData->action == NAV_WP_ACTION_RTH || wpData->action == NAV_WP_ACTION_HOLD_TIME || wpData->action == NAV_WP_ACTION_LAND || wpData->action == NAV_WP_ACTION_SET_POI || wpData->action == NAV_WP_ACTION_SET_HEAD ) {
+            // JUMP target is a WP number, it has to reference another WP of the mission
+            if (wpData->action == NAV_WP_ACTION_JUMP && (wpData->p1 < 1 || wpData->p1 > NAV_MAX_WAYPOINTS)) {
+                return;
+            }
+
             // Only allow upload next waypoint (continue upload mission) or first waypoint (new mission)
             static int8_t nonGeoWaypointCount = 0;
 
@@ -6366,7 +6371,7 @@ navArmingBlocker_e navigationIsBlockingArming(bool *usedBypass)
     if (posControl.waypointCount) {
         for (uint8_t wp = posControl.startWpIndex; wp < posControl.waypointCount + posControl.startWpIndex; wp++){
             if (posControl.waypointList[wp].action == NAV_WP_ACTION_JUMP){
-                if (wp == posControl.startWpIndex || posControl.waypointList[wp].p1 >= posControl.waypointCount ||
+                if (wp == posControl.startWpIndex || posControl.waypointList[wp].p1 < 0 || posControl.waypointList[wp].p1 >= posControl.waypointCount ||
                 (posControl.waypointList[wp].p1 > (wp - posControl.startWpIndex - 2) && posControl.waypointList[wp].p1 < (wp - posControl.startWpIndex + 2)) || posControl.waypointList[wp].p2 < -1) {
                     return NAV_ARMING_BLOCKER_JUMP_WAYPOINT_ERROR;
                 }

--- a/src/main/navigation/navigation.c
+++ b/src/main/navigation/navigation.c
@@ -5468,17 +5468,17 @@ void setWaypoint(uint8_t wpNumber, const navWaypoint_t * wpData)
     else if ((wpNumber >= 1) && (wpNumber <= NAV_MAX_WAYPOINTS) && !FLIGHT_MODE(NAV_WP_MODE)) {
         // WP upload is not allowed why WP mode is active
         if (wpData->action == NAV_WP_ACTION_WAYPOINT || wpData->action == NAV_WP_ACTION_JUMP || wpData->action == NAV_WP_ACTION_RTH || wpData->action == NAV_WP_ACTION_HOLD_TIME || wpData->action == NAV_WP_ACTION_LAND || wpData->action == NAV_WP_ACTION_SET_POI || wpData->action == NAV_WP_ACTION_SET_HEAD ) {
-            // JUMP target is a WP number, it has to reference another WP of the mission
-            if (wpData->action == NAV_WP_ACTION_JUMP && (wpData->p1 < 1 || wpData->p1 > NAV_MAX_WAYPOINTS)) {
-                return;
-            }
-
             // Only allow upload next waypoint (continue upload mission) or first waypoint (new mission)
             static int8_t nonGeoWaypointCount = 0;
 
             if (wpNumber == (posControl.waypointCount + 1) || wpNumber == 1) {
                 if (wpNumber == 1) {
                     resetWaypointList();
+                    nonGeoWaypointCount = 0;
+                }
+                // Reject the new mission after clearing the previous one, before copying or converting the target.
+                if (wpData->action == NAV_WP_ACTION_JUMP && (wpData->p1 < 1 || wpData->p1 > NAV_MAX_WAYPOINTS)) {
+                    return;
                 }
                 posControl.waypointList[wpNumber - 1] = *wpData;
                 if(wpData->action == NAV_WP_ACTION_SET_POI || wpData->action == NAV_WP_ACTION_SET_HEAD || wpData->action == NAV_WP_ACTION_JUMP) {


### PR DESCRIPTION
## Problem
Fixes #11841. The reporter uploaded a mission via `MSP_SET_WP` containing a JUMP waypoint with `p1 = 0`. INAV accepted it: `setWaypoint()` converts the 1-based target to a 0-based index, so the stored target became `-1`. The arming check then computed `uint16_t target = p1 + startWpIndex` = 65535 and read `posControl.waypointList[65535]`; if the mission ran, the FSM assigned the negative value to `activeWaypointIndex`. @breadoven confirmed the bug.

## Cause
`src/main/navigation/navigation.c:5482` (maintenance-10.x): `posControl.waypointList[wpNumber - 1].p1 -= 1;` runs with no lower-bound check on `p1`. `navigationIsBlockingArming()` at `navigation.c:6369` only tests `p1 >= waypointCount`, not `p1 < 0`, before the lookup at `:6375`. The FSM uses the stored index unchecked at `:3050`.

## Change
In `setWaypoint()`, a JUMP with `p1 < 1` or `p1 > NAV_MAX_WAYPOINTS` returns before the waypoint is copied and before the index conversion, so nothing is stored. The check runs after the `wpNumber == 1` reset, so a rejected first waypoint leaves the list empty (`waypointCount` 0, `waypointListValid` false) instead of keeping the previous mission; that reset now also clears the static `nonGeoWaypointCount`. `navigationIsBlockingArming()` additionally returns `NAV_ARMING_BLOCKER_JUMP_WAYPOINT_ERROR` for a negative stored `p1`, which covers the CLI `wp` command (`cli.c:2015`, `:2031`) that writes `p1` straight into `waypointList`.

## Test
Not run on hardware or SITL. Cause verified by reading `navigation.c:5482` and `:6369` on maintenance-10.x; the `MSP_SET_WP` handler (`fc_msp.c:3336`) and the CLI `wp` path were traced to confirm both entry points are covered. No unit test exercises `setWaypoint()` or `navigationIsBlockingArming()` (`navigation_unittest.cc.txt` is disabled). Built by fork CI: pending. Compiled for all targets and the four SITL builds on the fork, green: https://github.com/Raffi1202/inav/actions/runs/34770668275

## Flash / RAM
Builds clean on all targets. No size comparison yet: the fork build has no baseline for this branch, and the upstream size report runs once CI is released for this PR.

## Docs
No documentation change needed: `docs/Navigation.md:86` (CLI `p1` = target WP index) and the `MSP_SET_WP` reference in `docs/development/msp/README.md:2485` describe the field, not the handling of an out-of-range target, which previously had no defined behaviour.
