### PR TITLE
Do not let a switched off beeper source block the output

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -223,6 +223,13 @@ void beeper(beeperMode_e mode)
         return;
     }
 
+    // A source that is switched off must not take over the beeper. Otherwise it
+    // stays selected as the current entry and blocks every source that is still
+    // enabled - including the beeper mode on an RC channel.
+    if (getBeeperOffMask() & (1 << (mode - 1))) {
+        return;
+    }
+
     const beeperTableEntry_t *selectedCandidate = NULL;
     for (uint32_t i = 0; i < BEEPER_TABLE_ENTRY_COUNT; i++) {
         const beeperTableEntry_t *candidate = &beeperTable[i];


### PR DESCRIPTION
## Problem
With `beeper -HW_FAILURE` set and the beeper mode assigned to an RC channel, the external beeper responds to the switch only while all hardware is healthy. As soon as the GPS receiver is disconnected the beeper stops; the same happens with `beeper -BAT_LOW` once the battery is low. The only workaround is `beeper all`. Reported in #9580 (Speedybee F405 V3, INAV 7.0.0).

Fixes #9580

## Cause
`beeper()` does not consult the off mask when it selects a source; the mask is applied only where the output is driven (src/main/io/beeper.c:359 on maintenance-10.x). A masked source therefore still becomes `currentBeeperEntry` and wins the priority comparison at src/main/io/beeper.c:238. `beeperUpdate()` requests `BEEPER_RX_SET` (priority 10) for the switch and then `BEEPER_HARDWARE_FAILURE` (priority 1) on every loop while a sensor is unhealthy (src/main/io/beeper.c:318-333). The failure sequence runs silently, ends in `beeperSilence()`, and is re-selected on the next loop, so the enabled source never reaches the output.

## Change
`beeper()` now returns early when the requested mode is set in the off mask, so a switched-off source never becomes `currentBeeperEntry`. The existing mask checks at the output stay in place, so a mask changed while a sequence is already running still takes effect. Because a masked source no longer becomes the current entry, it also no longer blinks the warning LED (`warningLedEnable()` at src/main/io/beeper.c:362 ran regardless of the mask).

## Test
Not run on hardware or SITL. Cause verified by reading src/main/io/beeper.c:219-253 and :318-362 on maintenance-10.x against the steps in #9580; `pwm_mapping_beeper_unittest.cc` covers timer pad mapping only, not `beeper()`. Compiled for all targets and the four SITL builds on the fork, green: https://github.com/Raffi1202/inav/actions/runs/34770677230

## Flash / RAM
Builds clean on all targets. No size comparison yet: the fork build has no baseline for this branch, and the upstream size report runs once CI is released for this PR.

## Docs
No documentation change needed: docs/Buzzer.md:70 already states that a minus in front of a name disables that source, which is the behaviour this change restores; nothing documents the previous blocking or the warning LED.
