### PR TITLE
Restart MSP over telemetry reply framing when a reply is discarded

### DIFF
--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -57,6 +57,7 @@ enum { // byte position(index) in msp-over-telemetry request payload
 };
 
 static uint8_t lastRequestVersion; // MSP version of last request. Temporary solution. It's better to keep it in requestPacket.
+static bool replyHeaderSent;       // true once the header of the reply being sent has been emitted
 STATIC_UNIT_TESTED mspPackage_t mspPackage;
 static mspRxBuffer_t mspRxBuffer;
 static mspTxBuffer_t mspTxBuffer;
@@ -74,6 +75,8 @@ void initSharedMsp(void)
     mspPackage.responsePacket = &mspTxPacket;
     mspPackage.responsePacket->buf.ptr = mspPackage.responseBuffer;
     mspPackage.responsePacket->buf.end = mspPackage.responseBuffer;
+
+    replyHeaderSent = false; // the reply that was in progress (if any) is discarded, the next one starts with a header
 }
 
 static bool processMspPacket(void)
@@ -206,7 +209,6 @@ bool handleMspFrame(uint8_t *const frameStart, const int payloadLength)
 bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)
 {
     static uint8_t seq = 0;
-    static bool headerSent = false;
 
     uint8_t payloadOut[payloadSize];
     sbuf_t payload;
@@ -214,7 +216,7 @@ bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)
     sbuf_t *txBuf = &mspPackage.responsePacket->buf;
 
     // detect first reply packet
-    if (!headerSent) {
+    if (!replyHeaderSent) {
 
         // header
         uint8_t status = TELEMETRY_MSP_START_MASK | (seq++ & TELEMETRY_MSP_SEQ_MASK) | (lastRequestVersion << TELEMETRY_MSP_VER_SHIFT);;
@@ -232,7 +234,7 @@ bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)
             sbufWriteU16(payloadBuf, mspPackage.responsePacket->cmd);    // command is 16 bit in MSPv2
             sbufWriteU16(payloadBuf, (uint16_t) size);        // size is 16 bit in MSPv2
         }
-        headerSent = true;
+        replyHeaderSent = true;
     } else {
         sbufWriteU8(payloadBuf, (seq++ & TELEMETRY_MSP_SEQ_MASK) | (lastRequestVersion << TELEMETRY_MSP_VER_SHIFT)); // header without 'start' flag
     }
@@ -241,7 +243,7 @@ bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)
     const uint8_t payloadBytesRemaining = sbufBytesRemaining(payloadBuf);
     uint8_t frame[payloadBytesRemaining];
 
-    if (bufferBytesRemaining >= payloadBytesRemaining) {
+    if (bufferBytesRemaining > payloadBytesRemaining) { // frame is filled up and more data is left for the next one
 
         sbufReadData(txBuf, frame, payloadBytesRemaining);
         sbufAdvance(txBuf, payloadBytesRemaining);
@@ -258,7 +260,7 @@ bool sendMspReply(uint8_t payloadSize, mspResponseFnPtr responseFn)
     sbufSwitchToReader(txBuf, mspPackage.responseBuffer);
 
     responseFn(payloadOut, payloadBuf->ptr - payloadOut);
-    headerSent = false; // <-- added: reset for the next response
+    replyHeaderSent = false; // reset for the next response
     return false;
 }
 


### PR DESCRIPTION
## Problem
MSPv1 replies sent over CRSF telemetry arrive without the function byte: after the length byte the payload follows directly (#10667, captured on INAV 8.0.0). The receiving side cannot tell which request a reply belongs to and parses the payload at the wrong offset.

## Cause
On maintenance-10.x the v1 reply header already contains the function byte (`src/main/telemetry/msp_shared.c:229`), but the same symptom is still produced by stale reply state. `headerSent` is a function-local static in `sendMspReply()` (`msp_shared.c:209`) and is cleared only after the last chunk (`:261`). When a new request arrives while a reply is still being sent, `handleMspFrame()` discards that reply through `initSharedMsp()` (`:119-125`, `:66-77`), which does not touch `headerSent`. The first chunk of the next reply then takes the continuation branch (`:237`): status byte only, no size, no function byte. Both transports reach this: SmartPort passes every incoming MSP payload to `handleMspFrame()` while a reply is pending (`smartport.c:450`), and CRSF drains several queued requests in one loop (`crsf.c:128-136`).

## Change
Moves the flag to file scope as `replyHeaderSent` and clears it in `initSharedMsp()`, so a reply that follows a discarded one starts with a full header again. Changes the chunk test at `msp_shared.c:244` from `>=` to `>`, so a payload that exactly fills the frame is sent as the last chunk instead of being followed by a frame that holds only a continuation status byte.

## Test
Not run on hardware or SITL. Cause verified by reading `msp_shared.c:209-261`, `crsf.c:128-136` and `smartport.c:450` on maintenance-10.x;  `src/test/` has no test that references `msp_shared.c`.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: nothing under docs/ describes the MSP-over-telemetry frame layout or chunking (checked docs/Telemetry.md, docs/Rx.md, docs/development/msp/).
