### PR TITLE
Fix the one degree hue shift in the LED fixed colour layer

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -441,7 +441,7 @@ static void applyLedFixedLayers(void)
         hsvColor_t color = *getSC(LED_SCOLOR_BACKGROUND);
 
         int fn = ledGetFunction(ledConfig);
-        int hOffset = HSV_HUE_MAX;
+        int hOffset = HSV_HUE_MAX + 1;  // a full turn, so that negative offsets below stay positive
         uint8_t channel = 0;
 
         switch (fn) {


### PR DESCRIPTION
## Problem
[#9633](https://github.com/iNavFlight/inav/issues/9633): on a SpeedyBee F405WING running INAV 7.0.0 with a WS2812 bar, an LED set to COLOR mode with colour 2 (documented as red) lights up pink. The same LED switched to GPS mode without a fix shows a proper red, so the reporter asked for colour 2 to be changed to match the GPS red.

## Cause
`src/main/io/ledstrip.c:444` on `maintenance-10.x`: `applyLedFixedLayers()` starts with `hOffset = HSV_HUE_MAX` (359, `src/main/common/color.h:40`) and applies it at line 498 as `color.h = (color.h + hOffset) % (HSV_HUE_MAX + 1)`. The offset is meant as a neutral full turn so the negative adjustments of the battery and RSSI branches (down to -30) cannot push the hue below zero, but a full turn is 360, not 359. Every hue through this layer comes out one degree low: red (hue 0) becomes hue 359, which `hsvToRgb24()` (`src/main/common/colorconversion.c:74`, case 5) renders as R255 G0 B4 instead of R255 G0 B0. The GPS layer (`ledstrip.c:637`) writes its colour through `applyLedHsv()` with no offset, which is why the same palette entry is correct there.

## Change
One line: `hOffset` starts at `HSV_HUE_MAX + 1` (360), with a comment stating why. The palette table, the conversion function and the function-channel branch (which assigns `hOffset` instead of adding to it) are untouched. No stored setting or default changes.

## Test
Not run on hardware or SITL. Cause verified by reading `ledstrip.c:444` and `:498` and `colorconversion.c:74`; the RGB values follow directly from the `switch (hue / 60)` cases: hue 359 vs 0 gives 255,0,4 vs 255,0,0 (red), hue 119 vs 120 gives 4,255,0 vs 0,255,0 (green). With the fix, the battery and RSSI ramps give hue 0 (red) at 20 % and hue 330 (deep pink) at 0 %, as listed in `docs/LedStrip.md`. No fork CI run exists for this branch yet.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: `docs/LedStrip.md` already lists colour 2 as red and the battery/RSSI ramps as red at 20 % and deep pink at 0 %; the fix makes the firmware match that text.
