### PR TITLE
Hide the RX downlink power element when the link does not report it

### DIFF
--- a/docs/OSD.md
+++ b/docs/OSD.md
@@ -192,7 +192,7 @@ Here are the OSD Elements provided by INAV.
 | 157 | OSD_CUSTOM_ELEMENT_7                             | 8.0.0  |       |
 | 158 | OSD_CUSTOM_ELEMENT_8                             | 8.0.0  |       |
 | 159 | OSD_LQ_DOWNLINK                                  | 8.0.0  |       |
-| 160 | OSD_RX_POWER_DOWNLINK                            | 8.0.0  |       |
+| 160 | OSD_RX_POWER_DOWNLINK                            | 8.0.0  | The element will be hidden unless the RC link reports the transmit power of the receiver. CRSF does not send this value, it is available on MSP and MAVLink RC links. |
 | 161 | OSD_RX_BAND                                      | 8.0.0  |       |
 | 162 | OSD_RX_MODE                                      | 8.0.0  |       |
 | 163 | OSD_COURSE_TO_FENCE                              | 8.0.0  |       |

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2845,6 +2845,11 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_RX_POWER_DOWNLINK:
         {
+            // Only the MSP and MAVLink RC links report the transmit power of the receiver, the CRSF
+            // link statistics frame has no such field. Hide the element instead of showing a permanent 0.
+            if (rxLinkStatistics.downlinkTXPower == 0)
+                return false;
+
             if (!failsafeIsReceivingRxData())
                 tfp_sprintf(buff, "%s%c%c", "    ", SYM_MW, SYM_AH_DECORATION_DOWN);
             else

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -2847,8 +2847,10 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             // Only the MSP and MAVLink RC links report the transmit power of the receiver, the CRSF
             // link statistics frame has no such field. Hide the element instead of showing a permanent 0.
-            if (rxLinkStatistics.downlinkTXPower == 0)
+            if (rxLinkStatistics.downlinkTXPower == 0) {
+                displayWrite(osdDisplayPort, elemPosX, elemPosY, "      ");
                 return false;
+            }
 
             if (!failsafeIsReceivingRxData())
                 tfp_sprintf(buff, "%s%c%c", "    ", SYM_MW, SYM_AH_DECORATION_DOWN);


### PR DESCRIPTION
## Problem
On an ExpressLRS receiver (BetaFPV SuperD 2.4, INAV 8.0.1, Matek H743 V3) the OSD element `OSD_RX_POWER_DOWNLINK` shows `0 mW` although the receiver transmits telemetry at 100 mW. The reporter expected the real value. Fixes #11136.

## Cause
`src/main/io/osd.c:2851` on maintenance-10.x prints `rxLinkStatistics.downlinkTXPower` unconditionally. The field is only written by `src/main/fc/fc_msp.c:3475` (`MSP2_COMMON_SET_MSP_RC_INFO`) and `src/main/fc/fc_mavlink.c:350` (mLRS radio link information). The CRSF parser handles only link statistics frame 0x14 (`src/main/rx/crsf.c:235-250`), whose payload (`crsf.c:113-124`) carries `uplinkTXPower` but no downlink power, so on CRSF the field keeps its initial 0.

## Change
In `osdDrawSingleElement()` the `OSD_RX_POWER_DOWNLINK` case blanks the six-character field and returns `false` when `downlinkTXPower == 0`, so `osdDrawNextElement()` (`osd.c:4270`) moves on to the next element. Zero already means "not reported" on the other paths: `mavlinkDbmToMilliwatts()` (`fc_mavlink.c:214-221`) returns 0 for `INT8_MAX` and for anything at or below 0 dBm. The blank write (fe5ea81) removes a previously drawn value when an MSP or MAVLink link stops reporting it. `docs/OSD.md` gets a note on the element.

## Test
Not run on hardware or SITL. Cause verified by reading `crsf.c:113-124` and `crsf.c:235-250` on maintenance-10.x: `downlinkTXPower` has no CRSF writer. Built by fork CI: pending. The upstream "Build firmware" run is waiting for maintainer approval (https://github.com/iNavFlight/inav/actions/runs/34619647336). Qodo's single finding (stale characters after the value drops to 0) is covered by the blank write in fe5ea81.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
`docs/OSD.md`: the `OSD_RX_POWER_DOWNLINK` row now states that the element is hidden unless the RC link reports the receiver's transmit power (MSP and MAVLink do, CRSF does not).
