### PR TITLE
Report the battery as unknown over MAVLink when none is connected

### DIFF
--- a/src/main/mavlink/mavlink_streams.c
+++ b/src/main/mavlink/mavlink_streams.c
@@ -412,6 +412,16 @@ void mavlinkSendExtendedSysState(void)
     mavlinkSendMessage();
 }
 
+// Running from USB without a battery leaves the battery state at
+// BATTERY_NOT_PRESENT, where voltage and remaining capacity are meaningless.
+// Reporting them as 0V/0% makes a GCS or radio announce a critical battery,
+// so they are reported as unknown instead. This matches the way the OSD and
+// HIGH_LATENCY2 only raise a battery warning for BATTERY_WARNING/CRITICAL.
+static bool mavlinkBatteryIsPresent(void)
+{
+    return feature(FEATURE_VBAT) && getBatteryState() != BATTERY_NOT_PRESENT;
+}
+
 void mavlinkSendSystemStatus(void)
 {
     // Receiver is assumed to be always present
@@ -529,9 +539,9 @@ void mavlinkSendSystemStatus(void)
         onboard_control_sensors_enabled,
         onboard_control_sensors_health,
         constrain(averageSystemLoadPercent * 10, 0, 1000),
-        feature(FEATURE_VBAT) ? getBatteryVoltage() * 10 : 0,
+        mavlinkBatteryIsPresent() ? getBatteryVoltage() * 10 : UINT16_MAX,
         isAmperageConfigured() ? getAmperage() : -1,
-        feature(FEATURE_VBAT) ? calculateBatteryPercentage() : 100,
+        mavlinkBatteryIsPresent() ? calculateBatteryPercentage() : -1,
         0,
         0,
         0,
@@ -821,7 +831,7 @@ void mavlinkSendBatteryStatus(void)
     uint16_t batteryVoltagesExt[MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_EXT_LEN];
     memset(batteryVoltages, UINT16_MAX, sizeof(batteryVoltages));
     memset(batteryVoltagesExt, 0, sizeof(batteryVoltagesExt));
-    if (feature(FEATURE_VBAT)) {
+    if (mavlinkBatteryIsPresent()) {
         uint8_t batteryCellCount = getBatteryCellCount();
         if (batteryCellCount > 0) {
             for (int cell = 0; cell < batteryCellCount && cell < MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_LEN + MAVLINK_MSG_BATTERY_STATUS_FIELD_VOLTAGES_EXT_LEN; cell++) {
@@ -836,9 +846,6 @@ void mavlinkSendBatteryStatus(void)
             batteryVoltages[0] = getBatteryVoltage() * 10;
         }
     }
-    else {
-        batteryVoltages[0] = 0;
-    }
 
     mavlink_msg_battery_status_pack(mavSystemId, mavComponentId, &mavSendMsg,
         0,
@@ -849,7 +856,7 @@ void mavlinkSendBatteryStatus(void)
         isAmperageConfigured() ? getAmperage() : -1,
         isAmperageConfigured() ? getMAhDrawn() : -1,
         isAmperageConfigured() ? getMWhDrawn() * 36 : -1,
-        feature(FEATURE_VBAT) ? calculateBatteryPercentage() : -1,
+        mavlinkBatteryIsPresent() ? calculateBatteryPercentage() : -1,
         0,
         0,
         batteryVoltagesExt,
@@ -1041,7 +1048,7 @@ void mavlinkSendHighLatency2(timeUs_t currentTimeUs)
     uint8_t epv = UINT8_MAX;
     int8_t temperatureAir = 0;
     int8_t climbRate = (int8_t)constrain(lrintf(getEstimatedActualVelocity(Z) / 10.0f), INT8_MIN, INT8_MAX);
-    int8_t battery = feature(FEATURE_VBAT) ? (int8_t)calculateBatteryPercentage() : -1;
+    int8_t battery = mavlinkBatteryIsPresent() ? (int8_t)calculateBatteryPercentage() : -1;
 
 #if defined(USE_GPS)
     if (sensors(SENSOR_GPS)


### PR DESCRIPTION
## Problem
Fixes #10381. With a MAVLink receiver and the aircraft on USB power without a battery, the reporter's TX12 kept announcing a critical battery with voice and haptic alarms, plus an "engines armed" alert (INAV 8.0, JHEMCUF405). `HEARTBEAT` sets `MAV_MODE_FLAG_SAFETY_ARMED` only under `ARMING_FLAG(ARMED)` (`src/main/mavlink/mavlink_streams.c:788`), so this PR covers the battery alarms.

## Cause
`calculateBatteryPercentage()` returns 0 while `batteryState == BATTERY_NOT_PRESENT` (`src/main/sensors/battery.c:946`), and the MAVLink senders gate only on `feature(FEATURE_VBAT)`, so 0 V / 0% goes out as a measurement: `SYS_STATUS` at `src/main/mavlink/mavlink_streams.c:532-534`, `BATTERY_STATUS` at `:840` and `:852`, `HIGH_LATENCY2` at `:1044`. With `FEATURE_VBAT` off, `SYS_STATUS` sends 0 mV and 100%.

## Change
Adds `mavlinkBatteryIsPresent()` in `mavlink_streams.c`, returning `feature(FEATURE_VBAT) && getBatteryState() != BATTERY_NOT_PRESENT`, so a missing battery never produces a warning, as the OSD (`osd.c:1125-1127`) and the `HIGH_LATENCY2` failure flags (`mavlink_streams.c:1011-1014`) already do. `SYS_STATUS`, `BATTERY_STATUS` and `HIGH_LATENCY2` use it instead of `feature(FEATURE_VBAT)` and send the MAVLink unknown sentinels when it is false: `UINT16_MAX` for voltage, `-1` for remaining percentage. The `else` branch writing `batteryVoltages[0] = 0` is removed; the `UINT16_MAX` memset covers it. Side effects: with `FEATURE_VBAT` off `SYS_STATUS` now reports unknown instead of 100%, and during `VBATT_STABLE_DELAY` after plugging in (`battery.c:471`) it reports unknown instead of a rising voltage.

## Test
Not run on hardware or SITL. Cause verified by reading `battery.c:946` and `mavlink_streams.c:532-534`, `840`, `852`, `1044`;  No unit test added; `mavlink_unittest.cc` stubs `getBatteryState()` to `BATTERY_OK` (line 3651) and does not assert the battery fields.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
`docs/Mavlink.md`: the `SYS_STATUS` and `BATTERY_STATUS` entries now state that voltage is sent as `UINT16_MAX` and remaining percentage as `-1` - the MAVLink unknown values - when no battery is detected or `FEATURE_VBAT` is off, so a ground station shows no reading instead of 0 V.
