### PR TITLE
Scale the gyro calibration movement threshold with sensitivity

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -377,7 +377,11 @@ void gyroStartCalibration(void)
 #endif
 
     gyroCalibrationComplete = false;
-    zeroCalibrationStartV(&gyroCalibration[0], CALIBRATING_GYRO_TIME_MS, CALIBRATING_GYRO_MORON_THRESHOLD, false);
+    // Zero calibration works on raw gyro readings, convert the movement threshold from dps into
+    // sensor LSB using the sensitivity of the detected gyro
+    const float movementThreshold = CALIBRATING_GYRO_MORON_THRESHOLD_DPS / gyroDev[0].scale;
+
+    zeroCalibrationStartV(&gyroCalibration[0], CALIBRATING_GYRO_TIME_MS, movementThreshold, false);
 }
 
 bool gyroIsCalibrationComplete(void)

--- a/src/main/sensors/sensors.h
+++ b/src/main/sensors/sensors.h
@@ -43,7 +43,10 @@ typedef union flightDynamicsTrims_u {
 #define CALIBRATING_PITOT_TIME_MS           4000
 #define CALIBRATING_GYRO_TIME_MS            2000
 #define CALIBRATING_ACC_TIME_MS             500
-#define CALIBRATING_GYRO_MORON_THRESHOLD    32
+// Gyro zero calibration movement threshold, in dps. Expressed as a physical rotation rate so
+// that it does not depend on the gyro sensitivity. Equals the legacy threshold of 32 LSB at
+// the default scale of 16.4 LSB/dps
+#define CALIBRATING_GYRO_MORON_THRESHOLD_DPS (32.0f / 16.4f)
 
 // These bits have to be aligned with sensorIndex_e
 typedef enum {


### PR DESCRIPTION
## Problem
@and-sh reported in #10650 that the gyro zero calibration never completes when the gyro is configured for a higher sensitivity than the default. He hit it on a custom board with an ICM45686 while testing different full-scale ranges, and pointed out that the standard deviation is computed from raw readings while the threshold does not depend on the gyro scale. Fixes #10650.

## Cause
`src/main/sensors/sensors.h:46` defines `CALIBRATING_GYRO_MORON_THRESHOLD 32` in raw counts, and `src/main/sensors/gyro.c:380` passes it unchanged to `zeroCalibrationStartV()`. `performGyroCalibration()` (`gyro.c:403-405`) feeds `gyroADCRaw[]` into the calibrator, and `src/main/common/calibration.c:159` compares the raw-count standard deviation against that fixed number, restarting the window whenever it is exceeded. A gyro with more LSB per dps shows a larger raw deviation for the same physical stillness, so every window fails.

## Change
`sensors.h` replaces the constant with `CALIBRATING_GYRO_MORON_THRESHOLD_DPS (32.0f / 16.4f)`, i.e. 1.95 dps, which is what 32 LSB meant at the default 16.4 LSB/dps. `gyroStartCalibration()` in `gyro.c` divides that by `gyroDev[0].scale` and passes the result as the threshold. Drivers with `scale = 1.0f / 16.4f` keep exactly 32 LSB; LSM6DXX Gen-V (`scale = 0.070f`) moves to 27.9 LSB and the fake gyro (`0.0625f`) to 31.2 LSB.

## Test
Not run on hardware or SITL. Cause verified by reading `sensors.h:46`, `gyro.c:380-405` and `calibration.c:154-171` on maintenance-10.x. Not compiled: no fork CI run exists for `fd6d88e`, and the upstream "Build firmware" run (https://github.com/iNavFlight/inav/actions/runs/34512924844) is waiting for approval with no jobs. `sensors/gyro.c` is compiled by `flight_imu_unittest` (`src/test/unit/CMakeLists.txt:20-23`); no test references the old macro. Compiled for all targets and the four SITL builds on the fork, green: https://github.com/Raffi1202/inav/actions/runs/34770676315

## Flash / RAM
Builds clean on all targets. No size comparison yet: the fork build has no baseline for this branch, and the upstream size report runs once CI is released for this PR.

## Docs
No documentation change needed: no setting or user-visible procedure changes; `docs/Buzzer.md:15` describes the calibration restart on movement and stays correct.

## Interaction with #11933

#11933 (dual-gyro blackbox logging, targeting `master`) adds a second
`zeroCalibrationStartV()` call in the same function, `gyroStartCalibration()`, and it passes
`CALIBRATING_GYRO_MORON_THRESHOLD` - the constant this PR removes. Whichever of the two lands
second will either fail to build or leave the secondary gyro on the unscaled threshold, which is
the bug this PR fixes. Raised by @MrScothh on #11933; noted here so whoever merges first sees it.

The clean end state is one expression per sensor over its own `gyroDev[n].scale`, since a dual-IMU
board may pair two unrelated parts and the primary's scale is the wrong reference for the
secondary.
