### PR TITLE
Embed the stats decimal separator and damp the battery percentage

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -5809,6 +5809,8 @@ static void osdShowArmed(void)
 static void osdFilterData(timeUs_t currentTimeUs)
 {
     static timeUs_t lastRefresh = 0;
+    static bool batteryWasPresent = false;
+    const bool batteryPresent = getBatteryState() != BATTERY_NOT_PRESENT;
     float refresh_dT = US2S(cmpTimeUs(currentTimeUs, lastRefresh));
 
     GForce = fast_fsqrtf(vectorNormSquared(&imuMeasuredAccelBF)) / GRAVITY_MSS;
@@ -5821,7 +5823,12 @@ static void osdFilterData(timeUs_t currentTimeUs)
         for (uint8_t axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
             GForceAxis[axis] = pt1FilterApply3(&GForceFilterAxis[axis], GForceAxis[axis], refresh_dT);
         }
-        batteryRemainingPercent = pt1FilterApply3(&batteryRemainingFilterState, calculateBatteryPercentage(), refresh_dT);
+        if (batteryPresent != batteryWasPresent) {
+            batteryRemainingPercent = calculateBatteryPercentage();
+            pt1FilterReset(&batteryRemainingFilterState, batteryRemainingPercent);
+        } else {
+            batteryRemainingPercent = pt1FilterApply3(&batteryRemainingFilterState, calculateBatteryPercentage(), refresh_dT);
+        }
     } else {   // init OSD filter f_cut values
         pt1FilterSetCutoff(&GForceFilter, GFORCE_FILTER_T_CUT_HZ);
         pt1FilterSetCutoff(&glideTimeFilterState, 0.5f);
@@ -5837,6 +5844,7 @@ static void osdFilterData(timeUs_t currentTimeUs)
             pt1FilterSetCutoff(&GForceFilterAxis[axis], GFORCE_FILTER_T_CUT_HZ);
         }
     }
+    batteryWasPresent = batteryPresent;
     lastRefresh = currentTimeUs;
 }
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -377,6 +377,35 @@ static int16_t osdGetFlightDirection(void)
 }
 
 /**
+ * Writes the integer part, a two digit fraction and a unit symbol to buff.
+ * DJI systems get an explicit decimal separator, every other system embeds
+ * it into the surrounding digits, the same way osdFormatCentiNumber() does.
+ * @param symbol Unit symbol written after the fraction
+ */
+static void osdFormatDistanceFractionStr(char *buff, int integerPart, int fraction, uint8_t symbol)
+{
+    bool djiCompat = false;  // Assume DJICOMPAT mode is not enabled
+
+#ifndef DISABLE_MSP_DJI_COMPAT // IF DJICOMPAT is not supported, there's no need to check for it
+    if (isDJICompatibleVideoSystem(osdConfig())) {
+        djiCompat = true;
+    }
+#endif
+
+    int integerDigits = tfp_sprintf(buff, "%d", integerPart);
+
+    if (djiCompat) {
+        // DJICOMPAT mode enabled
+        tfp_sprintf(buff + integerDigits, ".%02d%c", fraction, symbol);
+    } else {
+        tfp_sprintf(buff + integerDigits, "%02d%c", fraction, symbol);
+        // Embed the decimal separator
+        buff[integerDigits - 1] += SYM_ZERO_HALF_TRAILING_DOT - '0';
+        buff[integerDigits] += SYM_ZERO_HALF_LEADING_DOT - '0';
+    }
+}
+
+/**
  * Converts distance into a string based on the current unit system.
  * @param dist Distance in centimeters
  */
@@ -393,7 +422,7 @@ static void osdFormatDistanceStr(char *buff, int32_t dist)
             tfp_sprintf(buff, "%d%c", (int)(centifeet / 100), SYM_FT);
         } else {
             // Show miles when dist >= 0.5mi
-            tfp_sprintf(buff, "%d.%02d%c", (int)(centifeet / (100*FEET_PER_MILE)),
+            osdFormatDistanceFractionStr(buff, (int)(centifeet / (100*FEET_PER_MILE)),
                 (abs(centifeet) % (100 * FEET_PER_MILE)) / FEET_PER_MILE, SYM_MI);
         }
         break;
@@ -405,7 +434,7 @@ static void osdFormatDistanceStr(char *buff, int32_t dist)
             tfp_sprintf(buff, "%d%c", (int)(dist / 100), SYM_M);
         } else {
             // Show kilometers when dist >= 1km
-            tfp_sprintf(buff, "%d.%02d%c", (int)(dist / (100*METERS_PER_KILOMETER)),
+            osdFormatDistanceFractionStr(buff, (int)(dist / (100*METERS_PER_KILOMETER)),
                 (abs(dist) % (100 * METERS_PER_KILOMETER)) / METERS_PER_KILOMETER, SYM_KM);
         }
         break;
@@ -416,7 +445,7 @@ static void osdFormatDistanceStr(char *buff, int32_t dist)
             tfp_sprintf(buff, "%d%c", (int)(centifeet / 100), SYM_FT);
         } else {
             // Show nautical miles when dist >= 1000ft
-            tfp_sprintf(buff, "%d.%02d%c", (int)(centifeet / (100 * FEET_PER_NAUTICALMILE)),
+            osdFormatDistanceFractionStr(buff, (int)(centifeet / (100 * FEET_PER_NAUTICALMILE)),
                 (int)((abs(centifeet) % (int)(100 * FEET_PER_NAUTICALMILE)) / FEET_PER_NAUTICALMILE), SYM_NM);
         }
         break;
@@ -791,7 +820,7 @@ static void osdFormatCoordinate(char *buff, char sym, int32_t val)
 
     if (!djiCompat) {
         decimalDigits = tfp_sprintf(buff + 1 + integerDigits, "%07d", (int)decimalPart);
-        // Embbed the decimal separator
+        // Embed the decimal separator
         buff[1 + integerDigits - 1] += SYM_ZERO_HALF_TRAILING_DOT - '0';
         buff[1 + integerDigits] += SYM_ZERO_HALF_LEADING_DOT - '0';
     } else {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -137,6 +137,7 @@
 #define VIDEO_BUFFER_CHARS_DJIWTF 1320
 
 #define GFORCE_FILTER_T_CUT_HZ 0.8f
+#define BATTERY_PERCENT_FILTER_F_CUT_HZ 0.1f
 
 #define OSD_STATS_SINGLE_PAGE_MIN_ROWS 18
 #define IS_HI(X)  (rxGetChannelValue(X) > 1750)
@@ -180,11 +181,13 @@ static int layoutOverride = -1;
 static bool hasExtendedFont = false; // Wether the font supports characters > 256
 static timeMs_t layoutOverrideUntil = 0;
 static float GForce, GForceAxis[XYZ_AXIS_COUNT];
+static float batteryRemainingPercent;
 
 // OSD Filters
 static pt1Filter_t GForceFilter, GForceFilterAxis[XYZ_AXIS_COUNT];
 static pt1Filter_t glideTimeFilterState, glideSlopeFilterState;
 static pt1Filter_t climbEffFilterState, mahEffFilterState, whEffFilterState;
+static pt1Filter_t batteryRemainingFilterState;
 
 typedef struct statistic_s {
     uint16_t max_speed;
@@ -1975,7 +1978,7 @@ static bool osdDrawSingleElement(uint8_t item)
     }
     case OSD_BATTERY_REMAINING_PERCENT:
         osdFormatBatteryChargeSymbol(buff);
-        tfp_sprintf(buff + 1, "%3d%%", calculateBatteryPercentage());
+        tfp_sprintf(buff + 1, "%3d%%", (int)lrintf(batteryRemainingPercent));
         osdUpdateBatteryCapacityOrVoltageTextAttributes(&elemAttr);
         break;
 
@@ -5818,6 +5821,7 @@ static void osdFilterData(timeUs_t currentTimeUs)
         for (uint8_t axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
             GForceAxis[axis] = pt1FilterApply3(&GForceFilterAxis[axis], GForceAxis[axis], refresh_dT);
         }
+        batteryRemainingPercent = pt1FilterApply3(&batteryRemainingFilterState, calculateBatteryPercentage(), refresh_dT);
     } else {   // init OSD filter f_cut values
         pt1FilterSetCutoff(&GForceFilter, GFORCE_FILTER_T_CUT_HZ);
         pt1FilterSetCutoff(&glideTimeFilterState, 0.5f);
@@ -5825,6 +5829,9 @@ static void osdFilterData(timeUs_t currentTimeUs)
         pt1FilterSetCutoff(&climbEffFilterState, 1.0f);
         pt1FilterSetCutoff(&mahEffFilterState, 1.0f);
         pt1FilterSetCutoff(&whEffFilterState, 1.0f);
+        pt1FilterSetCutoff(&batteryRemainingFilterState, BATTERY_PERCENT_FILTER_F_CUT_HZ);
+        batteryRemainingPercent = calculateBatteryPercentage();
+        pt1FilterReset(&batteryRemainingFilterState, batteryRemainingPercent);
 
         for (uint8_t axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
             pt1FilterSetCutoff(&GForceFilterAxis[axis], GFORCE_FILTER_T_CUT_HZ);


### PR DESCRIPTION
## Problem
Two OSD reports. #10420: on the post-flight stats screen, Flight Distance and Maximum Distance From Home use DJI number formatting on every video system, a separate `.` character that costs a column; the reporter notes it was never a regression, it always looked like this. #10053: the Battery Remaining Percentage element is sampled so often that its digits change constantly and the value never settles in flight (INAV 7.1.1, quadcopter).

Fixes #10420
Fixes #10053

## Cause
`src/main/io/osd.c:396`, `:408`, `:419` on maintenance-10.x: the three fractional branches of `osdFormatDistanceStr()` print `"%d.%02d%c"`. `osdFormatCoordinate()` (`osd.c:795`) and `osdFormatCentiNumber()` only print an explicit dot on DJI systems and otherwise embed it with `SYM_ZERO_HALF_TRAILING_DOT` / `SYM_ZERO_HALF_LEADING_DOT`.
`src/main/io/osd.c:1949`: `OSD_BATTERY_REMAINING_PERCENT` prints `calculateBatteryPercentage()` raw on every `osdRefresh()` (TASK_OSD 250 Hz / `DRAW_FREQ_DENOM` 4 = 62.5 Hz), so every voltage dip reaches the digits.

## Change
New `osdFormatDistanceFractionStr()` writes integer part, two-digit fraction and unit symbol; DJI-compatible systems get the same bytes as before, every other system gets the separator embedded in the two neighbouring digits. The km, mi and NM branches call it; the whole-number branches are unchanged. The battery percentage now runs through a 0.1 Hz `pt1Filter_t` in `osdFilterData()`, seeded on the first refresh and reset whenever `getBatteryState()` crosses `BATTERY_NOT_PRESENT`; the element prints `lrintf()` of the filtered value. Charge symbol, blink attributes and `calculateBatteryPercentage()` itself keep the raw value. One comment typo ("Embbed") fixed.

## Test
Not run on hardware or SITL. Cause verified by reading `osd.c:396-419` and `osd.c:1949` on maintenance-10.x; the DJI branch reproduces the old format string byte for byte. Qodo review found that the filter carried the previous battery's value across a battery swap; commit 2860242 adds the presence-change reset. `osd_unittest.cc` builds only `osd_utils.c`, so `osd.c` has no unit coverage.  (no run exists for `fix/osd-number-formatting`).

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: `docs/OSD.md` lists the element and the stats rows but does not describe number formatting or smoothing for any element, and `docs/DJI compatible OSD.md` says nothing about the decimal separator.
