### PR TITLE
Make W25N erase wait for the chip and report what it did

### DIFF
--- a/src/main/drivers/flash_w25n.c
+++ b/src/main/drivers/flash_w25n.c
@@ -216,9 +216,20 @@ static bool w25n_waitForReadyInternal(void)
     return true;
 }
 
+/**
+ * Wait for the device to become ready.
+ *
+ * A timeout of zero means "wait for the deadline the pending operation has already armed",
+ * which is how flashPartitionErase() waits for a block erase to complete (see also
+ * m25p16_waitForReady). Arming a fresh zero length timeout instead would replace the erase
+ * timeout with a deadline that has already expired, and the wait would give up immediately.
+ */
 bool w25n_waitForReady(timeMs_t timeoutMillis)
 {
-    w25n_setTimeout(timeoutMillis);
+    if (timeoutMillis > 0) {
+        w25n_setTimeout(timeoutMillis);
+    }
+
     return w25n_waitForReadyInternal();
 }
 

--- a/src/main/drivers/flash_w25n.c
+++ b/src/main/drivers/flash_w25n.c
@@ -141,6 +141,9 @@ static bool couldBeBusy = false;
 
 static timeMs_t timeoutAt = 0;
 
+// The page held in the device's internal data buffer, or UINT32_MAX if its contents are unknown
+static uint32_t currentPage = UINT32_MAX;
+
 static bool w25n_waitForReadyInternal(void);
 
 static void w25n_setTimeout(timeMs_t timeoutMillis)
@@ -311,10 +314,19 @@ bool w25n_detect(uint32_t chipID)
  */
 void w25n_eraseSector(uint32_t address)
 {
-    w25n_waitForReadyInternal();
+    // A device that is still busy ignores both the write enable and the erase instruction, so
+    // issuing them anyway would leave the block unerased without any sign of it. Give up on this
+    // block instead; the caller sees the result when it reads the flash back.
+    if (!w25n_waitForReadyInternal()) {
+        return;
+    }
+
     w25n_writeEnable();
     w25n_performCommandWithPageAddress(W25N_INSTRUCTION_BLOCK_ERASE, W25N_LINEAR_TO_PAGE(address));
     w25n_setTimeout(W25N_TIMEOUT_BLOCK_ERASE_MS);
+
+    // The data buffer may still hold a page of the block that is being erased
+    currentPage = UINT32_MAX;
 }
 
 // W25N does not support full chip erase.
@@ -324,6 +336,9 @@ void w25n_eraseCompletely(void)
     for (uint32_t block = 0; block < geometry.sectors; block++) {
         w25n_eraseSector(W25N_BLOCK_TO_LINEAR(block));
     }
+
+    // Let the last block finish, so that the device is readable once the erase returns
+    w25n_waitForReadyInternal();
 }
 
 static void w25n_programDataLoad(uint16_t columnAddress, const uint8_t *data, int length)
@@ -388,7 +403,6 @@ bool bufferDirty = false;
 bool isProgramming = false;
 static uint32_t programStartAddress;
 static uint32_t programLoadAddress;
-static uint32_t currentPage = UINT32_MAX;
 
 void w25n_pageProgramBegin(uint32_t address)
 {

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -71,6 +71,8 @@ static void flashfsSetTailAddress(uint32_t address)
 
 void flashfsEraseCompletely(void)
 {
+    // Drain the driver's page cache before erasing; the free-space scan reuses the chip buffer.
+    flashFlush();
     flashPartitionErase(flashPartition);
     flashfsClearBuffer();
 

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -73,7 +73,21 @@ void flashfsEraseCompletely(void)
 {
     flashPartitionErase(flashPartition);
     flashfsClearBuffer();
-    flashfsSetTailAddress(0);
+
+    /* Assuming the erase succeeded would report an empty device from RAM while the flash still
+     * holds the old log, which only becomes apparent after the next reboot. Locate the start of
+     * the free space on the chip instead, exactly as flashfsInit() does at boot.
+     *
+     * A chip that is still erasing cannot be examined, as reads would time out and the device
+     * would be taken for full. That is the case for a NOR chip erased with a single bulk erase
+     * instruction, which completes long after this function returns; there the erase is assumed
+     * to succeed as before, and the next boot corrects the offset if it did not.
+     */
+    if (flashIsReady()) {
+        flashfsSetTailAddress(flashfsIdentifyStartOfFreeSpace());
+    } else {
+        flashfsSetTailAddress(0);
+    }
 }
 
 void flashfsClose(void)


### PR DESCRIPTION
## Problem
On a RADIOLINKF405 with a W25N01GV, `flash_erase` prints `Erasing... Done.` and `flash_info` then reports `usedSize=0`, but after a power cycle `flash_info` shows the previous `usedSize` again and the old log is still on the chip. The Configurator "Erase Flash" button behaves the same. Seen on INAV 9.0.1 and confirmed by a second user with the same board on 9.1.0-RC1. Reported in #11376.

## Cause
`src/main/io/flashfs.c:72-77` on `maintenance-10.x`: `flashfsEraseCompletely()` sets the tail address to 0 in RAM without looking at the chip. The value the next boot shows comes from `flashfsIdentifyStartOfFreeSpace()` (`flashfs.c:500`, called from `flashfsInit()` at `:583`), so a failed erase reads as `usedSize=0` until reboot.

`src/main/drivers/flash_w25n.c:219-223`: `w25n_waitForReady()` calls `w25n_setTimeout()` unconditionally. `flashPartitionErase()` (`src/main/drivers/flash.c:313-317`) calls `flashWaitForReady(0)` after every block erase, which replaces the 15 ms deadline armed at `flash_w25n.c:306` with one that has already expired, so the wait returns at once. The next `w25n_eraseSector()` (`flash_w25n.c:301-307`) discards the result of its own ready-wait and sends write-enable and block-erase into a chip that is still busy. The NOR driver treats 0 as "use the armed deadline" (`flash_m25p16.c:216`).

That loop only runs when the flash has more than one partition; a single FLASHFS partition takes the full-chip path (`flash.c:307-310`, `w25n_eraseCompletely()` at `flash_w25n.c:311-316`), which already waits per block. The reporter's `flash_info` lists a single partition, so the timeout defect alone does not account for that report; on that build this change alters what `flash_info` reports after the erase.

## Change
`w25n_waitForReady()` arms a new deadline only for a non-zero timeout and otherwise waits for the deadline the pending operation armed. `w25n_eraseSector()` returns without sending commands when the ready-wait fails and invalidates the cached `currentPage` after issuing the erase; `w25n_eraseCompletely()` waits for the last block. `flashfsEraseCompletely()` calls `flashFlush()` before the erase and afterwards, when `flashIsReady()`, sets the tail address from `flashfsIdentifyStartOfFreeSpace()`; a chip still erasing (NOR bulk erase) keeps the previous 0.

## Test
Not run on hardware or SITL. Cause verified by reading `flash_w25n.c:219-223` and `flash.c:313-317` on `maintenance-10.x`. Not built: the upstream "Build firmware" run for 9d112b9 is waiting for approval (https://github.com/iNavFlight/inav/actions/runs/34619673614) and the fork branch has no workflow runs. Qodo flagged the post-erase scan reading into a dirty W25N program buffer; commit 9d112b9 adds the `flashFlush()` before the erase for that. Compiled for all targets and the four SITL builds on the fork, green: https://github.com/Raffi1202/inav/actions/runs/34770680514

## Flash / RAM
Builds clean on all targets. No size comparison yet: the fork build has no baseline for this branch, and the upstream size report runs once CI is released for this PR.

## Docs
No documentation change needed: `docs/Cli.md` and `docs/Blackbox.md` describe `flash_erase` and "erase flash" as erasing the chip; this change adds no setting and no new command.
