### PR TITLE
ez_tune: apply the expo setting instead of the rate setting

### DIFF
--- a/src/main/flight/ez_tune.c
+++ b/src/main/flight/ez_tune.c
@@ -140,8 +140,8 @@ void ezTuneUpdate(void) {
         ((controlConfig_t*)currentControlProfile)->stabilized.rates[FD_PITCH] = scaleRange(ezTune()->rate, 0, 200, 30, 90);
         ((controlConfig_t*)currentControlProfile)->stabilized.rates[FD_YAW] = scaleRange(ezTune()->rate, 0, 200, 30, 90) - 10;
 
-        ((controlConfig_t*)currentControlProfile)->stabilized.rcExpo8 = scaleRange(ezTune()->rate, 0, 200, 40, 100);
-        ((controlConfig_t*)currentControlProfile)->stabilized.rcYawExpo8 = scaleRange(ezTune()->rate, 0, 200, 40, 100);
+        ((controlConfig_t*)currentControlProfile)->stabilized.rcExpo8 = scaleRange(ezTune()->expo, 0, 200, 40, 100);
+        ((controlConfig_t*)currentControlProfile)->stabilized.rcYawExpo8 = scaleRange(ezTune()->expo, 0, 200, 40, 100);
 
         //D-Boost snappiness
         pidProfileMutable()->dBoostMin = scaleRangef(ezTune()->snappiness, 0, 100, 1.0f, 0.0f);


### PR DESCRIPTION
## Problem
No issue was filed; found while writing the EZ-Tune documentation page (iNavFlight/iNavFlight.github.io#21). With EZ-Tune enabled, the expo slider (`ez_expo`) in the Configurator does nothing: the stick curve stays the same however it is set, although the Configurator draws a preview curve for it. Moving the rate slider (`ez_rate`) changes the expo as well, with nothing on screen saying so.

## Cause
`src/main/flight/ez_tune.c:143-144` on `maintenance-10.x`: `ezTuneUpdate()` computes `stabilized.rcExpo8` and `stabilized.rcYawExpo8` from `ezTune()->rate` instead of `ezTune()->expo`. The three lines above set the axis rates from the same field, so the expo lines read as a copy-paste slip. On that branch `ezTune()->expo` is read in only one other place, `src/main/fc/fc_msp.c:1948`, which sends it back over `MSP2_INAV_EZ_TUNE`; the setting never reaches the control profile. The same two lines exist on `release/9.1` (`src/main/flight/ez_tune.c:143-144`) and the diff applies there cleanly.

## Change
Two lines: the `rcExpo8` and `rcYawExpo8` assignments read `ezTune()->expo` instead of `ezTune()->rate`. The mapping `scaleRange(..., 0, 200, 40, 100)` is unchanged and is the one the Configurator uses for its expo preview (`tabs/pid_tuning.js:107`). `ez_rate` and `ez_expo` both default to 100, so the applied expo at defaults stays 70 for roll/pitch and yaw. A profile with `ez_rate` away from 100 gets a different expo on its next `ezTuneUpdate()`; that is the corrected behaviour and worth a release-note line.

## Test
Not run on hardware or SITL. Cause verified by reading `src/main/flight/ez_tune.c:143-144` and `src/main/fc/fc_msp.c:1948` on `maintenance-10.x`.  The upstream "Build firmware" run for 78aebbc is waiting for maintainer approval: https://github.com/iNavFlight/inav/actions/runs/34533382666.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: `docs/Settings.md` is generated from `settings.yaml`, which is unchanged, and its `ez_expo` entry ("EzTune expo") already describes the corrected behaviour. There is no EZ-Tune page under `docs/` on `maintenance-10.x`; the user-facing page is iNavFlight/iNavFlight.github.io#21.
