### PR TITLE
Refuse assigning SBUS output to a second serial port

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -929,6 +929,12 @@ static void cliSerial(char *cmdline)
         return;
     }
 
+    const uint32_t duplicatedFunctions = serialDuplicatedSinglePortFunctions(&portConfig);
+    if (duplicatedFunctions) {
+        cliPrintErrorLinef("Function %d is already assigned to another port", (int)duplicatedFunctions);
+        return;
+    }
+
     memcpy(currentConfig, &portConfig, sizeof(portConfig));
 }
 

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -313,6 +313,25 @@ bool isSerialConfigValid(const serialConfig_t *serialConfigToCheck)
     return true;
 }
 
+// Functions that are resolved with findSerialPortConfig() and therefore only ever use the
+// first port they are assigned to. Assigning one of them to a second port has no effect at
+// all, so the configuration layer refuses it instead of ignoring it silently.
+#define SERIAL_SINGLE_PORT_FUNCTIONS (FUNCTION_SERVO_SERIAL)
+
+uint32_t serialDuplicatedSinglePortFunctions(const serialPortConfig_t *portConfigToCheck)
+{
+    uint32_t functionMaskOfOtherPorts = 0;
+
+    for (int index = 0; index < SERIAL_PORT_COUNT; index++) {
+        const serialPortConfig_t *portConfig = &serialConfig()->portConfigs[index];
+        if (portConfig->identifier != portConfigToCheck->identifier) {
+            functionMaskOfOtherPorts |= portConfig->functionMask;
+        }
+    }
+
+    return portConfigToCheck->functionMask & functionMaskOfOtherPorts & SERIAL_SINGLE_PORT_FUNCTIONS;
+}
+
 serialPortConfig_t *serialFindPortConfiguration(serialPortIdentifier_e identifier)
 {
     for (int index = 0; index < SERIAL_PORT_COUNT; index++) {

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -159,6 +159,7 @@ void serialRemovePort(serialPortIdentifier_e identifier);
 uint8_t serialGetAvailablePortCount(void);
 bool serialIsPortAvailable(serialPortIdentifier_e identifier);
 bool isSerialConfigValid(const serialConfig_t *serialConfig);
+uint32_t serialDuplicatedSinglePortFunctions(const serialPortConfig_t *portConfigToCheck);
 serialPortConfig_t *serialFindPortConfiguration(serialPortIdentifier_e identifier);
 bool doesConfigurationUsePort(serialPortIdentifier_e portIdentifier);
 serialPortConfig_t *findSerialPortConfig(serialPortFunction_e function);


### PR DESCRIPTION
## Problem
Issue #11430: the reporter set `serial 0 4194304 0 0 0 0` and `serial 1 4194304 0 0 0 0` to get SBUS servo output on two UARTs. `serial` printed both lines back as valid, but only UART1 (`serial 0`) ever output SBUS. Nothing told the user that the second assignment does nothing.

## Cause
`sbusServoInitialize()` resolves the port with `findSerialPortConfig(FUNCTION_SERVO_SERIAL)` (src/main/io/servo_sbus.c:59), which returns the first port in ascending order that carries the function (src/main/io/serial.c:214-224). `cliSerial()` copies the edited port configuration without checking the other ports (src/main/fc/cli.c:932), so a second SERVO_SERIAL assignment is stored and printed but never opened.

## Change
Adds `serialDuplicatedSinglePortFunctions()` in serial.c, which returns the bits of `SERIAL_SINGLE_PORT_FUNCTIONS` (currently only `FUNCTION_SERVO_SERIAL`) that the proposed port shares with any other port. `cliSerial()` calls it before applying the line and refuses with `### ERROR: Function 4194304 is already assigned to another port` when the result is non-zero. Only the port being edited is compared, so removing the function from a port still works. `isSerialConfigValid()` and the MSP handler are unchanged, so a saved configuration with two ports is not rewritten at boot.

## Test
Not run on hardware or SITL. Cause verified by reading src/main/io/servo_sbus.c:59 and src/main/io/serial.c:214-224. Upstream CI is waiting for maintainer approval: https://github.com/iNavFlight/inav/actions/runs/34513470612. No fork build exists for this branch.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
`docs/Serial.md`: the Constraints list now carries the `SERVO_SERIAL` rule, next to the analogous telemetry one, including that a second assignment used to be accepted without the port ever being opened.
