### PR TITLE
osd: fix one byte out-of-bounds write when drawing HUD POIs

### DIFF
--- a/src/main/io/osd_hud.c
+++ b/src/main/io/osd_hud.c
@@ -127,7 +127,7 @@ void osdHudDrawPoi(uint32_t poiDistance, int16_t poiDirection, int32_t poiAltitu
     uint8_t center_x;
     uint8_t center_y;
     bool poi_is_oos = 0;
-    char buff[4];
+    char buff[5]; // 4 characters plus the terminator osdFormatCentiNumber and tfp_sprintf write at index 4
     int altc = 0;
 
     uint8_t minX = osdConfig()->hud_margin_h + 2;


### PR DESCRIPTION
## Problem
No issue was filed. The defect was found by reading the code while writing the OSD HUD documentation page (iNavFlight/iNavFlight.github.io#24). Whenever a radar POI (ESP32 craft radar peer) is drawn on the HUD, `osdHudDrawPoi()` writes one byte past the end of its local `buff` array, on every OSD frame that shows the marker. No visible symptom is known; the byte lands on adjacent stack memory.

## Cause
`src/main/io/osd_hud.c:130` on `maintenance-10.x` declares `char buff[4]`, but both `poiType == 1` (radar POI) paths write a terminator at index 4. `osd_hud.c:250` `tfp_sprintf(buff+1, "%3d", altc)` puts three digits in `buff[1..3]` and `'\0'` in `buff[4]`. `osd_hud.c:264`, `:273` and `:286` call `osdFormatCentiNumber(buff, ..., 4, 4, false)`, whose first statement is `buff[length] = '\0'` (`src/main/io/osd_utils.c:50`) with `length = 4`. The non-radar branches use width 3 and stay in bounds. All four characters `buff[0..3]` are read back at `osd_hud.c:295-299`, so the format cannot be shortened. The same lines are present at the same line numbers on `release/9.1`.

## Change
Enlarges `buff` from 4 to 5 bytes in `osdHudDrawPoi()` and adds a comment naming the two writers of index 4. No control-flow or output change.

## Test
Not run on hardware or SITL. Cause verified by reading `src/main/io/osd_hud.c:130,250,264,273,286` and `src/main/io/osd_utils.c:50` on `maintenance-10.x`. The upstream "Build firmware" run for the head commit is waiting for maintainer approval (https://github.com/iNavFlight/inav/actions/runs/34533380329); no fork build exists for the head SHA. Qodo review: no issues found.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: the displayed characters are unchanged; the fix only removes an out-of-bounds write.
