### PR TITLE
Require nav_fw_launch_accel for throw launch detection

### DIFF
--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -416,6 +416,7 @@ static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_MOTOR_IDLE(timeUs_t 
 static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_WAIT_DETECTION(timeUs_t currentTimeUs)
 {
     if (throttleStickIsLow()) {
+        forwardAccelHighTimeUs = 0;
         return FW_LAUNCH_EVENT_THROTTLE_LOW; // go back to FW_LAUNCH_STATE_WAIT_THROTTLE
     }
 
@@ -428,7 +429,11 @@ static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_WAIT_DETECTION(timeU
     }
     // The acceleration peak of a throw is over long before the GPS speed follows, so a peak seen shortly before still counts.
     // Without this the throw launch would trigger on accelerometer noise alone, or on a GPS speed glitch while the aircraft is held still.
-    const bool wasForwardAccelerationHigh = (forwardAccelHighTimeUs != 0) && (cmpTimeUs(currentTimeUs, forwardAccelHighTimeUs) < MS2US(THROW_LAUNCH_ACCEL_HOLD_TIME));
+    const timeDelta_t forwardAccelAgeUs = cmpTimeUs(currentTimeUs, forwardAccelHighTimeUs);
+    if (forwardAccelAgeUs < 0 || forwardAccelAgeUs >= MS2US(THROW_LAUNCH_ACCEL_HOLD_TIME)) {
+        forwardAccelHighTimeUs = 0;
+    }
+    const bool wasForwardAccelerationHigh = forwardAccelHighTimeUs != 0;
 
     const bool isBungeeLaunched = isForwardAccelerationHigh && isAircraftAlmostLevel;
     const bool isSwingLaunched = (swingVelocity > navConfig()->fw.launch_velocity_thresh) && (imuMeasuredAccelBF.x > 0);

--- a/src/main/navigation/navigation_fw_launch.c
+++ b/src/main/navigation/navigation_fw_launch.c
@@ -53,6 +53,7 @@
 
 #define SWING_LAUNCH_MIN_ROTATION_RATE      DEGREES_TO_RADIANS(100)     // expect minimum 100dps rotation rate
 #define LAUNCH_MOTOR_IDLE_SPINUP_TIME 1500                              // ms
+#define THROW_LAUNCH_ACCEL_HOLD_TIME 1000                               // ms, throw acceleration is remembered this long while waiting for the GPS speed to catch up
 #if !defined(UNUSED)
 #define UNUSED(x) ((void)(x))
 #endif
@@ -123,6 +124,7 @@ typedef struct fixedWingLaunchData_s {
 
 static EXTENDED_FASTRAM fixedWingLaunchData_t fwLaunch;
 static bool idleMotorAboutToStart;
+static timeUs_t forwardAccelHighTimeUs;
 
 static const fixedWingLaunchStateDescriptor_t launchStateMachine[FW_LAUNCH_STATE_COUNT] = {
 
@@ -421,9 +423,16 @@ static fixedWingLaunchEvent_t fwLaunchState_FW_LAUNCH_STATE_WAIT_DETECTION(timeU
     const bool isForwardAccelerationHigh = (imuMeasuredAccelBF.x > navConfig()->fw.launch_accel_thresh);
     const bool isAircraftAlmostLevel = (calculateCosTiltAngle() >= cos_approx(DEGREES_TO_RADIANS(navConfig()->fw.launch_max_angle)));
 
+    if (isForwardAccelerationHigh) {
+        forwardAccelHighTimeUs = currentTimeUs;
+    }
+    // The acceleration peak of a throw is over long before the GPS speed follows, so a peak seen shortly before still counts.
+    // Without this the throw launch would trigger on accelerometer noise alone, or on a GPS speed glitch while the aircraft is held still.
+    const bool wasForwardAccelerationHigh = (forwardAccelHighTimeUs != 0) && (cmpTimeUs(currentTimeUs, forwardAccelHighTimeUs) < MS2US(THROW_LAUNCH_ACCEL_HOLD_TIME));
+
     const bool isBungeeLaunched = isForwardAccelerationHigh && isAircraftAlmostLevel;
     const bool isSwingLaunched = (swingVelocity > navConfig()->fw.launch_velocity_thresh) && (imuMeasuredAccelBF.x > 0);
-    const bool isForwardLaunched = isGPSHeadingValid() && (gpsSol.groundSpeed > navConfig()->fw.launch_velocity_thresh) && (imuMeasuredAccelBF.x > 0);
+    const bool isForwardLaunched = isGPSHeadingValid() && (gpsSol.groundSpeed > navConfig()->fw.launch_velocity_thresh) && wasForwardAccelerationHigh;
 
     applyThrottleIdleLogic(false);
 
@@ -591,6 +600,8 @@ void applyFixedWingLaunchController(timeUs_t currentTimeUs)
 
 void resetFixedWingLaunchController(timeUs_t currentTimeUs)
 {
+    forwardAccelHighTimeUs = 0;
+
     if (navConfig()->fw.launch_manual_throttle) {
         // no detection or motor control required with manual launch throttle
         // so start at launch in progress


### PR DESCRIPTION
## Problem
Fixes #10995. On INAV 8.0.1 (SpeedyBee F405 Wing) the reporter armed in launch mode, raised the throttle and held the aircraft still in his hands. Launch mode triggered on its own and the motor spun up to launch throttle. His DVR showed GPS ground speed briefly reading 11 km/h with 6 satellites, a positioning error.

## Cause
`src/main/navigation/navigation_fw_launch.c:426` on maintenance-10.x. The throw path `isForwardLaunched` needs only `isGPSHeadingValid()`, `groundSpeed > nav_fw_launch_velocity` and `imuMeasuredAccelBF.x > 0`. `imuMeasuredAccelBF` is the raw body-frame accelerometer including gravity, so an aircraft held nose-up reads a permanently positive x. `isGPSHeadingValid()` (`src/main/io/gps.c:673`) is true with a fix, 6 satellites and 300 cm/s. A GPS speed glitch above 300 cm/s for 40 ms (`nav_fw_launch_detect_time`) was therefore enough. `nav_fw_launch_accel`, described as the "threshold for bungee launch or throw launch", was not used on this path.

## Change
`WAIT_DETECTION` now records the time at which `imuMeasuredAccelBF.x` last exceeded `nav_fw_launch_accel`. The throw path requires that this happened within the last 1000 ms (`THROW_LAUNCH_ACCEL_HOLD_TIME`) instead of `x > 0`, because the throw's acceleration peak is over before the GPS speed follows (@breadoven in the issue). The timestamp is cleared when it expires, when the throttle drops low in `WAIT_DETECTION`, and in `resetFixedWingLaunchController()`. Bungee and swing detection and all defaults are unchanged.

## Test
Not run on hardware or SITL. Cause verified by reading `navigation_fw_launch.c:426` and `gps.c:673` on maintenance-10.x;  Qodo's two findings on this PR (stale timestamp after signed-delta overflow, timestamp surviving a throttle-low abort) are addressed by commit 4888b74.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: `docs/Settings.md` already describes `nav_fw_launch_accel` as the "Forward acceleration threshold for bungee launch or throw launch"; the code now matches that text.
