### PR TITLE
Describe what tpa_pitch_compensation and fw_d_level really do

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -7187,7 +7187,7 @@ Throttle PID attenuation also reduces influence on YAW for multi-rotor, Should b
 
 ### tpa_pitch_compensation
 
-Pitch angle based throttle compensation for fixed wing. Positive values will increase throttle when pitching up, and decrease throttle when pitching down.
+Fixed wing only. Pitch angle bias for the throttle value that throttle based TPA reads. It does not change the throttle sent to the motor, it only shifts the point on the TPA curve: nose up adds about this many microseconds per degree of pitch (the exact term is value * sin(pitch) * 180/pi, limited to +/-1000us), nose down subtracts them, so the PIDs get attenuated as if throttle were higher while climbing and lower while descending. You only need this if throttle based TPA is actually running, meaning `tpa_rate` is not 0 and `fw_tpa_time_constant` is above 0; leave it at 0 if you do not use TPA or if airspeed based attenuation (`apa_pow`) is active.
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1445,7 +1445,7 @@ Minimum stick input [%], after applying deadband and expo, to start recording th
 
 ### fw_d_level
 
-Fixed-wing attitude stabilisation HORIZON transition point
+Fixed-wing HORIZON transition point, expressed as stick deflection in percent. At this deflection self-levelling is faded out completely and the axis behaves like ACRO; below it, ANGLE and ACRO are blended proportionally. Despite the 0-255 CLI range, which is shared with the other PID values, the number is not scaled to 255: it is clamped to 100 internally, so 75 really means 75% stick and any value above 100 acts the same as 100.
 
 | Default | Min | Max |
 | --- | --- | --- |

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -1469,7 +1469,7 @@ groups:
         min: PWM_RANGE_MIN
         max: PWM_RANGE_MAX
       - name: tpa_pitch_compensation
-        description: "Pitch angle based throttle compensation for fixed wing. Positive values will increase throttle when pitching up, and decrease throttle when pitching down."
+        description: "Fixed wing only. Pitch angle bias for the throttle value that throttle based TPA reads. It does not change the throttle sent to the motor, it only shifts the point on the TPA curve: nose up adds about this many microseconds per degree of pitch (the exact term is value * sin(pitch) * 180/pi, limited to +/-1000us), nose down subtracts them, so the PIDs get attenuated as if throttle were higher while climbing and lower while descending. You only need this if throttle based TPA is actually running, meaning `tpa_rate` is not 0 and `fw_tpa_time_constant` is above 0; leave it at 0 if you do not use TPA or if airspeed based attenuation (`apa_pow`) is active."
         default_value: 8
         field: throttle.tpa_pitch_compensation
         min: 0

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -2077,7 +2077,7 @@ groups:
         min: RPYL_PID_MIN
         max: RPYL_PID_MAX
       - name: fw_d_level
-        description: "Fixed-wing attitude stabilisation HORIZON transition point"
+        description: "Fixed-wing HORIZON transition point, expressed as stick deflection in percent. At this deflection self-levelling is faded out completely and the axis behaves like ACRO; below it, ANGLE and ACRO are blended proportionally. Despite the 0-255 CLI range, which is shared with the other PID values, the number is not scaled to 255: it is clamped to 100 internally, so 75 really means 75% stick and any value above 100 acts the same as 100."
         default_value: 75
         field: bank_fw.pid[PID_LEVEL].D
         min: RPYL_PID_MIN


### PR DESCRIPTION
## Problem
Two open documentation issues on the same settings table. In #11810 the reporter read the `tpa_pitch_compensation` entry in `docs/Settings.md` ("increase throttle when pitching up") and asked whether it should say that it changes TPA with pitch angle, not throttle; the thread then turned on when the setting has any effect at all next to `apa_pow`. In #10778 the reporter, tuning HORIZON on a fixed wing, read in `docs/INAV_Modes.pdf` that `fw_d_level = 75` means 75% stick, saw the 0-255 CLI range, and concluded that 75% is really 191.

## Cause
The description strings at `src/main/fc/settings.yaml:1472` (`tpa_pitch_compensation`) and `:2080` (`fw_d_level`) on maintenance-10.x do not match the code. `src/main/flight/pid.c:1351-1353` adds `tpa_pitch_compensation * groundCos * 90/(pi/2)` to `rcCommand[THROTTLE]` and returns that value only as the input of `calculateFixedWingTPAFactor()` (`pid.c:1391`); the motor throttle is untouched. `pid.c:1448` clamps `pid[PID_LEVEL].D` to 0-100 and divides by 100, so the value is a stick percentage; the 0-255 range is `RPYL_PID_MIN/MAX` (`settings.yaml:231-232`), shared by every PID field.

## Change
Rewrites the two description strings in `settings.yaml`. `tpa_pitch_compensation` now says it biases the throttle value that throttle based TPA reads (about `value * sin(pitch) * 180/pi` us, limited to +/-1000 us), not the motor throttle, and that it only matters while `tpa_rate` is not 0, `fw_tpa_time_constant` is above 0 and airspeed based attenuation is not in use. `fw_d_level` now says it is stick deflection in percent, clamped to 100 internally. `docs/Settings.md` is regenerated with `src/utils/update_cli_docs.py`; each of the two commits carries both files.

## Test
Not run on hardware or SITL; no code changes. Cause verified by reading `pid.c:1343-1358`, `1385-1392` and `1442-1461` on `upstream/maintenance-10.x`. Fork CI "Make sure docs are updated" passed on c4a5a0b: https://github.com/Raffi1202/inav/actions/runs/34512590111. The upstream runs for this head are waiting for workflow approval.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
`docs/Settings.md` is regenerated in this PR. No other file under `docs/` describes either setting; `docs/Control Profiles.md` only lists `set fw_d_level = 75` inside a dump.
