### PR TITLE
Derive the timer interrupt context index from the timer table

### DIFF
--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -55,14 +55,22 @@ typedef uint32_t timCNT_t;
 #error "Unknown CPU defined"
 #endif
 
+// TIMER_INDEX() maps a hardware timer number to its slot in timerDefinitions[] and
+// timerCtx[]. This is not always (n - 1): the tables are packed and not every MCU has
+// a contiguous range of timers (STM32H7 has no TIM9..TIM11, AT32F43x adds TMR20 after
+// TMR14). Timer tables and timer IRQ handlers must use this macro.
 #if defined(STM32F4)
 #define HARDWARE_TIMER_DEFINITION_COUNT 14
+#define TIMER_INDEX(n)                  ((n) - 1)                       // TIM1..TIM14
 #elif defined(STM32F7)
 #define HARDWARE_TIMER_DEFINITION_COUNT 14
+#define TIMER_INDEX(n)                  ((n) - 1)                       // TIM1..TIM14
 #elif defined(STM32H7)
 #define HARDWARE_TIMER_DEFINITION_COUNT 14
+#define TIMER_INDEX(n)                  ((n) < 9 ? (n) - 1 : (n) - 4)   // TIM1..TIM8, TIM12..TIM17
 #elif defined(AT32F43x)
 #define HARDWARE_TIMER_DEFINITION_COUNT 15
+#define TIMER_INDEX(n)                  ((n) < 20 ? (n) - 1 : 14)       // TMR1..TMR14, TMR20
 #elif defined(SITL_BUILD)
 #define HARDWARE_TIMER_DEFINITION_COUNT 0
 #elif defined(RP2350)

--- a/src/main/drivers/timer_at32f43x.c
+++ b/src/main/drivers/timer_at32f43x.c
@@ -34,65 +34,68 @@
  
     const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
     #if defined(TMR1)
-        [0] = { .tim = TMR1,  .rcc = RCC_APB2(TMR1),  .irq = TMR1_CH_IRQn, .secondIrq = TMR1_OVF_TMR10_IRQn },
+        [TIMER_INDEX(1)] = { .tim = TMR1,  .rcc = RCC_APB2(TMR1),  .irq = TMR1_CH_IRQn, .secondIrq = TMR1_OVF_TMR10_IRQn },
     #endif
  
     #if defined(TMR2)
-        [1] = { .tim = TMR2,  .rcc = RCC_APB1(TMR2),  .irq = TMR2_GLOBAL_IRQn},
+        [TIMER_INDEX(2)] = { .tim = TMR2,  .rcc = RCC_APB1(TMR2),  .irq = TMR2_GLOBAL_IRQn},
     #endif
 
     #if defined(TMR3)
-        [2] = { .tim = TMR3,  .rcc = RCC_APB1(TMR3),  .irq = TMR3_GLOBAL_IRQn},
+        [TIMER_INDEX(3)] = { .tim = TMR3,  .rcc = RCC_APB1(TMR3),  .irq = TMR3_GLOBAL_IRQn},
     #endif
 
     #if defined(TMR4)
-        [3] = { .tim = TMR4,  .rcc = RCC_APB1(TMR4),  .irq = TMR4_GLOBAL_IRQn},
+        [TIMER_INDEX(4)] = { .tim = TMR4,  .rcc = RCC_APB1(TMR4),  .irq = TMR4_GLOBAL_IRQn},
     #endif
 
     #if defined(TMR5)
-        [4] = { .tim = TMR5,  .rcc = RCC_APB1(TMR5),  .irq = TMR5_GLOBAL_IRQn},
+        [TIMER_INDEX(5)] = { .tim = TMR5,  .rcc = RCC_APB1(TMR5),  .irq = TMR5_GLOBAL_IRQn},
     #endif
 
     #if defined(TMR6)
-        [5] = { .tim = TMR6,  .rcc = RCC_APB1(TMR6),  .irq = 0},
+        [TIMER_INDEX(6)] = { .tim = TMR6,  .rcc = RCC_APB1(TMR6),  .irq = 0},
     #endif
 
     #if defined(TMR7)
-        [6] = { .tim = TMR7,  .rcc = RCC_APB1(TMR7),  .irq = 0},
+        [TIMER_INDEX(7)] = { .tim = TMR7,  .rcc = RCC_APB1(TMR7),  .irq = 0},
     #endif
 
     #if defined(TMR8)   
-        [7] = { .tim = TMR8,  .rcc = RCC_APB2(TMR8),  .irq = TMR8_CH_IRQn, .secondIrq = TMR8_OVF_TMR13_IRQn },
+        [TIMER_INDEX(8)] = { .tim = TMR8,  .rcc = RCC_APB2(TMR8),  .irq = TMR8_CH_IRQn, .secondIrq = TMR8_OVF_TMR13_IRQn },
     #endif
 
     #if defined(TMR9)
-        [8] = { .tim = TMR9,  .rcc = RCC_APB2(TMR9),  .irq = TMR1_BRK_TMR9_IRQn},
+        [TIMER_INDEX(9)] = { .tim = TMR9,  .rcc = RCC_APB2(TMR9),  .irq = TMR1_BRK_TMR9_IRQn},
     #endif
 
     #if defined(TMR10)
-        [9] = { .tim = TMR10, .rcc = RCC_APB2(TMR10), .irq = TMR1_OVF_TMR10_IRQn},
+        [TIMER_INDEX(10)] = { .tim = TMR10, .rcc = RCC_APB2(TMR10), .irq = TMR1_OVF_TMR10_IRQn},
     #endif
 
     #if defined(TMR11)
-        [10] = { .tim = TMR11, .rcc = RCC_APB2(TMR11), .irq = TMR1_TRG_HALL_TMR11_IRQn},
+        [TIMER_INDEX(11)] = { .tim = TMR11, .rcc = RCC_APB2(TMR11), .irq = TMR1_TRG_HALL_TMR11_IRQn},
     #endif
 
     #if defined(TMR12) 
-        [11] = { .tim = TMR12, .rcc = RCC_APB1(TMR12), .irq = TMR8_BRK_TMR12_IRQn},
+        [TIMER_INDEX(12)] = { .tim = TMR12, .rcc = RCC_APB1(TMR12), .irq = TMR8_BRK_TMR12_IRQn},
     #endif
 
     #if defined(TMR13)
-        [12] = { .tim = TMR13, .rcc = RCC_APB1(TMR13), .irq = TMR8_OVF_TMR13_IRQn},
+        [TIMER_INDEX(13)] = { .tim = TMR13, .rcc = RCC_APB1(TMR13), .irq = TMR8_OVF_TMR13_IRQn},
     #endif
 
     #if defined(TMR14)
-        [13] = { .tim = TMR14, .rcc = RCC_APB1(TMR14), .irq = TMR8_TRG_HALL_TMR14_IRQn},
+        [TIMER_INDEX(14)] = { .tim = TMR14, .rcc = RCC_APB1(TMR14), .irq = TMR8_TRG_HALL_TMR14_IRQn},
     #endif
 
     #if defined(TMR20)
-         [14] = { .tim = TMR20, .rcc = RCC_APB2(TMR20), .irq = TMR20_CH_IRQn},
+         [TIMER_INDEX(20)] = { .tim = TMR20, .rcc = RCC_APB2(TMR20), .irq = TMR20_CH_IRQn},
      #endif
     }; 
+
+// The timer table must cover every slot of timerCtx[] - see TIMER_INDEX() in timer.h
+STATIC_ASSERT(TIMER_INDEX(20) == HARDWARE_TIMER_DEFINITION_COUNT - 1, timer_definition_table_size_mismatch);
 
 uint32_t timerClock(tmr_type *tim)
 {

--- a/src/main/drivers/timer_impl.h
+++ b/src/main/drivers/timer_impl.h
@@ -17,22 +17,29 @@
 
 #pragma once
 
+#include "common/utils.h"
+
 #if defined(AT32F43x)
 #define IMPL_TIM_IT_UPDATE_INTERRUPT      TMR_OVF_INT
 #define TIM_IT_CCx(chIdx)                 (TMR_C1_INT << (chIdx))
 // 0x2 0x4 0x8 0x10 0\1\2\3
 
 #define _TIM_IRQ_HANDLER2(name, i, j)                                   \
+    STATIC_ASSERT(TIMER_INDEX(i) < HARDWARE_TIMER_DEFINITION_COUNT &&   \
+                  TIMER_INDEX(j) < HARDWARE_TIMER_DEFINITION_COUNT,     \
+                  name ## _timer_index_out_of_range);                   \
     void name(void)                                                     \
     {                                                                   \
-        impl_timerCaptureCompareHandler(TMR ## i, timerCtx[i - 1]); \
-        impl_timerCaptureCompareHandler(TMR ## j, timerCtx[j - 1]); \
+        impl_timerCaptureCompareHandler(TMR ## i, timerCtx[TIMER_INDEX(i)]); \
+        impl_timerCaptureCompareHandler(TMR ## j, timerCtx[TIMER_INDEX(j)]); \
     } struct dummy
 
 #define _TIM_IRQ_HANDLER(name, i)                                       \
+    STATIC_ASSERT(TIMER_INDEX(i) < HARDWARE_TIMER_DEFINITION_COUNT,     \
+                  name ## _timer_index_out_of_range);                   \
     void name(void)                                                     \
     {                                                                   \
-        impl_timerCaptureCompareHandler(TMR ## i, timerCtx[i - 1]); \
+        impl_timerCaptureCompareHandler(TMR ## i, timerCtx[TIMER_INDEX(i)]); \
     } struct dummy
 
 uint8_t lookupTimerIndex(const tmr_type *tim);
@@ -49,16 +56,21 @@ void impl_timerCaptureCompareHandler(tmr_type *tim, timHardwareContext_t * timer
 #endif
 
 #define _TIM_IRQ_HANDLER2(name, i, j)                                   \
+    STATIC_ASSERT(TIMER_INDEX(i) < HARDWARE_TIMER_DEFINITION_COUNT &&   \
+                  TIMER_INDEX(j) < HARDWARE_TIMER_DEFINITION_COUNT,     \
+                  name ## _timer_index_out_of_range);                   \
     void name(void)                                                     \
     {                                                                   \
-        impl_timerCaptureCompareHandler(TIM ## i, timerCtx[i - 1]); \
-        impl_timerCaptureCompareHandler(TIM ## j, timerCtx[j - 1]); \
+        impl_timerCaptureCompareHandler(TIM ## i, timerCtx[TIMER_INDEX(i)]); \
+        impl_timerCaptureCompareHandler(TIM ## j, timerCtx[TIMER_INDEX(j)]); \
     } struct dummy
 
 #define _TIM_IRQ_HANDLER(name, i)                                       \
+    STATIC_ASSERT(TIMER_INDEX(i) < HARDWARE_TIMER_DEFINITION_COUNT,     \
+                  name ## _timer_index_out_of_range);                   \
     void name(void)                                                     \
     {                                                                   \
-        impl_timerCaptureCompareHandler(TIM ## i, timerCtx[i - 1]); \
+        impl_timerCaptureCompareHandler(TIM ## i, timerCtx[TIMER_INDEX(i)]); \
     } struct dummy
 
 uint8_t lookupTimerIndex(const TIM_TypeDef *tim);

--- a/src/main/drivers/timer_stm32f4xx.c
+++ b/src/main/drivers/timer_stm32f4xx.c
@@ -35,65 +35,68 @@
 
 const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
 #if defined(TIM1)
-    [0] = { .tim = TIM1,  .rcc = RCC_APB2(TIM1),  .irq = TIM1_CC_IRQn, .secondIrq = TIM1_UP_TIM10_IRQn },
+    [TIMER_INDEX(1)] = { .tim = TIM1,  .rcc = RCC_APB2(TIM1),  .irq = TIM1_CC_IRQn, .secondIrq = TIM1_UP_TIM10_IRQn },
 #endif
 
 #if defined(TIM2)
-    [1] = { .tim = TIM2,  .rcc = RCC_APB1(TIM2),  .irq = TIM2_IRQn},
+    [TIMER_INDEX(2)] = { .tim = TIM2,  .rcc = RCC_APB1(TIM2),  .irq = TIM2_IRQn},
 #endif
 
 #if defined(TIM3)
-    [2] = { .tim = TIM3,  .rcc = RCC_APB1(TIM3),  .irq = TIM3_IRQn},
+    [TIMER_INDEX(3)] = { .tim = TIM3,  .rcc = RCC_APB1(TIM3),  .irq = TIM3_IRQn},
 #endif
 
 #if defined(TIM4)
-    [3] = { .tim = TIM4,  .rcc = RCC_APB1(TIM4),  .irq = TIM4_IRQn},
+    [TIMER_INDEX(4)] = { .tim = TIM4,  .rcc = RCC_APB1(TIM4),  .irq = TIM4_IRQn},
 #endif
 
 #if defined(TIM5)
-    [4] = { .tim = TIM5,  .rcc = RCC_APB1(TIM5),  .irq = TIM5_IRQn},
+    [TIMER_INDEX(5)] = { .tim = TIM5,  .rcc = RCC_APB1(TIM5),  .irq = TIM5_IRQn},
 #endif
 
 #if defined(TIM6)
-    [5] = { .tim = TIM6,  .rcc = RCC_APB1(TIM6),  .irq = 0},
+    [TIMER_INDEX(6)] = { .tim = TIM6,  .rcc = RCC_APB1(TIM6),  .irq = 0},
 #endif
 
 #if defined(TIM7)
-    [6] = { .tim = TIM7,  .rcc = RCC_APB1(TIM7),  .irq = 0},
+    [TIMER_INDEX(7)] = { .tim = TIM7,  .rcc = RCC_APB1(TIM7),  .irq = 0},
 #endif
 
 #if defined(TIM8) && !defined(STM32F411xE)
 #if defined(STM32F446xx)
-    [7] = { .tim = TIM8,  .rcc = RCC_APB2(TIM8),  .irq = 0 },
+    [TIMER_INDEX(8)] = { .tim = TIM8,  .rcc = RCC_APB2(TIM8),  .irq = 0 },
 #else
-    [7] = { .tim = TIM8,  .rcc = RCC_APB2(TIM8),  .irq = TIM8_CC_IRQn, .secondIrq = TIM8_UP_TIM13_IRQn },
+    [TIMER_INDEX(8)] = { .tim = TIM8,  .rcc = RCC_APB2(TIM8),  .irq = TIM8_CC_IRQn, .secondIrq = TIM8_UP_TIM13_IRQn },
 #endif
 #endif
 
 #if defined(TIM9)
-    [8] = { .tim = TIM9,  .rcc = RCC_APB2(TIM9),  .irq = TIM1_BRK_TIM9_IRQn},
+    [TIMER_INDEX(9)] = { .tim = TIM9,  .rcc = RCC_APB2(TIM9),  .irq = TIM1_BRK_TIM9_IRQn},
 #endif
 
 #if defined(TIM10)
-    [9] = { .tim = TIM10, .rcc = RCC_APB2(TIM10), .irq = TIM1_UP_TIM10_IRQn},
+    [TIMER_INDEX(10)] = { .tim = TIM10, .rcc = RCC_APB2(TIM10), .irq = TIM1_UP_TIM10_IRQn},
 #endif
 
 #if defined(TIM11)
-    [10] = { .tim = TIM11, .rcc = RCC_APB2(TIM11), .irq = TIM1_TRG_COM_TIM11_IRQn},
+    [TIMER_INDEX(11)] = { .tim = TIM11, .rcc = RCC_APB2(TIM11), .irq = TIM1_TRG_COM_TIM11_IRQn},
 #endif
 
 #if defined(TIM12) && !defined(STM32F411xE)
-    [11] = { .tim = TIM12, .rcc = RCC_APB1(TIM12), .irq = TIM8_BRK_TIM12_IRQn},
+    [TIMER_INDEX(12)] = { .tim = TIM12, .rcc = RCC_APB1(TIM12), .irq = TIM8_BRK_TIM12_IRQn},
 #endif
 
 #if defined(TIM13) && !defined(STM32F411xE)
-    [12] = { .tim = TIM13, .rcc = RCC_APB1(TIM13), .irq = TIM8_UP_TIM13_IRQn},
+    [TIMER_INDEX(13)] = { .tim = TIM13, .rcc = RCC_APB1(TIM13), .irq = TIM8_UP_TIM13_IRQn},
 #endif
 
 #if defined(TIM14) && !defined(STM32F411xE)
-    [13] = { .tim = TIM14, .rcc = RCC_APB1(TIM14), .irq = TIM8_TRG_COM_TIM14_IRQn},
+    [TIMER_INDEX(14)] = { .tim = TIM14, .rcc = RCC_APB1(TIM14), .irq = TIM8_TRG_COM_TIM14_IRQn},
 #endif
 };
+
+// The timer table must cover every slot of timerCtx[] - see TIMER_INDEX() in timer.h
+STATIC_ASSERT(TIMER_INDEX(14) == HARDWARE_TIMER_DEFINITION_COUNT - 1, timer_definition_table_size_mismatch);
 
 uint32_t timerClock(TIM_TypeDef *tim)
 {

--- a/src/main/drivers/timer_stm32f7xx.c
+++ b/src/main/drivers/timer_stm32f7xx.c
@@ -32,21 +32,24 @@
 #include "stm32f7xx.h"
 
 const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
-    [0] = { .tim = TIM1,  .rcc = RCC_APB2(TIM1),  .irq = TIM1_CC_IRQn, .secondIrq = TIM1_UP_TIM10_IRQn },
-    [1] = { .tim = TIM2,  .rcc = RCC_APB1(TIM2),  .irq = TIM2_IRQn},
-    [2] = { .tim = TIM3,  .rcc = RCC_APB1(TIM3),  .irq = TIM3_IRQn},
-    [3] = { .tim = TIM4,  .rcc = RCC_APB1(TIM4),  .irq = TIM4_IRQn},
-    [4] = { .tim = TIM5,  .rcc = RCC_APB1(TIM5),  .irq = TIM5_IRQn},
-    [5] = { .tim = TIM6,  .rcc = RCC_APB1(TIM6),  .irq = 0},
-    [6] = { .tim = TIM7,  .rcc = RCC_APB1(TIM7),  .irq = 0},
-    [7] = { .tim = TIM8,  .rcc = RCC_APB2(TIM8),  .irq = TIM8_CC_IRQn, .secondIrq = TIM8_UP_TIM13_IRQn},
-    [8] = { .tim = TIM9,  .rcc = RCC_APB2(TIM9),  .irq = TIM1_BRK_TIM9_IRQn},
-    [9] = { .tim = TIM10, .rcc = RCC_APB2(TIM10), .irq = TIM1_UP_TIM10_IRQn},
-    [10] = { .tim = TIM11, .rcc = RCC_APB2(TIM11), .irq = TIM1_TRG_COM_TIM11_IRQn},
-    [11] = { .tim = TIM12, .rcc = RCC_APB1(TIM12), .irq = TIM8_BRK_TIM12_IRQn},
-    [12] = { .tim = TIM13, .rcc = RCC_APB1(TIM13), .irq = TIM8_UP_TIM13_IRQn},
-    [13] = { .tim = TIM14, .rcc = RCC_APB1(TIM14), .irq = TIM8_TRG_COM_TIM14_IRQn},
+    [TIMER_INDEX(1)] = { .tim = TIM1,  .rcc = RCC_APB2(TIM1),  .irq = TIM1_CC_IRQn, .secondIrq = TIM1_UP_TIM10_IRQn },
+    [TIMER_INDEX(2)] = { .tim = TIM2,  .rcc = RCC_APB1(TIM2),  .irq = TIM2_IRQn},
+    [TIMER_INDEX(3)] = { .tim = TIM3,  .rcc = RCC_APB1(TIM3),  .irq = TIM3_IRQn},
+    [TIMER_INDEX(4)] = { .tim = TIM4,  .rcc = RCC_APB1(TIM4),  .irq = TIM4_IRQn},
+    [TIMER_INDEX(5)] = { .tim = TIM5,  .rcc = RCC_APB1(TIM5),  .irq = TIM5_IRQn},
+    [TIMER_INDEX(6)] = { .tim = TIM6,  .rcc = RCC_APB1(TIM6),  .irq = 0},
+    [TIMER_INDEX(7)] = { .tim = TIM7,  .rcc = RCC_APB1(TIM7),  .irq = 0},
+    [TIMER_INDEX(8)] = { .tim = TIM8,  .rcc = RCC_APB2(TIM8),  .irq = TIM8_CC_IRQn, .secondIrq = TIM8_UP_TIM13_IRQn},
+    [TIMER_INDEX(9)] = { .tim = TIM9,  .rcc = RCC_APB2(TIM9),  .irq = TIM1_BRK_TIM9_IRQn},
+    [TIMER_INDEX(10)] = { .tim = TIM10, .rcc = RCC_APB2(TIM10), .irq = TIM1_UP_TIM10_IRQn},
+    [TIMER_INDEX(11)] = { .tim = TIM11, .rcc = RCC_APB2(TIM11), .irq = TIM1_TRG_COM_TIM11_IRQn},
+    [TIMER_INDEX(12)] = { .tim = TIM12, .rcc = RCC_APB1(TIM12), .irq = TIM8_BRK_TIM12_IRQn},
+    [TIMER_INDEX(13)] = { .tim = TIM13, .rcc = RCC_APB1(TIM13), .irq = TIM8_UP_TIM13_IRQn},
+    [TIMER_INDEX(14)] = { .tim = TIM14, .rcc = RCC_APB1(TIM14), .irq = TIM8_TRG_COM_TIM14_IRQn},
 };
+
+// The timer table must cover every slot of timerCtx[] - see TIMER_INDEX() in timer.h
+STATIC_ASSERT(TIMER_INDEX(14) == HARDWARE_TIMER_DEFINITION_COUNT - 1, timer_definition_table_size_mismatch);
 
 uint32_t timerClock(TIM_TypeDef *tim)
 {

--- a/src/main/drivers/timer_stm32h7xx.c
+++ b/src/main/drivers/timer_stm32h7xx.c
@@ -32,21 +32,24 @@
 #include "stm32h7xx.h"
 
 const timerDef_t timerDefinitions[HARDWARE_TIMER_DEFINITION_COUNT] = {
-    [0] = { .tim = TIM1,  .rcc = RCC_APB2(TIM1),   .irq = TIM1_CC_IRQn},
-    [1] = { .tim = TIM2,  .rcc = RCC_APB1L(TIM2),  .irq = TIM2_IRQn},
-    [2] = { .tim = TIM3,  .rcc = RCC_APB1L(TIM3),  .irq = TIM3_IRQn},
-    [3] = { .tim = TIM4,  .rcc = RCC_APB1L(TIM4),  .irq = TIM4_IRQn},
-    [4] = { .tim = TIM5,  .rcc = RCC_APB1L(TIM5),  .irq = TIM5_IRQn},
-    [5] = { .tim = TIM6,  .rcc = RCC_APB1L(TIM6),  .irq = 0},
-    [6] = { .tim = TIM7,  .rcc = RCC_APB1L(TIM7),  .irq = 0},
-    [7] = { .tim = TIM8,  .rcc = RCC_APB2(TIM8),   .irq = TIM8_CC_IRQn},
-    [8] = { .tim = TIM12, .rcc = RCC_APB1L(TIM12), .irq = TIM8_BRK_TIM12_IRQn},
-    [9] = { .tim = TIM13, .rcc = RCC_APB1L(TIM13), .irq = TIM8_UP_TIM13_IRQn},
-    [10] = { .tim = TIM14, .rcc = RCC_APB1L(TIM14), .irq = TIM8_TRG_COM_TIM14_IRQn},
-    [11] = { .tim = TIM15, .rcc = RCC_APB2(TIM15),  .irq = TIM15_IRQn},
-    [12] = { .tim = TIM16, .rcc = RCC_APB2(TIM16),  .irq = TIM16_IRQn},
-    [13] = { .tim = TIM17, .rcc = RCC_APB2(TIM17),  .irq = TIM17_IRQn},
+    [TIMER_INDEX(1)] = { .tim = TIM1,  .rcc = RCC_APB2(TIM1),   .irq = TIM1_CC_IRQn},
+    [TIMER_INDEX(2)] = { .tim = TIM2,  .rcc = RCC_APB1L(TIM2),  .irq = TIM2_IRQn},
+    [TIMER_INDEX(3)] = { .tim = TIM3,  .rcc = RCC_APB1L(TIM3),  .irq = TIM3_IRQn},
+    [TIMER_INDEX(4)] = { .tim = TIM4,  .rcc = RCC_APB1L(TIM4),  .irq = TIM4_IRQn},
+    [TIMER_INDEX(5)] = { .tim = TIM5,  .rcc = RCC_APB1L(TIM5),  .irq = TIM5_IRQn},
+    [TIMER_INDEX(6)] = { .tim = TIM6,  .rcc = RCC_APB1L(TIM6),  .irq = 0},
+    [TIMER_INDEX(7)] = { .tim = TIM7,  .rcc = RCC_APB1L(TIM7),  .irq = 0},
+    [TIMER_INDEX(8)] = { .tim = TIM8,  .rcc = RCC_APB2(TIM8),   .irq = TIM8_CC_IRQn},
+    [TIMER_INDEX(12)] = { .tim = TIM12, .rcc = RCC_APB1L(TIM12), .irq = TIM8_BRK_TIM12_IRQn},
+    [TIMER_INDEX(13)] = { .tim = TIM13, .rcc = RCC_APB1L(TIM13), .irq = TIM8_UP_TIM13_IRQn},
+    [TIMER_INDEX(14)] = { .tim = TIM14, .rcc = RCC_APB1L(TIM14), .irq = TIM8_TRG_COM_TIM14_IRQn},
+    [TIMER_INDEX(15)] = { .tim = TIM15, .rcc = RCC_APB2(TIM15),  .irq = TIM15_IRQn},
+    [TIMER_INDEX(16)] = { .tim = TIM16, .rcc = RCC_APB2(TIM16),  .irq = TIM16_IRQn},
+    [TIMER_INDEX(17)] = { .tim = TIM17, .rcc = RCC_APB2(TIM17),  .irq = TIM17_IRQn},
 };
+
+// The timer table must cover every slot of timerCtx[] - see TIMER_INDEX() in timer.h
+STATIC_ASSERT(TIMER_INDEX(17) == HARDWARE_TIMER_DEFINITION_COUNT - 1, timer_definition_table_size_mismatch);
 
 uint32_t timerClock(TIM_TypeDef *tim)
 {


### PR DESCRIPTION
## Problem
On STM32H7 the timer IRQ handlers index `timerCtx[]` with `timer number - 1`, but H7 has no TIM9..TIM11 and its table is packed into 14 slots. `TIM15_IRQHandler`..`TIM17_IRQHandler` therefore read `timerCtx[14..16]`, past the end of the array, and the TIM12..TIM14 handlers get the context of TIM15..TIM17. Assigning PPM/PWM RC input or ESC RPM telemetry to a TIM15/16/17 pad on an H7 board enables that IRQ and can hard fault (#11368, found by code analysis; the reporter has no H7 board). AT32F43x has the same defect: `TMR20_CH_IRQHandler` reads `timerCtx[19]` in a 15-entry array.

## Cause
`src/main/drivers/timer_impl.h:61` on maintenance-10.x (also :54-55, and :28-29/:35 for AT32): `impl_timerCaptureCompareHandler(TIM ## i, timerCtx[i - 1]);`. The H7 table `timer_stm32h7xx.c:43-48` places TIM12..TIM17 in slots 8..13. `timer_impl_hal.c:254` calls `timerCtx->ch[0].cb->callbackEdge` guarded only by a NULL check on `timerCtx` itself (:235), so a foreign or out-of-bounds context faults.

## Change
`timer.h` gains `TIMER_INDEX(n)` per MCU family (`n-1` on F4/F7; `n<9 ? n-1 : n-4` on H7; `n<20 ? n-1 : 14` on AT32F43x). The four platform tables use it as their array designators and both handler macros in `timer_impl.h` use `timerCtx[TIMER_INDEX(i)]`, so table and ISR share one mapping. A `STATIC_ASSERT` in each handler macro rejects an index outside `HARDWARE_TIMER_DEFINITION_COUNT`, each platform file asserts its last timer lands in the last slot, and `timer_impl.h` includes `common/utils.h` for `STATIC_ASSERT`. F4/F7 indices are unchanged.

## Test
Not run on hardware. Cause verified by reading `timer_impl.h:61`, `timer_stm32h7xx.c:43-48` and `timer_impl_hal.c:235-254` on maintenance-10.x. The upstream "Build firmware" run is waiting for maintainer approval: https://github.com/iNavFlight/inav/actions/runs/34511424067. Built by fork CI: pending. Compiled for all targets and the four SITL builds on the fork, green: https://github.com/Raffi1202/inav/actions/runs/34770670426

## Flash / RAM
Builds clean on all targets. No size comparison yet: the fork build has no baseline for this branch, and the upstream size report runs once CI is released for this PR.

## Docs
No documentation change needed: internal driver indexing with no setting, CLI or user-visible option; the only docs mention of `HARDWARE_TIMER_DEFINITION_COUNT` (docs/development/msp/README.md:3451) is unaffected.
