### PR TITLE
beeper: play the success sequence when a config save completes

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -378,7 +378,8 @@ void processSaveConfigAndNotify(void)
     writeEEPROM();
     readEEPROM();
     resumeRxSignal();
-    beeperConfirmationBeeps(1);
+    // Distinct sequence so the pilot can tell a completed save from a plain stick command acknowledgement
+    beeper(BEEPER_ACTION_SUCCESS);
 #ifdef USE_OSD
     osdShowEEPROMSavedNotification();
 #endif


### PR DESCRIPTION
## Problem
Saving settings with the stick command gives no audible sign that the save actually completed. The reporter of #8359 flies without goggles when maidening and tuning: the beep after the gesture only says that some stick input was seen, so a wrong gesture and a completed save sound the same, and the OSD "EEPROM SAVED" notice is not visible. Fixes #8359.

## Cause
`src/main/fc/config.c:381` on maintenance-10.x: `processSaveConfigAndNotify()` calls `beeperConfirmationBeeps(1)`, a single 20 ms tick (`src/main/io/beeper.c:156`). The same tick is used for a blocked arm (`src/main/fc/fc_core.c:643`), a flight-mode change (`src/main/fc/runtime_config.c:100`) and a downward inflight adjustment (`src/main/fc/rc_adjustments.c:381`).

## Change
Replaces the tick with `beeper(BEEPER_ACTION_SUCCESS)`, the existing two-short-beeps sequence (`src/main/io/beeper.c:117`) that the stick handler already plays for waypoint list save and load (`src/main/fc/rc_controls.c:273`). It sounds after `writeEEPROM()` and `readEEPROM()` return, so it reports the completed write, not the gesture. Every `saveConfigAndNotify()` caller (stick command, CMS, calibrations, autotrim) gets the same sequence; Configurator saves via `MSP_EEPROM_WRITE` (`src/main/fc/fc_msp.c:3088`) do not use this path and are unchanged. No new setting, beeper mode or MSP change.

## Test
Not run on hardware or SITL. Cause verified by reading the files above on maintenance-10.x; 

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
`docs/Buzzer.md`: the success-beep row now names the settings save as a second meaning. Its index and name were also stale (the table said 10 ACC_CALIBRATION where `beeper.c` has 11 ACTION_SUCCESS) and are corrected. The rest of that table is off by one against `beeper.c` and is left for its own pass.
