### PR TITLE
Let the motor test drive DSHOT motors below the configured idle

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -546,9 +546,13 @@ void FAST_CODE writeMotors(void)
                 }
             }
             else {
+                // While disarmed only the mixer stop value means motor off, so the
+                // motor test can drive a motor below the configured idle. Armed
+                // behaviour is unchanged: there the configured idle stays the
+                // threshold, so failsafe and turtle mode are not affected.
                 motorValue = handleOutputScaling(
                     motor[i],
-                    throttleIdleValue,
+                    ARMING_FLAG(ARMED) ? throttleIdleValue : (motorZeroCommand + 1),
                     DSHOT_DISARM_COMMAND,
                     motorConfig()->mincommand,
                     getMaxThrottle(),


### PR DESCRIPTION
## Problem
In the Outputs tab motor test, a DSHOT motor does not spin when its slider is set below "Motors IDLE power" but above the point where the motor would normally start (reporter's example: idle 15 %, slider 10 %). With MULTISHOT the same slider position spins the motor; only DSHOT is affected. Reported in #9634 on a SpeedyBee F405 V3 running INAV 7.0.0.

## Cause
`src/main/flight/mixer.c:551` (maintenance-10.x): for non-reversible DSHOT, `writeMotors()` passes `throttleIdleValue` as the stop threshold to `handleOutputScaling()`, which sends `DSHOT_DISARM_COMMAND` for any input below that threshold (`mixer.c:426`). While disarmed, `motor[i]` is `motor_disarmed[i]` (`mixer.c:652`), written directly by `MSP_SET_MOTOR` (`src/main/fc/fc_msp.c:2522`). The analog non-reversible branch forwards `motor[i]` unchanged (`mixer.c:589`), so only DSHOT turns a below-idle test value into a stop command.

## Change
One line in `writeMotors()`: the DSHOT stop threshold is `throttleIdleValue` only while armed; while disarmed it is `motorZeroCommand + 1`, so a disarmed value above `mincommand` is scaled to a DSHOT throttle. `handleOutputScaling()` still clamps the result to `DSHOT_MIN_THROTTLE`..`DSHOT_MAX_THROTTLE`, so the DSHOT command range 1-47 cannot be produced, and `motorZeroCommand` still yields the stop command. Armed behaviour (failsafe, turtle mode, motor stop) is unchanged.

## Test
Not run on hardware or SITL (`writeMotors()` is compiled out for SITL). Cause verified by reading `mixer.c:426/551/589/652` and `fc_msp.c:2522` on maintenance-10.x. Not built: there is no fork CI run for `fix/motor-test-below-idle`, and the upstream firmware build for 3ee1df0 (https://github.com/iNavFlight/inav/actions/runs/34513097267) is waiting for maintainer approval with 0 jobs. Qodo review of 3ee1df0 reported no issues.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: `docs/Controls.md` and `docs/Settings.md` describe `throttle_idle` as the minimum throttle while armed, which is unchanged; no firmware doc describes the disarmed motor-test output.
