### PR TITLE
Report UNCALIBRATED sensors in status

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -254,6 +254,17 @@ static const char * const hardwareSensorStatusNames[] = {
     "NONE", "OK", "UNAVAILABLE", "FAILING"
 };
 
+// A sensor that is detected and healthy, but has never been calibrated, is reported as
+// UNCALIBRATED. Every other state is reported exactly as hardwareSensorStatus_e defines it.
+static const char * hardwareSensorStatusName(hardwareSensorStatus_e status, bool isCalibrated)
+{
+    if ((status == HW_SENSOR_OK) && !isCalibrated) {
+        return "UNCALIBRATED";
+    }
+
+    return hardwareSensorStatusNames[status];
+}
+
 static const char * const *sensorHardwareNames[] = {
         gyroNames,
         table_acc_hardware,
@@ -4184,10 +4195,16 @@ static void cliStatus(char *cmdline)
 #endif // for if at32
 #endif // for SITL
 
+#ifdef USE_MAG
+    const bool compassIsCalibrated = compassIsCalibrationComplete();
+#else
+    const bool compassIsCalibrated = true;
+#endif
+
     cliPrintLinef("Sensor status: GYRO=%s, ACC=%s, MAG=%s, BARO=%s, RANGEFINDER=%s, OPFLOW=%s, PITOT=%s, GPS=%s",
-        hardwareSensorStatusNames[getHwGyroStatus()],
-        hardwareSensorStatusNames[getHwAccelerometerStatus()],
-        hardwareSensorStatusNames[getHwCompassStatus()],
+        hardwareSensorStatusName(getHwGyroStatus(), gyroIsCalibrationComplete()),
+        hardwareSensorStatusName(getHwAccelerometerStatus(), STATE(ACCELEROMETER_CALIBRATED)),
+        hardwareSensorStatusName(getHwCompassStatus(), compassIsCalibrated),
         hardwareSensorStatusNames[getHwBarometerStatus()],
         hardwareSensorStatusNames[getHwRangefinderStatus()],
         hardwareSensorStatusNames[getHwOpticalFlowStatus()],


### PR DESCRIPTION
## Problem
Issue #9997: the CLI `status` command prints `GYRO=OK, ACC=OK, MAG=OK` as soon as a sensor is detected and healthy, even when it has never been calibrated. A user whose navigation modes refuse to arm because of a missing calibration gets no hint from the one command they are usually asked to run. The reporter asked for `UNCALIBRATED` instead of `OK` for compass, accelerometer and gyro.

## Cause
`src/main/fc/cli.c:4187-4190` on maintenance-10.x: the sensor line indexes `hardwareSensorStatusNames[]` (`cli.c:253`, values `NONE/OK/UNAVAILABLE/FAILING` from `hardwareSensorStatus_e` in `src/main/sensors/diagnostics.h:12`) with the hardware health status only. Calibration state is never consulted, so a healthy but uncalibrated sensor prints `OK`.

## Change
Adds a static helper `hardwareSensorStatusName(status, isCalibrated)` in `cli.c` that returns `"UNCALIBRATED"` when the status is `HW_SENSOR_OK` and the sensor is not calibrated, and the existing name otherwise. `cliStatus()` uses it for GYRO, ACC and MAG with `gyroIsCalibrationComplete()`, `STATE(ACCELEROMETER_CALIBRATED)` (the same flag `fc_core.c:296` uses for the arming block) and `compassIsCalibrationComplete()` (treated as calibrated when `USE_MAG` is not built). `hardwareSensorStatus_e` is unchanged, so `MSP_SENSOR_STATUS` (`fc_msp.c:512`) and the two-bit blackbox packing (`blackbox.c:1491`) keep their values.

## Test
Not run on hardware or SITL. Cause verified by reading `cli.c:4187-4190` and the three calibration functions on maintenance-10.x; 

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: `docs/Cli.md:124` lists `status` only as "Show status" and no file under `docs/` enumerates the sensor status words.
