### PR TITLE
UART-IRQ - UART F7/H7 - clear stale TC flag instead of calling HAL_UA…

### DIFF
--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -312,8 +312,15 @@ void uartIrqHandler(uartPort_t *s)
     }
 
     /* UART in mode Transmitter (transmission end) -----------------------------*/
+    // TCIE is never enabled here, so TC is only a stale status flag left over from
+    // the last transmitted byte. It used to be forwarded to HAL_UART_IRQHandler(),
+    // which treats a pending overrun as a blocking error and permanently disables
+    // the RX interrupts (UART_EndRxTransfer) - a receiver on a busy UART then dies
+    // after any long IRQ-disabled window such as an internal flash write. Nothing
+    // in the HAL handler is needed for INAV's own TXE/RXNE-driven transfers, so
+    // just acknowledge the flag.
     if ((__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET)) {
-        HAL_UART_IRQHandler(huart);
+        __HAL_UART_CLEAR_IT(huart, UART_CLEAR_TCF);
     }
 }
 

--- a/src/main/drivers/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/serial_uart_stm32h7xx.c
@@ -358,8 +358,15 @@ void uartIrqHandler(uartPort_t *s)
     }
 
     /* UART in mode Transmitter (transmission end) -----------------------------*/
+    // TCIE is never enabled here, so TC is only a stale status flag left over from
+    // the last transmitted byte. It used to be forwarded to HAL_UART_IRQHandler(),
+    // which treats a pending overrun as a blocking error and permanently disables
+    // the RX interrupts (UART_EndRxTransfer) - a receiver on a busy UART then dies
+    // after any long IRQ-disabled window such as an internal flash write. Nothing
+    // in the HAL handler is needed for INAV's own TXE/RXNE-driven transfers, so
+    // just acknowledge the flag.
     if ((__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET)) {
-        HAL_UART_IRQHandler(huart);
+        __HAL_UART_CLEAR_IT(huart, UART_CLEAR_TCF);
     }
 }
 


### PR DESCRIPTION
Insidious bug in UART IRQ handler for H7 and F7 CPU. 

How to reproduce: 
1) set continuous servo trim to INAV save data to eeprom after disarm
2) arm plane
3) disarm plane

**What happen there (at least what I think, it's not easy to debug):**
The main problem is if uartIrqHandler is interupted between src/main/drivers/serial_uart_stm32h7xx.c:338 and src/main/drivers/serial_uart_stm32h7xx.c:369 and interupt who interupted uartIrqHandler is long enought to UART receives 2 bytes.  Second byte set OREF and calling **HAL_UART_IRQHandler(huart);** disable UART IRQ. 

It caused that all UARTS will stop working. UART is not fully dead, because transmit via UART will fire UART IRQ handler and random byte is read from buffer. 

It't very small window and probablity is small, but durring saving to eeprom can't be executed IRQs and all IRQs are waiting to finish saving to eeprom. It increases probability a lot. 

Sometimes when I save configuration then receiver stopped working, I did not know what is happen there and I thought it's coicidence. 

Probability of this concurrency is much higter after adding bidir dshot, the IRQ for bidir dshot is long enought to be posible receive two bytes (I will check why dshot IRQ is as long for bidir variant). But dshot IRQ does not cause issue, just increase probability of concurrency that it was possible to debug it. The probability of concurrency  with activated bidir dshot is aprox 20 - 30%. 


