### PR TITLE
Remove OSD Debug Field Duplicate Last Line

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3721,7 +3721,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 );
                 displayWrite(osdDisplayPort, elemPosX, elemPosY, buff);
             }
-            break;
+            return true;
         }
 
     case OSD_IMU_TEMPERATURE:


### PR DESCRIPTION
Displays OSD debug field correctly without duplicated last line.