### PR TITLE
Merge release/9.1 into maintenance-10.x

### DIFF
--- a/.github/scripts/fetch-size-baseline.sh
+++ b/.github/scripts/fetch-size-baseline.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# Fetch the size baseline for a PR's TRUE base commit — the merge-base of
+# the PR head and base ref — rather than the base branch's latest tip, so
+# the size-diff delta doesn't include unrelated changes merged to the base
+# after the PR forked (see the +9,788 B stale-RAM regression on PR #11785).
+#
+# Strategy, in order:
+#   1. Exact: size-baseline-<merge-base-sha> in the companion builds repo.
+#   2. Nearest ancestor: walk first-parents of the merge-base (older commits
+#      on the base branch) up to MAX_WALK steps, using the first per-commit
+#      baseline tag found. Nightly baselines exist only for commits that were
+#      actually pushed to the branch, so the walk finds the closest nightly
+#      build at-or-before the fork point.
+#   3. Otherwise report found=false (caller emits the graceful
+#      "no size baseline available" comment path).
+#
+# The base branch's LATEST-tip baseline is deliberately NOT used as a
+# fallback: comparing against it is exactly the stale-delta bug this fixes.
+#
+# Usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>
+#   <main-repo>      the firmware repo, e.g. iNavFlight/inav
+#   <builds-repo>    companion repo holding the baselines, e.g. iNavFlight/pr-test-builds
+#   <base-ref>       PR base branch, e.g. maintenance-10.x (validated)
+#   <merge-base-sha> full 40-hex SHA of the PR's merge-base commit (validated)
+#   <out-dir>        directory to write size-report.json into
+#
+# Env: GH_TOKEN with read access to both repos (secrets.PR_BUILDS_TOKEN in
+# the pr-comment job has it; the companion repo is private).
+#
+# Prints key=value lines to stdout for the workflow to append to
+# $GITHUB_OUTPUT: found, baseline_commit (full SHA), baseline_commit_short,
+# baseline_exact (true when the merge-base itself had a stored baseline).
+
+set -euo pipefail
+
+MAIN_REPO=${1:?usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>}
+BUILDS_REPO=${2:?usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>}
+BASE_REF=${3:?usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>}
+MERGE_BASE_SHA=${4:?usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>}
+OUT_DIR=${5:?usage: fetch-size-baseline.sh <main-repo> <builds-repo> <base-ref> <merge-base-sha> <out-dir>}
+
+MAX_WALK=30
+
+if ! [[ "$BASE_REF" =~ ^[A-Za-z0-9._/-]{1,100}$ ]]; then
+    echo "::error::Invalid base ref: $BASE_REF" >&2
+    exit 1
+fi
+if ! [[ "$MERGE_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "::error::Invalid merge-base SHA: $MERGE_BASE_SHA" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+# Set of per-commit baseline SHAs currently stored in the builds repo.
+# One paginated call; tags are built by publish-size-baseline.sh and match
+# the strict 40-hex pattern by construction. @tsv keeps the output raw
+# (gh api has no -r/--raw flag; string filters would JSON-quote values).
+list_baseline_shas() {
+    gh api "repos/${BUILDS_REPO}/releases?per_page=100" --paginate \
+        --jq '.[] | select(.tag_name | test("^size-baseline-[0-9a-f]{40}$")) |
+              [.tag_name | sub("^size-baseline-"; "")] | @tsv'
+}
+
+# publish-size-baseline replaces the asset in place (--clobber), which still
+# briefly deletes-then-uploads under the hood; a few short retries absorb
+# that window instead of misreporting "no baseline available".
+download_baseline() { # $1 = 40-hex sha
+    local tag="size-baseline-${1}"
+    for attempt in 1 2 3; do
+        if gh release download "$tag" --repo "$BUILDS_REPO" \
+            --pattern size-report.json --dir "$OUT_DIR" 2>/dev/null; then
+            return 0
+        fi
+        sleep 3
+    done
+    return 1
+}
+
+emit_found() { # $1 = 40-hex sha, $2 = true|false (exact)
+    echo "found=true"
+    echo "baseline_commit=${1}"
+    echo "baseline_commit_short=${1:0:7}"
+    echo "baseline_exact=${2}"
+}
+
+BASELINE_SHAS=$(list_baseline_shas) || true
+
+if grep -qx "$MERGE_BASE_SHA" <<< "$BASELINE_SHAS" && download_baseline "$MERGE_BASE_SHA"; then
+    emit_found "$MERGE_BASE_SHA" true
+    exit 0
+fi
+
+# Nearest-ancestor walk along the base branch's first-parent chain.
+sha="$MERGE_BASE_SHA"
+for _ in $(seq 1 "$MAX_WALK"); do
+    parent=$(gh api "repos/${MAIN_REPO}/commits/${sha}" --jq '.parents[0].sha // empty' 2>/dev/null || true)
+    if [ -z "$parent" ] || ! [[ "$parent" =~ ^[0-9a-f]{40}$ ]]; then
+        break
+    fi
+    sha="$parent"
+    if grep -qx "$sha" <<< "$BASELINE_SHAS" && download_baseline "$sha"; then
+        emit_found "$sha" false
+        exit 0
+    fi
+done
+
+echo "found=false"

--- a/.github/scripts/fetch-size-baseline.sh
+++ b/.github/scripts/fetch-size-baseline.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 #
+# WARNING: This script is invoked from a GitHub Actions job via
+# `bash .github/scripts/...`. It MUST NEVER be called from a job that has
+# not first checked out a known branch (e.g. `- uses: actions/checkout@v4`
+# as the job's first step): the runner workspace is empty until then, so
+# the script doesn't exist and the call fails with exit 127, silently
+# reporting no baseline. Every job calling this script must check out
+# first.
+#
 # Fetch the size baseline for a PR's TRUE base commit — the merge-base of
 # the PR head and base ref — rather than the base branch's latest tip, so
 # the size-diff delta doesn't include unrelated changes merged to the base

--- a/.github/scripts/fetch-size-baseline.sh
+++ b/.github/scripts/fetch-size-baseline.sh
@@ -55,12 +55,10 @@ mkdir -p "$OUT_DIR"
 
 # Set of per-commit baseline SHAs currently stored in the builds repo.
 # One paginated call; tags are built by publish-size-baseline.sh and match
-# the strict 40-hex pattern by construction. @tsv keeps the output raw
-# (gh api has no -r/--raw flag; string filters would JSON-quote values).
+# the strict 40-hex pattern by construction.
 list_baseline_shas() {
     gh api "repos/${BUILDS_REPO}/releases?per_page=100" --paginate \
-        --jq '.[] | select(.tag_name | test("^size-baseline-[0-9a-f]{40}$")) |
-              [.tag_name | sub("^size-baseline-"; "")] | @tsv'
+        --jq '.[].tag_name | select(test("^size-baseline-[0-9a-f]{40}$")) | sub("^size-baseline-"; "")'
 }
 
 # publish-size-baseline replaces the asset in place (--clobber), which still
@@ -87,23 +85,27 @@ emit_found() { # $1 = 40-hex sha, $2 = true|false (exact)
 
 BASELINE_SHAS=$(list_baseline_shas) || true
 
-if grep -qx "$MERGE_BASE_SHA" <<< "$BASELINE_SHAS" && download_baseline "$MERGE_BASE_SHA"; then
-    emit_found "$MERGE_BASE_SHA" true
-    exit 0
-fi
-
-# Nearest-ancestor walk along the base branch's first-parent chain.
+# Exact merge-base first, then nearest ancestors along the base branch's
+# first-parent chain. The loop STARTS at the merge-base itself so a
+# transient download failure on the exact commit is retried here instead
+# of silently degrading to a nearest-ancestor baseline.
 sha="$MERGE_BASE_SHA"
-for _ in $(seq 1 "$MAX_WALK"); do
+first=1
+for _ in $(seq 1 $((MAX_WALK + 1))); do
+    if grep -qx "$sha" <<< "$BASELINE_SHAS" && download_baseline "$sha"; then
+        if [ "$first" = 1 ]; then
+            emit_found "$sha" true
+        else
+            emit_found "$sha" false
+        fi
+        exit 0
+    fi
+    first=0
     parent=$(gh api "repos/${MAIN_REPO}/commits/${sha}" --jq '.parents[0].sha // empty' 2>/dev/null || true)
     if [ -z "$parent" ] || ! [[ "$parent" =~ ^[0-9a-f]{40}$ ]]; then
         break
     fi
     sha="$parent"
-    if grep -qx "$sha" <<< "$BASELINE_SHAS" && download_baseline "$sha"; then
-        emit_found "$sha" false
-        exit 0
-    fi
 done
 
 echo "found=false"

--- a/.github/scripts/publish-size-baseline.sh
+++ b/.github/scripts/publish-size-baseline.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# Publish the nightly size report as release assets in the companion
+# pr-test-builds repo, keyed by BRANCH (latest-tip pointer, kept for
+# backward compatibility) AND by COMMIT SHA (primary — lets PR size-diff
+# comparisons use the PR's exact base commit instead of the branch tip),
+# then prune old per-commit baselines so the companion repo doesn't grow
+# unbounded.
+#
+# Usage: publish-size-baseline.sh <builds-repo> <branch> <commit-sha> <report-json> [--dry-run]
+#   <builds-repo>  companion repo, e.g. iNavFlight/pr-test-builds
+#   <branch>       branch the nightly was pushed to (e.g. maintenance-10.x)
+#   <commit-sha>   full 40-hex SHA of the pushed commit (workflow_run.head_sha)
+#   <report-json>  merged size-report.json artifact
+#   --dry-run      print what would be published/pruned without touching GitHub
+#
+# Env: GH_TOKEN with write access to <builds-repo> (Contents: write).
+#
+# Per-commit baseline releases carry a machine-readable `branch: <name>`
+# first line in their notes so pruning can group them per branch. Tags are
+# `size-baseline-<40-hex-sha>`; branch-tip tags are `size-baseline-<branch>`.
+#
+# Pruning policy: keep the newest KEEP_PER_BRANCH per-commit baselines per
+# branch, plus a GLOBAL_CAP safety net for orphaned baselines (deleted
+# branches, notes parse failures) so the repo can never grow unbounded.
+
+set -euo pipefail
+
+BUILDS_REPO=${1:?usage: publish-size-baseline.sh <builds-repo> <branch> <commit-sha> <report-json> [--dry-run]}
+BRANCH=${2:?usage: publish-size-baseline.sh <builds-repo> <branch> <commit-sha> <report-json> [--dry-run]}
+COMMIT_SHA=${3:?usage: publish-size-baseline.sh <builds-repo> <branch> <commit-sha> <report-json> [--dry-run]}
+REPORT_JSON=${4:?usage: publish-size-baseline.sh <builds-repo> <branch> <commit-sha> <report-json> [--dry-run]}
+DRY_RUN=${5:-}
+
+KEEP_PER_BRANCH=50
+GLOBAL_CAP=300
+
+# --- Validate inputs: never trust artifact content or context values before
+# they are used to build shell commands or release tags.
+if ! [[ "$BRANCH" =~ ^[A-Za-z0-9._/-]{1,100}$ ]]; then
+    echo "::error::Invalid branch name in artifact: $BRANCH" >&2
+    exit 1
+fi
+if ! [[ "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "::error::Invalid commit SHA: $COMMIT_SHA" >&2
+    exit 1
+fi
+if [ ! -f "$REPORT_JSON" ]; then
+    echo "::error::Size report not found: $REPORT_JSON" >&2
+    exit 1
+fi
+
+# publish one baseline release: create once, then only ever replace the
+# asset in place (--clobber) so the release/tag stays continuously
+# resolvable for concurrent PR comparisons.
+publish_asset() {
+    local tag="$1" title="$2" notes="$3"
+    if gh release view "$tag" --repo "$BUILDS_REPO" >/dev/null 2>&1; then
+        gh release upload "$tag" "$REPORT_JSON" --repo "$BUILDS_REPO" --clobber
+    else
+        gh release create "$tag" "$REPORT_JSON" --repo "$BUILDS_REPO" --prerelease \
+            --title "$title" --notes "$notes"
+    fi
+}
+
+BRANCH_TAG="size-baseline-${BRANCH}"
+COMMIT_TAG="size-baseline-${COMMIT_SHA}"
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+    echo "[dry-run] would publish ${BRANCH_TAG} and ${COMMIT_TAG} in ${BUILDS_REPO}"
+else
+    publish_asset "$BRANCH_TAG" "Size baseline: ${BRANCH}" \
+        "Latest per-target flash/RAM size report for ${BRANCH}. Auto-updated on every push. Not for human consumption."
+    publish_asset "$COMMIT_TAG" "Size baseline: ${COMMIT_SHA}" \
+        "branch: ${BRANCH}
+Per-commit per-target flash/RAM size report for ${COMMIT_SHA}. Consumed by PR size-diff comparisons; pruned to the newest ${KEEP_PER_BRANCH} per branch."
+fi
+
+# ---------------------------------------------------------------------------
+# Prune per-commit baselines
+# ---------------------------------------------------------------------------
+# Emit <created_at>\t<tag>\t<branch> for every per-commit baseline release,
+# newest first (GitHub release listing is newest-first). Branch comes from
+# the notes' `branch: <name>` first line; '?' when unparseable. @tsv keeps
+# the output raw (gh api has no -r/--raw flag; string filters would
+# JSON-quote values).
+list_per_commit_baselines() {
+    gh api "repos/${BUILDS_REPO}/releases?per_page=100" --paginate \
+        --jq '.[] | select(.tag_name | test("^size-baseline-[0-9a-f]{40}$")) |
+              [.created_at, .tag_name,
+               ((.body // "") | capture("^branch: (?<b>[A-Za-z0-9._/-]+)$") | .b // "?")] | @tsv'
+}
+
+prune() {
+    local tmp
+    tmp=$(mktemp)
+    trap 'rm -f "$tmp"' RETURN
+
+    # Pass 1 (NR==FNR): per-branch keep-set — newest KEEP_PER_BRANCH tags per
+    # branch. Pass 2: apply the global cap to the kept set in input order.
+    # Prints the tags to DELETE (kept per-branch but cut by the cap, or never
+    # in the keep-set at all). The API lists newest-first but pagination can
+    # interleave pages, so re-sort descending by created_at for a guaranteed
+    # newest-first input to the keep-selection.
+    list_per_commit_baselines | sort -r > "$tmp"
+
+    awk -F '\t' -v keep="$KEEP_PER_BRANCH" -v cap="$GLOBAL_CAP" '
+        NR == FNR {
+            if (count[$3] < keep) { count[$3]++; keepTag[$2] = 1 }
+            next
+        }
+        {
+            if (keepTag[$2]) {
+                if (kept < cap) { kept++; keepFinal[$2] = 1 }
+            }
+        }
+        END {
+            for (t in keepTag) if (!keepFinal[t]) print t
+        }
+    ' "$tmp" "$tmp" | while read -r tag; do
+        if [ "$DRY_RUN" = "--dry-run" ]; then
+            echo "[dry-run] would prune ${tag}"
+        else
+            gh release delete "$tag" --repo "$BUILDS_REPO" --yes --cleanup-tag \
+                || echo "::warning::failed to prune ${tag}" >&2
+        fi
+    done
+}
+
+prune

--- a/.github/scripts/publish-size-baseline.sh
+++ b/.github/scripts/publish-size-baseline.sh
@@ -127,4 +127,7 @@ prune() {
     done
 }
 
-prune
+# Pruning is housekeeping: a failure here must not fail the publish (the
+# baseline itself already landed above), or the nightly would look broken
+# for a cosmetic reason. Warn loudly instead.
+prune || echo "::warning::per-commit baseline pruning failed (see stderr)" >&2

--- a/.github/scripts/publish-size-baseline.sh
+++ b/.github/scripts/publish-size-baseline.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 #
+# WARNING: This script is invoked from a GitHub Actions job via
+# `bash .github/scripts/...`. It MUST NEVER be called from a job that has
+# not first checked out a known branch (e.g. `- uses: actions/checkout@v4`
+# as the job's first step): the runner workspace is empty until then, so
+# the script doesn't exist and the call fails with exit 127, silently
+# publishing nothing. Every job calling this script must check out first.
+#
 # Publish the nightly size report as release assets in the companion
 # pr-test-builds repo, keyed by BRANCH (latest-tip pointer, kept for
 # backward compatibility) AND by COMMIT SHA (primary — lets PR size-diff

--- a/.github/scripts/publish-size-baseline.sh
+++ b/.github/scripts/publish-size-baseline.sh
@@ -81,14 +81,15 @@ fi
 # ---------------------------------------------------------------------------
 # Emit <created_at>\t<tag>\t<branch> for every per-commit baseline release,
 # newest first (GitHub release listing is newest-first). Branch comes from
-# the notes' `branch: <name>` first line; '?' when unparseable. @tsv keeps
-# the output raw (gh api has no -r/--raw flag; string filters would
-# JSON-quote values).
+# the notes' `branch: <name>` FIRST LINE; the (?m) flag is required — the
+# notes are multi-line, and without it ^/$ anchor to the whole string so
+# the capture never matches and every baseline collapses into the '?'
+# bucket, which would make pruning treat all branches as one.
 list_per_commit_baselines() {
     gh api "repos/${BUILDS_REPO}/releases?per_page=100" --paginate \
         --jq '.[] | select(.tag_name | test("^size-baseline-[0-9a-f]{40}$")) |
               [.created_at, .tag_name,
-               ((.body // "") | capture("^branch: (?<b>[A-Za-z0-9._/-]+)$") | .b // "?")] | @tsv'
+               ((.body // "") | capture("(?m)^branch: (?<b>[A-Za-z0-9._/-]+)$") | .b // "?")] | @tsv'
 }
 
 prune() {
@@ -96,16 +97,17 @@ prune() {
     tmp=$(mktemp)
     trap 'rm -f "$tmp"' RETURN
 
-    # Pass 1 (NR==FNR): per-branch keep-set — newest KEEP_PER_BRANCH tags per
-    # branch. Pass 2: apply the global cap to the kept set in input order.
-    # Prints the tags to DELETE (kept per-branch but cut by the cap, or never
-    # in the keep-set at all). The API lists newest-first but pagination can
-    # interleave pages, so re-sort descending by created_at for a guaranteed
-    # newest-first input to the keep-selection.
+    # Pass 1 (NR==FNR): record every tag in `all`, and the per-branch
+    # keep-set — newest KEEP_PER_BRANCH tags per branch — in `keepTag`.
+    # Pass 2: apply the global cap to the kept set in input order.
+    # END: delete every tag in `all` that did not survive to keepFinal.
+    # (Explicit `all` set so pruning never depends on awk's create-on-
+    # reference semantics of reading keepTag[$2] in pass 2.)
     list_per_commit_baselines | sort -r > "$tmp"
 
     awk -F '\t' -v keep="$KEEP_PER_BRANCH" -v cap="$GLOBAL_CAP" '
         NR == FNR {
+            all[$2] = 1
             if (count[$3] < keep) { count[$3]++; keepTag[$2] = 1 }
             next
         }
@@ -115,7 +117,7 @@ prune() {
             }
         }
         END {
-            for (t in keepTag) if (!keepFinal[t]) print t
+            for (t in all) if (!keepFinal[t]) print t
         }
     ' "$tmp" "$tmp" | while read -r tag; do
         if [ "$DRY_RUN" = "--dry-run" ]; then

--- a/.github/scripts/size-diff-comment.js
+++ b/.github/scripts/size-diff-comment.js
@@ -66,14 +66,19 @@ function diffSizeReports(prReport, baselineReport) {
 //   stored baseline and a nearest-ancestor baseline was used instead.
 function renderComment({ prReport, baselineReport, shortSha, baselineCommit, baselineIsNearest, docLink, marker }) {
     const rows = diffSizeReports(prReport, baselineReport);
-    const vs = baselineCommit ? `vs. base commit \`${baselineCommit}\`` : 'vs. base branch';
+    // Only name the baseline commit when there is actually a baseline to
+    // compare against (the workflow only sets baselineCommit in that case,
+    // but the renderer must not emit a contradictory header otherwise).
+    const vs = (baselineReport && baselineCommit)
+        ? `vs. base commit \`${baselineCommit}\`` : 'vs. base branch';
     const lines = [marker, `**RAM / Flash usage ${vs}** — commit \`${shortSha}\``, ''];
 
     if (!baselineReport) {
         lines.push(
             '> No size baseline is available yet for this PR\'s base commit ' +
-            '(first run after this feature shipped, or a new branch). ' +
-            'This comment will show deltas once a baseline exists.',
+            '(no per-commit baseline has been published for it). This comment ' +
+            'will show deltas once one exists — rebasing the PR refreshes its ' +
+            'base commit.',
             ''
         );
     } else if (baselineIsNearest) {

--- a/.github/scripts/size-diff-comment.js
+++ b/.github/scripts/size-diff-comment.js
@@ -60,15 +60,26 @@ function diffSizeReports(prReport, baselineReport) {
 }
 
 // docLink: string URL to link, or null/undefined to omit the doc-link line.
-function renderComment({ prReport, baselineReport, shortSha, docLink, marker }) {
+// baselineCommit: short SHA of the baseline commit the delta was computed
+//   against, or null/undefined to fall back to the generic "base branch"
+//   wording. baselineIsNearest: true when the exact base commit had no
+//   stored baseline and a nearest-ancestor baseline was used instead.
+function renderComment({ prReport, baselineReport, shortSha, baselineCommit, baselineIsNearest, docLink, marker }) {
     const rows = diffSizeReports(prReport, baselineReport);
-    const lines = [marker, '**RAM / Flash usage vs. base branch** — commit `' + shortSha + '`', ''];
+    const vs = baselineCommit ? `vs. base commit \`${baselineCommit}\`` : 'vs. base branch';
+    const lines = [marker, `**RAM / Flash usage ${vs}** — commit \`${shortSha}\``, ''];
 
     if (!baselineReport) {
         lines.push(
-            '> No size baseline is available yet for this PR\'s base branch ' +
+            '> No size baseline is available yet for this PR\'s base commit ' +
             '(first run after this feature shipped, or a new branch). ' +
             'This comment will show deltas once a baseline exists.',
+            ''
+        );
+    } else if (baselineIsNearest) {
+        lines.push(
+            '> Using the nearest available size baseline — the PR\'s exact base ' +
+            'commit has no stored baseline yet.',
             ''
         );
     }

--- a/.github/scripts/size-diff-comment.test.js
+++ b/.github/scripts/size-diff-comment.test.js
@@ -84,12 +84,12 @@ test('diffSizeReports: notable is gated at exactly NOISE_THRESHOLD_BYTES', () =>
 
 test('diffSizeReports: notable also triggers from ramDelta alone, and honors negative deltas via Math.abs', () => {
     const base = { MATEKF405: { flash: 100000, ram: 50000 } };
-    const pr = { MATEKF405: { flash: 100000, ram: 50000 - 40 } }; // flash unchanged, ram shrank by 40
+    const pr = { MATEKF405: { flash: 100000, ram: 50000 - 300 } }; // flash unchanged, ram shrank by 300
     const row = diffSizeReports(pr, base).find((r) => r.target === 'MATEKF405');
 
     assert.equal(row.flashDelta, 0);
-    assert.equal(row.ramDelta, -40);
-    assert.equal(row.notable, true, 'a -40 ram delta exceeds the 32-byte threshold in magnitude');
+    assert.equal(row.ramDelta, -300);
+    assert.equal(row.notable, true, 'a -300 ram delta exceeds NOISE_THRESHOLD_BYTES in magnitude');
 });
 
 test('diffSizeReports: target missing from PR report but present in baseline -> missing-from-pr', () => {
@@ -155,9 +155,9 @@ test('renderComment: baseline present, all 4 targets compared, mix of notable/no
         MATEKH743: [530000, 63000],
     });
     const prReport = fullReport({
-        MATEKF405: [500100, 60000], // +100 flash -> notable
+        MATEKF405: [500300, 60000], // +300 flash -> notable
         MATEKF722: [510010, 61000], // +10 flash -> not notable
-        MATEKF765: [519960, 62000], // -40 flash -> notable
+        MATEKF765: [519700, 62000], // -300 flash -> notable
         MATEKH743: [530000, 63000], // no change -> not notable
     });
 
@@ -179,9 +179,9 @@ test('renderComment: baseline present, all 4 targets compared, mix of notable/no
     const matekf765Line = lines.find((l) => l.startsWith('| MATEKF765'));
     const matekh743Line = lines.find((l) => l.startsWith('| MATEKH743'));
 
-    assert.ok(matekf405Line.includes('⚠️'), 'MATEKF405 (+100 flash) should be flagged notable');
+    assert.ok(matekf405Line.includes('⚠️'), 'MATEKF405 (+300 flash) should be flagged notable');
     assert.ok(!matekf722Line.includes('⚠️'), 'MATEKF722 (+10 flash) should NOT be flagged notable');
-    assert.ok(matekf765Line.includes('⚠️'), 'MATEKF765 (-40 flash) should be flagged notable');
+    assert.ok(matekf765Line.includes('⚠️'), 'MATEKF765 (-300 flash) should be flagged notable');
     assert.ok(!matekh743Line.includes('⚠️'), 'MATEKH743 (no change) should NOT be flagged notable');
 
     // No "no baseline available" note when a baseline was supplied.
@@ -285,4 +285,71 @@ test('renderComment: result always ends with exactly one trailing newline', () =
 
     assert.ok(body.endsWith('\n'));
     assert.ok(!body.endsWith('\n\n'));
+});
+
+// ---------------------------------------------------------------------------
+// renderComment: baseline-commit header
+// ---------------------------------------------------------------------------
+
+test('renderComment: baselineCommit supplied -> header names the baseline commit', () => {
+    const body = renderComment({
+        prReport: fullReport({ MATEKF405: [500000, 60000] }),
+        baselineReport: fullReport({ MATEKF405: [499000, 60000] }),
+        shortSha: 'abc1234',
+        baselineCommit: '9e932ba',
+        baselineIsNearest: false,
+        docLink: null,
+        marker: '<!-- marker -->',
+    });
+
+    assert.ok(body.includes('vs. base commit `9e932ba`'), 'header should name the baseline commit');
+    assert.ok(body.includes('commit `abc1234`'), 'header should still name the PR head commit');
+    assert.ok(!body.includes('vs. base branch'), 'exact baseline should not use the generic "base branch" wording');
+    assert.ok(!body.includes('nearest available size baseline'), 'exact baseline should not show the fallback note');
+    assert.ok(!body.includes('No size baseline is available yet'), 'baseline present means no "no baseline" note');
+});
+
+test('renderComment: baselineCommit + baselineIsNearest -> fallback note shown', () => {
+    const body = renderComment({
+        prReport: fullReport({ MATEKF405: [500000, 60000] }),
+        baselineReport: fullReport({ MATEKF405: [499000, 60000] }),
+        shortSha: 'abc1234',
+        baselineCommit: '7f133b3',
+        baselineIsNearest: true,
+        docLink: null,
+        marker: '<!-- marker -->',
+    });
+
+    assert.ok(body.includes('vs. base commit `7f133b3`'), 'header should name the nearest baseline commit');
+    assert.ok(body.includes('nearest available size baseline'), 'fallback note should explain the nearest-baseline choice');
+});
+
+test('renderComment: baselineCommit omitted -> generic "vs. base branch" wording kept', () => {
+    const body = renderComment({
+        prReport: fullReport({ MATEKF405: [500000, 60000] }),
+        baselineReport: fullReport({ MATEKF405: [499000, 60000] }),
+        shortSha: 'abc1234',
+        docLink: null,
+        marker: '<!-- marker -->',
+    });
+
+    assert.ok(body.includes('vs. base branch'), 'legacy callers without baselineCommit keep the old wording');
+    assert.ok(!body.includes('base commit `'), 'no baseline commit rendered when none supplied');
+});
+
+test('renderComment: baselineCommit supplied but no baseline report -> graceful note still wins', () => {
+    // Defensive: the workflow only sets baselineCommit when a baseline was
+    // found, so this combination should not occur; if it ever does, the
+    // "no baseline available" note must still be present (never silently
+    // claim a comparison happened).
+    const body = renderComment({
+        prReport: fullReport({ MATEKF405: [500000, 60000] }),
+        baselineReport: null,
+        shortSha: 'abc1234',
+        baselineCommit: '9e932ba',
+        docLink: null,
+        marker: '<!-- marker -->',
+    });
+
+    assert.ok(body.includes('No size baseline is available yet'));
 });

--- a/.github/scripts/size-diff-comment.test.js
+++ b/.github/scripts/size-diff-comment.test.js
@@ -337,11 +337,11 @@ test('renderComment: baselineCommit omitted -> generic "vs. base branch" wording
     assert.ok(!body.includes('base commit `'), 'no baseline commit rendered when none supplied');
 });
 
-test('renderComment: baselineCommit supplied but no baseline report -> graceful note still wins', () => {
+test('renderComment: baselineCommit supplied but no baseline report -> graceful note wins, no contradictory header', () => {
     // Defensive: the workflow only sets baselineCommit when a baseline was
     // found, so this combination should not occur; if it ever does, the
-    // "no baseline available" note must still be present (never silently
-    // claim a comparison happened).
+    // header must NOT claim a base commit was compared (no "vs. base
+    // commit") and the "no baseline available" note must be present.
     const body = renderComment({
         prReport: fullReport({ MATEKF405: [500000, 60000] }),
         baselineReport: null,
@@ -352,4 +352,6 @@ test('renderComment: baselineCommit supplied but no baseline report -> graceful 
     });
 
     assert.ok(body.includes('No size baseline is available yet'));
+    assert.ok(!body.includes('vs. base commit `9e932ba`'), 'header must not name a baseline commit when no baseline exists');
+    assert.ok(body.includes('vs. base branch'), 'header should fall back to the generic wording');
 });

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -103,6 +103,13 @@ every PR.
 `.github/scripts/size-diff-comment.js` (pure diff + markdown rendering,
 unit tested in `.github/scripts/size-diff-comment.test.js`)
 
+**⚠️ Every job that calls a `.github/scripts/` file MUST first run
+`- uses: actions/checkout@v4` as its first step.** The runner workspace is
+empty until a checkout — `bash .github/scripts/...` then fails with exit
+127 and the job silently does nothing, so a missing checkout looks like a
+missing baseline/artifact instead of a broken job. Repo scripts MUST NEVER
+be invoked from a job that has not checked out a known branch first.
+
 **Uses the same `PR_BUILDS_TOKEN` secret and `workflow_run` trigger pattern
 as `pr-test-builds.yml`** (secrets available even for fork PRs).
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -77,20 +77,29 @@ every PR.
    `nightly-build.yml` ("Build pre-release") invokes `ci.yml` via
    `workflow_call` as part of building nightly releases — this already
    produces the size report above at no extra build cost. When that
-   completes, `ci-size-report.yml` persists it as a release asset
-   (`size-baseline-<branch>`) in the companion `iNavFlight/pr-test-builds`
-   repo — the "known good" baseline for that branch, overwritten on every
-   push. (`ci.yml`'s *own* `on: push:` trigger is broken — a `branches:`
-   list containing only a negative pattern matches nothing per GitHub's
-   docs — so this deliberately listens to `nightly-build.yml` instead of
-   trying to fix that separately; verified empirically that `ci.yml` alone
-   has zero push-triggered runs in this repo's history.)
-3. On PR builds, it fetches the PR's base branch's persisted baseline (no
-   rebuild), diffs it against the PR's own size report, and posts/updates a
-   comment (marker `<!-- pr-size-diff -->`).
+   completes, `ci-size-report.yml` persists it as TWO release assets in the
+   companion `iNavFlight/pr-test-builds` repo: `size-baseline-<branch>`
+   (latest-tip pointer, kept for backward compatibility) and
+   `size-baseline-<commit-sha>` (primary — lets PR comparisons key off the
+   exact base commit). Per-commit baselines are pruned to the newest 50 per
+   branch (plus a global cap) so the companion repo doesn't grow unbounded.
+   (`ci.yml`'s *own* `on: push:` trigger is broken — a `branches:` list
+   containing only a negative pattern matches nothing per GitHub's docs —
+   so this deliberately listens to `nightly-build.yml` instead of trying to
+   fix that separately; verified empirically that `ci.yml` alone has zero
+   push-triggered runs in this repo's history.)
+3. On PR builds, it computes the PR's TRUE base commit — the merge-base of
+   the PR head and base ref via the compare API — fetches the per-commit
+   baseline for that exact commit, falling back to the nearest ancestor
+   commit that has one (never the branch tip, which would include unrelated
+   changes merged after the PR forked), diffs it against the PR's own size
+   report, and posts/updates a comment (marker `<!-- pr-size-diff -->`)
+   naming the baseline commit that was used.
 
-**Script:** `.github/scripts/extract-size-report.sh` (size extraction),
+**Scripts:** `.github/scripts/extract-size-report.sh` (size extraction),
 `.github/scripts/merge-size-reports.sh` (merges per-shard reports),
+`.github/scripts/publish-size-baseline.sh` (per-commit publish + pruning),
+`.github/scripts/fetch-size-baseline.sh` (merge-base baseline resolution),
 `.github/scripts/size-diff-comment.js` (pure diff + markdown rendering,
 unit tested in `.github/scripts/size-diff-comment.test.js`)
 

--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -48,6 +48,14 @@ jobs:
     permissions:
       actions: read   # to download artifacts and query job conclusions from the triggering workflow run
     steps:
+      # REQUIRED FIRST STEP: check out a known branch before any step calls
+      # a script from .github/scripts/. Repo scripts MUST NEVER be invoked
+      # from a job that has not checked out first: the runner workspace is
+      # empty until a checkout, so `bash .github/scripts/...` fails with
+      # exit 127 and the job silently publishes nothing. workflow_run runs
+      # this file from the default branch, so checkout's default ref is the
+      # trusted one to use.
+      - uses: actions/checkout@v4
       # Don't gate on github.event.workflow_run.conclusion: "Build
       # pre-release" also runs a separate Release job (nightly upload to
       # iNavFlight/inav-nightly) that can fail for reasons unrelated to the

--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -12,18 +12,22 @@ name: CI Size Report
 #    runs exist). "Build pre-release" is push-triggered correctly and
 #    already invokes ci.yml's jobs via `uses:` (workflow_call) as part of
 #    building nightly releases — piggybacking here costs nothing extra,
-#    no second build. Persists the size report as a release asset in the
+#    no second build. Persists the size report as release assets in the
 #    companion iNavFlight/pr-test-builds repo, so PR runs never need to
-#    rebuild the base branch to get a comparison point. Only fires for
-#    branches nightly-build.yml's own push trigger covers (currently
-#    master, maintenance-9.x, maintenance-10.x, release/9.1 — see that
-#    file). Stale baselines for since-deleted branches aren't cleaned up
-#    automatically (same known limitation pr-test-builds has for old PR
-#    releases).
+#    rebuild the base branch to get a comparison point. Two assets are
+#    written per push: size-baseline-<BRANCH> (latest-tip pointer, kept
+#    for backward compatibility) and size-baseline-<COMMIT_SHA> (primary —
+#    PR comparisons key off the exact base commit). Per-commit baselines
+#    are pruned to the newest 50 per branch (plus a global cap) so the
+#    companion repo doesn't grow unbounded; baselines for since-deleted
+#    branches aren't otherwise cleaned up (same known limitation
+#    pr-test-builds has for old PR releases).
 #  - pr-comment listens for "Build firmware" (ci.yml) directly — PR builds
 #    genuinely do trigger it via `pull_request`, that part isn't broken.
-#    Fetches the persisted baseline, diffs the 4 representative targets,
-#    and posts/updates a PR comment.
+#    Resolves the PR's TRUE base commit (merge-base of head and base ref),
+#    fetches the per-commit baseline for it (falling back to the nearest
+#    ancestor commit that has one), diffs the 4 representative targets,
+#    and posts/updates a PR comment showing which baseline was used.
 #
 # Requires the same repository secret PR_BUILDS_TOKEN as pr-test-builds.yml
 # (Contents: write access to iNavFlight/pr-test-builds).
@@ -95,24 +99,22 @@ jobs:
         if: steps.check.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           BRANCH=$(cat branch.txt)
-          TAG="size-baseline-${BRANCH}"
-          # Never delete+recreate the release: that leaves a window where
-          # the release doesn't exist at all, which a concurrent PR's
-          # "Fetch base branch baseline" step could hit and misreport as
-          # "no baseline available yet". Create it once, then only ever
-          # replace the asset in place (--clobber) on later pushes — the
-          # release/tag itself stays continuously resolvable.
-          if gh release view "$TAG" --repo iNavFlight/pr-test-builds >/dev/null 2>&1; then
-            gh release upload "$TAG" size-report.json --repo iNavFlight/pr-test-builds --clobber
-          else
-            gh release create "$TAG" size-report.json \
-              --repo iNavFlight/pr-test-builds \
-              --prerelease \
-              --title "Size baseline: ${BRANCH}" \
-              --notes "Latest per-target flash/RAM size report for ${BRANCH}. Auto-updated on every push. Not for human consumption."
-          fi
+          # Publishes size-baseline-<BRANCH> (latest-tip pointer) and
+          # size-baseline-<COMMIT_SHA> (primary), then prunes old per-commit
+          # baselines. Never delete+recreate the release: that leaves a
+          # window where the release doesn't exist at all, which a concurrent
+          # PR's "Fetch base branch baseline" step could hit and misreport as
+          # "no baseline available yet". Assets are replaced in place
+          # (--clobber) on later pushes — the release/tag stays continuously
+          # resolvable.
+          bash .github/scripts/publish-size-baseline.sh \
+            iNavFlight/pr-test-builds \
+            "${BRANCH}" \
+            "${COMMIT_SHA}" \
+            size-report.json
 
   pr-comment:
     runs-on: ubuntu-latest
@@ -181,30 +183,49 @@ jobs:
           echo "base_ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
-      - name: Fetch base branch baseline
+      - name: Compute PR base commit (merge-base)
+        id: mergebase
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # The PR's TRUE base commit is the merge-base of the PR head and
+          # base ref — NOT the base branch's latest tip (comparing against
+          # the tip includes unrelated changes merged after the PR forked).
+          # The compare API resolves fork-PR head SHAs too (verified).
+          # base_ref was already regex-validated in the step above; the
+          # returned SHA is validated here before any use.
+          MERGE_BASE=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_REF}...${HEAD_SHA}" \
+            --jq '.merge_base_commit.sha // empty' 2>/dev/null || true)
+          if [[ "$MERGE_BASE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "merge_base=${MERGE_BASE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::could not determine merge-base for ${BASE_REF}...${HEAD_SHA}"
+            echo "merge_base=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch size baseline for PR base commit
         id: baseline
         env:
           GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          MERGE_BASE: ${{ steps.mergebase.outputs.merge_base }}
         run: |
-          TAG="size-baseline-${BASE_REF}"
           mkdir -p baseline
-
-          # publish-baseline replaces the asset in place (--clobber) rather
-          # than deleting/recreating the release, but an individual asset
-          # replace still briefly deletes-then-uploads under the hood. A
-          # few short retries absorb that narrow window instead of a
-          # concurrent run misreporting "no baseline available yet" for a
-          # baseline that actually exists.
-          FOUND=false
-          for attempt in 1 2 3; do
-            if gh release download "$TAG" --repo iNavFlight/pr-test-builds --pattern size-report.json --dir baseline 2>/dev/null; then
-              FOUND=true
-              break
-            fi
-            sleep 3
-          done
-          echo "found=${FOUND}" >> "$GITHUB_OUTPUT"
+          if [ -n "${MERGE_BASE}" ]; then
+            # Exact per-commit baseline for the merge-base first, then the
+            # nearest ancestor commit that has one; the branch-tip baseline
+            # is deliberately NOT a fallback (stale-delta bug).
+            bash .github/scripts/fetch-size-baseline.sh \
+              "${GITHUB_REPOSITORY}" \
+              iNavFlight/pr-test-builds \
+              "${BASE_REF}" \
+              "${MERGE_BASE}" \
+              baseline >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Check for doc on PR head commit
         id: doc
@@ -225,6 +246,8 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           SHORT_SHA: ${{ steps.pr.outputs.short_sha }}
           BASELINE_FOUND: ${{ steps.baseline.outputs.found }}
+          BASELINE_COMMIT: ${{ steps.baseline.outputs.baseline_commit_short }}
+          BASELINE_EXACT: ${{ steps.baseline.outputs.baseline_exact }}
           DOC_LINK: ${{ steps.doc.outputs.link }}
         with:
           script: |
@@ -247,6 +270,8 @@ jobs:
               prReport,
               baselineReport,
               shortSha: process.env.SHORT_SHA,
+              baselineCommit: process.env.BASELINE_COMMIT || null,
+              baselineIsNearest: !!process.env.BASELINE_COMMIT && process.env.BASELINE_EXACT !== 'true',
               docLink: process.env.DOC_LINK || null,
               marker,
             });

--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -47,6 +47,7 @@ jobs:
       cancel-in-progress: true
     permissions:
       actions: read   # to download artifacts and query job conclusions from the triggering workflow run
+      contents: read  # for the checkout step (scripts live in this repo)
     steps:
       # REQUIRED FIRST STEP: check out a known branch before any step calls
       # a script from .github/scripts/. Repo scripts MUST NEVER be invoked

--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -28,6 +28,14 @@ name: CI Size Report
 #    fetches the per-commit baseline for it (falling back to the nearest
 #    ancestor commit that has one), diffs the 4 representative targets,
 #    and posts/updates a PR comment showing which baseline was used.
+#    ci.yml's own `name: Build firmware` is also used, unmodified, by
+#    .github/workflows/non-code-change.yaml — a stub with the exact
+#    `paths-ignore:` complement of ci.yml's `paths:` filter, so exactly one
+#    of the two fires per PR and either satisfies the same required-status-
+#    check name. `workflow_run` can't tell the two apart by name (see
+#    github-actions-workflows.md), and the stub's only job is `test` — no
+#    `upload-artifacts`, none of the artifacts this job needs — so a guard
+#    step checks for that job directly before downloading anything.
 #
 # Requires the same repository secret PR_BUILDS_TOKEN as pr-test-builds.yml
 # (Contents: write access to iNavFlight/pr-test-builds).
@@ -146,7 +154,32 @@ jobs:
       # untrusted code is never checked out in this privileged context.
       - uses: actions/checkout@v4
 
+      # ci.yml's "Build firmware" name is shared with the non-code-change.yaml
+      # stub (see comment at the top of this file), whose only job is `test`
+      # — no upload-artifacts, none of the artifacts downloaded below. Check
+      # for that job directly rather than trusting the aggregate
+      # workflow_run.conclusion, which the job-level `if:` above already
+      # confirmed is 'success' for either workflow.
+      - name: Check upload-artifacts job succeeded
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          CONCLUSION=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --paginate \
+            --jq '.jobs[] | select(.name == "upload-artifacts") | .conclusion')
+          if [ -z "$CONCLUSION" ]; then
+            echo "::notice::upload-artifacts job not found in run ${RUN_ID} — likely the non-code-change.yaml stub (or the job was renamed), skipping size comment"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          elif [ "$CONCLUSION" != "success" ]; then
+            echo "::notice::upload-artifacts did not succeed (conclusion: ${CONCLUSION}), skipping size comment"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download PR number
+        if: steps.check.outputs.proceed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: pr-number
@@ -154,6 +187,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download base ref
+        if: steps.check.outputs.proceed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: base-ref
@@ -161,6 +195,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download PR size report
+        if: steps.check.outputs.proceed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: size-report
@@ -168,6 +203,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read PR number and base ref
+        if: steps.check.outputs.proceed == 'true'
         id: pr
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -193,6 +229,7 @@ jobs:
           echo "short_sha=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       - name: Compute PR base commit (merge-base)
+        if: steps.check.outputs.proceed == 'true'
         id: mergebase
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -215,6 +252,7 @@ jobs:
           fi
 
       - name: Fetch size baseline for PR base commit
+        if: steps.check.outputs.proceed == 'true'
         id: baseline
         env:
           GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
@@ -237,6 +275,7 @@ jobs:
           fi
 
       - name: Check for doc on PR head commit
+        if: steps.check.outputs.proceed == 'true'
         id: doc
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -250,6 +289,7 @@ jobs:
           fi
 
       - name: Post or update PR comment
+        if: steps.check.outputs.proceed == 'true'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: matrix-${{ env.BUILD_NAME }}.${{ matrix.id }}
-          path: ./build/*.hex
+          path: |
+            ./build/*.hex
+            ./build/*.uf2
           retention-days: 1
       - name: Upload size report
         uses: actions/upload-artifact@v4
@@ -167,7 +169,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: matrix-${{ env.BUILD_NAME }}.single
-          path: ./build/*.hex
+          path: |
+            ./build/*.hex
+            ./build/*.uf2
           retention-days: 1
       - name: Upload size report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-test-builds.yml
+++ b/.github/workflows/pr-test-builds.yml
@@ -86,10 +86,17 @@ jobs:
           PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
           printf '%s\n\n%s\n\n%s\n' \
             "Test build for [PR #${PR_NUMBER}](${PR_URL}) — commit \`${SHORT_SHA}\`" \
-            "**${HEX_COUNT} targets built.** Find your board's \`.hex\` file by name (e.g. \`MATEKF405SE.hex\`)." \
+            "**${HEX_COUNT} targets built.** Find your board's \`.hex\` file by name (e.g. \`MATEKF405SE.hex\`); targets that also publish a \`.uf2\` (e.g. \`RP2350_PICO\`) attach it alongside for BOOTSEL drag-and-drop flashing." \
             "> Development build for testing only. Use Full Chip Erase when flashing." \
             > release-notes.md
-          gh release create "pr-${PR_NUMBER}" hexes/*.hex \
+          # Attach .uf2 images when present (RP2350 targets publish them for
+          # BOOTSEL drag-and-drop). Build an explicit asset list so a PR that
+          # produced no .uf2 doesn't pass a literal unmatched glob to gh.
+          ASSETS=(hexes/*.hex)
+          if compgen -G "hexes/*.uf2" > /dev/null; then
+            ASSETS+=(hexes/*.uf2)
+          fi
+          gh release create "pr-${PR_NUMBER}" "${ASSETS[@]}" \
             --repo iNavFlight/pr-test-builds \
             --prerelease \
             --title "PR #${PR_NUMBER} (${SHORT_SHA})" \

--- a/docs/development/ram-and-flash-optimization.md
+++ b/docs/development/ram-and-flash-optimization.md
@@ -40,7 +40,7 @@ A narrow audit produces a confident-looking wrong answer.
 
 Example: a first pass on the tunnel buffer checked only MSP2 handlers
 (432 B largest reply); MSP1 legacy handlers reachable through the same
-buffer needed 512 B (`MSP_LED_STRIP_CONFIG`, unbounded).
+buffer needed 512 B.
 
 ### Chunk a large buffer into a circular buffer when the peripheral drains continuously
 

--- a/docs/development/ram-and-flash-optimization.md
+++ b/docs/development/ram-and-flash-optimization.md
@@ -50,8 +50,8 @@ array. Refill must come from a real hardware DMA interrupt — a
 task-scheduler tick leaves gaps that read as a protocol reset.
 
 Example: the WS2812 driver buffered all 128 possible LEDs in one static
-array (6,230 B) for a single DMA burst; a circular buffer holding 2 groups
-of 4 LEDs (384 B), refilled from the DMA interrupt as each group finishes,
+array (12,460 B) for a single DMA burst; a circular buffer holding 2 groups
+of 4 LEDs (768 B), refilled from the DMA interrupt as each group finishes,
 cut it >16x with no protocol change.
 
 ### A minimum-duration constraint doesn't need buffer space
@@ -77,6 +77,34 @@ transfer proportionally, at zero cost to full-length users.
 Example: the LED driver processed all 128 possible slots every update;
 threading `ledCounts.count` into the fill loop and DMA transfer length cut
 work for short strips.
+
+### Budget speculative reads against the shared cache they consume
+
+A feature that pre-reads a shared cache (tile cache, lookup tables) must
+size its speculative distance against that cache's capacity, not against
+what the feature would like to know. Otherwise the speculative consumer can
+evict the block the cache's primary consumer needs next, turning the cache
+into a thrash loop. Compute the budget from the cache size with margin for
+the primary consumer, and additionally cap by a time horizon so the scan
+scales with what the aircraft can actually reach.
+
+Example: PR #11785's terrain lookahead caps its scan at
+`(TERRAIN_GRID_BLOCK_CACHE_SIZE - 3) * 540 m` per query cycle — the `-3`
+reserves the current block plus margin — and then at `groundspeed * 35 s`.
+On an 8-entry cache (F765/H743) that is a 2,700 m ceiling, with the time
+horizon usually binding first. The scan can never evict the block the AGL
+query reads.
+
+### Consume an existing cache in place; add no private copy
+
+When a feature needs data from a cache-backed source, read through the
+existing cache and mark misses for loading instead of allocating its own
+shadow buffer "for cleanliness". A miss is a `return not-ready`, not a
+reason to copy.
+
+Example: PR #11785's `terrainNavGetHeightAtLocation()` reads the #11438
+terrain grid cache directly and calls `markGridBlockNeedRead()` on a miss;
+the whole terrain_nav layer holds zero tile buffers of its own.
 
 ## Sending data
 
@@ -153,6 +181,21 @@ Example: PR #11553 added navigation FSM states as
 `[NAV_STATE_...] = { ... }` entries in `navFSM[NAV_STATE_COUNT]`, and its
 mixer-profile transition FSM uses a dense `switch` the compiler can turn
 into a jump table.
+
+### Keep a feature's whole static state in ONE caller-owned struct
+
+When a feature's decision logic has many state fields, don't scatter them
+as file-scope statics across the module — hold them in one struct that the
+caller passes in/out. That makes the feature's RAM cost equal to one
+visible `sizeof()`, keeps the core logic pure (unit-testable without
+linking the subsystem), and makes reset = one memset-style function
+instead of a dozen assignments.
+
+Example: PR #11785's terrain_nav_hold layer keeps its entire state machine
+in `terrainNavHoldState_t` (64 B on MATEKF765, verified via nm) plus one
+small output struct — the whole feature's static RAM is ~100 B, not
+scattered buffers. `terrain_nav_hold_core.c` is pure logic with zero
+file-scope state; `terrain_nav_hold.c` owns the single state struct.
 
 ## Duplication: state vs code
 

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -79,6 +79,7 @@ typedef enum {
     DEBUG_GPS,
     DEBUG_LULU,
     DEBUG_SBUS2,
+    DEBUG_ESC,
     DEBUG_COUNT // also update debugModeNames in cli.c
 } debugType_e;
 

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -222,7 +222,8 @@ static const char *debugModeNames[DEBUG_COUNT] = {
     "HEADTRACKER",
     "GPS",
     "LULU",
-    "SBUS2"
+    "SBUS2",
+    "ESC"
 };
 
 /* Sensor names (used in lookup tables for *_hardware settings and in status

--- a/src/main/fc/settings.yaml
+++ b/src/main/fc/settings.yaml
@@ -84,7 +84,7 @@ tables:
       "VIBE", "CRUISE", "REM_FLIGHT_TIME", "SMARTAUDIO", "ACC",
       "NAV_YAW", "PCF8574", "DYN_GYRO_LPF", "AUTOLEVEL", "ALTITUDE",
       "AUTOTRIM", "AUTOTUNE", "RATE_DYNAMICS", "LANDING", "POS_EST",
-      "ADAPTIVE_FILTER", "HEADTRACKER", "GPS", "LULU", "SBUS2"]
+      "ADAPTIVE_FILTER", "HEADTRACKER", "GPS", "LULU", "SBUS2", "ESC"]
   - name: aux_operator
     values: ["OR", "AND"]
     enum: modeActivationOperator_e

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -178,7 +178,6 @@ typedef struct servoConfig_s {
     uint8_t servo_protocol;                 // See servoProtocolType_e
     uint8_t tri_unarmed_servo;              // send tail servo correction pulses even when unarmed
     uint8_t servo_autotrim_rotation_limit;  // Max rotation for servo midpoints to be updated
-    uint8_t servo_autotrim_iterm_threshold; // How much of the Iterm is carried over to the servo midpoints on each update
 } servoConfig_t;
 
 PG_DECLARE(servoConfig_t, servoConfig);

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -33,6 +33,7 @@
 #include "drivers/pwm_output.h"
 #include "drivers/light_led.h"
 #include "drivers/system.h"
+#include "build/debug.h"
 
 #include "flight/mixer.h"
 
@@ -352,16 +353,21 @@ static uint8_t Connect(uint8_32_u *pDeviceInfo)
             return 1;
         } else {
             if (BL_ConnectEx(pDeviceInfo)) {
+                DEBUG_SET(DEBUG_ESC, 0, pDeviceInfo->words[0]);
                 if  SILABS_DEVICE_MATCH {
                     CurrentInterfaceMode = imSIL_BLB;
+                    DEBUG_SET(DEBUG_ESC, 1, 1);
                     return 1;
                 } else if ATMEL_DEVICE_MATCH {
                     CurrentInterfaceMode = imATM_BLB;
+                    DEBUG_SET(DEBUG_ESC, 1, 2);
                     return 1;
                 } else if ARM_DEVICE_MATCH {
                     CurrentInterfaceMode = imARM_BLB;
+                    DEBUG_SET(DEBUG_ESC, 1, 3);
                     return 1;
                 }
+                DEBUG_SET(DEBUG_ESC, 1, 0);
             }
         }
         #elif defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER)

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "platform.h"
+#include "build/debug.h"
 
 #ifdef  USE_SERIAL_4WAY_BLHELI_INTERFACE
 
@@ -33,7 +34,6 @@
 #include "drivers/pwm_output.h"
 #include "drivers/light_led.h"
 #include "drivers/system.h"
-#include "build/debug.h"
 
 #include "flight/mixer.h"
 
@@ -80,12 +80,6 @@
 
 #define SERIAL_4WAY_PROTOCOL_VER 108
 // *** end
-
-// Timeout values for 4-way interface communication (from Betaflight PR #13287)
-#define CMD_TIMEOUT_US  50000
-#define ARG_TIMEOUT_US  25000
-#define DAT_TIMEOUT_US  10000
-#define CRC_TIMEOUT_US  10000
 
 #if (SERIAL_4WAY_VER_MAIN > 24)
 #error "beware of SERIAL_4WAY_VER_SUB_1 is uint8_t"
@@ -336,7 +330,7 @@ uint16_t _crc_xmodem_update (uint16_t crc, uint8_t data) {
 #define ATMEL_DEVICE_MATCH ((pDeviceInfo->words[0] == 0x9307) || (pDeviceInfo->words[0] == 0x930A) || \
         (pDeviceInfo->words[0] == 0x930F) || (pDeviceInfo->words[0] == 0x940B))
 
-// Range-based detection for Bluejay/AM32 compatibility (from Betaflight PR #13287)
+// Range-based detection for newer SiLabs BLHeli_S MCUs (EFM8BB51x reports 0xE8B5)
 #define SILABS_DEVICE_MATCH ((pDeviceInfo->words[0] > 0xE800) && (pDeviceInfo->words[0] < 0xF900))
 
 // BLHeli_32 MCU ID hi > 0x00 and < 0x90 / lo always = 0x06
@@ -346,25 +340,32 @@ static uint8_t CurrentInterfaceMode;
 
 static uint8_t Connect(uint8_32_u *pDeviceInfo)
 {
+    // DEBUG_ESC: [0] = raw bootloader signature (words[0]), [1] = interface mode
+    // (imSIL_BLB=1 SiLabs/BLHeli_S-Bluejay, imATM_BLB=2 Atmel, imSK=3 SimonK, imARM_BLB=4 ARM/BLHeli32-AM32).
+    DEBUG_SET(DEBUG_ESC, 0, 0);
+    DEBUG_SET(DEBUG_ESC, 1, 0);
+
     for (uint8_t I = 0; I < 3; ++I) {
         #if (defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER) && defined(USE_SERIAL_4WAY_SK_BOOTLOADER))
         if ((CurrentInterfaceMode != imARM_BLB) && Stk_ConnectEx(pDeviceInfo) && ATMEL_DEVICE_MATCH) {
             CurrentInterfaceMode = imSK;
+            DEBUG_SET(DEBUG_ESC, 0, pDeviceInfo->words[0]);
+            DEBUG_SET(DEBUG_ESC, 1, imSK);
             return 1;
         } else {
             if (BL_ConnectEx(pDeviceInfo)) {
                 DEBUG_SET(DEBUG_ESC, 0, pDeviceInfo->words[0]);
                 if  SILABS_DEVICE_MATCH {
                     CurrentInterfaceMode = imSIL_BLB;
-                    DEBUG_SET(DEBUG_ESC, 1, 1);
+                    DEBUG_SET(DEBUG_ESC, 1, imSIL_BLB);
                     return 1;
                 } else if ATMEL_DEVICE_MATCH {
                     CurrentInterfaceMode = imATM_BLB;
-                    DEBUG_SET(DEBUG_ESC, 1, 2);
+                    DEBUG_SET(DEBUG_ESC, 1, imATM_BLB);
                     return 1;
                 } else if ARM_DEVICE_MATCH {
                     CurrentInterfaceMode = imARM_BLB;
-                    DEBUG_SET(DEBUG_ESC, 1, 3);
+                    DEBUG_SET(DEBUG_ESC, 1, imARM_BLB);
                     return 1;
                 }
                 DEBUG_SET(DEBUG_ESC, 1, 0);
@@ -395,26 +396,19 @@ static uint8_t Connect(uint8_32_u *pDeviceInfo)
 
 static serialPort_t *port;
 
-static bool ReadByte(uint8_t *data, timeDelta_t timeoutUs)
+static uint8_t ReadByte(void)
 {
-    timeUs_t startTime = micros();
-    while (!serialRxBytesWaiting(port)) {
-        if (timeoutUs && (cmpTimeUs(micros(), startTime) > timeoutUs)) {
-            return true;  // timeout occurred
-        }
-    }
-    *data = serialRead(port);
-    return false;  // success
+    // need timeout?
+    while (!serialRxBytesWaiting(port));
+    return serialRead(port);
 }
 
 static uint8_16_u CRC_in;
-static bool ReadByteCrc(uint8_t *data, timeDelta_t timeoutUs)
+static uint8_t ReadByteCrc(void)
 {
-    bool timedOut = ReadByte(data, timeoutUs);
-    if (!timedOut) {
-        CRC_in.word = _crc_xmodem_update(CRC_in.word, *data);
-    }
-    return timedOut;
+    uint8_t b = ReadByte();
+    CRC_in.word = _crc_xmodem_update(CRC_in.word, b);
+    return b;
 }
 
 static void WriteByte(uint8_t b)
@@ -455,13 +449,10 @@ void esc4wayProcess(serialPort_t *mspPort)
     bool isExitScheduled = false;
 
     while (1) {
-        bool timedOut = false;
-
         // restart looking for new sequence from host
         do {
             CRC_in.word = 0;
-            // No timeout - BLHeliSuite32 waits indefinitely for input
-            ReadByteCrc(&ESC, 0);
+            ESC = ReadByteCrc();
         } while (ESC != cmd_Local_Escape);
 
         RX_LED_ON;
@@ -469,25 +460,23 @@ void esc4wayProcess(serialPort_t *mspPort)
         Dummy.word = 0;
         O_PARAM = &Dummy.bytes[0];
         O_PARAM_LEN = 1;
+        CMD = ReadByteCrc();
+        ioMem.D_FLASH_ADDR_H = ReadByteCrc();
+        ioMem.D_FLASH_ADDR_L = ReadByteCrc();
+        I_PARAM_LEN = ReadByteCrc();
 
-        timedOut = ReadByteCrc(&CMD, CMD_TIMEOUT_US) ||
-                   ReadByteCrc(&ioMem.D_FLASH_ADDR_H, ARG_TIMEOUT_US) ||
-                   ReadByteCrc(&ioMem.D_FLASH_ADDR_L, ARG_TIMEOUT_US) ||
-                   ReadByteCrc(&I_PARAM_LEN, ARG_TIMEOUT_US);
+        InBuff = ParamBuf;
+        uint8_t i = I_PARAM_LEN;
+        do {
+            *InBuff = ReadByteCrc();
+            InBuff++;
+            i--;
+        } while (i != 0);
 
-        if (!timedOut) {
-            uint8_t i = I_PARAM_LEN;
-            InBuff = ParamBuf;
-            do {
-                timedOut = ReadByteCrc(InBuff++, DAT_TIMEOUT_US);
-            } while ((--i > 0) && !timedOut);
+        CRC_check.bytes[1] = ReadByte();
+        CRC_check.bytes[0] = ReadByte();
 
-            for (int8_t j = 1; (j >= 0) && !timedOut; j--) {
-                timedOut = ReadByte(&CRC_check.bytes[j], CRC_TIMEOUT_US);
-            }
-        }
-
-        if ((CRC_check.word == CRC_in.word) && !timedOut) {
+        if (CRC_check.word == CRC_in.word) {
             ACK_OUT = ACK_OK;
         } else {
             ACK_OUT = ACK_I_INVALID_CRC;
@@ -604,7 +593,8 @@ void esc4wayProcess(serialPort_t *mspPort)
                         case imARM_BLB:
                         {
                             BL_SendCMDRunRestartBootloader(&DeviceInfo);
-                            // ESC reboot logic for Bluejay/AM32 (from Betaflight PR #14214)
+                            // Bluejay/AM32 ESCs enter their bootloader after the signal line is
+                            // pulled low briefly and released.
                             if (rebootEsc) {
                                 ESC_OUTPUT;
                                 setEscLo(selected_esc);

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -898,7 +898,7 @@ void esc4wayProcess(serialPort_t *mspPort)
         WriteByteCrc(ioMem.D_FLASH_ADDR_L);
         WriteByteCrc(O_PARAM_LEN);
 
-        uint8_t i = O_PARAM_LEN;
+        i = O_PARAM_LEN;
         do {
             while (!serialTxBytesFree(port));
 

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -27,6 +27,7 @@
 #include "drivers/buf_writer.h"
 #include "drivers/io.h"
 #include "drivers/serial.h"
+#include "drivers/time.h"
 #include "drivers/timer.h"
 #include "drivers/pwm_mapping.h"
 #include "drivers/pwm_output.h"
@@ -74,10 +75,16 @@
 // *** change to adapt Revision
 #define SERIAL_4WAY_VER_MAIN 20
 #define SERIAL_4WAY_VER_SUB_1 (uint8_t) 0
-#define SERIAL_4WAY_VER_SUB_2 (uint8_t) 05
+#define SERIAL_4WAY_VER_SUB_2 (uint8_t) 06
 
-#define SERIAL_4WAY_PROTOCOL_VER 107
+#define SERIAL_4WAY_PROTOCOL_VER 108
 // *** end
+
+// Timeout values for 4-way interface communication (from Betaflight PR #13287)
+#define CMD_TIMEOUT_US  50000
+#define ARG_TIMEOUT_US  25000
+#define DAT_TIMEOUT_US  10000
+#define CRC_TIMEOUT_US  10000
 
 #if (SERIAL_4WAY_VER_MAIN > 24)
 #error "beware of SERIAL_4WAY_VER_SUB_1 is uint8_t"
@@ -328,10 +335,8 @@ uint16_t _crc_xmodem_update (uint16_t crc, uint8_t data) {
 #define ATMEL_DEVICE_MATCH ((pDeviceInfo->words[0] == 0x9307) || (pDeviceInfo->words[0] == 0x930A) || \
         (pDeviceInfo->words[0] == 0x930F) || (pDeviceInfo->words[0] == 0x940B))
 
-#define SILABS_DEVICE_MATCH ((pDeviceInfo->words[0] == 0xF310)||(pDeviceInfo->words[0] == 0xF330) || \
-        (pDeviceInfo->words[0] == 0xF410) || (pDeviceInfo->words[0] == 0xF390) || \
-        (pDeviceInfo->words[0] == 0xF850) || (pDeviceInfo->words[0] == 0xE8B1) || \
-        (pDeviceInfo->words[0] == 0xE8B2))
+// Range-based detection for Bluejay/AM32 compatibility (from Betaflight PR #13287)
+#define SILABS_DEVICE_MATCH ((pDeviceInfo->words[0] > 0xE800) && (pDeviceInfo->words[0] < 0xF900))
 
 // BLHeli_32 MCU ID hi > 0x00 and < 0x90 / lo always = 0x06
 #define ARM_DEVICE_MATCH ((pDeviceInfo->bytes[1] > 0x00) && (pDeviceInfo->bytes[1] < 0x90) && (pDeviceInfo->bytes[0] == 0x06))
@@ -384,19 +389,26 @@ static uint8_t Connect(uint8_32_u *pDeviceInfo)
 
 static serialPort_t *port;
 
-static uint8_t ReadByte(void)
+static bool ReadByte(uint8_t *data, timeDelta_t timeoutUs)
 {
-    // need timeout?
-    while (!serialRxBytesWaiting(port));
-    return serialRead(port);
+    timeUs_t startTime = micros();
+    while (!serialRxBytesWaiting(port)) {
+        if (timeoutUs && (cmpTimeUs(micros(), startTime) > timeoutUs)) {
+            return true;  // timeout occurred
+        }
+    }
+    *data = serialRead(port);
+    return false;  // success
 }
 
 static uint8_16_u CRC_in;
-static uint8_t ReadByteCrc(void)
+static bool ReadByteCrc(uint8_t *data, timeDelta_t timeoutUs)
 {
-    uint8_t b = ReadByte();
-    CRC_in.word = _crc_xmodem_update(CRC_in.word, b);
-    return b;
+    bool timedOut = ReadByte(data, timeoutUs);
+    if (!timedOut) {
+        CRC_in.word = _crc_xmodem_update(CRC_in.word, *data);
+    }
+    return timedOut;
 }
 
 static void WriteByte(uint8_t b)
@@ -437,10 +449,13 @@ void esc4wayProcess(serialPort_t *mspPort)
     bool isExitScheduled = false;
 
     while (1) {
+        bool timedOut = false;
+
         // restart looking for new sequence from host
         do {
             CRC_in.word = 0;
-            ESC = ReadByteCrc();
+            // No timeout - BLHeliSuite32 waits indefinitely for input
+            ReadByteCrc(&ESC, 0);
         } while (ESC != cmd_Local_Escape);
 
         RX_LED_ON;
@@ -448,23 +463,25 @@ void esc4wayProcess(serialPort_t *mspPort)
         Dummy.word = 0;
         O_PARAM = &Dummy.bytes[0];
         O_PARAM_LEN = 1;
-        CMD = ReadByteCrc();
-        ioMem.D_FLASH_ADDR_H = ReadByteCrc();
-        ioMem.D_FLASH_ADDR_L = ReadByteCrc();
-        I_PARAM_LEN = ReadByteCrc();
 
-        InBuff = ParamBuf;
-        uint8_t i = I_PARAM_LEN;
-        do {
-          *InBuff = ReadByteCrc();
-          InBuff++;
-          i--;
-        } while (i != 0);
+        timedOut = ReadByteCrc(&CMD, CMD_TIMEOUT_US) ||
+                   ReadByteCrc(&ioMem.D_FLASH_ADDR_H, ARG_TIMEOUT_US) ||
+                   ReadByteCrc(&ioMem.D_FLASH_ADDR_L, ARG_TIMEOUT_US) ||
+                   ReadByteCrc(&I_PARAM_LEN, ARG_TIMEOUT_US);
 
-        CRC_check.bytes[1] = ReadByte();
-        CRC_check.bytes[0] = ReadByte();
+        if (!timedOut) {
+            uint8_t i = I_PARAM_LEN;
+            InBuff = ParamBuf;
+            do {
+                timedOut = ReadByteCrc(InBuff++, DAT_TIMEOUT_US);
+            } while ((--i > 0) && !timedOut);
 
-        if (CRC_check.word == CRC_in.word) {
+            for (int8_t j = 1; (j >= 0) && !timedOut; j--) {
+                timedOut = ReadByte(&CRC_check.bytes[j], CRC_TIMEOUT_US);
+            }
+        }
+
+        if ((CRC_check.word == CRC_in.word) && !timedOut) {
             ACK_OUT = ACK_OK;
         } else {
             ACK_OUT = ACK_I_INVALID_CRC;
@@ -561,9 +578,13 @@ void esc4wayProcess(serialPort_t *mspPort)
 
                 case cmd_DeviceReset:
                 {
+                    bool rebootEsc = false;
                     if (ParamBuf[0] < escCount) {
                         // Channel may change here
                         selected_esc = ParamBuf[0];
+                        if (ioMem.D_FLASH_ADDR_L == 1) {
+                            rebootEsc = true;
+                        }
                     }
                     else {
                         ACK_OUT = ACK_I_INVALID_CHANNEL;
@@ -577,6 +598,15 @@ void esc4wayProcess(serialPort_t *mspPort)
                         case imARM_BLB:
                         {
                             BL_SendCMDRunRestartBootloader(&DeviceInfo);
+                            // ESC reboot logic for Bluejay/AM32 (from Betaflight PR #14214)
+                            if (rebootEsc) {
+                                ESC_OUTPUT;
+                                setEscLo(selected_esc);
+                                timeMs_t m = millis();
+                                while (millis() - m < 300);
+                                setEscHi(selected_esc);
+                                ESC_INPUT;
+                            }
                             break;
                         }
                         #endif
@@ -872,7 +902,7 @@ void esc4wayProcess(serialPort_t *mspPort)
         WriteByteCrc(ioMem.D_FLASH_ADDR_L);
         WriteByteCrc(O_PARAM_LEN);
 
-        i=O_PARAM_LEN;
+        uint8_t i = O_PARAM_LEN;
         do {
             while (!serialTxBytesFree(port));
 


### PR DESCRIPTION
## Summary
Syncs 21 commits from `release/9.1` (merged since the last sync, PR #11681) into `maintenance-10.x`. Follows the project's release->next-version merge procedure: branched off `maintenance-10.x`, merged `release/9.1` into the new branch, resolved conflicts there. `release/9.1` itself was never touched or pushed to.

## Changes
Notable commits carried forward include:
- Port Betaflight ESC passthrough fixes for Bluejay/AM32 compatibility, plus a new `DEBUG_ESC` debug mode
- CI: publish .uf2 test builds (RP2350) alongside .hex in PR releases
- CI: size-report/size-baseline fixes (commit matching, branch grouping, non-fatal pruning failures)
- RAM/flash optimization documentation updates
- Removal of orphaned `servo_autotrim_iterm_threshold` field

## Conflict Resolution
3 files conflicted, all the same shape: `release/9.1` added a new `DEBUG_ESC` debug mode in `src/main/build/debug.h`, `src/main/fc/cli.c` (`debugModeNames[]`), and `src/main/fc/settings.yaml` (`debug_modes`), while `maintenance-10.x` had independently added 4 other debug modes (`DEBUG_OSD_REFRESH`, `DEBUG_VTOL_TRANSITION`, `DEBUG_VTOL_MC_PROTECT`, `DEBUG_TERRAIN_NAV`) in the same enum. Resolved by keeping all of `maintenance-10.x`'s additions and appending `DEBUG_ESC` after them, consistently across all three files. `servos.h` and `serial_4way.c` auto-merged with no conflicts.

## Testing
- SITL build: clean, zero warnings/errors
- MATEKF405 (hardware target) build: clean, zero warnings/errors, RAM/flash well within budget
- Verified all three `DEBUG_ESC`-related tables (enum, name array, settings.yaml list) match in order and count (31 entries each)
- Diffed every resolved file against `maintenance-10.x` to confirm no base-branch content was silently dropped
- Verified `release/9.1` was not modified (still at its original tip)

## Code Review
Reviewed the full `maintenance-10.x..HEAD` diff with the `inav-code-review` agent, focused on the merge resolution and interaction between the two branches' changes. No issues found.