### PR TITLE
Fix reading the stored geozones back on startup

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -4305,6 +4305,11 @@ static void cliStatus(char *cmdline)
     }
 #endif
 
+#if defined(USE_GEOZONE)
+    if ((armingFlags & ARMING_DISABLED_GEOZONE) && geozoneIsConfigInvalid()) {
+        cliPrintErrorLinef("Geozone vertices are incomplete, no zone is active");
+    }
+#endif
 
 #else
     cliPrintLinef("Arming disabled flags: 0x%lx", armingFlags & ARMING_DISABLED_ALL_FLAGS);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -933,6 +933,10 @@ static const char * osdArmingDisabledReasonMessage(void)
 
         case ARMING_DISABLED_GEOZONE:
 #ifdef USE_GEOZONE
+            // Check the exact reason
+            if (geozoneIsConfigInvalid()) {
+                return OSD_MESSAGE_STR(OSD_MSG_GEOZONE_MISCONFIG);
+            }
             return OSD_MESSAGE_STR(OSD_MSG_NFZ);
 #else
             FALLTHROUGH;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -161,6 +161,7 @@
 
 #if defined(USE_GEOZONE)
 #define OSD_MSG_NFZ                 "NO FLY ZONE"
+#define OSD_MSG_GEOZONE_MISCONFIG   "GEOZONE MISCONFIGURED"
 #define OSD_MSG_LEAVING_FZ          "LEAVING FZ IN %s"
 #define OSD_MSG_OUTSIDE_FZ          "OUTSIDE FZ"
 #define OSD_MSG_ENTERING_NFZ        "ENTERING NFZ IN %s %s"

--- a/src/main/io/osd_dji_hd.c
+++ b/src/main/io/osd_dji_hd.c
@@ -519,6 +519,11 @@ static char * osdArmingDisabledReasonMessage(void)
             return OSD_MESSAGE_STR("MOTOR BEEPER ACTIVE");
             // Cases without message
         case ARMING_DISABLED_GEOZONE:
+#ifdef USE_GEOZONE
+            if (geozoneIsConfigInvalid()) {
+                return OSD_MESSAGE_STR("GEOZONE CONFIG ERR");
+            }
+#endif
             return OSD_MESSAGE_STR("NO FLY ZONE");
         case ARMING_DISABLED_LANDING_DETECTED:
             FALLTHROUGH;

--- a/src/main/navigation/navigation.h
+++ b/src/main/navigation/navigation.h
@@ -217,6 +217,7 @@ void geozoneReset(int8_t idx);
 void geozoneResetVertices(int8_t zoneId, int16_t idx);
 void geozoneUpdate(timeUs_t curentTimeUs);
 bool geozoneIsBlockingArming(void);
+bool geozoneIsConfigInvalid(void);
 void geozoneAdvanceRthAvoidWaypoint(void);
 int8_t geozoneCheckForNFZAtCourse(bool isRTH);
 bool geoZoneIsLastRthWaypoint(void);

--- a/src/main/navigation/navigation_geozone.c
+++ b/src/main/navigation/navigation_geozone.c
@@ -113,6 +113,7 @@ static geoZoneRuntimeConfig_t *nearestHorZone = NULL;
 static geoZoneRuntimeConfig_t *nearestInclusiveZone = NULL;
 static fpVector3_t avoidingPoint;
 static bool geozoneIsEnabled = false;
+static bool configIsInvalid = false;
 static fpVector3_t rthWaypoints[MAX_RTH_WAYPOINTS];
 static uint8_t rthWaypointIndex = 0;
 static int8_t rthWaypointCount = 0;
@@ -1606,33 +1607,40 @@ static void endFenceAction(void)
 static void geoZoneInit(void)
 {
     activeGeoZonesCount = 0;
+    configIsInvalid = false;
     uint8_t expectedVertices = 0, configuredVertices = 0;
     for (uint8_t i = 0; i < MAX_GEOZONES_IN_CONFIG; i++)
     {
         if (geoZonesConfig(i)->vertexCount > 0) {
-            memcpy(&activeGeoZones[activeGeoZonesCount].config, geoZonesConfig(i), sizeof(geoZoneRuntimeConfig_t));
-            if (activeGeoZones[i].config.maxAltitude == 0) {
-                activeGeoZones[i].config.maxAltitude = INT32_MAX;
+            // activeGeoZones is packed, zones without vertices are skipped, so the config index i is not the runtime index
+            geoZoneRuntimeConfig_t *zone = &activeGeoZones[activeGeoZonesCount];
+
+            memcpy(&zone->config, geoZonesConfig(i), sizeof(geoZoneConfig_t));
+            zone->radius = 0;
+            zone->verticesLocal = NULL;
+
+            if (zone->config.maxAltitude == 0) {
+                zone->config.maxAltitude = INT32_MAX;
             }
 
-            if (activeGeoZones[i].config.isSealevelRef) {
-                
-                if (activeGeoZones[i].config.maxAltitude != 0) {
-                    activeGeoZones[i].config.maxAltitude -= GPS_home.alt;
+            if (zone->config.isSealevelRef) {
+
+                if (zone->config.maxAltitude != 0) {
+                    zone->config.maxAltitude -= GPS_home.alt;
                 }
-                
-                if (activeGeoZones[i].config.minAltitude != 0) {
-                    activeGeoZones[i].config.minAltitude -= GPS_home.alt;
+
+                if (zone->config.minAltitude != 0) {
+                    zone->config.minAltitude -= GPS_home.alt;
                 }
-            }
-            
-            activeGeoZones[i].isInfZone = activeGeoZones[i].config.maxAltitude == INT32_MAX && activeGeoZones[i].config.minAltitude == 0;
-            
-            if (!STATE(AIRPLANE) && activeGeoZones[i].config.fenceAction == GEOFENCE_ACTION_AVOID) {
-                activeGeoZones[i].config.fenceAction = GEOFENCE_ACTION_POS_HOLD;
             }
 
-            activeGeoZones[activeGeoZonesCount].enable = true;
+            zone->isInfZone = zone->config.maxAltitude == INT32_MAX && zone->config.minAltitude == 0;
+
+            if (!STATE(AIRPLANE) && zone->config.fenceAction == GEOFENCE_ACTION_AVOID) {
+                zone->config.fenceAction = GEOFENCE_ACTION_POS_HOLD;
+            }
+
+            zone->enable = true;
             activeGeoZonesCount++;
         }
         expectedVertices += geoZonesConfig(i)->vertexCount;
@@ -1644,29 +1652,36 @@ static void geoZoneInit(void)
             gpsLocation_t vertexLoc;
             fpVector3_t posLocal3;
 
-            if (geoZoneVertices(i)->zoneId >= 0 && geoZoneVertices(i)->zoneId < MAX_GEOZONES_IN_CONFIG && geoZoneVertices(i)->idx <= MAX_VERTICES_IN_CONFIG) {         
+            const int8_t zoneId = geoZoneVertices(i)->zoneId;
+            if (zoneId >= 0 && zoneId < MAX_GEOZONES_IN_CONFIG && geoZoneVertices(i)->idx < geoZonesConfig(zoneId)->vertexCount) {
                 configuredVertices++;
-                if (geoZonesConfig(geoZoneVertices(i)->zoneId)->shape == GEOZONE_SHAPE_CIRCULAR && geoZoneVertices(i)->idx == 1) {
-                    activeGeoZones[geoZoneVertices(i)->zoneId].radius = geoZoneVertices(i)->lat;
-                    activeGeoZones[geoZoneVertices(i)->zoneId].config.vertexCount = 1;
+
+                // Map the config zone id onto the packed runtime index and onto the start of the zones vertices
+                uint8_t zoneIdx = 0, vertexIdx = 0;
+                for (uint8_t j = 0; j < zoneId; j++) {
+                    if (geoZonesConfig(j)->vertexCount > 0) {
+                        vertexIdx += geoZonesConfig(j)->vertexCount;
+                        zoneIdx++;
+                    }
+                }
+
+                if (geoZonesConfig(zoneId)->shape == GEOZONE_SHAPE_CIRCULAR && geoZoneVertices(i)->idx == 1) {
+                    activeGeoZones[zoneIdx].radius = geoZoneVertices(i)->lat;
+                    activeGeoZones[zoneIdx].config.vertexCount = 1;
                     continue;
                 }
-                
+
                 vertexLoc.lat = geoZoneVertices(i)->lat;
                 vertexLoc.lon = geoZoneVertices(i)->lon;
                 geoConvertGeodeticToLocal(&posLocal3, &posControl.gpsOrigin, &vertexLoc, GEO_ALT_ABSOLUTE);
 
-                uint8_t vertexIdx = 0;
-                for (uint8_t j = 0; j < geoZoneVertices(i)->zoneId; j++) {
-                    vertexIdx += activeGeoZones[j].config.vertexCount;
-                }
                 vertexIdx += geoZoneVertices(i)->idx;
 
                 verticesLocal[vertexIdx].x = posLocal3.x;
                 verticesLocal[vertexIdx].y = posLocal3.y;
 
                 if (geoZoneVertices(i)->idx == 0) {
-                    activeGeoZones[geoZoneVertices(i)->zoneId].verticesLocal = &verticesLocal[vertexIdx];
+                    activeGeoZones[zoneIdx].verticesLocal = &verticesLocal[vertexIdx];
                 }
             }
         }
@@ -1687,6 +1702,20 @@ static void geoZoneInit(void)
         activeGeoZonesCount++;
         expectedVertices++;
         configuredVertices++;
+    }
+
+    // Vertices are missing or do not belong to any zone, the fences can not be reconstructed.
+    // Report this instead of taking off with an incomplete set of zones.
+    bool verticesAreComplete = expectedVertices == configuredVertices;
+    for (uint8_t i = 0; i < activeGeoZonesCount && verticesAreComplete; i++) {
+        verticesAreComplete = activeGeoZones[i].verticesLocal != NULL;
+    }
+
+    if (!verticesAreComplete) {
+        configIsInvalid = true;
+        setTaskEnabled(TASK_GEOZONE, false);
+        geozoneIsEnabled = false;
+        return;
     }
 
     updateCurrentZones();
@@ -1718,7 +1747,7 @@ static void geoZoneInit(void)
     }
 
     activeGeoZonesCount = newActiveZoneCount;
-    if (activeGeoZonesCount == 0 || expectedVertices != configuredVertices) {
+    if (activeGeoZonesCount == 0) {
         setTaskEnabled(TASK_GEOZONE, false);
         geozoneIsEnabled = false;
         return;
@@ -2071,9 +2100,19 @@ void geozoneUpdateMaxHomeAltitude(void) {
     }
 }
 
-// Avoid arming in NFZ 
+bool geozoneIsConfigInvalid(void)
+{
+    return isInitalised && configIsInvalid;
+}
+
+// Avoid arming in NFZ
 bool geozoneIsBlockingArming(void)
 {
+    // The configured zones could not be loaded, don't take off without the fences the user set up
+    if (geozoneIsConfigInvalid()) {
+        return true;
+    }
+
     // Do not generate arming flags unless we are sure about them
     if (!isInitalised || !geozoneIsEnabled || activeGeoZonesCount == 0)  {
         return false;


### PR DESCRIPTION
## Problem
https://github.com/iNavFlight/inav/issues/11721: on 9.1.0 the reporter creates a geozone in Mission Control, saves to EEPROM, reboots, and "Load from EEPROM" returns nothing. A second reporter sees the zones and vertices in the CLI, yet a HIL test in X-Plane does not trigger RTH on a breach. The stored zones are present; the firmware does not restore them into the runtime table at startup, so no fence is enforced. Why the Configurator does not display zones the CLI shows is not covered by this change: `MSP2_INAV_GEOZONE` reads the parameter group directly (`src/main/fc/fc_msp.c:2027`).

## Cause
`src/main/navigation/navigation_geozone.c:1613` on maintenance-10.x copies `sizeof(geoZoneRuntimeConfig_t)` (28 bytes on 32-bit targets) into `activeGeoZones[n].config`, a 16-byte `geoZoneConfig_t` (`:83-90`), so `enable`, `isInfZone`, `radius` and `verticesLocal` are overwritten with the following PG entry. Lines 1614-1632 apply the altitude, sea-level and fence-action fix-ups to `activeGeoZones[i]` (config id) instead of the packed slot, and lines 1650-1669 attach radius and vertices by config id as well. Line 1647 accepts `idx <= MAX_VERTICES_IN_CONFIG`, which can index past the end of `verticesLocal` (127 entries). A vertex-count mismatch at line 1721 silently disables the task, after `updateCurrentZones()` has already dereferenced the pointers.

## Change
`geoZoneInit()` copies `sizeof(geoZoneConfig_t)` into the packed slot, initialises `radius` and `verticesLocal`, and applies the fix-ups to that slot. The vertex loop maps the config zone id to the packed index, derives the `verticesLocal` offset from the config vertex counts, and accepts only `idx < vertexCount` of its zone. The completeness check (expected == configured vertices, every active zone has vertices) now runs before `updateCurrentZones()`; on failure the task is disabled and the new `geozoneIsConfigInvalid()` makes `geozoneIsBlockingArming()` return true, so an unloadable set blocks arming through the existing `ARMING_DISABLED_GEOZONE` flag (part of the emergency override, `runtime_config.h:68`). The OSD shows `GEOZONE MISCONFIGURED`, DJI HD `GEOZONE CONFIG ERR`, and CLI `status` prints "Geozone vertices are incomplete, no zone is active".

## Test
Not run on hardware or SITL. Cause verified by reading `navigation_geozone.c:83-90` and `:1606-1725` on maintenance-10.x; fork CI build: pending. Upstream checks have not run on 7e4ad41b. Qodo flagged the missing DJI HD message; addressed in 7e4ad41b.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
`docs/Geozones.md`: the CLI-editing warning now says that an incomplete vertex set blocks arming, names the OSD messages (`GEOZONE MISCONFIGURED`, `GEOZONE CONFIG ERR`) and points at `geozone reset`.
