### PR TITLE
Clean only the named target, and drop dead Spektrum RPM code

### DIFF
--- a/cmake/at32.cmake
+++ b/cmake/at32.cmake
@@ -423,20 +423,14 @@ function(target_at32)
     endif()
 
     # clean_<target>
-    set(generator_cmd "")
-    if (CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-        set(generator_cmd "make")
-    elseif(CMAKE_GENERATOR STREQUAL "Ninja")
-        set(generator_cmd "ninja")
+    set(clean_executables ${main_target_name})
+    set(clean_files ${main_hex_filename} ${main_bin_filename})
+    if(args_BOOTLOADER)
+        list(APPEND clean_executables ${bl_target_name} ${for_bl_target_name})
+        list(APPEND clean_files
+            ${bl_hex_filename} ${bl_bin_filename}
+            ${for_bl_hex_filename} ${for_bl_bin_filename}
+            ${combined_hex})
     endif()
-    if (NOT generator_cmd STREQUAL "")
-        set(clean_target "clean_${name}")
-        add_custom_target(${clean_target}
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            COMMAND ${generator_cmd} clean
-            COMMENT "Removing intermediate files for ${name}")
-        set_property(TARGET ${clean_target} PROPERTY
-            EXCLUDE_FROM_ALL 1
-            EXCLUDE_FROM_DEFAULT_BUILD 1)
-    endif()
+    add_clean_target(${name} EXECUTABLES ${clean_executables} FILES ${clean_files})
 endfunction()

--- a/cmake/clean_target.cmake
+++ b/cmake/clean_target.cmake
@@ -1,0 +1,26 @@
+# Removes the build artefacts of a single firmware target. Run at build time
+# by the clean_<target> targets added by add_clean_target():
+#
+#   cmake -P cmake/clean_target.cmake <path> [<path>...]
+#
+# Every path that is a directory is treated as the object directory of an
+# executable and only the compiler output below it is removed. The directory
+# itself is kept, because the Makefile generator stores the build rules of the
+# target (build.make, DependInfo.cmake, ...) next to the object files and
+# removing those breaks the next "make <target>" until CMake is run again.
+# Every other path is removed as a file, missing files are ignored.
+
+if(CMAKE_ARGC GREATER 3)
+    math(EXPR last_argument "${CMAKE_ARGC} - 1")
+    foreach(argument RANGE 3 ${last_argument})
+        set(path "${CMAKE_ARGV${argument}}")
+        if(IS_DIRECTORY "${path}")
+            file(GLOB_RECURSE objects "${path}/*.o" "${path}/*.obj" "${path}/*.d")
+            if(objects)
+                file(REMOVE ${objects})
+            endif()
+        else()
+            file(REMOVE "${path}")
+        endif()
+    endforeach()
+endif()

--- a/cmake/main.cmake
+++ b/cmake/main.cmake
@@ -116,6 +116,40 @@ function(exclude_from_all target)
         EXCLUDE_FROM_DEFAULT_BUILD ON)
 endfunction()
 
+# Adds a clean_<name> target which removes the artefacts of the firmware
+# target <name>. Neither "make clean" nor "ninja clean" can be limited to a
+# single target, so the artefacts are removed explicitly by cmake, which
+# behaves the same for the Makefile and the Ninja generator.
+#
+# EXECUTABLES: executable targets of <name>. Their binary, map file and
+#              object files are removed.
+# FILES: additional artefacts of <name>, e.g. the .hex and .bin files.
+function(add_clean_target name)
+    cmake_parse_arguments(args "" "" "EXECUTABLES;FILES" ${ARGN})
+
+    get_generated_files_dir(generated_dir ${name})
+    set(paths ${args_FILES}
+        ${generated_dir}/${SETTINGS_GENERATED_H}
+        ${generated_dir}/${SETTINGS_GENERATED_C})
+    foreach(exe ${args_EXECUTABLES})
+        list(APPEND paths $<TARGET_FILE:${exe}>)
+        # Same name as the map file added by generate_map_file()
+        if(CMAKE_VERSION VERSION_LESS 3.15)
+            list(APPEND paths $<TARGET_FILE:${exe}>.map)
+        else()
+            list(APPEND paths $<TARGET_FILE_DIR:${exe}>/$<TARGET_FILE_BASE_NAME:${exe}>.map)
+        endif()
+        # Object directory used by both generators for ${exe}
+        list(APPEND paths ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${exe}.dir)
+    endforeach()
+
+    set(clean_target clean_${name})
+    add_custom_target(${clean_target}
+        COMMAND ${CMAKE_COMMAND} -P ${MAIN_DIR}/cmake/clean_target.cmake ${paths}
+        COMMENT "Removing intermediate files for ${name}")
+    exclude_from_all(${clean_target})
+endfunction()
+
 function(collect_targets)
     get_property(targets GLOBAL PROPERTY VALID_TARGETS)
     list(SORT targets)

--- a/cmake/rp2350.cmake
+++ b/cmake/rp2350.cmake
@@ -419,20 +419,7 @@ function(target_rp2350 name)
     setup_firmware_target(${exe_target} ${name} ${ARGN})
 
     # clean_<target>
-    set(generator_cmd "")
-    if (CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-        set(generator_cmd "make")
-    elseif(CMAKE_GENERATOR STREQUAL "Ninja")
-        set(generator_cmd "ninja")
-    endif()
-    if (NOT generator_cmd STREQUAL "")
-        set(clean_target "clean_${name}")
-        add_custom_target(${clean_target}
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            COMMAND ${generator_cmd} clean
-            COMMENT "Removing intermediate files for ${name}")
-        set_property(TARGET ${clean_target} PROPERTY
-            EXCLUDE_FROM_ALL 1
-            EXCLUDE_FROM_DEFAULT_BUILD 1)
-    endif()
+    add_clean_target(${name}
+        EXECUTABLES ${exe_target}
+        FILES ${hex_filename} ${bin_filename} ${uf2_filename})
 endfunction()

--- a/cmake/sitl.cmake
+++ b/cmake/sitl.cmake
@@ -164,20 +164,5 @@ function (target_sitl name)
 
     setup_firmware_target(${exe_target} ${name} ${ARGN})
     #clean_<target>
-    set(generator_cmd "")
-    if (CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-        set(generator_cmd "make")
-    elseif(CMAKE_GENERATOR STREQUAL "Ninja")
-        set(generator_cmd "ninja")
-    endif()
-    if (NOT generator_cmd STREQUAL "")
-        set(clean_target "clean_${name}")
-        add_custom_target(${clean_target}
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            COMMAND ${generator_cmd} clean
-            COMMENT "Removing intermediate files for ${name}")
-        set_target_properties(${clean_target} PROPERTIES
-            EXCLUDE_FROM_ALL ON
-            EXCLUDE_FROM_DEFAULT_BUILD ON)
-    endif()
+    add_clean_target(${name} EXECUTABLES ${exe_target} FILES ${exe_filename})
 endfunction()

--- a/cmake/stm32.cmake
+++ b/cmake/stm32.cmake
@@ -370,6 +370,7 @@ function(target_stm32)
         LINKER_SCRIPT ${args_LINKER_SCRIPT}
         OPTIMIZATION ${args_OPTIMIZATION}
 
+        OUTPUT_BIN_FILENAME main_bin_filename
         OUTPUT_HEX_FILENAME main_hex_filename
         OUTPUT_TARGET_NAME main_target_name
     )
@@ -433,20 +434,14 @@ function(target_stm32)
     endif()
 
     # clean_<target>
-    set(generator_cmd "")
-    if (CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-        set(generator_cmd "make")
-    elseif(CMAKE_GENERATOR STREQUAL "Ninja")
-        set(generator_cmd "ninja")
+    set(clean_executables ${main_target_name})
+    set(clean_files ${main_hex_filename} ${main_bin_filename})
+    if(args_BOOTLOADER AND NOT args_NO_BOOTLOADER)
+        list(APPEND clean_executables ${bl_target_name} ${for_bl_target_name})
+        list(APPEND clean_files
+            ${bl_hex_filename} ${bl_bin_filename}
+            ${for_bl_hex_filename} ${for_bl_bin_filename}
+            ${combined_hex})
     endif()
-    if (NOT generator_cmd STREQUAL "")
-        set(clean_target "clean_${name}")
-        add_custom_target(${clean_target}
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            COMMAND ${generator_cmd} clean
-            COMMENT "Removing intermediate files for ${name}")
-        set_property(TARGET ${clean_target} PROPERTY
-            EXCLUDE_FROM_ALL 1
-            EXCLUDE_FROM_DEFAULT_BUILD 1)
-    endif()
+    add_clean_target(${name} EXECUTABLES ${clean_executables} FILES ${clean_files})
 endfunction()

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -58,7 +58,6 @@
 
 #include "sensors/battery.h"
 //#include "sensors/adcinternal.h"
-#include "sensors/esc_sensor.h"
 
 #include "telemetry/telemetry.h"
 #include "telemetry/srxl.h"
@@ -175,50 +174,11 @@ typedef struct
 
 #define SPEKTRUM_RPM_UNUSED 0xffff
 #define SPEKTRUM_TEMP_UNUSED 0x7fff
-#define MICROSEC_PER_MINUTE 60000000
-
-//Original range of 1 - 65534 uSec gives an RPM range of 915 - 60000000rpm, 60MegaRPM
-#define SPEKTRUM_MIN_RPM 999      // Min RPM to show the user, indicating RPM is really below 999
-#define SPEKTRUM_MAX_RPM 60000000
 
 uint16_t getMotorAveragePeriod(void)
 {
-
-#if defined( USE_ESC_SENSOR_TELEMETRY) || defined( USE_DSHOT_TELEMETRY)
-    uint32_t rpm = 0;
-    uint16_t period_us = SPEKTRUM_RPM_UNUSED;
-
-#if defined( USE_ESC_SENSOR_TELEMETRY)
-    escSensorData_t *escData = getEscSensorData(ESC_SENSOR_COMBINED);
-    if (escData != NULL) {
-        rpm = escData->rpm;
-    }
-#endif
-
-#if defined(USE_DSHOT_TELEMETRY)
-    if (useDshotTelemetry) {
-        uint16_t motors = getMotorCount();
-
-        if (motors > 0) {
-            for (int motor = 0; motor < motors; motor++) {
-                rpm += getDshotTelemetry(motor);
-            }
-            rpm = 100.0f / (motorConfig()->motorPoleCount / 2.0f) * rpm;  // convert erpm freq to RPM.
-            rpm /= motors;           // Average combined rpm
-        }
-    }
-#endif
-
-    if (rpm > SPEKTRUM_MIN_RPM && rpm < SPEKTRUM_MAX_RPM) {
-        period_us = MICROSEC_PER_MINUTE / rpm; // revs/minute -> microSeconds
-    } else {
-        period_us = MICROSEC_PER_MINUTE / SPEKTRUM_MIN_RPM;
-    }
-
-    return period_us;
-#else
+    // Not implemented for INAV, report the RPM field as unused
     return SPEKTRUM_RPM_UNUSED;
-#endif
 }
 
 bool srxlFrameRpm(sbuf_t *dst, timeUs_t currentTimeUs)


### PR DESCRIPTION
## Problem
#6135 (stronnag): after `make MATEKF405 WINGFC MATEKF722`, running `make clean_MATEKF405` removed the hex files of all three targets, and the following `make MATEKF722` was a full rebuild instead of a no-op. #11298 (error414): `getMotorAveragePeriod()` in `src/main/telemetry/srxl.c` carries RPM code under `USE_ESC_SENSOR_TELEMETRY` / `USE_DSHOT_TELEMETRY` that calls `getEscSensorData(ESC_SENSOR_COMBINED)`; none of these exist in INAV, the block was copied from Betaflight. Fixes #6135, fixes #11298.

## Cause
`cmake/stm32.cmake:444-446` on maintenance-10.x defines `clean_<name>` as `COMMAND ${generator_cmd} clean` with `WORKING_DIRECTORY ${CMAKE_BINARY_DIR}`, i.e. the generator's global clean; `<name>` is never used. The same block sits in `cmake/at32.cmake:434-436`, `cmake/rp2350.cmake:430-432` and `cmake/sitl.cmake:175-177`.
`src/main/telemetry/srxl.c:187-221`: the two guards are defined nowhere in the tree, so only the `#else` branch (line 220, `return SPEKTRUM_RPM_UNUSED;`) was ever compiled. `getEscSensorData()` at line 192 does not exist; INAV has `escSensorGetData()` / `getEscTelemetry()` (`src/main/sensors/esc_sensor.h:48-49`).

## Change
Adds `add_clean_target()` to `cmake/main.cmake` and the script `cmake/clean_target.cmake`, run with `cmake -P` so it is generator-independent. stm32, at32, rp2350 and sitl call it with their executables and output files (hex/bin/uf2/exe, plus bootloader and combined hex where built); the helper adds each executable's binary, map file, the target's generated settings files and the `*.o` / `*.obj` / `*.d` files under `CMakeFiles/<exe>.dir`, keeping the directory so the Makefile generator's `build.make` survives. `stm32.cmake` now also captures `main_bin_filename`. `srxl.c` drops the two dead branches, `MICROSEC_PER_MINUTE`, `SPEKTRUM_MIN_RPM`, `SPEKTRUM_MAX_RPM` and the `sensors/esc_sensor.h` include; `getMotorAveragePeriod()` still returns `SPEKTRUM_RPM_UNUSED` to `srxlFrameRpm()`.

## Test
Not run on hardware or in a local build. Cause verified by reading the lines above on maintenance-10.x;  The upstream "Build firmware" run for 119a2458 is awaiting approval: https://github.com/iNavFlight/inav/actions/runs/34513105859. CI configures with `-G Ninja` only and never invokes a `clean_<target>`, so a green build confirms configure and compile, not the clean itself.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: `docs/development/Building in Linux.md:148-157` already describes `make clean_MATEKF405` as cleaning a single target; this change makes that description true.
