### PR TITLE
Keep the servo speed carry over when switching mixer profiles back

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -231,10 +231,12 @@ void loadCustomServoMixer(void)
     // target-profile response.
     if (carryOverServoSpeedLimitsOnNextLoad) {
         for (int i = 0; i < servoRuleCount; i++) {
-            if(currentServoMixer[i].inputSource == INPUT_MIXER_SWITCH_HELPER || movefilterCount >= MAX_SERVO_RULES_SWITCH_CARRY) {
-                //will not carry over INPUT_MIXER_SWITCH_HELPER rules
-                break;
+            if (movefilterCount >= MAX_SERVO_RULES_SWITCH_CARRY) {
+                break; // no room left to carry more filter states
             }
+            // INPUT_MIXER_SWITCH_HELPER rules are carried over as well. They hold the
+            // still decaying output of an earlier switch, so dropping them would make
+            // the servo jump when switching back before that decay has finished.
             if(currentServoMixer[i].speed != 0 && fabsf(servoSpeedLimitFilter[i].state) > 0.01f) {
                 servoMixerSwitchHelper[movefilterCount].targetChannel = currentServoMixer[i].targetChannel;
                 servoMixerSwitchHelper[movefilterCount].speed = currentServoMixer[i].speed;


### PR DESCRIPTION
## Problem
Fixes #11503. On a VTOL with a servo speed set on the tilt servos, switching from vertical to transition and back to vertical before the servos have reached the mid position makes the servos snap to mid and only then travel back up. Reported on a MATEK F765 with INAV 9.0.1, video in the issue. @shota3527 confirmed in the issue that #10986 (the servo speed carry over on a mixer profile switch) did not account for switching back.

## Cause
`src/main/flight/servos.c:234` on maintenance-10.x. Before a profile reload, `loadCustomServoMixer()` saves the speed-limited filter state of every still-active rule so it can decay on a helper rule (`INPUT_MIXER_SWITCH_HELPER`). The loop breaks at the first helper rule. Helpers are always appended after the real rules (`servos.c:264-273`), so the loop stops exactly where the remainder of the previous switch lives. Switching back before that remainder has decayed drops it, the reloaded rule starts from a zeroed filter (`servos.c:259`), and the output jumps by the dropped amount. The reload is reached via `outputProfileHotSwitch()` (`mixer_profile.c:1844`) -> `mixerConfigInit()` -> `servosInit()` -> `loadCustomServoMixer()` (`servos.c:196`).

## Change
The capacity check and the helper detection are separated. Only `movefilterCount >= MAX_SERVO_RULES_SWITCH_CARRY` ends the loop; helper rules with a speed and a non-zero state are saved and re-appended like any other speed-limited rule, so they keep decaying after the switch back. The carry capacity, the `MAX_SERVO_RULES` bound on re-appending and the direct-switch opt-out (`servoMixerSetCarryoverOnNextLoad(false)`) are unchanged.

## Test
Not run on hardware or SITL. Cause verified by reading `servos.c:222-273` and the hot-switch path above on maintenance-10.x. No fork CI run exists for branch `fix/vtol-servo-speed-carryover` and no upstream checks are reported for 5c4db1d.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: `docs/Mixer.md:52` already defines speed as the maximum rate of change of a rule's output; this restores that behaviour across a profile switch and adds no setting.
