### PR TITLE
Only consume artifacts from the real firmware workflow

### DIFF
--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -137,6 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.name == 'Build firmware' &&
+      github.event.workflow_run.path == '.github/workflows/ci.yml' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     concurrency:

--- a/.github/workflows/pr-test-builds.yml
+++ b/.github/workflows/pr-test-builds.yml
@@ -16,6 +16,7 @@ jobs:
     # Only act on pull_request-triggered runs that succeeded.
     if: >
       github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.path == '.github/workflows/ci.yml' &&
       github.event.workflow_run.conclusion == 'success'
     # Prevent concurrent runs for the same PR branch racing on the
     # release delete/create cycle.


### PR DESCRIPTION
## Problem
No issue filed; observed on upstream CI. When a PR touches only non-code paths, the `non-code-change.yaml` stub runs instead of `ci.yml`. Both are named "Build firmware", so the stub's success triggers "PR Test Builds", whose `publish` job fails at "Download PR number" with `Artifact not found for name: pr-number`. Upstream examples: [run 34502954072](https://github.com/iNavFlight/inav/actions/runs/34502954072) (triggered by stub run [34502620127](https://github.com/iNavFlight/inav/actions/runs/34502620127)) and [run 34253938364](https://github.com/iNavFlight/inav/actions/runs/34253938364) (stub run [34253603715](https://github.com/iNavFlight/inav/actions/runs/34253603715)); six such failures between 2026-09-08 and 2026-09-10. The size-report job on master already skips the stub via the guard step from #11878, but only after starting a runner, checking out and querying the jobs API.

## Cause
`.github/workflows/ci.yml:1` and `.github/workflows/non-code-change.yaml:1` share `name: Build firmware`. `.github/workflows/pr-test-builds.yml:17-19` gates `publish` only on `workflow_run.event == 'pull_request'` and `conclusion == 'success'`, both true for the stub, then downloads `pr-number` unconditionally (lines 31-36). `.github/workflows/ci-size-report.yml:138-141` uses the same job-level condition; the added name check does not tell the two files apart.

## Change
Adds `github.event.workflow_run.path == '.github/workflows/ci.yml'` to the job-level `if:` of `publish` in `pr-test-builds.yml` and `pr-comment` in `ci-size-report.yml`. Stub runs no longer enter either job. `publish-baseline` and the existing "Check upload-artifacts job succeeded" step are untouched.

## Test
Not run upstream: the "Build firmware" run for this head ([34614441492](https://github.com/iNavFlight/inav/actions/runs/34614441492)) is awaiting approval, and `workflow_run` consumers execute the default-branch file anyway. Verified in the fork, where the same guard is on the default branch (Raffi1202/inav#12, merge ac6fbcde):
- Before: stub run [34612708023](https://github.com/Raffi1202/inav/actions/runs/34612708023) triggered CI Size Report [34613019605](https://github.com/Raffi1202/inav/actions/runs/34613019605), `pr-comment` failed at "Download PR number" (fork master then lacked the #11878 guard step).
- After: CI Size Report [34614556238](https://github.com/Raffi1202/inav/actions/runs/34614556238) and [34616048856](https://github.com/Raffi1202/inav/actions/runs/34616048856) ran `pr-comment` through all artifact downloads and the PR comment, so `workflow_run.path` is populated and matches for real `ci.yml` runs.
- `pr-test-builds.yml` does not execute in the fork (gated on `github.repository == 'iNavFlight/inav'`); its hunk is the identical expression, checked by reading only.

## Flash / RAM
Not measured yet. The upstream firmware CI has not been released for this PR, so no size report exists.

## Docs
No documentation change needed: no file under `docs/` describes the consumer trigger conditions, and `.github/workflows/README.md` documents the triggers by workflow name, which is unchanged.
