### PR TITLE
osd: fix sidebar scale scroll direction

### DIFF
--- a/src/main/io/osd_grid.c
+++ b/src/main/io/osd_grid.c
@@ -300,7 +300,11 @@ static uint16_t osdUpdateSidebar(osd_sidebar_scroll_e scroll, osd_sidebar_t *sid
             break;
     }
     if (offset) {
-        decoration -= steps % SYM_AH_DECORATION_COUNT;
+        // Higher symbol codes draw the tick marks lower inside the character cell,
+        // so adding the steps scrolls the scale down as the value goes up. This
+        // matches a primary flight display, where climbing or accelerating brings
+        // the higher numbers down towards the center marker.
+        decoration += steps % SYM_AH_DECORATION_COUNT;
         if (decoration > SYM_AH_DECORATION_MAX) {
             decoration -= SYM_AH_DECORATION_COUNT;
         } else if (decoration < SYM_AH_DECORATION_MIN) {


### PR DESCRIPTION
## Problem
Fixes #9195: with `osd_left_sidebar_scroll` / `osd_right_sidebar_scroll` set to altitude or speed, the scrolling scale beside the artificial horizon on the character OSD moves the wrong way. @malinhiles' DVR clip shows airspeed falling and altitude rising while the tick marks travel opposite to the Garmin tape the sidebars emulate, where a rising value brings the higher numbers down towards the centre marker. @b14ckyy confirmed it and noted the pixel OSD scrolls correctly.

## Cause
`osdUpdateSidebar()`, `src/main/io/osd_grid.c:303` on maintenance-10.x: `decoration -= steps % SYM_AH_DECORATION_COUNT;`. The glyphs `SYM_AH_DECORATION_MIN..MAX` (0x12E..0x133) draw their tick marks 3 px lower for each higher code in every analogue font, so subtracting walks the ticks upwards as the value rises. The pixel OSD draws its sidebars via `osdCanvasDrawSidebars()` (osd_common.c:364) and never reaches this line. `release/9.1` has the same line at `osd_grid.c:303`.

## Change
Adds the step count instead of subtracting it and documents the glyph order in a comment above the line. A rising value now scrolls the scale downwards, bringing the higher numbers towards the centre marker. The existing wrap-around keeps the code inside the font range for either sign; the trend arrows and the pixel OSD path are untouched.

## Test
Not run on hardware or SITL. Cause verified by reading `osd_grid.c:303` and by decoding glyphs 302-307 of all eight Configurator analogue fonts (`resources/osd/analogue/*.mcm`): each higher code shifts the ticks 3 px down, and six codes span the 18 px cell, which the wrap-around relies on. The upstream Build firmware run for this PR (https://github.com/iNavFlight/inav/actions/runs/34532676799) is waiting for maintainer approval and has not built. The commit cherry-picks onto `release/9.1` without conflicts (`git merge-tree`).

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: neither `docs/OSD.md` (OSD_HORIZON_SIDEBARS) nor `docs/Settings.md` (`osd_*_sidebar_scroll`) describes the scroll direction, and no setting or default changes.
